### PR TITLE
Clean and run project tests

### DIFF
--- a/hud/agents/base.py
+++ b/hud/agents/base.py
@@ -1,0 +1,49 @@
+"""Base classes for MCP agents."""
+
+from __future__ import annotations
+
+from abc import ABC
+from typing import Any, TYPE_CHECKING
+from pydantic import BaseModel
+
+from ..agent import MCPAgent
+from ..types import AgentResult
+
+if TYPE_CHECKING:
+    from ..datasets import TaskConfig
+
+
+class ModelResponse(BaseModel):
+    """Response from a model."""
+    content: str
+    isError: bool = False
+    error_message: str | None = None
+    
+    def model_dump(self, **kwargs) -> dict[str, Any]:
+        """Dump model to dict."""
+        return {
+            "content": self.content,
+            "isError": self.isError,
+            "error_message": self.error_message
+        }
+
+
+class BaseMCPAgent(MCPAgent):
+    """
+    Base class for MCP agents with common functionality.
+    
+    This class extends MCPAgent with provider-specific implementations
+    and common helper methods.
+    """
+    
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the base MCP agent."""
+        super().__init__(**kwargs)
+    
+    async def get_model_response(self, messages: list[Any], **kwargs: Any) -> ModelResponse:
+        """Get response from the model. Should be implemented by subclasses."""
+        raise NotImplementedError("Subclasses must implement get_model_response")
+    
+    async def execute_tools(self, *, tool_calls: list[Any], **kwargs: Any) -> list[AgentResult]:
+        """Execute tool calls. Should be implemented by subclasses."""
+        raise NotImplementedError("Subclasses must implement execute_tools")

--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -16,7 +16,7 @@ import pytest
 from mcp import types
 from mcp.types import CallToolRequestParams as MCPToolCall
 
-from hud.mcp.base import BaseMCPAgent
+from hud.agents.base import BaseMCPAgent
 from hud.tools.executors.base import BaseExecutor
 
 if TYPE_CHECKING:

--- a/hud/agents/tests/test_claude.py
+++ b/hud/agents/tests/test_claude.py
@@ -10,7 +10,7 @@ from anthropic import BadRequestError
 from mcp import types
 from mcp.types import CallToolRequestParams as MCPToolCall
 
-from hud.mcp.claude import (
+from hud.agents.claude import (
     ClaudeMCPAgent,
     base64_to_content_block,
     text_to_content_block,
@@ -70,7 +70,7 @@ class TestClaudeMCPAgent:
     @pytest.fixture
     def mock_anthropic(self):
         """Create a mock Anthropic client."""
-        with patch("hud.mcp.claude.AsyncAnthropic") as mock:
+        with patch("hud.agents.claude.AsyncAnthropic") as mock:
             client = AsyncMock()
             # Add beta attribute with messages
             client.beta = AsyncMock()
@@ -97,7 +97,7 @@ class TestClaudeMCPAgent:
     @pytest.mark.asyncio
     async def test_init_without_model_client(self, mock_mcp_client):
         """Test agent initialization without model client."""
-        with patch("hud.mcp.claude.settings.anthropic_api_key", "test_key"):
+        with patch("hud.agents.claude.settings.anthropic_api_key", "test_key"):
             agent = ClaudeMCPAgent(mcp_client=mock_mcp_client, model="claude-3-opus-20240229")
 
             assert agent.model_name == "claude-3-opus-20240229"

--- a/hud/agents/tests/test_client.py
+++ b/hud/agents/tests/test_client.py
@@ -8,7 +8,7 @@ import pytest
 from mcp import types
 from pydantic import AnyUrl
 
-from hud.mcp.client import MCPClient
+from hud.client import MCPClient
 
 
 class TestMCPClient:
@@ -24,8 +24,8 @@ class TestMCPClient:
         mock_instance.close_all_sessions = AsyncMock()
         mock_instance.get_all_active_sessions = MagicMock(return_value={})
 
-        # Patch MCPUseClient that's imported in hud.mcp.client
-        with patch("hud.mcp.client.MCPUseClient") as mock_class:
+        # Patch MCPUseClient that's imported in hud.client
+        with patch("hud.client.MCPUseClient") as mock_class:
             mock_class.from_dict = MagicMock(return_value=mock_instance)
             yield mock_instance
 
@@ -40,7 +40,7 @@ class TestMCPClient:
             }
         }
 
-        with patch("hud.mcp.client.MCPUseClient") as mock_use_client:
+        with patch("hud.client.MCPUseClient") as mock_use_client:
             client = MCPClient(mcp_config=mcp_config, verbose=True)
 
             assert client.verbose is True

--- a/hud/agents/tests/test_openai.py
+++ b/hud/agents/tests/test_openai.py
@@ -8,7 +8,7 @@ import pytest
 from mcp import types
 from mcp.types import CallToolRequestParams as MCPToolCall
 
-from hud.mcp.openai import OpenAIMCPAgent
+from hud.agents.openai import OpenAIMCPAgent
 
 
 class TestOpenAIMCPAgent:
@@ -25,7 +25,7 @@ class TestOpenAIMCPAgent:
     @pytest.fixture
     def mock_openai(self):
         """Create a mock OpenAI client."""
-        with patch("hud.mcp.openai.AsyncOpenAI") as mock:
+        with patch("hud.agents.openai.AsyncOpenAI") as mock:
             client = AsyncMock()
             mock.return_value = client
             yield client


### PR DESCRIPTION
Refactor and fix pytest imports and class references across `hud` and `hud/agents` directories to resolve incorrect paths, address a missing base class, and remove outdated test logic.

The primary issue addressed was the non-existence of `hud.agents.base.py`, which multiple agent classes were attempting to import from. This PR creates the necessary `BaseMCPAgent` and `ModelResponse` classes in this file, allowing for the correction of numerous import paths from `hud.mcp.*` to `hud.agents.*` or `hud.client.*`. Additionally, outdated tests related to a non-existent `OperatorAgent` were removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-e060b74c-bb06-4118-b8d8-d587eb2d25ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e060b74c-bb06-4118-b8d8-d587eb2d25ff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

