### PR TITLE
chore: Update example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,10 @@ Explore the core concepts and features of the SDK:
 
 We recommend you first take a look at the example notebooks showing how to use the HUD SDK:
 
-1. [Browser Basics](examples/browser_use.ipynb) - Simple browser interaction with live view
-2. [Task Design](examples/tasks.ipynb) - Creating and customizing tasks
-3. [OSWorld](examples/osworld.ipynb) - Running the OSWorld benchmark
-4. [Local Development](examples/local.ipynb) - Setting up local custom environments
+1. [Browser Basics](examples/environments/simple_browser_example.py) - Simple browser interaction with live view
+2. [Task Design](examples/evaluations/tasks.ipynb) - Creating and customizing tasks
+3. [OSWorld](examples/evaluations/osworld.ipynb) - Running the OSWorld benchmark
+4. [Local Development](examples/environments/gmail_local.ipynb) - Setting up local custom environments
 
 ## Documentation
 


### PR DESCRIPTION
# What
- I updated the example links in the top level README to point to valid file paths

## Why
- When clicking on the example links in the current main branch, all of them lead to 404 not found.

## Comment
- The `gmail_local` example may or may not be the one you want to use for the `local` example. It seems like you have a few options of local now.