### PR TITLE
fix: increase initialization timeout to 10 minutes

### DIFF
--- a/hud/clients/fastmcp.py
+++ b/hud/clients/fastmcp.py
@@ -73,7 +73,7 @@ class FastMCPHUDClient(BaseHUDClient):
             return
 
         # Create FastMCP client with the custom transport
-        timeout = 5 * 60  # 5 minutes
+        timeout = 10 * 60  # 5 minutes
         os.environ["FASTMCP_CLIENT_INIT_TIMEOUT"] = str(timeout)
 
         # Create custom transport with retry support for HTTP servers


### PR DESCRIPTION
This increases the client side initialization request timeout limit from 5 minutes (300s) to 10 minutes (600s) to support long running initializations for complex envs.