### PR TITLE
Debug and fix telemetry trace completion issue

### DIFF
--- a/docs/core-concepts/task-system.mdx
+++ b/docs/core-concepts/task-system.mdx
@@ -159,6 +159,24 @@ results = await run_dataset_parallel(
 )
 ```
 
+## Parallel execution
+
+For large datasets, use the process‑based parallel runner. It launches a pool of worker processes, each with its own asyncio event loop and bounded concurrency.
+
+Key pieces
+- run_dataset_parallel: Auto‑configures worker count and per‑worker concurrency based on dataset size and CPU resources.
+- run_dataset_parallel_manual: Manual control over workers, per‑worker concurrency, and an optional total concurrency cap. Workers instantiate the agent per task from the provided class and config.
+
+Worker lifecycle
+- Each worker calls configure_telemetry() (idempotent), sets up its own event loop, and processes its assigned batch concurrently (bounded by max_concurrent_per_worker).
+- Each task runs inside a hud.trace so it is individually visible in HUD and linked to the job via job_id.
+- After processing its batch, a worker performs a best‑effort provider.force_flush() with a short timeout to reduce telemetry tail loss without risking a shutdown hang. It then closes the event loop and exits.
+
+Fault tolerance
+- KeyboardInterrupt: Remaining tasks are marked as interrupted.
+- Worker failure: All tasks in that batch are marked failed and execution continues.
+- Watchdog: The manual runner includes a per‑worker watchdog (worker_timeout_s) so the main process cannot hang indefinitely if a worker becomes unresponsive; stuck workers are cancelled and their tasks are marked failed.
+
 ## Creating Datasets
 
 ```python

--- a/docs/core-concepts/telemetry.mdx
+++ b/docs/core-concepts/telemetry.mdx
@@ -1,0 +1,35 @@
+---
+title: Telemetry and Tracing
+---
+
+HUD SDK includes a first‑class OpenTelemetry integration that records agent and MCP activity as structured traces and ships them to the HUD backend.
+
+What gets installed
+• configure_telemetry: Creates a global TracerProvider, adds processors/exporters, and installs MCP auto‑instrumentation. It is idempotent and safe to call from any process/thread.
+• HudEnrichmentProcessor: A SpanProcessor that enriches every span with HUD context from OTel baggage/contextvars:
+  - hud.task_run_id, hud.job_id
+  - step counters: hud.base_mcp_steps, hud.mcp_tool_steps, hud.agent_steps
+• HudSpanExporter: A synchronous exporter that groups spans by hud.task_run_id and POSTs them to the HUD telemetry endpoint (/trace/<id>/telemetry-upload). It translates spans into HUD’s TraceStep wire format.
+• In‑memory collector (optional): When enabled, spans are also kept in memory for replay/debug via get_trace.
+
+Trace lifecycle
+• Start: Use hud.trace(name, job_id=..., task_id=...). This creates a root span and sets OTel baggage so that child spans inherit the task/job context.
+• During: Agent and MCP spans are created by instrumentation. HudEnrichmentProcessor updates per‑span step counters and copies baggage into attributes.
+• Status updates: On entering hud.trace, HUD sends a “running” status asynchronously. On exit, status is finalized synchronously as “completed” or “error,” ensuring the run is visible in HUD even if the process exits quickly.
+• Export: BatchSpanProcessor buffers spans and calls HudSpanExporter periodically or on flush/shutdown.
+
+Flush and shutdown
+• Flush is handled by OpenTelemetry’s BatchSpanProcessor. The exporter itself does not buffer.
+• Providers expose provider.force_flush(timeout_millis=...), which we call in long‑running workers when appropriate to reduce tail loss, but we keep the timeout short to avoid hangs.
+• The exporter uses a bounded‑timeout httpx.Client (15s) with minimal retries so shutdown can’t be blocked by slow networks.
+
+What to look for in logs
+• “HUD exporter sending … spans …” when batches are exported
+• Status updates to /trace/<id>/status for running/completed/error
+• If network issues occur, exporter returns FAILURE so OTel can retry internally; the SDK will not throw or exit on exporter errors.
+
+Operational guidance
+• You can safely call configure_telemetry() in every process, including forked workers.
+• Avoid long sleeps or blocking work inside SpanProcessor.force_flush() or exporter.force_flush(); the SDK must be able to shut down promptly.
+• If using a custom OTLP backend, pass enable_otlp=True and optionally endpoint/headers to configure_telemetry().
+

--- a/hud/otel/processors.py
+++ b/hud/otel/processors.py
@@ -116,6 +116,7 @@ class HudEnrichmentProcessor(SpanProcessor):
         pass
 
     def force_flush(self, timeout_millis: int | None = None) -> bool:  # type: ignore[override]
-        if timeout_millis:
-            time.sleep(timeout_millis / 1000)
+        # No-op and return immediately. We never want a SpanProcessor to block
+        # shutdown/flush in worker processes. BatchSpanProcessor handles flushing
+        # its own queue and exporter.
         return True


### PR DESCRIPTION
Prevent parallel evaluation hangs by adding a worker watchdog, bounding telemetry flush timeouts, and making the OTel exporter non-blocking.

Previously, worker processes could block indefinitely during telemetry `force_flush` operations or due to slow network responses from the OTel exporter. Additionally, the main runner lacked a mechanism to detect and recover from unresponsive worker processes, leading to the entire evaluation freezing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7979fc2-bfea-42f0-9967-d9f9b932a06b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7979fc2-bfea-42f0-9967-d9f9b932a06b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

