### PR TITLE
--mock option added for hud eval

### DIFF
--- a/hud/agents/mock_agent.py
+++ b/hud/agents/mock_agent.py
@@ -1,0 +1,42 @@
+from hud.agents.base import MCPAgent, find_reward
+from hud.types import Trace
+from typing import Any
+
+
+class MockToolRunner(MCPAgent):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.metadata = {}
+
+    async def run(self, task: Any, max_steps: int = 10) -> Trace:  # noqa: ARG002
+        try:
+            # Initialize using base to set up client and telemetry correctly
+            await self.initialize(task)
+
+            # Validate task shape
+            if not getattr(task, "mock_tool", None):
+                raise ValueError("--mock requires task.mock_tool (single call)")
+            if getattr(task, "setup_tool", None) or getattr(task, "evaluate_tool", None):
+                raise ValueError("--mock requires only mock_tool; remove setup_tool/evaluate_tool")
+
+            # Execute the tool via base helper (gets MCPToolResult list)
+            results = await self.call_tools(task.mock_tool)
+            reward = float(find_reward(results[0])) if results else 0.0
+
+            return Trace(done=True, reward=reward, info={})
+        finally:
+            # Ensure resources are cleaned up so the CLI can exit cleanly
+            await self._cleanup()
+
+    # Stub implementations to satisfy abstract base class; not used in --mock path
+    async def get_system_messages(self) -> list[Any]:
+        return []
+
+    async def get_response(self, messages: list[Any]):  # noqa: ARG002
+        raise NotImplementedError("MockToolRunner does not implement agent loop")
+
+    async def format_blocks(self, blocks: list[Any]) -> list[Any]:  # noqa: ARG002
+        return []
+
+    async def format_tool_results(self, tool_calls: list[Any], tool_results: list[Any]) -> list[Any]:  # noqa: ARG002
+        return []

--- a/hud/agents/mock_agent.py
+++ b/hud/agents/mock_agent.py
@@ -5,6 +5,7 @@ from typing import Any
 
 class MockToolRunner(MCPAgent):
     def __init__(self, **kwargs: Any) -> None:
+        kwargs["auto_trace"] = False
         super().__init__(**kwargs)
         self.metadata = {}
 

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -829,6 +829,11 @@ def eval(
         "--verbose",
         help="Enable verbose output from the agent",
     ),
+    mock: bool = typer.Option(
+        False,
+        "--mock",
+        help="Run mock_problem tool, where problem is setup, actions are applied, and evaluation is performed, without spinning up an agent",
+    ),
 ) -> None:
     """🚀 Run evaluation on datasets or individual tasks with agents."""
     from hud.utils.hud_console import HUDConsole
@@ -884,22 +889,24 @@ def eval(
             source = file_choice
             hud_console.success(f"Selected: {source}")
 
-    # If no agent specified, prompt for selection
-    if agent is None:
-        agent = hud_console.select(
-            "Select an agent to use:",
-            choices=[
-                {"name": "Claude 4 Sonnet", "value": "claude"},
-                {"name": "OpenAI Computer Use", "value": "openai"},
-            ],
-            default="Claude 4 Sonnet",
-        )
+    # If --mock, skip agent selection/validation entirely
+    if not mock:
+        # If no agent specified, prompt for selection
+        if agent is None:
+            agent = hud_console.select(
+                "Select an agent to use:",
+                choices=[
+                    {"name": "Claude 4 Sonnet", "value": "claude"},
+                    {"name": "OpenAI Computer Use", "value": "openai"},
+                ],
+                default="Claude 4 Sonnet",
+            )
 
-    # Validate agent choice
-    valid_agents = ["claude", "openai"]
-    if agent not in valid_agents:
-        hud_console.error(f"Invalid agent: {agent}. Must be one of: {', '.join(valid_agents)}")
-        raise typer.Exit(1)
+        # Validate agent choice
+        valid_agents = ["claude", "openai"]
+        if agent not in valid_agents:
+            hud_console.error(f"Invalid agent: {agent}. Must be one of: {', '.join(valid_agents)}")
+            raise typer.Exit(1)
 
     # Import eval_command lazily to avoid importing agent dependencies
     try:
@@ -924,6 +931,7 @@ def eval(
         max_workers=max_workers,
         max_concurrent_per_worker=max_concurrent_per_worker,
         verbose=verbose,
+        mock=mock,
     )
 
 

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -12,8 +12,7 @@ import typer
 
 import hud
 from hud.utils.hud_console import HUDConsole
-from hud.agents.base import MCPAgent, find_reward
-from hud.types import Trace
+from hud.agents.mock_agent import MockToolRunner
 
 logger = logging.getLogger(__name__)
 hud_console = HUDConsole()
@@ -70,45 +69,6 @@ def build_agent(
             model=model,
             verbose=verbose,
         )
-
-
-class MockToolRunner(MCPAgent):
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        self.metadata = {}
-
-    async def run(self, task: Any, max_steps: int = 10) -> Trace:  # noqa: ARG002
-        try:
-            # Initialize using base to set up client and telemetry correctly
-            await self.initialize(task)
-
-            # Validate task shape
-            if not getattr(task, "mock_tool", None):
-                raise ValueError("--mock requires task.mock_tool (single call)")
-            if getattr(task, "setup_tool", None) or getattr(task, "evaluate_tool", None):
-                raise ValueError("--mock requires only mock_tool; remove setup_tool/evaluate_tool")
-
-            # Execute the tool via base helper (gets MCPToolResult list)
-            results = await self.call_tools(task.mock_tool)
-            reward = float(find_reward(results[0])) if results else 0.0
-
-            return Trace(done=True, reward=reward, info={})
-        finally:
-            # Ensure resources are cleaned up so the CLI can exit cleanly
-            await self._cleanup()
-
-    # Stub implementations to satisfy abstract base class; not used in --mock path
-    async def get_system_messages(self) -> list[Any]:
-        return []
-
-    async def get_response(self, messages: list[Any]):  # noqa: ARG002
-        raise NotImplementedError("MockToolRunner does not implement agent loop")
-
-    async def format_blocks(self, blocks: list[Any]) -> list[Any]:  # noqa: ARG002
-        return []
-
-    async def format_tool_results(self, tool_calls: list[Any], tool_results: list[Any]) -> list[Any]:  # noqa: ARG002
-        return []
 
 
 async def run_single_task(

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -12,6 +12,8 @@ import typer
 
 import hud
 from hud.utils.hud_console import HUDConsole
+from hud.agents.base import MCPAgent
+from hud.types import Trace
 
 logger = logging.getLogger(__name__)
 hud_console = HUDConsole()
@@ -78,6 +80,7 @@ async def run_single_task(
     allowed_tools: list[str] | None = None,
     max_steps: int = 10,
     verbose: bool = False,
+    mock: bool = False,
 ) -> None:
     """Load one task and execute it, or detect if JSON contains a list and run as dataset."""
 
@@ -91,12 +94,99 @@ async def run_single_task(
         )
         raise typer.Exit(1) from e
 
-    # Check if it's a JSON file
+    # Check if it's a JSON or YAML file
     path = Path(source)
-    if path.exists() and path.suffix == ".json":
+    if path.exists() and path.suffix in {".json", ".yaml", ".yml"}:
         hud_console.info("📊 Loading task file…")
-        with open(path) as f:  # noqa: ASYNC230
-            json_data = json.load(f)
+        # Load JSON or YAML depending on extension
+        if path.suffix in {".yaml", ".yml"}:
+            try:
+                import yaml  # type: ignore
+            except Exception as e:  # pragma: no cover - optional dependency
+                hud_console.error(
+                    "YAML support is not installed. Please install with: pip install 'pyyaml'"
+                )
+                raise typer.Exit(1) from e
+
+            with open(path) as f:  # noqa: ASYNC230
+                json_data = yaml.safe_load(f)
+        else:
+            with open(path) as f:  # noqa: ASYNC230
+                json_data = json.load(f)
+
+        # If --mock, run a single mock tool call directly (no agent)
+        if mock:
+            # Build single task object
+            if isinstance(json_data, list):
+                if len(json_data) != 1:
+                    hud_console.error("--mock requires a single task file (or a single-item list)")
+                    raise typer.Exit(1)
+                task_data = json_data[0]
+            elif isinstance(json_data, dict):
+                task_data = json_data
+            else:
+                hud_console.error("Unsupported file format for --mock. Provide a task object or single-item list.")
+                raise typer.Exit(1)
+
+            task = Task(**task_data)
+
+            # Wrap in hud.trace so the platform prints the trace link automatically
+            task_prompt = task.prompt[:50] + "..." if len(task.prompt) > 50 else task.prompt
+            with hud.trace(name=task_prompt):
+                hud_console.info("🧪 --mock: calling tool directly (no agent)")
+
+                # Create MCP client from task.mcp_config
+                try:
+                    from hud.clients import MCPClient
+                except ImportError as e:
+                    hud_console.error("MCP client dependencies are not installed.")
+                    raise typer.Exit(1) from e
+
+                client = MCPClient(mcp_config=task.mcp_config, verbose=verbose)  # type: ignore[call-arg]
+                await client.initialize()
+
+                # Enforce ONLY mock_tool in --mock mode
+                if not task.mock_tool:
+                    await client.shutdown()
+                    hud_console.error("--mock requires mock_tool")
+                    raise typer.Exit(1)
+                if task.setup_tool or task.evaluate_tool:
+                    await client.shutdown()
+                    hud_console.error("--mock requires only mock_tool; remove setup_tool/evaluate_tool")
+                    raise typer.Exit(1)
+
+                # Execute the single mock tool call (e.g., hub "mock_problem").
+                # The MCP tool result can be returned in two shapes:
+                # 1) structuredContent (preferred): a structured JSON payload
+                # 2) content[0].text: a JSON string we need to parse
+                res = await client.call_tool(task.mock_tool)
+                payload: dict[str, Any] | None = None
+                # Prefer structuredContent.result if available (most robust shape)
+                sc = getattr(res, "structuredContent", None)
+                try:
+                    if sc and isinstance(sc, dict) and "result" in sc:
+                        payload = sc["result"]  # type: ignore[index]
+                    elif res.content and len(res.content) > 0:
+                        text = getattr(res.content[0], "text", None)
+                        if isinstance(text, str):
+                            import json as _json
+
+                            payload = _json.loads(text)
+                except Exception:
+                    payload = None
+
+                await client.shutdown()
+
+                # Extract a numeric score. Support top-level reward and nested evaluation.reward
+                reward = 0.0
+                if isinstance(payload, dict):
+                    if isinstance(payload.get("reward"), (int, float)):
+                        reward = float(payload.get("reward", 0.0))
+                    elif isinstance(payload.get("evaluation"), dict):
+                        reward = float(payload.get("evaluation", {}).get("reward", 0.0))
+
+                hud_console.success(f"Reward: {reward}")
+                return
 
         # Check if JSON contains multiple tasks (list with more than 1 task)
         if isinstance(json_data, list) and len(json_data) > 1:
@@ -140,7 +230,7 @@ async def run_single_task(
 
             # Run as dataset with single-task concurrency to maintain debug behavior
             results = await run_dataset(
-                name=f"JSON Dataset: {path.name}",
+                name=f"Dataset: {path.name}",
                 dataset=json_data,  # Pass the list directly
                 agent_class=agent_class,
                 agent_config=agent_config,
@@ -156,7 +246,7 @@ async def run_single_task(
 
         # Single task JSON (either direct object or list with 1 task)
         if isinstance(json_data, list) and len(json_data) == 1:
-            hud_console.info("Found 1 task in JSON file, running as single task…")
+            hud_console.info("Found 1 task in file, running as single task…")
             task = Task(**json_data[0])
         elif isinstance(json_data, dict):
             task = Task(**json_data)
@@ -177,7 +267,7 @@ async def run_single_task(
 
         dataset = load_dataset(source, split="train")
 
-        # Get first task from dataset
+        # Get first task from dataset (non-mock single-task debug)
         sample_task = dataset[0]  # type: ignore[index]
         task = Task(**sample_task)  # type: ignore[arg-type]
 
@@ -223,21 +313,33 @@ async def run_full_dataset(
         )
         raise typer.Exit(1) from e
 
-    # Check if source is a JSON file with list of tasks
+    # Check if source is a JSON/YAML file with list of tasks
     path = Path(source)
     dataset_or_tasks = source
     dataset_name = source.split("/")[-1]
 
-    if path.exists() and path.suffix == ".json":
-        with open(path) as f:  # noqa: ASYNC230
-            json_data = json.load(f)
+    if path.exists() and path.suffix in {".json", ".yaml", ".yml"}:
+        if path.suffix in {".yaml", ".yml"}:
+            try:
+                import yaml  # type: ignore
+            except Exception as e:  # pragma: no cover - optional dependency
+                hud_console.error(
+                    "YAML support is not installed. Please install with: pip install 'pyyaml'"
+                )
+                raise typer.Exit(1) from e
+
+            with open(path) as f:  # noqa: ASYNC230
+                json_data = yaml.safe_load(f)
+        else:
+            with open(path) as f:  # noqa: ASYNC230
+                json_data = json.load(f)
 
         if isinstance(json_data, list):
             dataset_or_tasks = json_data
-            dataset_name = f"JSON Dataset: {path.name}"
-            hud_console.info(f"Found {len(json_data)} tasks in JSON file")
+            dataset_name = f"Dataset: {path.name}"
+            hud_console.info(f"Found {len(json_data)} tasks in file: {path.name}")
         else:
-            hud_console.error("JSON file must contain a list of tasks when using --full flag")
+            hud_console.error("File must contain a list of tasks when using --full flag")
             raise typer.Exit(1)
 
     # Build agent class + config for run_dataset
@@ -374,6 +476,11 @@ def eval_command(
         "--verbose",
         help="Enable verbose output from the agent",
     ),
+    mock: bool = typer.Option(
+        False,
+        "--mock",
+        help="Run mock_problem tool, where problem is setup, actions are applied, and evaluation is performed, without spinning up an agent",
+    ),
 ) -> None:
     """🚀 Run evaluation on datasets or individual tasks with agents.
 
@@ -459,5 +566,6 @@ def eval_command(
                 allowed_tools=allowed_tools_list,
                 max_steps=max_steps,
                 verbose=verbose,
+                mock=mock,
             )
         )

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -72,6 +72,68 @@ def build_agent(
         )
 
 
+class MockToolRunner(MCPAgent):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.metadata = {}
+
+    async def run(self, task: Any, max_steps: int = 10) -> Trace:  # noqa: ARG002
+        try:
+            # Initialize using base to set up client and telemetry correctly
+            await self.initialize(task)
+
+            # Validate task shape
+            if not getattr(task, "mock_tool", None):
+                raise ValueError("--mock requires task.mock_tool (single call)")
+            if getattr(task, "setup_tool", None) or getattr(task, "evaluate_tool", None):
+                raise ValueError("--mock requires only mock_tool; remove setup_tool/evaluate_tool")
+
+            # Execute the tool
+            if self.mcp_client is None:
+                raise ValueError("MCP client not initialized")
+            res = await self.mcp_client.call_tool(task.mock_tool)
+
+            # Extract payload and numeric reward
+            payload: dict[str, Any] | None = None
+            sc = getattr(res, "structuredContent", None)
+            try:
+                if sc and isinstance(sc, dict) and "result" in sc:
+                    payload = sc["result"]  # type: ignore[index]
+                elif res.content and len(res.content) > 0:
+                    text = getattr(res.content[0], "text", None)
+                    if isinstance(text, str):
+                        import json as _json
+
+                        payload = _json.loads(text)
+            except Exception:
+                payload = None
+
+            reward = 0.0
+            if isinstance(payload, dict):
+                if isinstance(payload.get("reward"), (int, float)):
+                    reward = float(payload.get("reward", 0.0))
+                elif isinstance(payload.get("evaluation"), dict):
+                    reward = float(payload.get("evaluation", {}).get("reward", 0.0))
+
+            return Trace(done=True, reward=reward, info={})
+        finally:
+            # Ensure resources are cleaned up so the CLI can exit cleanly
+            await self._cleanup()
+
+    # Stub implementations to satisfy abstract base class; not used in --mock path
+    async def get_system_messages(self) -> list[Any]:
+        return []
+
+    async def get_response(self, messages: list[Any]):  # noqa: ARG002
+        raise NotImplementedError("MockToolRunner does not implement agent loop")
+
+    async def format_blocks(self, blocks: list[Any]) -> list[Any]:  # noqa: ARG002
+        return []
+
+    async def format_tool_results(self, tool_calls: list[Any], tool_results: list[Any]) -> list[Any]:  # noqa: ARG002
+        return []
+
+
 async def run_single_task(
     source: str,
     *,
@@ -119,7 +181,7 @@ async def run_single_task(
             # Build single task object
             if isinstance(json_data, list):
                 if len(json_data) != 1:
-                    hud_console.error("--mock requires a single task file (or a single-item list)")
+                    hud_console.error("--mock without --full requires a single task. add --full to run all task mocks.")
                     raise typer.Exit(1)
                 task_data = json_data[0]
             elif isinstance(json_data, dict):
@@ -297,6 +359,7 @@ async def run_full_dataset(
     max_workers: int | None = None,
     max_concurrent_per_worker: int = 25,
     verbose: bool = False,
+    mock: bool = False,
 ) -> list[Any]:
     """Run evaluation across the entire dataset.
 
@@ -341,6 +404,30 @@ async def run_full_dataset(
         else:
             hud_console.error("File must contain a list of tasks when using --full flag")
             raise typer.Exit(1)
+
+        # If --mock in full mode: run via dataset runner with MockToolRunner (supports parallel)
+        if mock:
+            if parallel:
+                return await run_dataset_parallel(
+                    name=f"Evaluation (mock): {dataset_name}",
+                    dataset=dataset_or_tasks,
+                    agent_class=MockToolRunner,  # type: ignore[arg-type]
+                    agent_config={"verbose": verbose},
+                    max_concurrent=max_concurrent,
+                    metadata={"dataset": source, "parallel": True, "mock": True},
+                    max_steps=max_steps,
+                    auto_respond=True,
+                )
+            else:
+                return await run_dataset(
+                    name=f"Evaluation (mock): {dataset_name}",
+                    dataset=dataset_or_tasks,
+                    agent_class=MockToolRunner,  # type: ignore[arg-type]
+                    agent_config={"verbose": verbose},
+                    max_concurrent=max_concurrent,
+                    metadata={"dataset": source, "mock": True},
+                    max_steps=max_steps,
+                )
 
     # Build agent class + config for run_dataset
     if agent_type == "openai":
@@ -555,6 +642,7 @@ def eval_command(
                 max_workers=max_workers,
                 max_concurrent_per_worker=max_concurrent_per_worker,
                 verbose=verbose,
+                mock=mock,
             )
         )
     else:

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -12,7 +12,7 @@ import typer
 
 import hud
 from hud.utils.hud_console import HUDConsole
-from hud.agents.base import MCPAgent
+from hud.agents.base import MCPAgent, find_reward
 from hud.types import Trace
 
 logger = logging.getLogger(__name__)
@@ -88,32 +88,9 @@ class MockToolRunner(MCPAgent):
             if getattr(task, "setup_tool", None) or getattr(task, "evaluate_tool", None):
                 raise ValueError("--mock requires only mock_tool; remove setup_tool/evaluate_tool")
 
-            # Execute the tool
-            if self.mcp_client is None:
-                raise ValueError("MCP client not initialized")
-            res = await self.mcp_client.call_tool(task.mock_tool)
-
-            # Extract payload and numeric reward
-            payload: dict[str, Any] | None = None
-            sc = getattr(res, "structuredContent", None)
-            try:
-                if sc and isinstance(sc, dict) and "result" in sc:
-                    payload = sc["result"]  # type: ignore[index]
-                elif res.content and len(res.content) > 0:
-                    text = getattr(res.content[0], "text", None)
-                    if isinstance(text, str):
-                        import json as _json
-
-                        payload = _json.loads(text)
-            except Exception:
-                payload = None
-
-            reward = 0.0
-            if isinstance(payload, dict):
-                if isinstance(payload.get("reward"), (int, float)):
-                    reward = float(payload.get("reward", 0.0))
-                elif isinstance(payload.get("evaluation"), dict):
-                    reward = float(payload.get("evaluation", {}).get("reward", 0.0))
+            # Execute the tool via base helper (gets MCPToolResult list)
+            results = await self.call_tools(task.mock_tool)
+            reward = float(find_reward(results[0])) if results else 0.0
 
             return Trace(done=True, reward=reward, info={})
         finally:
@@ -164,25 +141,33 @@ async def run_single_task(
         if path.suffix in {".yaml", ".yml"}:
             try:
                 import yaml  # type: ignore
-            except Exception as e:  # pragma: no cover - optional dependency
-                hud_console.error(
-                    "YAML support is not installed. Please install with: pip install 'pyyaml'"
-                )
+            except Exception as e:
+                hud_console.error("YAML support is not installed. Please install with: pip install 'pyyaml'")
                 raise typer.Exit(1) from e
 
-            with open(path) as f:  # noqa: ASYNC230
+            with open(path) as f:
                 json_data = yaml.safe_load(f)
         else:
-            with open(path) as f:  # noqa: ASYNC230
+            with open(path) as f:
                 json_data = json.load(f)
 
-        # If --mock, run a single mock tool call directly (no agent)
+        # --mock mode
         if mock:
-            # Build single task object
+            # Build single task object (or forward to full runner if multiple)
             if isinstance(json_data, list):
-                if len(json_data) != 1:
-                    hud_console.error("--mock without --full requires a single task. add --full to run all task mocks.")
-                    raise typer.Exit(1)
+                if len(json_data) > 1:
+                    await run_full_dataset(
+                        source,
+                        agent_type=agent_type,
+                        model=model,
+                        allowed_tools=allowed_tools,
+                        max_concurrent=1,
+                        max_steps=max_steps,
+                        parallel=False,
+                        verbose=verbose,
+                        mock=True,
+                    )
+                    return
                 task_data = json_data[0]
             elif isinstance(json_data, dict):
                 task_data = json_data
@@ -192,62 +177,14 @@ async def run_single_task(
 
             task = Task(**task_data)
 
-            # Wrap in hud.trace so the platform prints the trace link automatically
+            # Run via MockToolRunner but wrap with hud.trace for visible link output
             task_prompt = task.prompt[:50] + "..." if len(task.prompt) > 50 else task.prompt
             with hud.trace(name=task_prompt):
-                hud_console.info("🧪 --mock: calling tool directly (no agent)")
-
-                # Create MCP client from task.mcp_config
-                try:
-                    from hud.clients import MCPClient
-                except ImportError as e:
-                    hud_console.error("MCP client dependencies are not installed.")
-                    raise typer.Exit(1) from e
-
-                client = MCPClient(mcp_config=task.mcp_config, verbose=verbose)  # type: ignore[call-arg]
-                await client.initialize()
-
-                # Enforce ONLY mock_tool in --mock mode
-                if not task.mock_tool:
-                    await client.shutdown()
-                    hud_console.error("--mock requires mock_tool")
-                    raise typer.Exit(1)
-                if task.setup_tool or task.evaluate_tool:
-                    await client.shutdown()
-                    hud_console.error("--mock requires only mock_tool; remove setup_tool/evaluate_tool")
-                    raise typer.Exit(1)
-
-                # Execute the single mock tool call (e.g., hub "mock_problem").
-                # The MCP tool result can be returned in two shapes:
-                # 1) structuredContent (preferred): a structured JSON payload
-                # 2) content[0].text: a JSON string we need to parse
-                res = await client.call_tool(task.mock_tool)
-                payload: dict[str, Any] | None = None
-                # Prefer structuredContent.result if available (most robust shape)
-                sc = getattr(res, "structuredContent", None)
-                try:
-                    if sc and isinstance(sc, dict) and "result" in sc:
-                        payload = sc["result"]  # type: ignore[index]
-                    elif res.content and len(res.content) > 0:
-                        text = getattr(res.content[0], "text", None)
-                        if isinstance(text, str):
-                            import json as _json
-
-                            payload = _json.loads(text)
-                except Exception:
-                    payload = None
-
-                await client.shutdown()
-
-                # Extract a numeric score. Support top-level reward and nested evaluation.reward
-                reward = 0.0
-                if isinstance(payload, dict):
-                    if isinstance(payload.get("reward"), (int, float)):
-                        reward = float(payload.get("reward", 0.0))
-                    elif isinstance(payload.get("evaluation"), dict):
-                        reward = float(payload.get("evaluation", {}).get("reward", 0.0))
-
-                hud_console.success(f"Reward: {reward}")
+                hud_console.info('Prompt: ' + task.prompt)
+                hud_console.info("🧪 --mock: setting up problem, taking actions, evaluating. No llm involved.")
+                agent = MockToolRunner(verbose=verbose)
+                result = await agent.run(task, max_steps=max_steps)
+                hud_console.success(f"Reward: {result.reward}")
                 return
 
         # Check if JSON contains multiple tasks (list with more than 1 task)
@@ -376,25 +313,23 @@ async def run_full_dataset(
         )
         raise typer.Exit(1) from e
 
-    # Check if source is a JSON/YAML file with list of tasks
     path = Path(source)
     dataset_or_tasks = source
     dataset_name = source.split("/")[-1]
 
+    # Check if source is a JSON/YAML file with list of tasks
     if path.exists() and path.suffix in {".json", ".yaml", ".yml"}:
         if path.suffix in {".yaml", ".yml"}:
             try:
                 import yaml  # type: ignore
-            except Exception as e:  # pragma: no cover - optional dependency
-                hud_console.error(
-                    "YAML support is not installed. Please install with: pip install 'pyyaml'"
-                )
+            except Exception as e:
+                hud_console.error("YAML support is not installed. Please install with: pip install 'pyyaml'")
                 raise typer.Exit(1) from e
 
-            with open(path) as f:  # noqa: ASYNC230
+            with open(path) as f:
                 json_data = yaml.safe_load(f)
         else:
-            with open(path) as f:  # noqa: ASYNC230
+            with open(path) as f:
                 json_data = json.load(f)
 
         if isinstance(json_data, list):
@@ -405,32 +340,12 @@ async def run_full_dataset(
             hud_console.error("File must contain a list of tasks when using --full flag")
             raise typer.Exit(1)
 
-        # If --mock in full mode: run via dataset runner with MockToolRunner (supports parallel)
-        if mock:
-            if parallel:
-                return await run_dataset_parallel(
-                    name=f"Evaluation (mock): {dataset_name}",
-                    dataset=dataset_or_tasks,
-                    agent_class=MockToolRunner,  # type: ignore[arg-type]
-                    agent_config={"verbose": verbose},
-                    max_concurrent=max_concurrent,
-                    metadata={"dataset": source, "parallel": True, "mock": True},
-                    max_steps=max_steps,
-                    auto_respond=True,
-                )
-            else:
-                return await run_dataset(
-                    name=f"Evaluation (mock): {dataset_name}",
-                    dataset=dataset_or_tasks,
-                    agent_class=MockToolRunner,  # type: ignore[arg-type]
-                    agent_config={"verbose": verbose},
-                    max_concurrent=max_concurrent,
-                    metadata={"dataset": source, "mock": True},
-                    max_steps=max_steps,
-                )
 
     # Build agent class + config for run_dataset
-    if agent_type == "openai":
+    if mock: # --mock mode
+        agent_class = MockToolRunner  # type: ignore[assignment]
+        agent_config = {"verbose": verbose}
+    elif agent_type == "openai":
         try:
             from hud.agents import OperatorAgent
 
@@ -477,7 +392,7 @@ async def run_full_dataset(
                 agent_class=agent_class,
                 agent_config=agent_config,
                 max_concurrent=max_concurrent,
-                metadata={"dataset": source, "parallel": True},
+                metadata={"dataset": source, "parallel": True, **({"mock": True} if mock else {})},
                 max_steps=max_steps,
                 auto_respond=True,
             )
@@ -491,7 +406,7 @@ async def run_full_dataset(
                 max_workers=max_workers,
                 max_concurrent_per_worker=max_concurrent_per_worker,
                 max_concurrent=max_concurrent,
-                metadata={"dataset": source, "parallel": True},
+                metadata={"dataset": source, "parallel": True, **({"mock": True} if mock else {})},
                 max_steps=max_steps,
                 auto_respond=True,
             )
@@ -503,7 +418,7 @@ async def run_full_dataset(
             agent_class=agent_class,
             agent_config=agent_config,
             max_concurrent=max_concurrent,
-            metadata={"dataset": source},
+            metadata={"dataset": source, **({"mock": True} if mock else {})},
             max_steps=max_steps,
         )
 

--- a/hud/datasets/task.py
+++ b/hud/datasets/task.py
@@ -40,6 +40,7 @@ class Task(BaseModel):
     mcp_config: dict[str, Any]
     setup_tool: MCPToolCall | list[MCPToolCall] | None = None
     evaluate_tool: MCPToolCall | list[MCPToolCall] | None = None
+    mock_tool: MCPToolCall | list[MCPToolCall] | None = None
     system_prompt: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -56,7 +57,7 @@ class Task(BaseModel):
                 raise HudConfigError(f"Invalid JSON string: {e}") from e
         return v
 
-    @field_validator("setup_tool", "evaluate_tool", mode="before")
+    @field_validator("setup_tool", "evaluate_tool", "mock_tool", mode="before")
     @classmethod
     def convert_dict_to_tool_call(cls, v: Any) -> Any:
         """Convert dict to MCPToolCall instance, parsing JSON strings first."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,237 +4,98 @@ version = "0.4.24"
 description = "SDK for the HUD platform."
 readme = "README.md"
 requires-python = ">=3.11, <3.14"
-authors = [
-{ name = "HUD SDK", email = "founders@hud.so" },
-]
-license = { file = "LICENSE" }
-dependencies = [
-    # Core dependencies - minimal for MCP servers and CLI
-    "httpx>=0.23.0,<1",
-    "pydantic>=2,<3",
-    "pydantic-settings>=2,<3",
-    # MCP dependencies
-    "hud-mcp-python-sdk>=3.13.2",
-    "hud-fastmcp-python-sdk>=0.1.2",
-    "hud-mcp-use-python-sdk>=2.3.16",
-    "pathspec>=0.12.1",
-    "wrapt>=1.14.0",
-    # CLI dependencies
-    "typer>=0.9.0",
-    "rich>=13.0.0",
-    "toml>=0.10.2",
-    "watchfiles>=0.21.0",
-    "questionary==2.1.0",
-    "prompt-toolkit==3.0.51",
-    # Telemetry
-    "opentelemetry-instrumentation-mcp>=0.44.1",
-    "opentelemetry-api>=1.34.1",
-    "opentelemetry-sdk>=1.34.1",
-    "opentelemetry-exporter-otlp-proto-http>=1.34.1",
-]
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-]
+dependencies = [ "httpx>=0.23.0,<1", "pydantic>=2,<3", "pydantic-settings>=2,<3", "hud-mcp-python-sdk>=3.13.2", "hud-fastmcp-python-sdk>=0.1.2", "hud-mcp-use-python-sdk>=2.3.16", "pathspec>=0.12.1", "wrapt>=1.14.0", "typer>=0.9.0", "rich>=13.0.0", "toml>=0.10.2", "watchfiles>=0.21.0", "questionary==2.1.0", "prompt-toolkit==3.0.51", "opentelemetry-instrumentation-mcp>=0.44.1", "opentelemetry-api>=1.34.1", "opentelemetry-sdk>=1.34.1", "opentelemetry-exporter-otlp-proto-http>=1.34.1",]
+classifiers = [ "Development Status :: 4 - Beta", "Intended Audience :: Developers", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13",]
+[[project.authors]]
+name = "HUD SDK"
+email = "founders@hud.so"
+
+[build-system]
+requires = [ "hatchling",]
+build-backend = "hatchling.build"
+
+[project.license]
+file = "LICENSE"
 
 [project.urls]
-"Homepage" = "https://github.com/hud-evals/hud-python"
+Homepage = "https://github.com/hud-evals/hud-python"
 "Bug Tracker" = "https://github.com/hud-evals/hud-python/issues"
-"Documentation" = "https://docs.hud.so"
+Documentation = "https://docs.hud.so"
 
 [project.scripts]
 hud = "hud.cli:main"
 hud-python = "hud.cli:main"
 
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build]
-exclude = [
-    "environments/",
-    "docs/",
-    "examples/",
-    "/rl/",  # Only exclude top-level rl directory, not hud/cli/rl/
-]
-
-[tool.hud.clone]
-title = "🚀 Welcome to HUD SDK!"
-message = """[bold cyan]Thanks for using the hud SDK![/bold cyan]
-
-[yellow]Quick Start:[/yellow]
-• Install in development mode: [green]pip install -e .[/green]
-• Try the CLI: [green]hud --help[/green]
-• Analyze an MCP server: [green]hud analyze hud-text-2048:latest[/green]
-• Read the docs: [green]docs/[/green]
-
-[dim]For more examples, check out the [cyan]examples/[/cyan] directory.[/dim]
-
-[bold]Happy coding! 🎉[/bold]"""
-style = "blue"
-
-[tool.hatch.metadata]
-allow-direct-references = true
-
-[tool.hatch.build.targets.sdist]
-include = [
-    "hud/**",  # Include all files under hud/, including hud/cli/rl/
-    "README.md",
-    "LICENSE",
-    "pyproject.toml"
-]
-exclude = [
-    "*/tests/",
-    "*/__pycache__/",
-    "*.pyc",
-    "*.pyo",
-    "*~",
-    ".DS_Store"
-]
-
-[tool.hatch.build.targets.wheel]
-packages = ["hud"]
-
-# Ensure py.typed is included in the package
-[tool.hatch.build.targets.wheel.force-include]
-"hud/py.typed" = "hud/py.typed"
-
-
 [project.optional-dependencies]
-# Agent dependencies - AI capabilities + telemetry + datasets
-agent = [
-    # AI providers
-    "anthropic",
-    "openai",
-    "langchain",
-    "langchain-openai",
-    "langchain-anthropic",
-    # Data and evaluation
-    "datasets>=2.14.0",
-    "numpy>=1.24.0",
-    "pillow>=11.1.0",
-    # Jupyter support
-    "ipykernel",
-    "ipython <9",
-    "jupyter_client",
-    "jupyter_core",
-    "dotenv>=0.9.9",
-]
+agent = [ "anthropic", "openai", "langchain", "langchain-openai", "langchain-anthropic", "datasets>=2.14.0", "numpy>=1.24.0", "pillow>=11.1.0", "ipykernel", "ipython <9", "jupyter_client", "jupyter_core", "dotenv>=0.9.9",]
+agents = [ "hud-python[agent]",]
+dev = [ "hud-python[agent]", "ruff >=0.11.8", "pytest >=8.1.1,<9", "pytest-asyncio", "pytest-mock", "pytest-cov", "pyright==1.1.401", "playwright", "pyautogui>=0.9.54", "pillow>=11.1.0", "textdistance>=4.5.0,<5", "inspect-ai>=0.3.80", "aiodocker>=0.24.0", "setuptools",]
 
-agents = ["hud-python[agent]"]
-
-# Development dependencies - includes testing, linting, and automation tools
-dev = [
-    # Include agent dependencies
-    "hud-python[agent]",
-    # Testing and linting
-    "ruff >=0.11.8",
-    "pytest >=8.1.1,<9",
-    "pytest-asyncio",
-    "pytest-mock",
-    "pytest-cov",
-    "pyright==1.1.401",
-    # Automation and computer control
-    "playwright",
-    "pyautogui>=0.9.54",
-    "pillow>=11.1.0",
-    # Legacy v2 dependencies
-    "textdistance>=4.5.0,<5",
-    "inspect-ai>=0.3.80",
-    # Other utilities
-    "aiodocker>=0.24.0",
-    "setuptools",
-]
+[tool.hud]
+image = "hud-hud-python:dev"
 
 [tool.ruff]
 target-version = "py311"
 line-length = 100
-lint.extend-select = [
-    "I",       # isort
-    "F",       # pyflakes
-    "ANN",     # flake8-annotations
-    "Q",       # flake8-quotes
-    "ASYNC",   # flake8-async
-    "TID",     # flake8-tidy
-    "RSE",     # flake8-raise
-    "G",       # flake8-logging-format
-    "B",       # flake8-bugbear
-    "E",       # pycodestyle errors
-    "W",       # pycodestyle warnings
-    "PIE",     # flake8-pie
-    "S",       # flake8-bandit
-    "PERF",    # Perflint
-    "PLC",     # Pylint
-    "UP",      # pyupgrade
-    "SIM",     # flake8-simplify
-    "INP",     # flake8-no-pep420
-    "T20",     # flake8-print
-    "PYI",     # flake8-pyi
-    "TCH",     # Flake-8 TCH
-    "T10",     # flake-8 debugger
-    "RUF",     # Ruff-specific
-]
-lint.ignore = [
-    "ANN401", # Allow Any.
-    "W293",   # Ignore blank line contains whitespace
-    "PLC0415", # Allow function-local imports.
-]
-
-[tool.ruff.lint.extend-per-file-ignores]
-"**/tests/**/*.py" = ["PYI", "B", "S", "ANN"]
-"*.ipynb" = ["ALL"] # Disables all rules for Jupyter.
-"**/examples/**/*.py" = ["ALL"]
-"**/environments/**/*.py" = ["ALL"]
-
-
-[tool.ruff.format]
-docstring-code-format = true
-
-[tool.ruff.lint.isort]
-required-imports = ["from __future__ import annotations"]
-
-[tool.ruff.lint.flake8-type-checking]
-runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 
 [tool.pyright]
-include = ["hud"]
-exclude = [
-    "**/node_modules",
-    "**/__pycache__",
-    "**/venv",
-    "hud/misc/claude_plays_pokemon.py",
-]
+include = [ "hud",]
+exclude = [ "**/node_modules", "**/__pycache__", "**/venv", "hud/misc/claude_plays_pokemon.py",]
 pythonVersion = "3.11"
 typeCheckingMode = "basic"
 reportMissingImports = "warning"
 
+[tool.hatch.build]
+exclude = [ "environments/", "docs/", "examples/", "/rl/",]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hud.clone]
+title = "🚀 Welcome to HUD SDK!"
+message = "[bold cyan]Thanks for using the hud SDK![/bold cyan]\n\n[yellow]Quick Start:[/yellow]\n• Install in development mode: [green]pip install -e .[/green]\n• Try the CLI: [green]hud --help[/green]\n• Analyze an MCP server: [green]hud analyze hud-text-2048:latest[/green]\n• Read the docs: [green]docs/[/green]\n\n[dim]For more examples, check out the [cyan]examples/[/cyan] directory.[/dim]\n\n[bold]Happy coding! 🎉[/bold]"
+style = "blue"
+
+[tool.ruff.lint]
+extend-select = [ "I", "F", "ANN", "Q", "ASYNC", "TID", "RSE", "G", "B", "E", "W", "PIE", "S", "PERF", "PLC", "UP", "SIM", "INP", "T20", "PYI", "TCH", "T10", "RUF",]
+ignore = [ "ANN401", "W293", "PLC0415",]
+
+[tool.ruff.format]
+docstring-code-format = true
+
 [tool.coverage.run]
-source = ["hud"]
-omit = ["*/tests/*", "*/examples/*"]
+source = [ "hud",]
+omit = [ "*/tests/*", "*/examples/*",]
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    "raise AssertionError",
-    "raise NotImplementedError",
-    "pass",
-    "pytest.mark.skip",
-    "@(typing\\.)?overload",
-    "if TYPE_CHECKING:",
-    "if typing.TYPE_CHECKING:",
-    "class .*\bProtocol\\):",
-    "@(abc\\.)?abstractmethod",
-]
+exclude_lines = [ "pragma: no cover", "raise AssertionError", "raise NotImplementedError", "pass", "pytest.mark.skip", "@(typing\\.)?overload", "if TYPE_CHECKING:", "if typing.TYPE_CHECKING:", "class .*x08Protocol\\):", "@(abc\\.)?abstractmethod",]
 show_missing = true
 fail_under = 58
-omit = ["*/tests/*", "*/examples/*"]
+omit = [ "*/tests/*", "*/examples/*",]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
-testpaths = ["hud", "examples"]
-# Ignore the dev folder and other non-test directories
+testpaths = [ "hud", "examples",]
 addopts = "--ignore=dev --ignore=ref --ignore=test_env --ignore=environments"
+
+[tool.ruff.lint.extend-per-file-ignores]
+"**/tests/**/*.py" = [ "PYI", "B", "S", "ANN",]
+"*.ipynb" = [ "ALL",]
+"**/examples/**/*.py" = [ "ALL",]
+"**/environments/**/*.py" = [ "ALL",]
+
+[tool.ruff.lint.isort]
+required-imports = [ "from __future__ import annotations",]
+
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = [ "pydantic.BaseModel",]
+
+[tool.hatch.build.targets.sdist]
+include = [ "hud/**", "README.md", "LICENSE", "pyproject.toml",]
+exclude = [ "*/tests/", "*/__pycache__/", "*.pyc", "*.pyo", "*~", ".DS_Store",]
+
+[tool.hatch.build.targets.wheel]
+packages = [ "hud",]
+
+[tool.hatch.build.targets.wheel.force-include]
+"hud/py.typed" = "hud/py.typed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,101 +1,254 @@
 [project]
 name = "hud-python"
-version = "0.4.24"
+version = "0.4.36"
 description = "SDK for the HUD platform."
 readme = "README.md"
-requires-python = ">=3.11, <3.14"
-dependencies = [ "httpx>=0.23.0,<1", "pydantic>=2,<3", "pydantic-settings>=2,<3", "hud-mcp-python-sdk>=3.13.2", "hud-fastmcp-python-sdk>=0.1.2", "hud-mcp-use-python-sdk>=2.3.16", "pathspec>=0.12.1", "wrapt>=1.14.0", "typer>=0.9.0", "rich>=13.0.0", "toml>=0.10.2", "watchfiles>=0.21.0", "questionary==2.1.0", "prompt-toolkit==3.0.51", "opentelemetry-instrumentation-mcp>=0.44.1", "opentelemetry-api>=1.34.1", "opentelemetry-sdk>=1.34.1", "opentelemetry-exporter-otlp-proto-http>=1.34.1",]
-classifiers = [ "Development Status :: 4 - Beta", "Intended Audience :: Developers", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13",]
-[[project.authors]]
-name = "HUD SDK"
-email = "founders@hud.so"
-
-[build-system]
-requires = [ "hatchling",]
-build-backend = "hatchling.build"
-
-[project.license]
-file = "LICENSE"
+requires-python = ">=3.11, <3.13"
+authors = [
+{ name = "HUD SDK", email = "founders@hud.so" },
+]
+license = { file = "LICENSE" }
+dependencies = [
+    # Core dependencies - minimal for MCP servers and CLI
+    "httpx>=0.23.0,<1",
+    "pydantic>=2.6,<3",
+    "pydantic-settings>=2.2,<3",
+    # MCP dependencies
+    "hud-mcp-python-sdk>=3.13.2",
+    "hud-fastmcp-python-sdk>=0.1.2",
+    "hud-mcp-use-python-sdk==2.3.19",
+    "pathspec>=0.12.1",
+    "wrapt>=1.14.0",
+    # CLI dependencies
+    "typer>=0.9.0",
+    "rich>=13.0.0",
+    "toml>=0.10.2",
+    "watchfiles>=0.21.0",
+    "questionary==2.1.0",
+    "prompt-toolkit==3.0.51",
+    # Telemetry
+    "opentelemetry-instrumentation-mcp==0.47.0",
+    "opentelemetry-api>=1.34.1",
+    "opentelemetry-sdk>=1.34.1",
+    "opentelemetry-exporter-otlp-proto-http>=1.34.1",
+    # Data and evaluation
+    "datasets>=2.14.0",
+    "numpy>=1.24.0",
+    "pillow>=11.1.0",
+    # AI providers
+    "anthropic",
+    "openai",
+    "pyyaml>=6.0.2",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 
 [project.urls]
-Homepage = "https://github.com/hud-evals/hud-python"
+"Homepage" = "https://github.com/hud-evals/hud-python"
 "Bug Tracker" = "https://github.com/hud-evals/hud-python/issues"
-Documentation = "https://docs.hud.so"
+"Documentation" = "https://docs.hud.so"
 
 [project.scripts]
 hud = "hud.cli:main"
 hud-python = "hud.cli:main"
 
-[project.optional-dependencies]
-agent = [ "anthropic", "openai", "langchain", "langchain-openai", "langchain-anthropic", "datasets>=2.14.0", "numpy>=1.24.0", "pillow>=11.1.0", "ipykernel", "ipython <9", "jupyter_client", "jupyter_core", "dotenv>=0.9.9",]
-agents = [ "hud-python[agent]",]
-dev = [ "hud-python[agent]", "ruff >=0.11.8", "pytest >=8.1.1,<9", "pytest-asyncio", "pytest-mock", "pytest-cov", "pyright==1.1.401", "playwright", "pyautogui>=0.9.54", "pillow>=11.1.0", "textdistance>=4.5.0,<5", "inspect-ai>=0.3.80", "aiodocker>=0.24.0", "setuptools",]
-
-[tool.hud]
-image = "hud-hud-python:dev"
-
-[tool.ruff]
-target-version = "py311"
-line-length = 100
-
-[tool.pyright]
-include = [ "hud",]
-exclude = [ "**/node_modules", "**/__pycache__", "**/venv", "hud/misc/claude_plays_pokemon.py",]
-pythonVersion = "3.11"
-typeCheckingMode = "basic"
-reportMissingImports = "warning"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [tool.hatch.build]
-exclude = [ "environments/", "docs/", "examples/", "/rl/",]
+exclude = [
+    "environments/",
+    "docs/",
+    "examples/",
+    "**/checkpoints/",
+    "**/*.safetensors",
+    "**/*.ckpt",
+    "**/*.pth",
+]
+
+[tool.hud.clone]
+title = "🚀 Welcome to HUD SDK!"
+message = """[bold cyan]Thanks for using the hud SDK![/bold cyan]
+
+[yellow]Quick Start:[/yellow]
+• Install in development mode: [green]pip install -e .[/green]
+• Try the CLI: [green]hud --help[/green]
+• Analyze an MCP server: [green]hud analyze hud-text-2048:latest[/green]
+• Read the docs: [green]docs/[/green]
+
+[dim]For more examples, check out the [cyan]examples/[/cyan] directory.[/dim]
+
+[bold]Happy coding! 🎉[/bold]"""
+style = "blue"
 
 [tool.hatch.metadata]
 allow-direct-references = true
 
-[tool.hud.clone]
-title = "🚀 Welcome to HUD SDK!"
-message = "[bold cyan]Thanks for using the hud SDK![/bold cyan]\n\n[yellow]Quick Start:[/yellow]\n• Install in development mode: [green]pip install -e .[/green]\n• Try the CLI: [green]hud --help[/green]\n• Analyze an MCP server: [green]hud analyze hud-text-2048:latest[/green]\n• Read the docs: [green]docs/[/green]\n\n[dim]For more examples, check out the [cyan]examples/[/cyan] directory.[/dim]\n\n[bold]Happy coding! 🎉[/bold]"
-style = "blue"
+[tool.hatch.build.targets.sdist]
+include = [
+    "hud/**",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml"
+]
+exclude = [
+    "*/tests/",
+    "*/__pycache__/",
+    "**/*.safetensors",
+    "**/*.ckpt",
+    "**/*.pth",
+    "*.pyc",
+    "*.pyo",
+    "*~",
+    ".DS_Store"
+]
 
-[tool.ruff.lint]
-extend-select = [ "I", "F", "ANN", "Q", "ASYNC", "TID", "RSE", "G", "B", "E", "W", "PIE", "S", "PERF", "PLC", "UP", "SIM", "INP", "T20", "PYI", "TCH", "T10", "RUF",]
-ignore = [ "ANN401", "W293", "PLC0415",]
+[tool.hatch.build.targets.wheel]
+packages = ["hud"]
+
+# Ensure py.typed is included in the package
+[tool.hatch.build.targets.wheel.force-include]
+"hud/py.typed" = "hud/py.typed"
+
+[project.optional-dependencies]
+rl = [
+    "peft>=0.17.1",
+    "vllm==0.10.1.1",
+    "bitsandbytes>=0.41.0 ; sys_platform == 'linux'",  # For 8-bit optimizers (Linux only)
+    "liger-kernel>=0.5.0 ; sys_platform == 'linux'",  # Optimized Triton kernels for LLM training (Linux only)
+    # Note: flash-attn is recommended but optional
+    # Install separately with: uv pip install flash-attn --no-build-isolation
+]
+
+# Development dependencies - includes testing, linting, and automation tools
+dev = [
+    # Include agent dependencies
+    "langchain",
+    "langchain-openai",
+    "langchain-anthropic",
+    # Jupyter support
+    "ipykernel",
+    "ipython <9",
+    "jupyter_client",
+    "jupyter_core",
+    "dotenv>=0.9.9",
+    # Testing and linting
+    "ruff >=0.11.8",
+    "pytest >=8.1.1,<9",
+    "pytest-asyncio",
+    "pytest-mock",
+    "pytest-cov",
+    "pyright==1.1.401",
+    # Automation and computer control
+    "playwright",
+    "pyautogui>=0.9.54",
+    "pillow>=11.1.0",
+    # Legacy v2 dependencies
+    "textdistance>=4.5.0,<5",
+    "inspect-ai>=0.3.80",
+    # Other utilities
+    "aiodocker>=0.24.0",
+    "setuptools",
+]
+
+# Agent dependencies extend dev
+agent = ["hud-python[dev]"]
+
+agents = ["hud-python[agent]"]
+
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+lint.extend-select = [
+    "I",       # isort
+    "F",       # pyflakes
+    "ANN",     # flake8-annotations
+    "Q",       # flake8-quotes
+    "ASYNC",   # flake8-async
+    "TID",     # flake8-tidy
+    "RSE",     # flake8-raise
+    "G",       # flake8-logging-format
+    "B",       # flake8-bugbear
+    "E",       # pycodestyle errors
+    "W",       # pycodestyle warnings
+    "PIE",     # flake8-pie
+    "S",       # flake8-bandit
+    "PERF",    # Perflint
+    "PLC",     # Pylint
+    "UP",      # pyupgrade
+    "SIM",     # flake8-simplify
+    "INP",     # flake8-no-pep420
+    "T20",     # flake8-print
+    "PYI",     # flake8-pyi
+    "TCH",     # Flake-8 TCH
+    "T10",     # flake-8 debugger
+    "RUF",     # Ruff-specific
+]
+lint.ignore = [
+    "ANN401", # Allow Any.
+    "W293",   # Ignore blank line contains whitespace
+    "PLC0415", # Allow function-local imports.
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"**/tests/**/*.py" = ["PYI", "B", "S", "ANN"]
+"*.ipynb" = ["ALL"] # Disables all rules for Jupyter.
+"**/examples/**/*.py" = ["ALL"]
+"**/environments/**/*.py" = ["ALL"]
+
 
 [tool.ruff.format]
 docstring-code-format = true
 
+[tool.ruff.lint.isort]
+required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.lint.flake8-type-checking]
+runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
+[tool.pyright]
+include = ["hud"]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+    "**/venv",
+    "hud/misc/claude_plays_pokemon.py",
+]
+pythonVersion = "3.11"
+typeCheckingMode = "basic"
+reportMissingImports = "warning"
+
 [tool.coverage.run]
-source = [ "hud",]
-omit = [ "*/tests/*", "*/examples/*",]
+source = ["hud"]
+omit = ["*/tests/*", "*/examples/*"]
 
 [tool.coverage.report]
-exclude_lines = [ "pragma: no cover", "raise AssertionError", "raise NotImplementedError", "pass", "pytest.mark.skip", "@(typing\\.)?overload", "if TYPE_CHECKING:", "if typing.TYPE_CHECKING:", "class .*x08Protocol\\):", "@(abc\\.)?abstractmethod",]
+exclude_lines = [
+    "pragma: no cover",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "pass",
+    "pytest.mark.skip",
+    "@(typing\\.)?overload",
+    "if TYPE_CHECKING:",
+    "if typing.TYPE_CHECKING:",
+    "class .*\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]
 show_missing = true
 fail_under = 58
-omit = [ "*/tests/*", "*/examples/*",]
+omit = ["*/tests/*", "*/examples/*"]
 
 [tool.pytest.ini_options]
 asyncio_default_fixture_loop_scope = "function"
-testpaths = [ "hud", "examples",]
+testpaths = ["hud", "examples"]
+# Ignore the dev folder and other non-test directories
 addopts = "--ignore=dev --ignore=ref --ignore=test_env --ignore=environments"
-
-[tool.ruff.lint.extend-per-file-ignores]
-"**/tests/**/*.py" = [ "PYI", "B", "S", "ANN",]
-"*.ipynb" = [ "ALL",]
-"**/examples/**/*.py" = [ "ALL",]
-"**/environments/**/*.py" = [ "ALL",]
-
-[tool.ruff.lint.isort]
-required-imports = [ "from __future__ import annotations",]
-
-[tool.ruff.lint.flake8-type-checking]
-runtime-evaluated-base-classes = [ "pydantic.BaseModel",]
-
-[tool.hatch.build.targets.sdist]
-include = [ "hud/**", "README.md", "LICENSE", "pyproject.toml",]
-exclude = [ "*/tests/", "*/__pycache__/", "*.pyc", "*.pyo", "*~", ".DS_Store",]
-
-[tool.hatch.build.targets.wheel]
-packages = [ "hud",]
-
-[tool.hatch.build.targets.wheel.force-include]
-"hud/py.typed" = "hud/py.typed"


### PR DESCRIPTION
it's possible to do:
`uv run hud eval --mock --full /path/to/taskset.yaml `
mock will setup problem, take actions, evaluate problem all within one tool (mock_tool), without the involvement of llm. It's a way to quickly mock problems - test whether tasks are good, whether graders are working.

to use it with hud-gmail-environment:
go to branch 'rs' in hud-gmail-environment
some basic mock_tool tasks are visible in taskset.yaml

1) run taskset_convert.py tool  (Note - change file paths)
`uv run python /home/rs/projects/hud-gmail-environment/taskset_convert.py   /home/rs/projects/hud-gmail-environment/taskset.yaml   /home/rs/projects/hud-gmail-environment/taskset2.yaml`

2) from hud-python run: (Note - change file paths)
`uv run hud eval --mock --full /home/rs/projects/hud-gmail-environment/taskset2.yaml`