### PR TITLE
Feature: Add callback system to BaseTool

### DIFF
--- a/docs/reference/tools.mdx
+++ b/docs/reference/tools.mdx
@@ -418,6 +418,52 @@ async def evaluate(name: str, **kwargs):
     return await evaluators.call_tool(name, kwargs)
 ```
 
+### Callback Functions
+
+Callback functions help you monitor certain types of actions and hook 
+behaviors to them. You can manage callbacks using three main methods,
+```python
+add_callback(self, event_type: str, callback: Callable)
+remove_callback(self, event_type: str, callback: Callable)
+_trigger_callbacks(self, event_type: str, **kwargs)  
+```
+*Special note*: Make sure the callback functions are defined by `async def`
+
+For example, when you want to take a screenshot every 
+time the webpage changes in `Playwright`
+ ```python
+from hud.tools.playwright import PlaywrightTool
+import base64
+
+class MyPlaywrightTool(PlaywrightTool):
+    def __init__(self, context: Any = None, cdp_url: str | None = None) -> None:
+        super().__init__(cdp_url=cdp_url)
+        self.screenshots: List = []
+        self.add_callback("webpage_change", self._on_webpage_change)
+
+    async def _on_webpage_change(self, **kwargs) -> None:
+        """Callback to capture screenshots on webpage changes"""
+        try:
+            await self._ensure_browser()
+            if self.page:
+                screenshot_bytes = await self.page.screenshot(full_page=True)
+                screenshot_b64 = base64.b64encode(screenshot_bytes).decode("utf-8")
+                self.screenshots.append(screenshot_b64)
+        except Exception as e:
+            pass
+
+    async def navigate(self, url: str, wait_for_load_state="networkidle"):
+        result = await super().navigate(url, wait_for_load_state)
+        # Trigger callbacks with event data
+        await self._trigger_callbacks("webpage_change")
+        return result
+
+    async def click(self, selector: str, **kwargs):
+        result = await super().click(selector, **kwargs)
+        await self._trigger_callbacks("webpage_change")
+        return result
+```
+
 ## See Also
 
 - [Build Environments](/build-environments) - Using tools in environments

--- a/hud/tools/base.py
+++ b/hud/tools/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, Awaitable
 
 from fastmcp import FastMCP
 
@@ -60,7 +60,10 @@ class BaseTool(ABC):
         self.title = title or self.__class__.__name__.replace("Tool", "").replace("_", " ").title()
         self.description = description or (self.__doc__.strip() if self.__doc__ else None)
         self.meta = meta
-        self._callbacks: dict[str, list[Callable]] = {}  # {"event_name": [callback_functions]}
+        self._callbacks: dict[
+            str,
+            list[Callable[..., Awaitable[Any]]],
+        ] = {}  # {"event_name": [callback_functions]}
 
         # Expose attributes FastMCP expects when registering an instance directly
         self.__name__ = self.name  # FastMCP uses fn.__name__ if name param omitted
@@ -103,7 +106,7 @@ class BaseTool(ABC):
             )
         return self._mcp_tool
 
-    def add_callback(self, event_type: str, callback: Callable):
+    def add_callback(self, event_type: str, callback: Callable[..., Awaitable[Any]]):
         """Register a callback function for specific event
         
         Args:
@@ -115,7 +118,7 @@ class BaseTool(ABC):
             self._callbacks[event_type] = []
         self._callbacks[event_type].append(callback)
 
-    def remove_callback(self, event_type: str, callback: Callable):
+    def remove_callback(self, event_type: str, callback: Callable[..., Awaitable[Any]]):
         """Remove a registered callback
         Args:
             event_type: (Required) Specific event name to trigger callback

--- a/hud/tools/base.py
+++ b/hud/tools/base.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 # Basic result types for tools
 BaseResult = list[ContentBlock] | EvaluationResult
 
+import logging
+logger = logging.getLogger(__name__)
 
 class BaseTool(ABC):
     """
@@ -58,6 +60,7 @@ class BaseTool(ABC):
         self.title = title or self.__class__.__name__.replace("Tool", "").replace("_", " ").title()
         self.description = description or (self.__doc__.strip() if self.__doc__ else None)
         self.meta = meta
+        self._callbacks: dict[str, list[Callable]] = {}  # {"event_name": [callback_functions]}
 
         # Expose attributes FastMCP expects when registering an instance directly
         self.__name__ = self.name  # FastMCP uses fn.__name__ if name param omitted
@@ -100,6 +103,36 @@ class BaseTool(ABC):
             )
         return self._mcp_tool
 
+    def add_callback(self, event_type: str, callback: Callable):
+        """Register a callback function for specific event
+        
+        Args:
+            event_type: (Required) Specific event name to trigger callback
+                        e.g. "after_click", "before_navigate"
+            callback: (Required) Async function to call. Must be defined by `async def f(...)`
+        """
+        if event_type not in self._callbacks:
+            self._callbacks[event_type] = []
+        self._callbacks[event_type].append(callback)
+
+    def remove_callback(self, event_type: str, callback: Callable):
+        """Remove a registered callback
+        Args:
+            event_type: (Required) Specific event name to trigger callback
+                        e.g. "after_click", "before_navigate"
+            callback: (Required) Function to remove from callback list.
+        """
+        if (event_type in self._callbacks) and (callback in self._callbacks[event_type]):
+            self._callbacks[event_type].remove(callback)
+    
+    async def _trigger_callbacks(self, event_type: str, **kwargs):
+        """Trigger all registered callback functions of an event type"""
+        callback_list = self._callbacks.get(event_type, [])
+        for callback in callback_list:
+            try:
+                await callback(self, event_type, **kwargs)
+            except Exception as e:
+                logger.warning(f"Callback failed for {event_type}: {e}")
 
 # Prefix for internal tool names
 _INTERNAL_PREFIX = "int_"

--- a/hud/tools/base.py
+++ b/hud/tools/base.py
@@ -130,7 +130,7 @@ class BaseTool(ABC):
         callback_list = self._callbacks.get(event_type, [])
         for callback in callback_list:
             try:
-                await callback(self, event_type, **kwargs)
+                await callback(**kwargs)
             except Exception as e:
                 logger.warning(f"Callback failed for {event_type}: {e}")
 


### PR DESCRIPTION
In [base.py](hud/tools/base.py)
 - Added `_callbacks` dict for event registration
 - Added `add_callback(...)` and `remove_callback(...)` to manage callback function registration
 - Added `_trigger_callbacks(...)` to call callback functions by action type
 - Added logging support for callback failures