### PR TITLE
Bug Fix: "Bad display name '0' " Exception

### DIFF
--- a/hud/tools/executors/pyautogui.py
+++ b/hud/tools/executors/pyautogui.py
@@ -31,7 +31,7 @@ def _get_pyautogui() -> Any | None:
             try:
                 from hud.tools.computer import computer_settings
 
-                os.environ["DISPLAY"] = str(computer_settings.DISPLAY_NUM)
+                os.environ["DISPLAY"] = f":{computer_settings.DISPLAY_NUM}"
             except (ImportError, AttributeError):
                 os.environ["DISPLAY"] = ":0"
 


### PR DESCRIPTION
## Bug Description

in `hud/tools/computer/settings.py` line 26 :
``` python
    DISPLAY_NUM: int = Field(
        default=0,
        description="Number of the display to use for the computer tools",
        validation_alias="DISPLAY_NUM",
    )
```
while in `hud/tools/executors/pyautogui.py` line 28  :
```
    if _pyautogui is None:
        # Set display if not already set
        if "DISPLAY" not in os.environ:
            try:
                from hud.tools.computer import computer_settings

                os.environ["DISPLAY"] = str(computer_settings.DISPLAY_NUM)
            except (ImportError, AttributeError):
                os.environ["DISPLAY"] = ":0"
```
here if `$DISPLAY` is not set int `ENV` and `hud.tools.computer` is imported, os.environ["DISPLAY"]  will be "0"  rather than ":0" . It causes the exception
```
WARNING:hud.tools.executors.pyautogui:Failed to initialize PyAutoGUI: Bad display name "0"
```

## Fix
Replace `hud/tools/executors/pyautogui.py` line 34 with
```
os.environ["DISPLAY"] = f":{computer_settings.DISPLAY_NUM}"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change DISPLAY assignment to f":{computer_settings.DISPLAY_NUM}" when unset to ensure valid X display format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e7ee80932b340fd0a7f81eb4491956b305e336c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->