### PR TITLE
Agent config

### DIFF
--- a/docs/build-environments/spec.mdx
+++ b/docs/build-environments/spec.mdx
@@ -114,7 +114,9 @@ The same structure is used by `hud init`’s template and by programmatic tasks.
       }
     }
   },
-  "agent_tools": ["act"],
+  "agent_config": {
+    "allowed_tools": ["act"]
+  },
   "setup_tool": { "name": "setup", "arguments": {} },
   "evaluate_tool": { "name": "evaluate", "arguments": {"target": 10} }
 }
@@ -132,7 +134,9 @@ The same structure is used by `hud init`’s template and by programmatic tasks.
         "args": ["run", "--rm", "-i", "my-env:latest"]
       }
     },
-    "agent_tools": ["act"],
+    "agent_config": {
+      "allowed_tools": ["act"]
+    },
     "setup_tool": { "name": "setup", "arguments": {} },
     "evaluate_tool": { "name": "evaluate", "arguments": {"target": 10} }
   }

--- a/docs/reference/tasks.mdx
+++ b/docs/reference/tasks.mdx
@@ -22,7 +22,7 @@ Pydantic model that defines an agent's objective, setup, and evaluation criteria
 | `mcp_config` | `dict[str, Any]` | MCP server configuration | Required |
 | `setup_tool` | `MCPToolCall \| list[MCPToolCall] \| None` | Tool(s) to prepare environment | `None` |
 | `evaluate_tool` | `MCPToolCall \| list[MCPToolCall] \| None` | Tool(s) to score performance | `None` |
-| `system_prompt` | `str \| None` | Additional system prompt | `None` |
+| `agent_config` | `dict[str, Any] \| None` | Agent configuration (system_prompt, allowed_tools, etc.) | `None` |
 | `metadata` | `dict[str, Any]` | Extra task metadata | `{}` |
 
 ### Environment Variable Substitution
@@ -455,14 +455,18 @@ task = Task(
     mcp_config={...},
     setup_tool={...},
     evaluate_tool={...},
-    system_prompt="Be very careful with form fields"
+    agent_config={
+        "system_prompt": "Be very careful with form fields",
+        "allowed_tools": ["computer", "search"],
+        "append_setup_output": True
+    }
 )
 
 agent = ClaudeAgent()
 
 # When agent.run(task) is called:
 # 1. If no mcp_client, creates one from task.mcp_config
-# 2. Adds task.system_prompt to agent's system prompt
+# 2. Applies task.agent_config to agent (system_prompt, allowed_tools, etc.)
 # 3. Adds lifecycle tools to agent.lifecycle_tools
 # 4. Runs setup_tool (hidden from agent)
 # 5. Executes task.prompt
@@ -470,11 +474,23 @@ agent = ClaudeAgent()
 # 7. Returns Trace with evaluation reward
 ```
 
+### Agent Config Options
+
+The `agent_config` field supports the following options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `system_prompt` | `str` | Custom system prompt appended to agent's default |
+| `allowed_tools` | `list[str]` | Tools the agent can use (replaces `agent_tools`) |
+| `disallowed_tools` | `list[str]` | Tools to exclude from the agent |
+| `append_setup_output` | `bool` | Include setup output in first message (default: True) |
+| `initial_screenshot` | `bool` | Take screenshot before first action (default: True) |
+
 ## Best Practices
 
 1. **Use UUIDs for task IDs** - Required for HuggingFace datasets
 2. **Save dictionaries, not objects** - Preserves env var templates
-3. **Include system_prompt.txt** - Upload to dataset repo root
+3. **Use agent_config for agent settings** - Centralize agent configuration in one place
 4. **Use metadata for filtering** - Category, difficulty, tags
 5. **Test locally first** - Before uploading to HuggingFace
 6. **Version your datasets** - Use meaningful repo names

--- a/environments/blank/tasks.json
+++ b/environments/blank/tasks.json
@@ -13,7 +13,8 @@
       }
     },
     "agent_config": {
-      "allowed_tools": ["act"]
+      "allowed_tools": ["act"],
+      "append_setup_output": true
     },
     "setup_tool": {
       "name": "setup",

--- a/environments/blank/tasks.json
+++ b/environments/blank/tasks.json
@@ -1,12 +1,20 @@
 [
   {
-    "prompt": "Increment the counter to reach 10",
+    "prompt": "Increment the counter to reach 2",
     "mcp_config": {
       "local": {
-        "url": "http://localhost:8765/mcp"
+        "command": "docker",
+        "args": [
+          "run",
+          "--rm",
+          "-i",
+          "hud-blank:latest"
+        ]
       }
     },
-    "agent_tools": ["act"],
+    "agent_config": {
+      "allowed_tools": ["act"]
+    },
     "setup_tool": {
       "name": "setup",
       "arguments": {}

--- a/hud/agents/base.py
+++ b/hud/agents/base.py
@@ -154,9 +154,18 @@ class MCPAgent(ABC):
                 if "initial_screenshot" in task.agent_config:
                     self.initial_screenshot = task.agent_config["initial_screenshot"]
                 if "allowed_tools" in task.agent_config:
-                    self.allowed_tools = task.agent_config["allowed_tools"]
+                    # If allowed_tools has already been set, we take the intersection of the two
+                    # If the list had been empty, we were allowing all tools, so we overwrite in this
+                    if isinstance(self.allowed_tools, list) and len(self.allowed_tools) > 0:
+                        self.allowed_tools = [tool for tool in self.allowed_tools if tool in task.agent_config["allowed_tools"]]
+                    else:  # If allowed_tools is None, we overwrite it
+                        self.allowed_tools = task.agent_config["allowed_tools"]
                 if "disallowed_tools" in task.agent_config:
-                    self.disallowed_tools = task.agent_config["disallowed_tools"]
+                    # If disallowed_tools has already been set, we take the union of the two
+                    if isinstance(self.disallowed_tools, list):
+                        self.disallowed_tools.extend(task.agent_config["disallowed_tools"])
+                    else:  # If disallowed_tools is None, we overwrite it
+                        self.disallowed_tools = task.agent_config["disallowed_tools"]
 
         all_tools = await self.mcp_client.list_tools()
         self._available_tools = []

--- a/hud/agents/base.py
+++ b/hud/agents/base.py
@@ -181,6 +181,10 @@ class MCPAgent(ABC):
                 if any(fnmatch.fnmatch(tool.name, pattern) for pattern in self.disallowed_tools):
                     continue
             self._available_tools.append(tool)
+        
+        self.console.info(
+            f"Agent initialized with {len(self.get_available_tools())} tools: {', '.join([t.name for t in self.get_available_tools()])}"  # noqa: E501
+        )
 
     async def run(self, prompt_or_task: str | Task | dict[str, Any], max_steps: int = 10) -> Trace:
         """

--- a/hud/agents/claude.py
+++ b/hud/agents/claude.py
@@ -326,7 +326,7 @@ class ClaudeAgent(MCPAgent):
         selected_computer_tool = None
 
         for priority_name in computer_tool_priority:
-            for tool in self._available_tools:
+            for tool in self.get_available_tools():
                 # Check both exact match and suffix match (for prefixed tools)
                 if tool.name == priority_name or tool.name.endswith(f"_{priority_name}"):
                     selected_computer_tool = tool
@@ -350,13 +350,12 @@ class ClaudeAgent(MCPAgent):
             )
 
         # Add other non-computer tools
-        for tool in self._available_tools:
-            # Skip computer tools (already handled) and lifecycle tools
-            is_computer_tool = any(
+        for tool in self.get_available_tools():
+            # Skip computer tools (already handled)
+            if any(
                 tool.name == priority_name or tool.name.endswith(f"_{priority_name}")
                 for priority_name in computer_tool_priority
-            )
-            if is_computer_tool or tool.name in self.lifecycle_tools:
+            ):
                 continue
 
             claude_tool = {

--- a/hud/agents/misc/integration_test_agent.py
+++ b/hud/agents/misc/integration_test_agent.py
@@ -17,6 +17,8 @@ class IntegrationTestRunner(MCPAgent):
             # Initialize using base to set up client and telemetry correctly
             await self.initialize(task)
 
+            self.console.info(f"Full system prompt: {self.system_prompt}")
+
             # Validate task shape
             if not getattr(task, "integration_test_tool", None):
                 raise ValueError(

--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -326,9 +326,6 @@ class TestBaseMCPAgent:
         """Test getting tool schemas."""
         agent = MockMCPAgent()
 
-        # Add setup to lifecycle tools to test filtering
-        agent.lifecycle_tools = ["setup"]
-
         agent._available_tools = [
             types.Tool(name="tool1", description="Tool 1", inputSchema={"type": "object"}),
             types.Tool(name="setup", description="Setup", inputSchema={"type": "object"}),
@@ -598,7 +595,7 @@ class TestMCPAgentExtended:
         agent = MockAgentExtended(mcp_client=mock_client, allowed_tools=["tool1", "tool3"])
         await agent.initialize("test")
 
-        available_names = [tool.name for tool in agent._available_tools]
+        available_names = [tool.name for tool in agent.get_available_tools()]
         assert "tool1" in available_names
         assert "tool3" in available_names
         assert "tool2" not in available_names
@@ -617,7 +614,7 @@ class TestMCPAgentExtended:
         agent = MockAgentExtended(mcp_client=mock_client, disallowed_tools=["tool2"])
         await agent.initialize("test")
 
-        available_names = [tool.name for tool in agent._available_tools]
+        available_names = [tool.name for tool in agent.get_available_tools()]
         assert "tool1" in available_names
         assert "tool3" in available_names
         assert "tool2" not in available_names

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -375,7 +375,7 @@ async def run_full_dataset(
     hud_console.info(f"📊 Loading tasks from: {source}…")
     tasks: list[Task] = load_tasks(source)  # type: ignore[assignment]
 
-    if not tasks:
+    if len(tasks) == 0:
         hud_console.error(f"No tasks found in: {source}")
         raise typer.Exit(1)
 

--- a/hud/cli/flows/tasks.py
+++ b/hud/cli/flows/tasks.py
@@ -364,10 +364,8 @@ def convert_tasks_to_remote(tasks_file: str) -> str:
             item["setup_tool"] = _simplify_tool_call(t.setup_tool)
         if t.evaluate_tool is not None:
             item["evaluate_tool"] = _simplify_tool_call(t.evaluate_tool)
-        if t.agent_tools is not None:
-            item["agent_tools"] = t.agent_tools
-        if t.system_prompt is not None:
-            item["system_prompt"] = t.system_prompt
+        if t.agent_config is not None:
+            item["agent_config"] = t.agent_config
         if t.metadata:
             item["metadata"] = t.metadata
         if t.id is not None:

--- a/hud/cli/tests/test_analyze_metadata.py
+++ b/hud/cli/tests/test_analyze_metadata.py
@@ -214,6 +214,7 @@ class TestAnalyzeFromMetadata:
 
     @mock.patch("hud.cli.utils.metadata.check_local_cache")
     @mock.patch("hud.cli.utils.metadata.fetch_lock_from_registry")
+    @mock.patch("hud.cli.utils.metadata.hud_console")
     @mock.patch("hud.cli.utils.metadata.console")
     async def test_analyze_not_found(self, mock_console, mock_hud_console, mock_fetch, mock_check):
         """Test when environment not found anywhere."""
@@ -222,9 +223,9 @@ class TestAnalyzeFromMetadata:
 
         await analyze_from_metadata("test/notfound:latest", "json", verbose=False)
 
-        # Should show error
+        # Should show error via hud_console
         mock_hud_console.error.assert_called_with("Environment metadata not found")
-        # Should print suggestions
+        # Should print suggestions via console
         mock_console.print.assert_called()
 
     @mock.patch("hud.cli.utils.metadata.check_local_cache")

--- a/hud/cli/tests/test_eval.py
+++ b/hud/cli/tests/test_eval.py
@@ -1,0 +1,119 @@
+"""Tests for hud.cli.eval module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from hud.cli.eval import build_agent, eval_command, get_available_models, run_full_dataset, run_single_task
+from hud.types import Task, Trace
+
+class TestBuildAgent:
+    """Test the build_agent function."""
+
+    def test_builds_integration_test_agent(self) -> None:
+        """
+        Test building an integration test agent.
+        """
+        with patch("hud.agents.misc.integration_test_agent.IntegrationTestRunner") as mock_runner:
+            mock_instance = Mock()
+            mock_runner.return_value = mock_instance
+            
+            # Test with verbose=False
+            result = build_agent("integration_test", verbose=False)
+            
+            mock_runner.assert_called_once_with(verbose=False)
+            assert result == mock_instance
+
+    def test_builds_claude_agent(self) -> None:
+        """
+        Test building a Claude agent with default model.
+        """
+        with patch("hud.agents.ClaudeAgent") as mock_runner:
+            mock_instance = Mock()
+            mock_runner.return_value = mock_instance
+            
+            # Test with verbose=False
+            result = build_agent("claude", verbose=False)
+            
+            mock_runner.assert_called_once_with(
+                model="claude-sonnet-4-20250514",
+                verbose=False
+            )
+            assert result == mock_instance
+
+    def test_builds_claude_agent_with_custom_model_and_allowed_tools(self) -> None:
+        """
+        Test building a Claude agent with custom model name and allowed tools.
+        """
+        with patch("hud.agents.ClaudeAgent") as mock_runner:
+            mock_instance = Mock()
+            mock_runner.return_value = mock_instance
+            
+            # Test with verbose=False
+            result = build_agent(
+                "claude",
+                model="claude-sonnet-4-20250514",
+                allowed_tools=["act"],
+                verbose=True,
+            )
+            
+            mock_runner.assert_called_once_with(
+                model="claude-sonnet-4-20250514",
+                allowed_tools=["act"],
+                verbose=True,
+            )
+            assert result == mock_instance
+
+
+class TestRunSingleTask:
+    """Test the run_single_task function."""
+
+    @pytest.mark.asyncio
+    async def test_applies_agent_config_from_task(self) -> None:
+        """Test that task.agent_config is applied during agent initialization."""
+        mock_task = Task(
+            prompt="Test",
+            mcp_config={"local": {"url": "http://localhost:8765/mcp"}},
+            agent_config={
+                "system_prompt": "Custom instructions",
+                "allowed_tools": ["tool1", "tool2"],
+                "append_setup_output": False,
+            }
+        )
+        mock_agent = AsyncMock(
+            initialize=AsyncMock(),
+            run=AsyncMock(return_value=Trace(reward=1.0, done=True))
+        )
+        
+        with patch("hud.utils.tasks.load_tasks", return_value=[mock_task]), \
+             patch("hud.agents.misc.integration_test_agent.IntegrationTestRunner", return_value=mock_agent), \
+             patch("hud.cli.eval.find_environment_dir", return_value=None), \
+             patch("hud.cli.eval.hud.trace"):
+            await run_single_task("test.json", agent_type="integration_test", max_steps=10)
+            
+            # Verify agent.run was called with the task containing agent_config
+            mock_agent.run.assert_called_once()
+            called_task = mock_agent.run.call_args[0][0]
+            assert called_task.agent_config == mock_task.agent_config
+
+    @pytest.mark.asyncio
+    async def test_runs_with_group_size_greater_than_one(self) -> None:
+        """Test that group_size > 1 triggers run_tasks_grouped instead of agent.run."""
+        mock_task = Task(prompt="Test", mcp_config={"local": {"url": "http://localhost:8765/mcp"}})
+        
+        with patch("hud.utils.tasks.load_tasks", return_value=[mock_task]), \
+             patch("hud.cli.eval.run_tasks_grouped", new_callable=AsyncMock) as mock_grouped, \
+             patch("hud.cli.eval.display_group_statistics"), \
+             patch("hud.cli.eval.find_environment_dir", return_value=None), \
+             patch("hud.cli.eval.hud.trace"):
+            
+            mock_grouped.return_value = [{"task": mock_task, "rewards": [1.0, 0.5]}]
+            
+            await run_single_task("test.json", agent_type="integration_test", group_size=3, max_steps=10)
+            
+            # Verify run_tasks_grouped was called with correct group_size
+            mock_grouped.assert_called_once()
+            assert mock_grouped.call_args.kwargs["group_size"] == 3
+            assert mock_grouped.call_args.kwargs["max_steps"] == 10

--- a/hud/cli/tests/test_eval.py
+++ b/hud/cli/tests/test_eval.py
@@ -223,3 +223,167 @@ class TestToolFiltering:
         
         assert len(result) == 1
         assert result[0].name == "browser_click"
+
+
+class TestRunDatasetToolFiltering:
+    """Test tool filtering via run_dataset with agent_config in both init and task."""
+
+    @pytest.fixture
+    def all_tools(self):
+        """Fixture for a standard set of tools."""
+        return [
+            types.Tool(name="browser_click", description="Click", inputSchema={}),
+            types.Tool(name="browser_type", description="Type", inputSchema={}),
+            types.Tool(name="browser_debug", description="Debug", inputSchema={}),
+            types.Tool(name="system_screenshot", description="Screenshot", inputSchema={}),
+            types.Tool(name="system_execute", description="Execute", inputSchema={}),
+        ]
+
+    @pytest.fixture
+    def captured_agent_fixture(self):
+        """Fixture that returns a dictionary to capture the agent instance."""
+        return {"agent": None}
+
+    @pytest.fixture
+    def mock_run_context(self, captured_agent_fixture):
+        """Fixture for mocking _run_context."""
+        async def _mock(self, context, max_steps=10):
+            captured_agent_fixture["agent"] = self
+            return Trace(reward=1.0, done=True, content="Done")
+        return _mock
+
+    @pytest.fixture
+    def mock_call_tools(self):
+        """Fixture for mocking call_tools."""
+        async def _mock(self, tool_call=None):
+            return []
+        return _mock
+
+    @pytest.fixture
+    def mock_client_instance(self, all_tools):
+        """Fixture for mock MCP client instance."""
+        mock_client = MagicMock()
+        mock_client.initialize = AsyncMock()
+        mock_client.list_tools = AsyncMock(return_value=all_tools)
+        mock_client.shutdown = AsyncMock()
+        mock_client.mcp_config = {"local": {"url": "http://localhost:8765/mcp"}}
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_agent_config_intersection_union_via_run_dataset(
+        self, all_tools, captured_agent_fixture, mock_run_context, mock_call_tools, mock_client_instance
+    ) -> None:
+        """Test that allowed_tools intersect and disallowed_tools union when set in both __init__ and task.agent_config."""
+        from hud.agents import ClaudeAgent
+        from hud.datasets.runner import run_dataset
+        
+        # Create a task with its own agent_config
+        task_dict = {
+            "prompt": "Test task",
+            "mcp_config": {"local": {"url": "http://localhost:8765/mcp"}},
+            "agent_config": {
+                "allowed_tools": ["browser_*", "system_screenshot"],  # Task wants browser_* and system_screenshot
+                "disallowed_tools": ["*_debug", "*_execute"],  # Task disallows *_debug and *_execute
+            }
+        }
+        
+        # Agent config passed to __init__ via run_dataset
+        agent_init_config = {
+            "allowed_tools": ["browser_*", "system_*"],  # Agent init wants browser_* and system_*
+            "disallowed_tools": ["browser_debug"],  # Agent init disallows browser_debug
+            "validate_api_key": False,
+        }
+        
+        with patch("hud.job"), \
+             patch("hud.trace"), \
+             patch.object(ClaudeAgent, "_run_context", mock_run_context), \
+             patch.object(ClaudeAgent, "call_tools", mock_call_tools), \
+             patch("hud.clients.MCPClient", return_value=mock_client_instance):
+            
+            # Run the dataset
+            await run_dataset(
+                name="test_job",
+                dataset=[task_dict],
+                agent_class=ClaudeAgent,
+                agent_config=agent_init_config,
+                max_steps=10,
+            )
+            
+            # Verify agent was created and ran
+            captured_agent = captured_agent_fixture["agent"]
+            assert captured_agent is not None
+            
+            # Get the filtered tools
+            filtered_tools = captured_agent.get_available_tools()
+            filtered_names = {tool.name for tool in filtered_tools}
+            
+            # Expected behavior:
+            # 1. allowed_tools intersection: ["browser_*", "system_*"] ∩ ["browser_*", "system_screenshot"]
+            #    Exact string intersection: only "browser_*" is in both lists
+            #    So only tools matching browser_* are allowed: browser_click, browser_type, browser_debug
+            # 2. disallowed_tools union: ["browser_debug"] ∪ ["*_debug", "*_execute"]
+            #    Result: ["browser_debug", "*_debug", "*_execute"] (all patterns included)
+            # 3. Final: {browser_click, browser_type, browser_debug} - {browser_debug}
+            #    Result: browser_click, browser_type
+            
+            expected_tools = {"browser_click", "browser_type"}
+            assert filtered_names == expected_tools, f"Expected {expected_tools}, got {filtered_names}"
+
+    @pytest.mark.asyncio
+    async def test_no_allowed_tools_keeps_all_tools_except_disallowed(
+        self, all_tools, captured_agent_fixture, mock_run_context, mock_call_tools, mock_client_instance
+    ) -> None:
+        """Test that when allowed_tools is not set, all tools are available except disallowed ones."""
+        from hud.agents import ClaudeAgent
+        from hud.datasets.runner import run_dataset
+        
+        # Create a task with its own agent_config (no allowed_tools)
+        task_dict = {
+            "prompt": "Test task",
+            "mcp_config": {"local": {"url": "http://localhost:8765/mcp"}},
+            "agent_config": {
+                # No allowed_tools set - should allow all tools
+                "disallowed_tools": ["*_execute"],  # Task disallows *_execute
+            }
+        }
+        
+        # Agent config passed to __init__ via run_dataset (no allowed_tools)
+        agent_init_config = {
+            # No allowed_tools set - should allow all tools
+            "disallowed_tools": ["browser_debug"],  # Agent init disallows browser_debug
+            "validate_api_key": False,
+        }
+        
+        with patch("hud.job"), \
+             patch("hud.trace"), \
+             patch.object(ClaudeAgent, "_run_context", mock_run_context), \
+             patch.object(ClaudeAgent, "call_tools", mock_call_tools), \
+             patch("hud.clients.MCPClient", return_value=mock_client_instance):
+            
+            # Run the dataset
+            await run_dataset(
+                name="test_job",
+                dataset=[task_dict],
+                agent_class=ClaudeAgent,
+                agent_config=agent_init_config,
+                max_steps=10,
+            )
+            
+            # Verify agent was created and ran
+            captured_agent = captured_agent_fixture["agent"]
+            assert captured_agent is not None
+            
+            # Get the filtered tools
+            filtered_tools = captured_agent.get_available_tools()
+            filtered_names = {tool.name for tool in filtered_tools}
+            
+            # Expected behavior:
+            # 1. allowed_tools: None (no allowed_tools set in either init or task)
+            #    Result: All tools are initially allowed
+            # 2. disallowed_tools union: ["browser_debug"] ∪ ["*_execute"]
+            #    Result: ["browser_debug", "*_execute"] (all patterns included)
+            # 3. Final: {all tools} - {browser_debug, system_execute}
+            #    Result: browser_click, browser_type, system_screenshot
+            
+            expected_tools = {"browser_click", "browser_type", "system_screenshot"}
+            assert filtered_names == expected_tools, f"Expected {expected_tools}, got {filtered_names}"

--- a/hud/cli/tests/test_utils.py
+++ b/hud/cli/tests/test_utils.py
@@ -22,7 +22,7 @@ class TestColors:
         assert Colors.YELLOW == "\033[93m"
         assert Colors.GOLD == "\033[33m"
         assert Colors.RED == "\033[91m"
-        assert Colors.GRAY == "\033[90m"
+        assert Colors.GRAY == "\033[37m"
         assert Colors.ENDC == "\033[0m"
         assert Colors.BOLD == "\033[1m"
 

--- a/hud/datasets/parallel.py
+++ b/hud/datasets/parallel.py
@@ -261,7 +261,6 @@ async def run_dataset_parallel_manual(
     max_steps: int = 10,
     split: str = "train",
     auto_respond: bool = False,
-    custom_system_prompt: str | None = None,
 ) -> list[Any]:
     """
     Run all tasks in a dataset using process-based parallelism with manual configuration.
@@ -282,7 +281,6 @@ async def run_dataset_parallel_manual(
         max_steps: Maximum steps per task
         split: Dataset split when loading from string
         auto_respond: Whether to use ResponseAgent
-        custom_system_prompt: Override system prompt for all tasks
 
     Returns:
         List of results in the same order as the input dataset
@@ -349,17 +347,6 @@ async def run_dataset_parallel_manual(
     else:
         raise ValueError(f"Dataset must be string, Dataset, or list, got {type(dataset)}")
 
-    # Apply custom system prompt if provided
-    if custom_system_prompt:
-        for task_dict in task_dicts:
-            # Add custom system prompt to agent_config
-            if "agent_config" not in task_dict:
-                task_dict["agent_config"] = {}
-            if "system_prompt" not in task_dict["agent_config"]:
-                task_dict["agent_config"]["system_prompt"] = custom_system_prompt
-            else:
-                task_dict["agent_config"]["system_prompt"] += "\n" + custom_system_prompt
-
     # Prepare job metadata
     job_metadata = metadata or {}
     job_metadata.update(
@@ -382,8 +369,6 @@ async def run_dataset_parallel_manual(
             dataset_link = f"{project}/{dataset_name}"
         except Exception:
             logger.warning("Failed to extract dataset verification info")
-
-    # task_dicts = task_dicts[:10]
 
     # Create job context
     with hud.job(name, metadata=job_metadata, dataset_link=dataset_link) as job_obj:

--- a/hud/datasets/parallel.py
+++ b/hud/datasets/parallel.py
@@ -352,10 +352,13 @@ async def run_dataset_parallel_manual(
     # Apply custom system prompt if provided
     if custom_system_prompt:
         for task_dict in task_dicts:
-            if "system_prompt" not in task_dict:
-                task_dict["system_prompt"] = custom_system_prompt
+            # Add custom system prompt to agent_config
+            if "agent_config" not in task_dict:
+                task_dict["agent_config"] = {}
+            if "system_prompt" not in task_dict["agent_config"]:
+                task_dict["agent_config"]["system_prompt"] = custom_system_prompt
             else:
-                task_dict["system_prompt"] += "\n" + custom_system_prompt
+                task_dict["agent_config"]["system_prompt"] += "\n" + custom_system_prompt
 
     # Prepare job metadata
     job_metadata = metadata or {}

--- a/hud/datasets/runner.py
+++ b/hud/datasets/runner.py
@@ -102,8 +102,12 @@ async def run_dataset(
             async with sem:
                 # Create trace for this task
                 task_name = task_dict.get("prompt") or f"Task {index}"
-                if custom_system_prompt and "system_prompt" not in task_dict:
-                    task_dict["system_prompt"] = custom_system_prompt
+                if custom_system_prompt:
+                    # Add custom system prompt to agent_config if not already present
+                    if "agent_config" not in task_dict:
+                        task_dict["agent_config"] = {}
+                    if "system_prompt" not in task_dict["agent_config"]:
+                        task_dict["agent_config"]["system_prompt"] = custom_system_prompt
                 # Ensure task_id is a string for baggage propagation
                 raw_task_id = task_dict.get("id")
                 safe_task_id = str(raw_task_id) if raw_task_id is not None else None

--- a/hud/datasets/runner.py
+++ b/hud/datasets/runner.py
@@ -27,7 +27,6 @@ async def run_dataset(
     max_steps: int = 10,
     split: str = "train",
     auto_respond: bool = False,
-    custom_system_prompt: str | None = None,
 ) -> list[Any]:
     """
     Run all tasks in a dataset with automatic job tracking.
@@ -43,7 +42,6 @@ async def run_dataset(
         max_steps: Maximum steps per task
         split: Dataset split to use when loading from string (default: "train")
         auto_respond: Whether to use auto-response agent
-        custom_system_prompt: Override system prompt for all tasks
 
     Returns:
         List of results from agent.run() in dataset order
@@ -102,12 +100,7 @@ async def run_dataset(
             async with sem:
                 # Create trace for this task
                 task_name = task_dict.get("prompt") or f"Task {index}"
-                if custom_system_prompt:
-                    # Add custom system prompt to agent_config if not already present
-                    if "agent_config" not in task_dict:
-                        task_dict["agent_config"] = {}
-                    if "system_prompt" not in task_dict["agent_config"]:
-                        task_dict["agent_config"]["system_prompt"] = custom_system_prompt
+
                 # Ensure task_id is a string for baggage propagation
                 raw_task_id = task_dict.get("id")
                 safe_task_id = str(raw_task_id) if raw_task_id is not None else None

--- a/hud/rl/actor.py
+++ b/hud/rl/actor.py
@@ -151,7 +151,9 @@ if __name__ == "__main__":
                 "name": "evaluate",
                 "arguments": {"name": "game_2048_max_number", "arguments": {"target": 128}},
             },
-            "system_prompt": "You are an expert 2048 game player. Use arrow keys to reach the target tile. First take a screenshot, then make strategic moves.",  # noqa: E501
+            "agent_config": {
+                "system_prompt": "You are an expert 2048 game player. Use arrow keys to reach the target tile. First take a screenshot, then make strategic moves.",  # noqa: E501
+            },
         }
 
         task = Task(**task_data)

--- a/hud/types.py
+++ b/hud/types.py
@@ -43,11 +43,10 @@ class Task(BaseModel):
     setup_tool: MCPToolCall | list[MCPToolCall] | None = None
     evaluate_tool: MCPToolCall | list[MCPToolCall] | None = None
     integration_test_tool: MCPToolCall | list[MCPToolCall] | None = None
-    agent_tools: list[str] | None = None
-    system_prompt: str | None = None
+    agent_config: dict[str, Any] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
-    @field_validator("mcp_config", "metadata", mode="before")
+    @field_validator("mcp_config", "metadata", "agent_config", mode="before")
     @classmethod
     def parse_json_strings(cls, v: Any) -> Any:
         """Parse JSON strings into dictionaries."""


### PR DESCRIPTION
Summary
- We now pass in `agent_config` in the json for `hud eval`, which accepts the fields `system_prompt`, `append_setup_output`, `initial_screenshot`, `allowed_tools`, and `disallowed_tools`.
- We no longer expose `agent_tools` in the top-level. `agent_tools` and `lifecycle_tools` have been completely excised internally in favor of determining the agent's tools via `allowed_tools` and `disallowed_tools`.
- `allowed_tools` and `disallowed_tools` allow wildcard matching for easier scoping.
- I added many unit tests for `hud eval`. If you discount the unit tests, this PR removes lines of code on net.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Task.agent_config (system_prompt, allowed/disallowed tools, etc.) with wildcard filtering and refactor agents/CLI/docs to remove agent_tools and top-level system_prompt.
> 
> - **Core/API**
>   - Replace `Task` fields `system_prompt` and `agent_tools` with `agent_config` (`system_prompt`, `allowed_tools`, `disallowed_tools`, `append_setup_output`, `initial_screenshot`).
>   - Add parsing for `agent_config`; update examples (RL actor uses `agent_config`).
> - **Agents**
>   - Refactor tool filtering in `MCPAgent`: use `allowed_tools`/`disallowed_tools` with wildcard matching; remove `agent_tools`/lifecycle-based filtering logic; simplify `get_available_tools`.
>   - Apply `task.agent_config` on initialize (merge allowed/disallowed; append system prompt; handle flags).
>   - Update Claude agent to use `get_available_tools`.
> - **CLI & Runners**
>   - `hud eval`: model/agent construction streamlined; improved empty-task check; new tests covering agent_config application, grouping, and wildcard filtering.
>   - `convert_tasks_to_remote`: emit `agent_config` instead of `agent_tools/system_prompt`.
>   - Remove `custom_system_prompt` param/handling from dataset runners.
> - **Docs**
>   - Update specs and reference: show `agent_config` usage; add table of agent config options; note best practice to centralize in `agent_config`.
> - **Templates/Examples**
>   - `environments/blank/tasks.json`: switch to local docker command; use `agent_config` with `allowed_tools` and `append_setup_output`.
> - **Tests/Utilities**
>   - Add comprehensive CLI eval tests; adjust existing agent tests for new APIs; tweak color constant (`GRAY`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac1bc4f99b9d4fc56c3ebec1ffea6fb477f3c8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->