### PR TITLE
remove kwargs and fix typing imports

### DIFF
--- a/hud/tools/bash.py
+++ b/hud/tools/bash.py
@@ -140,7 +140,7 @@ class BashTool(BaseTool):
         self.env = value
 
     async def __call__(
-        self, command: str | None = None, restart: bool = False, **kwargs: Any
+        self, command: str | None = None, restart: bool = False
     ) -> list[ContentBlock]:
         if restart:
             if self.session:

--- a/hud/tools/edit.py
+++ b/hud/tools/edit.py
@@ -1,15 +1,12 @@
-from __future__ import annotations
-
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, get_args
+from typing import Literal, get_args
 
 from .base import BaseTool
 from .types import ContentResult, ToolError
 from .utils import maybe_truncate, run
 
-if TYPE_CHECKING:
-    from mcp.types import ContentBlock
+from mcp.types import ContentBlock
 
 Command = Literal[
     "view",
@@ -55,8 +52,7 @@ class EditTool(BaseTool):
         view_range: list[int] | None = None,
         old_str: str | None = None,
         new_str: str | None = None,
-        insert_line: int | None = None,
-        **kwargs: Any,
+        insert_line: int | None = None
     ) -> list[ContentBlock]:
         _path = Path(path)
         self.validate_path(command, _path)


### PR DESCRIPTION
- Tools cannot have kwargs. I've removed these from the function signatures (these were previously unused).
- The type checking didn't like the `from __future__ import annotations` and assorted typing stuff we had in `edit.py` so I removed this.

Changes are minimal and shouldn't break anything since nothing anywhere uses these tools until now.