### PR TITLE
Solving Circular Import Issue #154

### DIFF
--- a/hud/server/router.py
+++ b/hud/server/router.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from hud.server import MCPServer
+from .server import MCPServer
 
 if TYPE_CHECKING:
     from collections.abc import Callable


### PR DESCRIPTION
#154

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Change `hud/server/router.py` to import `MCPServer` via relative path (`.server`) instead of absolute (`hud.server`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50b7b9540ab04e00ada2d00fd0802d2cd2169515. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->