### PR TITLE
fix test_initialize_with_filtering and remove test_get_tool_schemas

### DIFF
--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -94,7 +94,7 @@ class TestBaseMCPAgent:
 
         assert agent.mcp_client is not None
         assert agent.allowed_tools is None
-        assert agent.disallowed_tools == []
+        assert agent.disallowed_tools is None
         assert agent.initial_screenshot is True
         assert agent.system_prompt is not None  # Default system prompt is set
 
@@ -241,6 +241,13 @@ class TestBaseMCPAgent:
         assert "tool2" not in tool_names  # Not in allowed list
         assert "tool3" not in tool_names  # In disallowed list
 
+        # Make sure tool schemas are correct
+        schemas = agent.get_tool_schemas()
+        assert len(schemas) == 1
+        assert schemas[0]["name"] == "tool1"
+        assert schemas[0]["description"] == "Tool 1"
+        assert schemas[0]["parameters"] == {"type": "object"}
+
     @pytest.mark.asyncio
     async def test_call_tool_success(self):
         """Test successful tool call."""
@@ -321,21 +328,6 @@ class TestBaseMCPAgent:
 
         # call_tools doesn't validate empty names, it will return error
         await agent.call_tools(tool_call)
-
-    def test_get_tool_schemas(self):
-        """Test getting tool schemas."""
-        agent = MockMCPAgent()
-
-        agent._available_tools = [
-            types.Tool(name="tool1", description="Tool 1", inputSchema={"type": "object"}),
-            types.Tool(name="setup", description="Setup", inputSchema={"type": "object"}),
-        ]
-
-        schemas = agent.get_tool_schemas()
-
-        # Should include non-lifecycle tools
-        assert len(schemas) == 1
-        assert schemas[0]["name"] == "tool1"
 
     def test_get_tools_by_server(self):
         """Test getting tools grouped by server."""


### PR DESCRIPTION
- Fixed the tool filtering test
- Removed the schema test and appended schema checking to the end of the tool filtering test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update tests to expect `disallowed_tools` defaults to `None` and move tool schema assertions into the filtering test, removing the standalone schema test.
> 
> - **Tests**:
>   - **Defaults**: Expect `disallowed_tools` to be `None` in `test_init_defaults`.
>   - **Tool Filtering**: Extend `test_initialize_with_filtering` to validate `get_tool_schemas()` (expects only `tool1` with correct description and parameters).
>   - **Cleanup**: Remove standalone `test_get_tool_schemas` in favor of inline checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ee0d155613fecd38ef35971832161274bffd7ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->