### PR TITLE
feat: cli version notification

### DIFF
--- a/docs/reference/cli/eval.mdx
+++ b/docs/reference/cli/eval.mdx
@@ -36,11 +36,11 @@ hud eval [SOURCE] [AGENT] [OPTIONS]
   Comma-separated list of allowed tools
 </ParamField>
 
-<ParamField path="--max-concurrent" type="integer" default="50">
+<ParamField path="--max-concurrent" type="integer" default="30">
   Maximum concurrent tasks (1-200 recommended). Adjust based on your API rate limits and system resources.
 </ParamField>
 
-<ParamField path="--max-steps" type="integer" default="30">
+<ParamField path="--max-steps" type="integer" default="50">
   Maximum steps per task (default: 10 for single task, 50 for full dataset)
 </ParamField>
 

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -796,7 +796,7 @@ def eval(
         help="Comma-separated list of allowed tools",
     ),
     max_concurrent: int = typer.Option(
-        50,
+        30,
         "--max-concurrent",
         help="Maximum concurrent tasks (1-200 recommended, prevents rate limits)",
     ),
@@ -853,14 +853,14 @@ def eval(
 
             source = find_tasks_file(None, msg="Select a tasks file to run")
             hud_console.success(f"Selected: {source}")
-        except Exception as e:
+        except (FileNotFoundError, Exception):
             hud_console.error(
                 "No source provided and no task/eval JSON files found in current directory"
             )
             hud_console.info(
                 "Usage: hud eval <source> or create a task JSON file (e.g., task.json, tasks.jsonl)"
             )
-            raise typer.Exit(1) from e
+            raise typer.Exit(1)
 
     # Import eval_command lazily to avoid importing agent dependencies
     try:
@@ -1109,6 +1109,12 @@ def set(
 
 def main() -> None:
     """Main entry point for the CLI."""
+    # Check for updates (including on --version command)
+    # Skip only on help-only commands
+    if not (len(sys.argv) == 1 or (len(sys.argv) == 2 and sys.argv[1] in ["--help", "-h"])):
+        from .utils.version_check import display_update_prompt
+        display_update_prompt()
+    
     # Handle --version flag before Typer parses args
     if "--version" in sys.argv:
         try:

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -860,7 +860,7 @@ def eval(
             hud_console.info(
                 "Usage: hud eval <source> or create a task JSON file (e.g., task.json, tasks.jsonl)"
             )
-            raise typer.Exit(1)
+            raise typer.Exit(1) from None
 
     # Import eval_command lazily to avoid importing agent dependencies
     try:
@@ -1113,8 +1113,9 @@ def main() -> None:
     # Skip only on help-only commands
     if not (len(sys.argv) == 1 or (len(sys.argv) == 2 and sys.argv[1] in ["--help", "-h"])):
         from .utils.version_check import display_update_prompt
+
         display_update_prompt()
-    
+
     # Handle --version flag before Typer parses args
     if "--version" in sys.argv:
         try:

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -553,7 +553,7 @@ def eval_command(
         help="Comma-separated list of allowed tools",
     ),
     max_concurrent: int = typer.Option(
-        50,
+        30,
         "--max-concurrent",
         help=(
             "Maximum concurrent tasks (1-200 recommended, prevents rate limits "

--- a/hud/cli/utils/tasks.py
+++ b/hud/cli/utils/tasks.py
@@ -18,9 +18,12 @@ def find_tasks_file(tasks_file: str | None, msg: str = "Select a tasks file") ->
     ]
     all_files = [file for file in all_files if file[0] != "."]  # Remove all config files
 
+    if not all_files:
+        # No task files found - raise a clear exception
+        raise FileNotFoundError("No task JSON or JSONL files found in current directory")
+    
     if len(all_files) == 1:
         return str(all_files[0])
-
     else:
         # Prompt user to select a file
         return hud_console.select(msg, choices=all_files)

--- a/hud/cli/utils/tasks.py
+++ b/hud/cli/utils/tasks.py
@@ -21,7 +21,7 @@ def find_tasks_file(tasks_file: str | None, msg: str = "Select a tasks file") ->
     if not all_files:
         # No task files found - raise a clear exception
         raise FileNotFoundError("No task JSON or JSONL files found in current directory")
-    
+
     if len(all_files) == 1:
         return str(all_files[0])
     else:

--- a/hud/cli/utils/version_check.py
+++ b/hud/cli/utils/version_check.py
@@ -15,6 +15,7 @@ but is skipped for help and version commands to keep them fast.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import time
@@ -85,7 +86,7 @@ def _load_cache() -> VersionInfo | None:
         return None
 
     try:
-        with open(VERSION_CACHE_FILE, "r") as f:
+        with open(VERSION_CACHE_FILE) as f:
             data = json.load(f)
 
         # Check if cache is still valid
@@ -98,7 +99,7 @@ def _load_cache() -> VersionInfo | None:
             is_outdated=data["is_outdated"],
             checked_at=data["checked_at"],
         )
-    except Exception:  # noqa: S110
+    except Exception:
         # If cache is corrupted, return None
         return None
 
@@ -145,7 +146,7 @@ def _compare_versions(current: str, latest: str) -> bool:
         current_v = version.parse(current)
         latest_v = version.parse(latest)
         return latest_v > current_v
-    except Exception:  # noqa: S110
+    except Exception:
         # If we can't parse versions, assume no update needed
         return False
 
@@ -238,9 +239,7 @@ def force_version_check() -> VersionInfo | None:
     """
     # Clear the cache to force a fresh check
     if VERSION_CACHE_FILE.exists():
-        try:
+        with contextlib.suppress(Exception):
             VERSION_CACHE_FILE.unlink()
-        except Exception:  # noqa: S110
-            pass
 
     return check_for_updates()

--- a/hud/cli/utils/version_check.py
+++ b/hud/cli/utils/version_check.py
@@ -1,0 +1,246 @@
+"""Version checking utilities for HUD CLI.
+
+This module handles checking for updates to the hud-python package
+and prompting users to upgrade when a new version is available.
+
+Features:
+- Checks PyPI for the latest version of hud-python
+- Caches results for 6 hours to avoid excessive API calls
+- Displays a friendly prompt when an update is available
+- Can be disabled with HUD_SKIP_VERSION_CHECK=1 environment variable
+
+The version check runs automatically at the start of most CLI commands,
+but is skipped for help and version commands to keep them fast.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+import httpx
+from packaging import version
+
+from hud.utils.hud_console import HUDConsole
+
+# Cache location for version check data
+CACHE_DIR = Path.home() / ".hud" / ".cache"
+VERSION_CACHE_FILE = CACHE_DIR / "version_check.json"
+
+# Cache duration in seconds (6 hours)
+CACHE_DURATION = 6 * 60 * 60
+
+# PyPI API URL for package info
+PYPI_URL = "https://pypi.org/pypi/hud-python/json"
+
+
+class VersionInfo(NamedTuple):
+    """Version information from PyPI."""
+
+    latest: str
+    current: str
+    is_outdated: bool
+    checked_at: float
+
+
+def _get_current_version() -> str:
+    """Get the currently installed version of hud-python."""
+    try:
+        from hud import __version__
+
+        return __version__
+    except ImportError:
+        return "unknown"
+
+
+def _fetch_latest_version() -> str | None:
+    """Fetch the latest version from PyPI.
+
+    Returns:
+        The latest version string, or None if the request fails.
+    """
+    try:
+        with httpx.Client(timeout=3.0) as client:
+            response = client.get(PYPI_URL)
+            if response.status_code == 200:
+                data = response.json()
+                return data["info"]["version"]
+    except Exception:  # noqa: S110
+        # Silently fail - we don't want to disrupt the user's workflow
+        # if PyPI is down or there's a network issue
+        pass
+    return None
+
+
+def _load_cache() -> VersionInfo | None:
+    """Load cached version information.
+
+    Returns:
+        Cached VersionInfo if valid, None otherwise.
+    """
+    if not VERSION_CACHE_FILE.exists():
+        return None
+
+    try:
+        with open(VERSION_CACHE_FILE, "r") as f:
+            data = json.load(f)
+
+        # Check if cache is still valid
+        if time.time() - data["checked_at"] > CACHE_DURATION:
+            return None
+
+        return VersionInfo(
+            latest=data["latest"],
+            current=data["current"],
+            is_outdated=data["is_outdated"],
+            checked_at=data["checked_at"],
+        )
+    except Exception:  # noqa: S110
+        # If cache is corrupted, return None
+        return None
+
+
+def _save_cache(info: VersionInfo) -> None:
+    """Save version information to cache.
+
+    Args:
+        info: Version information to cache.
+    """
+    try:
+        # Create cache directory if it doesn't exist
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+        with open(VERSION_CACHE_FILE, "w") as f:
+            json.dump(
+                {
+                    "latest": info.latest,
+                    "current": info.current,
+                    "is_outdated": info.is_outdated,
+                    "checked_at": info.checked_at,
+                },
+                f,
+            )
+    except Exception:  # noqa: S110
+        # Silently fail if we can't write cache
+        pass
+
+
+def _compare_versions(current: str, latest: str) -> bool:
+    """Compare versions to determine if an update is available.
+
+    Args:
+        current: Current version string
+        latest: Latest version string
+
+    Returns:
+        True if latest is newer than current, False otherwise.
+    """
+    if current == "unknown":
+        return False
+
+    try:
+        current_v = version.parse(current)
+        latest_v = version.parse(latest)
+        return latest_v > current_v
+    except Exception:  # noqa: S110
+        # If we can't parse versions, assume no update needed
+        return False
+
+
+def check_for_updates() -> VersionInfo | None:
+    """Check for updates to hud-python.
+
+    This function checks PyPI for the latest version and caches the result
+    for 6 hours to avoid excessive API calls.
+
+    Returns:
+        VersionInfo if check succeeds, None otherwise.
+    """
+    # Check if we're in CI/testing environment
+    if os.environ.get("CI") or os.environ.get("HUD_SKIP_VERSION_CHECK"):
+        return None
+
+    # Try to load from cache first
+    cached_info = _load_cache()
+    if cached_info:
+        return cached_info
+
+    # Get current version
+    current = _get_current_version()
+    if current == "unknown":
+        return None
+
+    # Fetch latest version from PyPI
+    latest = _fetch_latest_version()
+    if not latest:
+        return None
+
+    # Compare versions
+    is_outdated = _compare_versions(current, latest)
+
+    # Create version info
+    info = VersionInfo(
+        latest=latest,
+        current=current,
+        is_outdated=is_outdated,
+        checked_at=time.time(),
+    )
+
+    # Save to cache
+    _save_cache(info)
+
+    return info
+
+
+def display_update_prompt(console: HUDConsole | None = None) -> None:
+    """Display update prompt if a new version is available.
+
+    This function checks for updates and displays a prompt to the user
+    if their version is outdated.
+
+    Args:
+        console: HUDConsole instance for output. If None, creates a new one.
+    """
+    if console is None:
+        console = HUDConsole()
+
+    try:
+        info = check_for_updates()
+        if info and info.is_outdated:
+            # Create update message
+            update_msg = (
+                f"🆕 A new version of hud-python is available: "
+                f"[bold cyan]{info.latest}[/bold cyan] "
+                f"(current: [dim]{info.current}[/dim])\n"
+                f"   Run: [bold yellow]uv tool upgrade hud-python[/bold yellow] to update"
+            )
+
+            # Display as a subtle but noticeable panel
+            console._stdout_console.print(
+                f"\n[yellow]{update_msg}[/yellow]\n",
+                highlight=False,
+            )
+    except Exception:  # noqa: S110
+        # Never let version checking disrupt the user's workflow
+        pass
+
+
+def force_version_check() -> VersionInfo | None:
+    """Force a version check, bypassing the cache.
+
+    This is useful for explicit version checks or testing.
+
+    Returns:
+        VersionInfo if check succeeds, None otherwise.
+    """
+    # Clear the cache to force a fresh check
+    if VERSION_CACHE_FILE.exists():
+        try:
+            VERSION_CACHE_FILE.unlink()
+        except Exception:  # noqa: S110
+            pass
+
+    return check_for_updates()

--- a/hud/otel/exporters.py
+++ b/hud/otel/exporters.py
@@ -51,11 +51,11 @@ def get_export_executor() -> ThreadPoolExecutor:
     The executor is automatically cleaned up on process exit via atexit.
 
     Returns:
-        ThreadPoolExecutor with 50 workers for high-throughput parallel uploads
+        ThreadPoolExecutor with 8 workers for high-throughput parallel uploads
     """
     global _export_executor
     if _export_executor is None:
-        # Use 50 workers to handle high-volume parallel uploads efficiently
+        # Use 8 workers to handle high-volume parallel uploads efficiently
         _export_executor = ThreadPoolExecutor(max_workers=8, thread_name_prefix="span-export")
 
         def cleanup() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = { file = "LICENSE" }
 dependencies = [
     # Core dependencies - minimal for MCP servers and CLI
     "httpx>=0.23.0,<1",
+    "packaging>=21.0",
     "pydantic>=2.6,<3",
     "pydantic-settings>=2.2,<3",
     # MCP dependencies


### PR DESCRIPTION
Notification and version check to make sure users are on the correct CLI version
<img width="998" height="346" alt="image" src="https://github.com/user-attachments/assets/c56109e2-c855-4cbc-a29f-926c5a8b8b63" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds startup version check prompt, lowers eval default concurrency to 30, improves task file discovery errors, updates docs, and adds packaging dependency.
> 
> - **CLI**:
>   - Add startup version update check and prompt via `hud/cli/utils/version_check.py` (PyPI lookup, 6h cache, env toggle) and invoke it in `hud/cli/__init__.py` main (skipped for help).
> - **Eval**:
>   - Change `--max-concurrent` default from `50` to `30` in `hud/cli/__init__.py` and `hud/cli/eval.py`.
>   - Improve missing source handling: catch `FileNotFoundError` and raise `typer.Exit` without chaining; `hud/cli/utils/tasks.py` now raises `FileNotFoundError` when no JSON/JSONL files found.
> - **Docs**:
>   - Update `docs/reference/cli/eval.mdx` defaults: `--max-concurrent` to `30`, `--max-steps` to `50`.
> - **Telemetry**:
>   - Clarify exporter thread pool comments to `8` workers in `hud/otel/exporters.py`.
> - **Dependencies**:
>   - Add `packaging` to `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ea65f47df0fc52be210f571f4fecc55c5c23c03. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->