### PR TITLE
openrouter support + Per task eval

### DIFF
--- a/examples/run_evaluation.py
+++ b/examples/run_evaluation.py
@@ -13,22 +13,22 @@ Prerequisites:
 Usage examples
 ──────────────
 # Run a single OSWorld-Verified task with OpenAI Operator agent (default single-task mode)
-python examples/run_evaluation.py hud-evals/OSWorld-Verified-XLang --agent openai
+python examples/run_evaluation.py hud-evals/OSWorld-Verified-Gold --agent openai
 
 # Same but with detailed agent step logs visible
-python examples/run_evaluation.py hud-evals/OSWorld-Verified-XLang --agent openai --verbose
+python examples/run_evaluation.py hud-evals/OSWorld-Verified-Gold --agent openai --verbose
 
 # Enable debug-level logs for maximum visibility
-python examples/run_evaluation.py hud-evals/OSWorld-Verified-XLang --agent openai --very-verbose
+python examples/run_evaluation.py hud-evals/OSWorld-Verified-Gold --agent openai --very-verbose
 
 # Evaluate the FULL SheetBench dataset with Claude (Single Process concurrency)
 python examples/run_evaluation.py hud-evals/SheetBench-50 --full --agent claude --max-concurrent 25
 
 # Run OSWorld-Verified dataset full with PARALLEL execution (300+ tasks)
-python examples/run_evaluation.py hud-evals/OSWorld-Verified-XLang --agent openai --full --parallel
+python examples/run_evaluation.py hud-evals/OSWorld-Verified-Gold --agent openai --full --parallel
 
 # Parallel mode with manual configuration (8 workers, 10 concurrent per worker)
-python examples/run_evaluation.py hud-evals/OSWorld-Verified-XLang --agent openai --full --parallel --max-workers 8 --max-concurrent-per-worker 10
+python examples/run_evaluation.py hud-evals/OSWorld-Verified-Gold --agent openai --full --parallel --max-workers 8 --max-concurrent-per-worker 10
 
 # Custom max steps per task (useful for complex tasks)
 python examples/run_evaluation.py hud-evals/SheetBench-50 --full --max-steps 100

--- a/hud/agents/__init__.py
+++ b/hud/agents/__init__.py
@@ -4,10 +4,12 @@ from .base import MCPAgent
 from .claude import ClaudeAgent
 from .openai import OperatorAgent
 from .openai_chat_generic import GenericOpenAIChatAgent
+from .litellm_claude import LiteLLMClaudeAgent
 
 __all__ = [
     "ClaudeAgent",
     "GenericOpenAIChatAgent",
+    "LiteLLMClaudeAgent",
     "MCPAgent",
     "OperatorAgent",
 ]

--- a/hud/agents/__init__.py
+++ b/hud/agents/__init__.py
@@ -4,11 +4,15 @@ from .base import MCPAgent
 from .claude import ClaudeAgent
 from .openai import OperatorAgent
 from .openai_chat_generic import GenericOpenAIChatAgent
-from .litellm_claude import LiteLLMClaudeAgent
+from .litellm_agent import LiteLLMAgent
+
+# Backwards compatibility
+LiteLLMClaudeAgent = LiteLLMAgent
 
 __all__ = [
     "ClaudeAgent",
     "GenericOpenAIChatAgent",
+    "LiteLLMAgent",
     "LiteLLMClaudeAgent",
     "MCPAgent",
     "OperatorAgent",

--- a/hud/agents/litellm_claude.py
+++ b/hud/agents/litellm_claude.py
@@ -1,0 +1,418 @@
+"""LiteLLM-powered Claude MCP Agent.
+
+This mirrors the MCP behavior of hud/agents/claude.py (Anthropic SDK),
+but routes requests through LiteLLM (e.g., model="openrouter/anthropic/claude-sonnet-4")
+and preserves:
+- Anthropic Computer Use tool mapping ("computer_2025-01-24" / "computer_2024-10-22")
+- Ephemeral prompt caching blocks ("cache_control": {"type": "ephemeral"})
+- The same MCP tool plumbing and result formatting (tool_use <-> tool_result)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar, cast
+
+import litellm
+import mcp.types as types
+
+import hud
+from hud.settings import settings  # not used here, but kept for parity
+from hud.tools.computer.settings import computer_settings
+from hud.types import AgentResponse, MCPToolCall, MCPToolResult
+from hud.utils.hud_console import HUDConsole
+
+from .base import MCPAgent
+
+logger = logging.getLogger(__name__)
+
+
+class LiteLLMClaudeAgent(MCPAgent):
+    """
+    Claude-style MCP agent (like hud/agents/claude.py) implemented on LiteLLM.
+
+    Key points:
+    - Exposes Anthropic tool specs (computer + function tools) to the model
+    - Converts Anthropic tool_use blocks into MCP tool calls
+    - Sends MCP tool results back as Anthropic tool_result blocks
+    - Uses LiteLLM acompletion() for transport
+    """
+
+    metadata: ClassVar[dict[str, Any]] = {
+        "display_width": computer_settings.ANTHROPIC_COMPUTER_WIDTH,
+        "display_height": computer_settings.ANTHROPIC_COMPUTER_HEIGHT,
+    }
+
+    def __init__(
+        self,
+        *,
+        model: str = "openrouter/anthropic/claude-sonnet-4",
+        max_tokens: int = 4096,
+        use_computer_beta: bool = True,
+        completion_kwargs: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+
+        self.model = model
+        self.model_name = f"litellm-{self.model}"
+        self.max_tokens = max_tokens
+        self.use_computer_beta = use_computer_beta
+        self.completion_kwargs = completion_kwargs or {}
+        self.hud_console = HUDConsole(logger=logger)
+
+        # Claude tool mapping (Claude tool name -> MCP tool name)
+        self._claude_to_mcp_tool_map: dict[str, str] = {}
+        self.claude_tools: list[dict] = []
+
+        # Append Claude-ish operating instructions (same spirit as claude.py)
+        claude_instructions = """
+        You are Claude (via LiteLLM). Be thorough, accurate, and autonomous.
+
+        When using tools:
+        1) Think through observations and next steps
+        2) Use tools decisively (no confirmation prompts)
+        3) Verify outcomes and continue until the task is complete
+        4) Prefer minimal steps and clear explanations
+
+        You have access to Anthropic-style tools (including computer use).
+        """.strip()
+
+        if self.system_prompt:
+            self.system_prompt = f"{self.system_prompt}\n\n{claude_instructions}"
+        else:
+            self.system_prompt = claude_instructions
+
+    async def initialize(self, task: Any = None) -> None:
+        await super().initialize(task)
+        self._convert_tools_for_claude()
+
+    #
+    # Message formatting (OpenAI-chat-like content blocks that LiteLLM accepts)
+    #
+
+    async def get_system_messages(self) -> list[dict[str, Any]]:
+        # LiteLLM accepts a system message in chat.completions format
+        return [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": self.system_prompt}],
+            }
+        ]
+
+    async def format_blocks(self, blocks: list[types.ContentBlock]) -> list[dict[str, Any]]:
+        """Convert MCP content blocks to LiteLLM chat message format."""
+        parts: list[dict[str, Any]] = []
+        for block in blocks:
+            if isinstance(block, types.TextContent):
+                parts.append({"type": "text", "text": block.text})
+            elif isinstance(block, types.ImageContent):
+                # Use image_url with data URI (what LiteLLM's docs show for Anthropic tools)
+                mime = getattr(block, "mimeType", "image/png")
+                parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{mime};base64,{block.data}"},
+                    }
+                )
+        return [{"role": "user", "content": parts}]
+
+    #
+    # Main step: call LiteLLM and parse tool_use / text / thinking
+    #
+
+    @hud.instrument(span_type="agent", record_args=False, record_result=True)
+    async def get_response(self, messages: list[dict[str, Any]]) -> AgentResponse:
+        current_messages = messages.copy()
+
+        # Add Anthropic ephemeral cache control to the most recent user message blocks
+        messages_cached = self._add_prompt_caching(current_messages)
+
+        # Build request
+        request_kwargs = self._build_litellm_request(messages_cached)
+
+        try:
+            response = await litellm.acompletion(**request_kwargs)
+        except Exception as e:
+            err = f"Error from LiteLLM: {e}"
+            self.hud_console.warning_log(err)
+            return AgentResponse(content=err, tool_calls=[], done=True, isError=True, raw=None)
+
+        choice = response.choices[0]
+        msg = choice.message  # OpenAI-style ChatCompletionMessage proxy from LiteLLM
+
+        # Make sure this assistant message is appended to history for the loop
+        assistant_payload: dict[str, Any] = {"role": "assistant"}
+        if getattr(msg, "content", None) is not None:
+            assistant_payload["content"] = msg.content
+        if getattr(msg, "tool_calls", None):
+            # Serialize in OpenAI tool_calls shape if present
+            serialized = []
+            for tc in msg.tool_calls:
+                serialized.append(
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                )
+            assistant_payload["tool_calls"] = serialized
+        messages.append(assistant_payload)
+
+        # Parse result into MCPAgentResponse
+        result = AgentResponse(content="", tool_calls=[], done=True, raw=response)
+
+        # Try both shapes:
+        # 1) OpenAI-style function `tool_calls`
+        # 2) Anthropic-style 'tool_use' blocks inside `content` (for computer use)
+        tool_calls_found = False
+
+        # (1) OpenAI / function tools
+        if getattr(msg, "tool_calls", None):
+            for tc in msg.tool_calls:
+                try:
+                    args = _safe_json_loads(tc.function.arguments)
+                except Exception:
+                    args = {}
+                if not isinstance(args, dict):
+                    args = {}
+                name = tc.function.name
+                if name in self._claude_to_mcp_tool_map:
+                    name = self._claude_to_mcp_tool_map[name]
+                result.tool_calls.append(MCPToolCall(id=tc.id, name=name, arguments=args))
+            tool_calls_found = len(result.tool_calls) > 0
+
+        # (2) Anthropic / tool_use blocks
+        # LiteLLM returns assistant.content either as str or list[dict{type,...}]
+        content_blocks = getattr(msg, "content", None)
+        if isinstance(content_blocks, list):
+            thinking_text = ""
+            plain_text = ""
+            for block in content_blocks:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "tool_use":
+                    # Convert to MCP tool call
+                    tool_name = block.get("name", "")
+                    mcp_name = self._claude_to_mcp_tool_map.get(tool_name, tool_name)
+                    tool_id = block.get("id")
+                    tool_input = block.get("input", {})
+                    if not isinstance(tool_input, dict):
+                        tool_input = {}
+                    result.tool_calls.append(MCPToolCall(id=tool_id, name=mcp_name, arguments=tool_input))
+                    tool_calls_found = True
+                elif btype == "text":
+                    plain_text += block.get("text", "")
+                elif btype == "thinking":
+                    # Optional: some Anthropic models expose thinking blocks via LiteLLM
+                    thinking_text += f"Thinking: {block.get('thinking', '')}\n"
+
+            # Accumulate text/thinking into result.content (when no immediate tool calls)
+            if not tool_calls_found:
+                result.content = (thinking_text + plain_text).strip()
+        else:
+            # Assistant content may just be a string
+            if isinstance(content_blocks, str) and not tool_calls_found:
+                result.content = content_blocks
+
+        # Mark done only if the model did not request tools or we hit length
+        result.done = not tool_calls_found or choice.finish_reason == "length"
+        return result
+
+    async def format_tool_results(
+        self, tool_calls: list[MCPToolCall], tool_results: list[MCPToolResult]
+    ) -> list[dict[str, Any]]:
+        """
+        Return Anthropic tool_result blocks embedded in a single user message.
+
+        LiteLLM passes this through to Anthropic correctly. We keep base64 image
+        blocks for screenshots (computer use) and text blocks for logs.
+        """
+        user_content: list[dict[str, Any]] = []
+
+        for call, res in zip(tool_calls, tool_results, strict=True):
+            # Anthropic tool_result wants: {"type": "tool_result", "tool_use_id": <id>, "content": [ ... ]}
+            tool_result_blocks: list[dict[str, Any]] = []
+
+            if res.isError:
+                error_msg = "Tool execution failed"
+                for c in res.content:
+                    if isinstance(c, types.TextContent):
+                        error_msg = c.text
+                        break
+                tool_result_blocks.append({"type": "text", "text": f"Error: {error_msg}"})
+            else:
+                for c in res.content:
+                    if isinstance(c, types.TextContent):
+                        tool_result_blocks.append({"type": "text", "text": c.text})
+                    elif isinstance(c, types.ImageContent):
+                        # Anthropic expects "image" with source base64 (not image_url) inside tool_result
+                        tool_result_blocks.append(
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": getattr(c, "mimeType", "image/png"),
+                                    "data": c.data,
+                                },
+                            }
+                        )
+
+            # Only include tool_result if we have a tool_use_id
+            if call.id:
+                user_content.append(
+                    {"type": "tool_result", "tool_use_id": call.id, "content": tool_result_blocks}
+                )
+
+        # One "user" message containing all tool_result blocks
+        return [{"role": "user", "content": user_content}]
+
+    #
+    # Helpers
+    #
+
+    def _convert_tools_for_claude(self) -> list[dict]:
+        """Build Anthropic tool specs from available MCP tools (same logic as hud/agents/claude.py)."""
+        claude_tools: list[dict] = []
+        self._claude_to_mcp_tool_map.clear()
+
+        # Prefer Anthropic computer MCP tool, with common suffix fallback
+        computer_tool_priority = ["anthropic_computer", "computer_anthropic", "computer"]
+        selected_computer_tool = None
+        for priority_name in computer_tool_priority:
+            for t in self._available_tools:
+                if t.name == priority_name or t.name.endswith(f"_{priority_name}"):
+                    selected_computer_tool = t
+                    break
+            if selected_computer_tool:
+                break
+
+        if selected_computer_tool:
+            ctype = self._choose_computer_tool_type()  # "computer_20250124" or "computer_20241022"
+            claude_tools.append(
+                {
+                    "type": ctype,
+                    "name": "computer",
+                    "display_width_px": self.metadata["display_width"],
+                    "display_height_px": self.metadata["display_height"],
+                }
+            )
+            self._claude_to_mcp_tool_map["computer"] = selected_computer_tool.name
+            self.hud_console.debug(f"Using '{selected_computer_tool.name}' as MCP computer tool")
+
+        # Add non-computer tools as Anthropic function-style tools (input_schema)
+        for t in self._available_tools:
+            is_computer = any(
+                t.name == p or t.name.endswith(f"_{p}") for p in computer_tool_priority
+            )
+            if is_computer or t.name in self.lifecycle_tools:
+                continue
+
+            claude_tools.append(
+                {
+                    "name": t.name,
+                    "description": t.description or f"Execute {t.name}",
+                    "input_schema": t.inputSchema
+                    or {
+                        "type": "object",
+                        "properties": {},
+                    },
+                }
+            )
+            self._claude_to_mcp_tool_map[t.name] = t.name
+
+        self.claude_tools = claude_tools
+        return claude_tools
+
+    def _choose_computer_tool_type(self) -> str:
+        """Heuristic: pick the correct Anthropic computer tool tag based on model."""
+        name = (self.model or "").lower()
+
+        # Latest models (Claude 4 Sonnet, Claude 3.7 Sonnet) use 2025-01-24
+        newer_markers = ("sonnet-4", "claude-4", "3-7-sonnet", "202502", "202503")
+        if any(m in name for m in newer_markers):
+            return "computer_20250124"
+
+        # Claude 3.5 Sonnet era
+        return "computer_20241022"
+
+    def _computer_beta_header(self) -> str:
+        """Return the Anthropic beta tag matching the selected computer tool."""
+        ctype = None
+        for tool in self.claude_tools:
+            if isinstance(tool, dict) and str(tool.get("type", "")).startswith("computer_"):
+                ctype = tool["type"]
+                break
+        if ctype == "computer_20250124":
+            return "computer-use-2025-01-24"
+        # default / legacy
+        return "computer-use-2024-10-22"
+
+    def _build_litellm_request(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
+        """
+        Build the kwargs for litellm.acompletion(...) matching the Anthropic MCP flow.
+        """
+        protected = {"model", "messages", "tools", "tool_choice", "max_tokens"}
+        extra = {k: v for k, v in (self.completion_kwargs or {}).items() if k not in protected}
+
+        kwargs: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "tools": self.claude_tools,
+            "tool_choice": "auto",  # Anthropic supports this via LiteLLM
+            "max_tokens": self.max_tokens,
+            # Be resilient when routing to non-Anthropic backends (OpenRouter, etc.)
+            "drop_params": True,
+            **extra,
+        }
+
+        # Opt into computer-use beta where appropriate
+        if self.use_computer_beta and any(
+            t.get("type", "").startswith("computer_") for t in self.claude_tools
+        ):
+            beta = self._computer_beta_header()
+
+            # Pass both forms; LiteLLM will forward what applies per provider
+            # - "betas" works on Anthropic API; "extra_headers" covers proxy/Bedrock paths.
+            existing_headers = kwargs.get("extra_headers", {}) or {}
+            existing_headers.setdefault("anthropic-beta", beta)
+            kwargs["extra_headers"] = existing_headers
+            kwargs.setdefault("betas", [beta])
+
+        return kwargs
+
+    def _add_prompt_caching(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """
+        Mark the *last user message's* content blocks as ephemeral cacheable for Anthropic.
+        (Other providers ignore this safely; LiteLLM drops unsupported params.)
+        """
+        msgs = list(messages)
+        if not msgs:
+            return msgs
+
+        last = msgs[-1]
+        if last.get("role") != "user":
+            return msgs
+
+        content = last.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") in {"text", "image_url"}:
+                    # Anthropic example allows cache_control on text blocks; we include it on both
+                    block["cache_control"] = {"type": "ephemeral"}  # type: ignore[typeddict-item]
+        return msgs
+
+
+def _safe_json_loads(s: str | None) -> Any:
+    import json
+
+    if not s:
+        return {}
+    try:
+        return json.loads(s)
+    except Exception:
+        return {}

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -976,6 +976,16 @@ def eval(
         "--group-size",
         help="Number of times to run each task (similar to RL training)",
     ),
+    task_id: str | None = typer.Option(
+        None,
+        "--task-id",
+        help="Specific task ID to run from the dataset (e.g., 'eee45d01')",
+    ),
+    list_ids: bool = typer.Option(
+        False,
+        "--list-ids",
+        help="List all task IDs in the dataset and exit",
+    ),
     integration_test: bool = typer.Option(
         False,
         "--integration-test",
@@ -1092,6 +1102,8 @@ def eval(
         very_verbose=very_verbose,
         vllm_base_url=vllm_base_url,
         group_size=group_size,
+        task_id=task_id,
+        list_ids=list_ids,
         integration_test=integration_test,
     )
 

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -79,9 +79,9 @@ def _select_litellm_agent(model: str | None) -> tuple[type[Any], dict[str, Any]]
     from hud.agents.lite_llm import LiteAgent
 
     if _is_litellm_claude_model(model):
-        from hud.agents.litellm_claude import LiteLLMClaudeAgent
+        from hud.agents.litellm_agent import LiteLLMAgent
 
-        return LiteLLMClaudeAgent, {
+        return LiteLLMAgent, {
             "model": model or "anthropic/claude-sonnet-4-20250514",
         }
 

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -82,7 +82,7 @@ def _select_litellm_agent(model: str | None) -> tuple[type[Any], dict[str, Any]]
         from hud.agents.litellm_claude import LiteLLMClaudeAgent
 
         return LiteLLMClaudeAgent, {
-            "model": model or "openrouter/anthropic/claude-sonnet-4",
+            "model": model or "anthropic/claude-sonnet-4-20250514",
         }
 
     return LiteAgent, {

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -654,10 +654,10 @@ def eval_command(
         hud eval hud-evals/SheetBench-50 --full --agent claude
 
         # Run large dataset with PARALLEL execution (auto-optimized)
-        hud eval hud-evals/OSWorld-Verified-XLang --full --parallel
+        hud eval hud-evals/OSWorld-Verified-Gold --full --parallel
 
         # Parallel mode with manual configuration (16 workers, 25 tasks each)
-        hud eval hud-evals/OSWorld-Verified-XLang --full --parallel --max-workers 16
+        hud eval hud-evals/OSWorld-Verified-Gold --full --parallel --max-workers 16
 
         # Limit total concurrent tasks to prevent rate limits
         hud eval hud-evals/SheetBench-50 --full --parallel --max-concurrent 20

--- a/hud/tools/tests/test_playwright_tool.py
+++ b/hud/tools/tests/test_playwright_tool.py
@@ -95,6 +95,38 @@ class TestPlaywrightTool:
             mock_page.fill.assert_called_once_with("input#name", "John Doe")
 
     @pytest.mark.asyncio
+    async def test_playwright_tool_press_with_keys(self):
+        """Test press action when keys list is provided."""
+        tool = PlaywrightTool()
+
+        mock_page = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+
+        with patch.object(tool, "_ensure_browser", new_callable=AsyncMock):
+            tool.page = mock_page
+
+            blocks = await tool(action="press", keys=["ctrl", "a"])
+
+            mock_page.keyboard.press.assert_called_once_with("Control+A")
+            assert any(isinstance(b, TextContent) for b in blocks)
+
+    @pytest.mark.asyncio
+    async def test_playwright_tool_press_with_text_chord(self):
+        """Test press action when chord is supplied via text."""
+        tool = PlaywrightTool()
+
+        mock_page = AsyncMock()
+        mock_page.keyboard.press = AsyncMock()
+
+        with patch.object(tool, "_ensure_browser", new_callable=AsyncMock):
+            tool.page = mock_page
+
+            blocks = await tool(action="press", text="cmd+enter")
+
+            mock_page.keyboard.press.assert_called_once_with("Meta+Enter")
+            assert any(isinstance(b, TextContent) for b in blocks)
+
+    @pytest.mark.asyncio
     async def test_playwright_tool_screenshot_with_mocked_browser(self):
         """Test screenshot action with mocked browser."""
         tool = PlaywrightTool()

--- a/hud/utils/tasks.py
+++ b/hud/utils/tasks.py
@@ -9,7 +9,9 @@ from hud.utils.hud_console import HUDConsole
 hud_console = HUDConsole()
 
 
-def load_tasks(tasks_input: str | list[dict], *, raw: bool = False) -> list[Task] | list[dict]:
+def load_tasks(
+    tasks_input: str | list[dict], *, raw: bool = False, task_id: str | None = None
+) -> list[Task] | list[dict]:
     """Load tasks from various sources.
 
     Args:
@@ -30,7 +32,10 @@ def load_tasks(tasks_input: str | list[dict], *, raw: bool = False) -> list[Task
         # Direct list of task dicts
         hud_console.info(f"Loading {len(tasks_input)} tasks from provided list")
         if raw:
-            return [item for item in tasks_input if isinstance(item, dict)]
+            raw_items = [item for item in tasks_input if isinstance(item, dict)]
+            if task_id:
+                raw_items = [item for item in raw_items if item.get("id") == task_id]
+            return raw_items
         for item in tasks_input:
             task = Task(**item)
             tasks.append(task)
@@ -49,7 +54,10 @@ def load_tasks(tasks_input: str | list[dict], *, raw: bool = False) -> list[Task
                             f"JSON file must contain an array of tasks, got {type(data)}"
                         )
                     if raw:
-                        return [item for item in data if isinstance(item, dict)]
+                        raw_items = [item for item in data if isinstance(item, dict)]
+                        if task_id:
+                            raw_items = [item for item in raw_items if item.get("id") == task_id]
+                        return raw_items
                     for item in data:
                         task = Task(**item)
                         tasks.append(task)
@@ -71,6 +79,8 @@ def load_tasks(tasks_input: str | list[dict], *, raw: bool = False) -> list[Task
                                 f"Invalid JSONL format: expected dict or list of dicts, got {type(item)}"  # noqa: E501
                             )
                     if raw:
+                        if task_id:
+                            raw_items = [item for item in raw_items if item.get("id") == task_id]
                         return raw_items
                     for it in raw_items:
                         task = Task(**it)
@@ -104,6 +114,8 @@ def load_tasks(tasks_input: str | list[dict], *, raw: bool = False) -> list[Task
                         )
                     raw_rows.append(item)
                 if raw:
+                    if task_id:
+                        raw_rows = [item for item in raw_rows if item.get("id") == task_id]
                     return raw_rows
                 for row in raw_rows:
                     task = Task(**row)
@@ -123,5 +135,8 @@ def load_tasks(tasks_input: str | list[dict], *, raw: bool = False) -> list[Task
 
     else:
         raise TypeError(f"tasks_input must be str or list, got {type(tasks_input)}")
+
+    if task_id and not raw:
+        tasks = [task for task in tasks if getattr(task, "id", None) == task_id]
 
     return tasks


### PR DESCRIPTION
currently used as basis the branch I used to do per task eval, with two new flags, so one can use the task id of a specific dataset (eg: sheetbench) and list or do eval on that specific id and used that to also add and test openrouter support


currently this is not yet ready for merge so will go and clean this real quick