### PR TITLE
Convert agent list to an enum

### DIFF
--- a/examples/run_evaluation.py
+++ b/examples/run_evaluation.py
@@ -44,6 +44,7 @@ import hud
 from datasets import load_dataset
 from hud.agents import ClaudeAgent, OperatorAgent
 from hud.datasets import Task, run_dataset
+from hud.types import AgentType
 
 logger = logging.getLogger(__name__)
 
@@ -58,14 +59,14 @@ logging.basicConfig(
 
 
 def _build_agent(
-    agent_type: Literal["claude", "openai"],
+    agent_type: Literal[AgentType.CLAUDE, AgentType.OPENAI],
     *,
     model: str | None = None,
     allowed_tools: list[str] | None = None,
 ) -> ClaudeAgent | OperatorAgent:
     """Create and return the requested agent type."""
 
-    if agent_type == "openai":
+    if agent_type == AgentType.OPENAI:
         # Only pass allowed_tools if explicitly provided
         # This allows tasks to specify their own via agent_config
         if allowed_tools:
@@ -105,7 +106,7 @@ def _build_agent(
 async def run_single_task(
     dataset_name: str,
     *,
-    agent_type: Literal["claude", "openai"] = "claude",
+    agent_type: Literal[AgentType.CLAUDE, AgentType.OPENAI] = AgentType.CLAUDE,
     model: str | None = None,
     allowed_tools: list[str] | None = None,
     max_steps: int = 10,
@@ -144,7 +145,7 @@ async def run_single_task(
 async def run_full_dataset(
     dataset_name: str,
     *,
-    agent_type: Literal["claude", "openai"] = "claude",
+    agent_type: Literal[AgentType.CLAUDE, AgentType.OPENAI] = AgentType.CLAUDE,
     model: str | None = None,
     allowed_tools: list[str] | None = None,
     max_concurrent: int = 50,
@@ -154,7 +155,7 @@ async def run_full_dataset(
 
     # Build agent class + config for run_dataset – we pass the *class* and a minimal
     # config dict, run_dataset will create a fresh agent per task.
-    if agent_type == "openai":
+    if agent_type == AgentType.OPENAI:
         agent_class = OperatorAgent
         agent_config: dict[str, Any] = {
             "validate_api_key": False,

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -12,6 +12,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from hud.types import AgentType
+
 from . import list_func as list_module
 from .analyze import (
     analyze_environment,
@@ -844,7 +846,7 @@ def eval(
     hud_console = HUDConsole()
 
     if integration_test:
-        agent = "integration_test"
+        agent = AgentType.INTEGRATION_TEST
 
     # If no source provided, reuse RL helper to find a tasks file interactively
     if source is None:
@@ -891,17 +893,17 @@ def eval(
         # Add standard agent choices
         choices.extend(
             [
-                {"name": "Claude 4 Sonnet", "value": "claude"},
-                {"name": "OpenAI Computer Use", "value": "openai"},
-                {"name": "vLLM (Local Server)", "value": "vllm"},
-                {"name": "LiteLLM (Multi-provider)", "value": "litellm"},
+                {"name": "Claude 4 Sonnet", "value": AgentType.CLAUDE},
+                {"name": "OpenAI Computer Use", "value": AgentType.OPENAI},
+                {"name": "vLLM (Local Server)", "value": AgentType.VLLM},
+                {"name": "LiteLLM (Multi-provider)", "value": AgentType.LITELLM},
             ]
         )
 
         agent = hud_console.select("Select an agent to use:", choices=choices, default=0)
 
     # Handle HUD model selection
-    if agent and agent not in ["claude", "openai", "vllm", "litellm", "integration_test"]:
+    if agent and agent not in [e.value for e in AgentType]:
         # Find remote model name
         model = agent
         if not vllm_base_url:
@@ -918,20 +920,23 @@ def eval(
             hud_console.error(f"Model {model} not found")
             raise typer.Exit(1)
         model = base_model
-        agent = "vllm"  # Use vLLM backend for HUD models
+        agent = AgentType.VLLM  # Use vLLM backend for HUD models
         hud_console.info(f"Using HUD model: {model} (trained on {base_model})")
 
     # Validate agent choice
-    valid_agents = ["claude", "openai", "vllm", "litellm", "integration_test"]
+    valid_agents = [e.value for e in AgentType]
     if agent not in valid_agents:
         hud_console.error(f"Invalid agent: {agent}. Must be one of: {', '.join(valid_agents)}")
         raise typer.Exit(1)
+
+    # Type narrowing: agent is now guaranteed to be an AgentType value after validation
+    agent = AgentType(agent)
 
     # Run the command
     eval_command(
         source=source,
         full=full,
-        agent=agent,  # type: ignore
+        agent=agent,
         model=model,
         allowed_tools=allowed_tools,
         max_concurrent=max_concurrent,

--- a/hud/cli/tests/test_eval.py
+++ b/hud/cli/tests/test_eval.py
@@ -11,7 +11,7 @@ from hud.cli.eval import (
     build_agent,
     run_single_task,
 )
-from hud.types import Task, Trace
+from hud.types import AgentType, Task, Trace
 
 
 class TestBuildAgent:
@@ -26,7 +26,7 @@ class TestBuildAgent:
             mock_runner.return_value = mock_instance
 
             # Test with verbose=False
-            result = build_agent("integration_test", verbose=False)
+            result = build_agent(AgentType.INTEGRATION_TEST, verbose=False)
 
             mock_runner.assert_called_once_with(verbose=False)
             assert result == mock_instance
@@ -40,7 +40,7 @@ class TestBuildAgent:
             mock_runner.return_value = mock_instance
 
             # Test with verbose=False
-            result = build_agent("claude", verbose=False)
+            result = build_agent(AgentType.CLAUDE, verbose=False)
 
             mock_runner.assert_called_once_with(model="claude-sonnet-4-20250514", verbose=False)
             assert result == mock_instance
@@ -55,7 +55,7 @@ class TestBuildAgent:
 
             # Test with verbose=False
             result = build_agent(
-                "claude",
+                AgentType.CLAUDE,
                 model="claude-sonnet-4-20250514",
                 allowed_tools=["act"],
                 verbose=True,
@@ -97,7 +97,7 @@ class TestRunSingleTask:
             patch("hud.cli.eval.find_environment_dir", return_value=None),
             patch("hud.cli.eval.hud.trace"),
         ):
-            await run_single_task("test.json", agent_type="integration_test", max_steps=10)
+            await run_single_task("test.json", agent_type=AgentType.INTEGRATION_TEST, max_steps=10)
 
             # Verify agent.run was called with the task containing agent_config
             mock_agent.run.assert_called_once()
@@ -119,7 +119,7 @@ class TestRunSingleTask:
             mock_grouped.return_value = [{"task": mock_task, "rewards": [1.0, 0.5]}]
 
             await run_single_task(
-                "test.json", agent_type="integration_test", group_size=3, max_steps=10
+                "test.json", agent_type=AgentType.INTEGRATION_TEST, group_size=3, max_steps=10
             )
 
             # Verify run_tasks_grouped was called with correct group_size

--- a/hud/types.py
+++ b/hud/types.py
@@ -5,6 +5,7 @@ import json
 import logging
 import uuid
 from collections import defaultdict
+from enum import Enum
 from string import Template
 from typing import Any, Literal
 
@@ -16,6 +17,14 @@ from hud.settings import settings
 from hud.utils.tool_shorthand import normalize_to_tool_call_dict
 
 logger = logging.getLogger(__name__)
+
+
+class AgentType(str, Enum):
+    CLAUDE = "claude"
+    OPENAI = "openai"
+    VLLM = "vllm"
+    LITELLM = "litellm"
+    INTEGRATION_TEST = "integration_test"
 
 
 class Task(BaseModel):
@@ -319,6 +328,7 @@ class Trace(BaseModel):
 
 __all__ = [
     "AgentResponse",
+    "AgentType",
     "MCPToolCall",
     "MCPToolResult",
     "Trace",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace string-based agent identifiers with a new AgentType enum and update CLI, evaluation flow, examples, and tests to use it consistently.
> 
> - **Types**:
>   - Introduce `AgentType` enum (`claude`, `openai`, `vllm`, `litellm`, `integration_test`) in `hud/types.py` and export it.
> - **CLI**:
>   - `hud/cli/__init__.py`: Use `AgentType` for agent selection/validation; update interactive choices to return enum values; normalize and cast to `AgentType` before invoking `eval_command`.
>   - `hud/cli/eval.py`: Switch `eval_command` and helpers to accept `AgentType`; update API key checks and branching logic to compare against enum values; adjust Typer option types.
> - **Evaluation helpers**:
>   - Update `build_agent`, `run_single_task`, and `run_full_dataset` to accept and branch on `AgentType` instead of string literals; propagate enum through config building.
> - **Examples**:
>   - `examples/run_evaluation.py`: Replace `Literal["claude","openai"]` with `Literal[AgentType.CLAUDE, AgentType.OPENAI]` and update comparisons accordingly.
> - **Tests**:
>   - Update tests in `hud/cli/tests/test_eval.py` to import and pass `AgentType` values instead of strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dbb9201baee4419f0b7965d82294f9dabc1665b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->