### PR TITLE
feat: update rubric env with more tasks + sec edgar

### DIFF
--- a/environments/rubrics/.env.example
+++ b/environments/rubrics/.env.example
@@ -2,3 +2,4 @@ EXA_API_KEY=your-exa-api-key
 ANTHROPIC_API_KEY=your-anthropic-api-key
 HUD_API_KEY=your-hud-api-key
 OPENAI_API_KEY=your-openai-api-key
+EDGAR_IDENTITY="Your Name your.email@example.com"

--- a/environments/rubrics/environment/edgar_utils.py
+++ b/environments/rubrics/environment/edgar_utils.py
@@ -1,0 +1,126 @@
+import asyncio
+import logging
+import os
+from typing import Any, Callable, Dict
+from urllib.parse import urlparse
+
+import httpx
+from edgar import Company, Filing
+
+logger = logging.getLogger(__name__)
+
+
+async def get_content_with_fallback(filing: Filing, filing_url: str) -> str:
+    content = ""
+    try:
+        content = filing.text()
+    except Exception:
+        try:
+            content = filing.text
+        except Exception:
+            content = ""
+
+    # Fallback to HTML
+    if not content:
+        try:
+            content = filing.html()
+        except Exception:
+            try:
+                content = filing.html
+            except Exception:
+                content = ""
+
+    if not content:
+        try:
+            edgar_identity = os.getenv("EDGAR_IDENTITY")
+            if not edgar_identity:
+                raise ValueError("EDGAR_IDENTITY environment variable not set")
+
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.get(filing_url, headers={"User-Agent": edgar_identity})
+                resp.raise_for_status()
+                content = resp.text
+        except Exception:
+            content = ""
+
+    return content
+
+
+def populate_financal_data(financials_fn: Callable[[], Any]) -> Dict[str, Any]:
+    fn_name = getattr(financials_fn, "__name__", "unknown")
+    try:
+        data = financials_fn()
+        if data is not None:
+            return {
+                fn_name: {
+                    "data": data.to_dict(orient="index")
+                    if hasattr(data, "to_dict")
+                    else str(data)[:5000],
+                    "columns": list(data.columns) if hasattr(data, "columns") else None,
+                }
+            }
+    except Exception as e:
+        logger.warning(f"Could not extract {fn_name}: {e}")
+    return {}
+
+
+def get_filing_from_url(filing_url: str) -> Filing:
+    parsed = urlparse(filing_url)
+    path_parts = parsed.path.split("/")
+
+    accession_no_dashes = None
+    for part in path_parts:
+        if len(part) >= 18 and part.isdigit():
+            accession_no_dashes = part
+            break
+
+    if not accession_no_dashes:
+        raise ValueError(f"Could not extract accession number from URL: {filing_url}")
+
+    accession = (
+        f"{accession_no_dashes[:10]}-{accession_no_dashes[10:12]}-{accession_no_dashes[12:]}"
+    )
+
+    filing = None
+    try:
+        cik = None
+        parts = [p for p in path_parts if p]
+        if "data" in parts:
+            idx = parts.index("data")
+            if idx + 1 < len(parts) and parts[idx + 1].isdigit():
+                cik = parts[idx + 1]
+
+        if cik:
+            comp = Company(cik)
+            for f in comp.get_filings():
+                if getattr(f, "accession_number", "").replace("-", "") == accession_no_dashes:
+                    filing = f
+                    break
+    except Exception:
+        filing = None
+
+    if filing is None:
+        try:
+            filing = Filing(accession)
+        except TypeError:
+            filing = None
+
+    if filing is None:
+        raise LookupError(f"Filing not found for accession {accession}")
+
+    return filing
+
+
+def get_filing_by_accession(identifier: str, accession_number: str) -> Filing:
+    company = Company(identifier)
+    filing = None
+
+    for f in company.get_filings():
+        if f.accession_number.replace("-", "") == accession_number.replace("-", ""):
+            filing = f
+            break
+
+    if filing is None:
+        raise LookupError(f"Filing {accession_number} not found for {identifier}")
+
+    return filing

--- a/environments/rubrics/environment/exa_utils.py
+++ b/environments/rubrics/environment/exa_utils.py
@@ -1,0 +1,57 @@
+import asyncio
+import logging
+import os
+from typing import Any, Callable, Dict
+from urllib.parse import urlparse
+
+import httpx
+from edgar import Company, Filing
+import asyncio
+import logging
+import os
+import socket
+from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+async def execute_fetch(url: str, exa_api_key: str, max_length: int = 2500) -> Dict[str, Any]:
+    """Execute the actual Exa contents API call."""
+    contents_url = "https://api.exa.ai/contents"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            contents_url,
+            headers={"x-api-key": exa_api_key, "Content-Type": "application/json"},
+            json={
+                "urls": [url],
+                "text": {"maxCharacters": max_length, "includeHtmlTags": False},
+                "highlights": {"numSentences": 5, "highlightsPerUrl": 3},
+                "summary": {"query": "main takeaways"},
+                "livecrawl": "fallback",
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+async def execute_search(query: str, exa_api_key: str, max_results: int = 1) -> Dict[str, Any]:
+    """Execute the actual Exa search API call."""
+    search_url = "https://api.exa.ai/search"
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            search_url,
+            headers={"x-api-key": exa_api_key, "Content-Type": "application/json"},
+            json={
+                "query": query,
+                "numResults": max_results,
+                "type": "keyword",
+                "userLocation": "us",
+                "contents": {"text": {"maxCharacters": 1000}},
+            },
+        )
+        response.raise_for_status()
+        return response.json()

--- a/environments/rubrics/environment/pyproject.toml
+++ b/environments/rubrics/environment/pyproject.toml
@@ -1,13 +1,14 @@
 [project]
 name = "rubrics-environment"
 version = "0.1.0"
-description = "Backend service for Rubrics environment"
+description = "Backend service for Rubrics environment with SEC EDGAR integration"
 requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.104.1",
     "uvicorn[standard]>=0.24.0",
     "httpx>=0.24.0",
-    "rubric>=1.1.7",
+    "rubric==1.1.8",
+    "edgartools>=4.21.3",
 ]
 
 [build-system]

--- a/environments/rubrics/environment/server.py
+++ b/environments/rubrics/environment/server.py
@@ -1,20 +1,31 @@
 """
-FastAPI server for Rubrics environment.
-Holds EXA API key on the server side and exposes simple HTTP endpoints
-that the controller calls. Mirrors the browser/blank environment pattern.
+FastAPI server for Rubrics environment with SEC EDGAR integration.
+Manages SEC filing data access and state.
 """
 
 import asyncio
 import logging
 import os
-import socket
+import traceback
+from datetime import datetime
 from typing import Any, Awaitable, Callable, Dict, List, Optional, TypeVar
 
 import httpx
+import uvicorn
+from edgar import Company, set_identity, get_filings as edgar_get_filings
+from edgar.financials import Financials
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from rubric import Rubric
 
+from .edgar_utils import (
+    get_content_with_fallback,
+    get_filing_by_accession,
+    get_filing_from_url,
+    populate_financal_data,
+)
+
+from .exa_utils import execute_fetch, execute_search
 
 T = TypeVar("T")
 
@@ -103,12 +114,19 @@ class _EnvState:
 state = _EnvState()
 
 
-class SearchRequest(BaseModel):
+class SearchCompanyRequest(BaseModel):
     query: str
 
 
-class FetchRequest(BaseModel):
-    url: str
+class GetFilingsRequest(BaseModel):
+    ticker: str | None = None
+    form_type: str | None = None
+    limit: int = 10
+    cutoff_date: str | None = None
+
+
+class GetFilingContentRequest(BaseModel):
+    filing_url: str
 
 
 class AnswerRequest(BaseModel):
@@ -119,23 +137,28 @@ class EvaluateRequest(BaseModel):
     rubric: list[dict[str, str | float]]
 
 
-app = FastAPI(title="DeepResearch Environment API", version="0.1.0")
+class FilingByAccessionRequest(BaseModel):
+    ticker: str
+    accession_number: str
+
+
+class FetchRequest(BaseModel):
+    url: str
+
+
+class SearchRequest(BaseModel):
+    query: str
+
+
+app = FastAPI(title="SEC EDGAR Environment API", version="0.1.0")
+
+
+set_identity(os.getenv("EDGAR_IDENTITY"))
 
 
 @app.get("/health")
 async def health() -> Dict[str, Any]:
     return {"status": "healthy"}
-
-
-async def _is_port_open(port: int) -> bool:
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(0.15)
-    try:
-        result = sock.connect_ex(("localhost", port))
-        sock.close()
-        return result == 0
-    except Exception:
-        return False
 
 
 @app.post("/setup")
@@ -144,27 +167,313 @@ async def setup() -> Dict[str, Any]:
     return {"ok": True}
 
 
-async def _execute_search(query: str, exa_api_key: str, max_results: int = 1) -> Dict[str, Any]:
-    """Execute the actual Exa search API call."""
-    search_url = "https://api.exa.ai/search"
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(
-            search_url,
-            headers={"x-api-key": exa_api_key, "Content-Type": "application/json"},
-            json={
-                "query": query,
-                "numResults": max_results,
-                "type": "keyword",
-                "userLocation": "us",
-                "contents": {"text": {"maxCharacters": 1000}},
-            },
+@app.post("/search_company")
+async def search_company(req: SearchCompanyRequest) -> List[Dict[str, str]]:
+    """Search for a company by ticker or name."""
+    try:
+        company = Company(req.query)
+
+        ticker = company.tickers[0] if company.tickers else ""
+
+        results = [
+            {
+                "ticker": ticker,
+                "name": company.name,
+                "cik": str(company.cik),
+                "message": f"Found company: {company.name} ({ticker})",
+            }
+        ]
+
+        state.search_count += 1
+        return results
+
+    except Exception as e:
+        logger.error(f"Company search failed: {type(e).__name__}: {e}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=500, detail=f"Company search failed: {type(e).__name__}: {e}"
         )
-        response.raise_for_status()
-        return response.json()
 
 
-@app.post("/search")
-async def search(req: SearchRequest) -> List[Dict[str, str]]:
+@app.post("/get_filings")
+async def get_filings(req: GetFilingsRequest) -> List[Dict[str, Any]]:
+    """Get filings for a company (by ticker/CIK) or globally.
+
+    Args:
+        ticker: Optional ticker or CIK. If omitted, returns global recent filings
+        form_type: Optional form filter (e.g., "10-K", "8-K", ["3","4","5"])
+        limit: Max number of results
+        cutoff_date: Optional date string (YYYY-MM-DD). Only filings on or after this date will be returned
+    """
+    try:
+        results: list[dict[str, Any]] = []
+
+        if req.cutoff_date:
+            try:
+                datetime.strptime(req.cutoff_date, "%Y-%m-%d")
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid cutoff_date format. Expected YYYY-MM-DD, got: {req.cutoff_date}. Error: {e}",
+                )
+
+        if req.ticker:
+            company = Company(req.ticker)
+            filings = (
+                company.get_filings(form=req.form_type) if req.form_type else company.get_filings()
+            )
+        else:
+            filings = edgar_get_filings(form=req.form_type, count=req.limit)
+
+        for i, filing in enumerate(filings):
+            if i >= req.limit:
+                break
+
+            if req.cutoff_date and filing.filing_date:
+                filing_date_str = (
+                    filing.filing_date
+                    if isinstance(filing.filing_date, str)
+                    else filing.filing_date.strftime("%Y-%m-%d")
+                )
+                if filing_date_str < req.cutoff_date:
+                    continue
+
+            results.append(
+                {
+                    "filing_date": filing.filing_date
+                    if isinstance(filing.filing_date, str)
+                    else filing.filing_date.strftime("%Y-%m-%d")
+                    if filing.filing_date
+                    else "",
+                    "form_type": filing.form,
+                    "company": getattr(filing, "company", None),
+                    "cik": getattr(filing, "cik", None),
+                    "file_number": getattr(filing, "file_number", None),
+                    "acceptance_datetime": getattr(filing, "acceptance_datetime", None),
+                    "period_of_report": getattr(filing, "period_of_report", None),
+                    "filing_url": getattr(filing, "filing_url", getattr(filing, "url", None)),
+                    "accession_number": filing.accession_number,
+                    "description": getattr(filing, "primary_doc_description", ""),
+                }
+            )
+
+        state.search_count += 1
+        return results
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Get filings failed: {type(e).__name__}: {e}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(status_code=500, detail=f"Get filings failed: {type(e).__name__}: {e}")
+
+
+@app.post("/get_filing_content")
+async def get_filing_content(req: GetFilingContentRequest) -> Dict[str, str]:
+    """Get the content of a specific filing."""
+    try:
+        filing = get_filing_from_url(req.filing_url)
+
+        content = await get_content_with_fallback(filing, req.filing_url)
+
+        max_length = 50000
+        if len(content) > max_length:
+            content = content[:max_length] + "\n\n...[truncated]"
+
+        state.fetch_count += 1
+        return {"content": content}
+
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Get filing content failed: {type(e).__name__}: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Get filing content failed: {type(e).__name__}: {e}"
+        )
+
+
+@app.post("/get_financial_data")
+async def get_financial_data(req: FilingByAccessionRequest) -> Dict[str, Any]:
+    """Extract financial statements and key metrics from a 10-K or 10-Q filing."""
+    try:
+        filing = get_filing_by_accession(req.ticker, req.accession_number)
+        company = Company(req.ticker)
+
+        result = {
+            "accession_number": filing.accession_number,
+            "form_type": filing.form,
+            "filing_date": filing.filing_date.isoformat()
+            if hasattr(filing.filing_date, "isoformat")
+            else str(filing.filing_date),
+            "has_financials": False,
+            "financial_data": None,
+        }
+
+        try:
+            financials = Financials.extract(filing)
+
+            if financials:
+                result["has_financials"] = True
+                result["cik"] = str(company.cik)
+                result["name"] = company.name
+                financial_data = {}
+
+                financial_sections = [
+                    financials.income_statement,
+                    financials.balance_sheet,
+                    financials.cashflow_statement,
+                    financials.statement_of_equity,
+                    financials.comprehensive_income,
+                ]
+
+                for section in financial_sections:
+                    financial_data.update(populate_financal_data(section))
+
+                result["financial_data"] = financial_data
+        except Exception as e:
+            logger.warning(f"Could not extract financials: {e}")
+
+        return {"success": True, **result}
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"get_financials failed: {type(e).__name__}: {e}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=500, detail=f"get_financials failed: {type(e).__name__}: {e}"
+        )
+
+
+@app.post("/get_segment_data")
+async def get_segment_data(req: FilingByAccessionRequest) -> Dict[str, Any]:
+    """Extract segment-level financial data from a 10-K or 10-Q filing."""
+    try:
+        filing = get_filing_by_accession(req.ticker, req.accession_number)
+        company = Company(req.ticker)
+
+        result = {
+            "success": True,
+            "accession_number": filing.accession_number,
+            "form_type": filing.form,
+            "filing_date": filing.filing_date.isoformat()
+            if hasattr(filing.filing_date, "isoformat")
+            else str(filing.filing_date),
+            "cik": str(company.cik),
+            "name": company.name,
+            "has_segment_data": False,
+            "segment_data": None,
+        }
+
+        try:
+            filing_obj = filing.obj()
+
+            if hasattr(filing_obj, "segments"):
+                result["has_segment_data"] = True
+                result["segment_data"] = str(filing_obj.segments)[:10000]
+            elif hasattr(filing_obj, "notes") and hasattr(filing_obj.notes, "segments"):
+                result["has_segment_data"] = True
+                result["segment_data"] = str(filing_obj.notes.segments)[:10000]
+        except Exception as e:
+            logger.warning(f"Could not extract segment data: {e}")
+
+        return result
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"get_segment_data failed: {type(e).__name__}: {e}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=500, detail=f"get_segment_data failed: {type(e).__name__}: {e}"
+        )
+
+
+@app.post("/answer")
+async def answer(req: AnswerRequest) -> Dict[str, Any]:
+    state.submitted_answer = req.final_answer
+    return {"ok": True, "message": "Answer submitted"}
+
+
+@app.post("/evaluate")
+async def evaluate(req: EvaluateRequest) -> Dict[str, Any]:
+    submitted = state.submitted_answer
+    if submitted is None:
+        return {
+            "reward": 0.0,
+            "content": f"No answer submitted. Searches: {state.search_count}, Fetches: {state.fetch_count}",
+            "done": False,
+        }
+
+    logger.info(f"Evaluating answer (length: {len(submitted)} chars)")
+    logger.info(f"Answer preview: {submitted}")
+
+    try:
+        rubric = Rubric.from_dict(req.rubric)
+        evaluation = await rubric.grade(submitted)
+        reward = evaluation.score
+        info = {"report": [r.model_dump() for r in evaluation.report] if evaluation.report else []}
+
+        logger.info(f"Rubric evaluation completed. Score: {reward}")
+        logger.info(f"Evaluation report: {info}")
+        return {"reward": reward / 100, "info": info, "done": True}
+    except Exception as e:
+        logger.error(f"Rubric evaluation failed: {type(e).__name__}: {e}")
+        logger.error(traceback.format_exc())
+        return {
+            "reward": 0.0,
+            "content": f"Evaluation failed: {type(e).__name__}: {e}",
+            "done": True,
+        }
+
+
+@app.post("/get_filing_sections")
+async def get_filing_sections(req: FilingByAccessionRequest) -> Dict[str, Any]:
+    """Get specific sections from a 10-K or 10-Q filing."""
+    try:
+        filing = get_filing_by_accession(req.ticker, req.accession_number)
+        form_type = filing.form
+
+        sections = {"form_type": form_type, "has_structure": False}
+
+        try:
+            filing_obj = filing.obj()
+            sections["has_structure"] = True
+
+            # Extract sections based on form type
+            if form_type in ["10-K", "10-Q"]:
+                if hasattr(filing_obj, "business"):
+                    sections["business"] = str(filing_obj.business)[:5000]
+                if hasattr(filing_obj, "risk_factors"):
+                    sections["risk_factors"] = str(filing_obj.risk_factors)[:5000]
+                if hasattr(filing_obj, "mda"):
+                    sections["mda"] = str(filing_obj.mda)[:5000]
+                if hasattr(filing_obj, "financials"):
+                    sections["has_financials"] = True
+        except Exception as e:
+            logger.warning(f"Could not get structured sections: {e}")
+
+        return {"success": True, "sections": sections}
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"get_filing_sections failed: {type(e).__name__}: {e}")
+        logger.error(traceback.format_exc())
+        raise HTTPException(
+            status_code=500, detail=f"get_filing_sections failed: {type(e).__name__}: {e}"
+        )
+
+
+@app.post("/web_search")
+async def web_search(req: SearchRequest) -> List[Dict[str, str]]:
     results: List[Dict[str, str]] = []
     max_results: int = 1
 
@@ -175,7 +484,7 @@ async def search(req: SearchRequest) -> List[Dict[str, str]]:
     try:
         # Use exponential backoff for the API call
         data = await call_with_exponential_backoff(
-            _execute_search,
+            execute_search,
             req.query,
             exa_api_key,
             max_results,
@@ -214,27 +523,8 @@ async def search(req: SearchRequest) -> List[Dict[str, str]]:
     return results
 
 
-async def _execute_fetch(url: str, exa_api_key: str, max_length: int = 2500) -> Dict[str, Any]:
-    """Execute the actual Exa contents API call."""
-    contents_url = "https://api.exa.ai/contents"
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        response = await client.post(
-            contents_url,
-            headers={"x-api-key": exa_api_key, "Content-Type": "application/json"},
-            json={
-                "urls": [url],
-                "text": {"maxCharacters": max_length, "includeHtmlTags": False},
-                "highlights": {"numSentences": 5, "highlightsPerUrl": 3},
-                "summary": {"query": "main takeaways"},
-                "livecrawl": "fallback",
-            },
-        )
-        response.raise_for_status()
-        return response.json()
-
-
-@app.post("/fetch")
-async def fetch(req: FetchRequest) -> Dict[str, str]:
+@app.post("/web_fetch")
+async def web_fetch(req: FetchRequest) -> Dict[str, str]:
     from urllib.parse import urlparse
 
     max_length: int = 2500
@@ -249,7 +539,7 @@ async def fetch(req: FetchRequest) -> Dict[str, str]:
     try:
         # Use exponential backoff for the API call
         data = await call_with_exponential_backoff(
-            _execute_fetch,
+            execute_fetch,
             req.url,
             exa_api_key,
             max_length,
@@ -298,41 +588,9 @@ async def fetch(req: FetchRequest) -> Dict[str, str]:
     return {"content": content}
 
 
-@app.post("/answer")
-async def answer(req: AnswerRequest) -> Dict[str, Any]:
-    state.submitted_answer = req.final_answer
-    return {"ok": True, "message": "Answer submitted"}
-
-
-@app.post("/evaluate")
-async def evaluate(req: EvaluateRequest) -> Dict[str, Any]:
-    submitted = state.submitted_answer
-    if submitted is None:
-        return {
-            "reward": 0.0,
-            "content": f"No answer submitted. Searches: {state.search_count}, Fetches: {state.fetch_count}",
-            "done": False,
-        }
-
-    rubric = Rubric.from_dict(req.rubric)
-
-    evaluation = await rubric.grade(submitted)
-
-    reward = evaluation.score
-    info = {"report": [r.model_dump() for r in evaluation.report] if evaluation.report else []}
-
-    return {"reward": reward, "info": info, "done": True}
-
-
 if __name__ == "__main__":
-    import uvicorn
-
-    # Configure logging
     logging.basicConfig(
         level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
-
-    if not os.getenv("EXA_API_KEY"):
-        raise ValueError("EXA_API_KEY is not set")
 
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/environments/rubrics/server/main.py
+++ b/environments/rubrics/server/main.py
@@ -1,13 +1,12 @@
-"""Controller bridges MCP tools to the Rubrics environment HTTP API."""
+"""MCP server for SEC EDGAR research environment."""
 
-from typing import List, Dict
+from typing import List, Dict, Any, Optional
 import httpx
 import os
 import sys
 import logging
 
 from hud.tools.types import EvaluationResult
-
 from hud.server import MCPServer
 
 # Configure logging
@@ -19,7 +18,7 @@ logging.basicConfig(
 )
 
 # MCP server
-mcp = MCPServer(name="rubrics")
+mcp = MCPServer(name="sec-rubrics")
 
 # Environment server URL (backend)
 ENV_SERVER_URL = os.getenv("ENV_SERVER_URL", "http://localhost:8000")
@@ -27,8 +26,8 @@ ENV_SERVER_URL = os.getenv("ENV_SERVER_URL", "http://localhost:8000")
 # Shared HTTP client to talk to the environment
 http_client = httpx.AsyncClient(
     base_url=ENV_SERVER_URL,
-    timeout=30.0,
-    headers={"User-Agent": "HUD-Rubrics-Controller/1.0"},
+    timeout=60.0,  # Increased timeout for SEC EDGAR operations
+    headers={"User-Agent": "HUD-SEC-Rubrics-Controller/1.0"},
 )
 
 
@@ -46,20 +45,65 @@ async def cleanup():
 @mcp.tool()
 async def setup() -> str:
     await http_client.post("/setup")
-    return "Environment setup"
+    return "Environment setup complete"
 
 
 @mcp.tool()
-async def search(query: str) -> List[Dict[str, str]]:
-    resp = await http_client.post("/search", json={"query": query})
+async def search_company(query: str) -> List[Dict[str, str]]:
+    resp = await http_client.post("/search_company", json={"query": query})
     return resp.json()
 
 
 @mcp.tool()
-async def fetch(url: str) -> str:
-    resp = await http_client.post("/fetch", json={"url": url})
+async def get_filings(
+    ticker: Optional[str] = None,
+    form_type: Optional[str] = None,
+    limit: int = 10,
+    cutoff_date: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    resp = await http_client.post(
+        "/get_filings",
+        json={
+            "ticker": ticker,
+            "form_type": form_type,
+            "limit": limit,
+            "cutoff_date": cutoff_date,
+        },
+    )
+    return resp.json()
+
+
+@mcp.tool()
+async def get_filing_content(filing_url: str) -> str:
+    resp = await http_client.post("/get_filing_content", json={"filing_url": filing_url})
     data = resp.json()
     return data.get("content", "")
+
+
+@mcp.tool()
+async def get_financial_data(ticker: str, accession_number: str) -> Any:
+    """Extract financial statements and key metrics from a 10-K or 10-Q filing."""
+    resp = await http_client.post(
+        "/get_financial_data",
+        json={
+            "ticker": ticker,
+            "accession_number": accession_number,
+        },
+    )
+    return resp.json()
+
+
+@mcp.tool()
+async def get_segment_data(ticker: str, accession_number: str) -> Any:
+    """Extract segment-level financial data from a 10-K or 10-Q filing."""
+    resp = await http_client.post(
+        "/get_segment_data",
+        json={
+            "ticker": ticker,
+            "accession_number": accession_number,
+        },
+    )
+    return resp.json()
 
 
 @mcp.tool()
@@ -70,8 +114,40 @@ async def answer(final_answer: str) -> str:
 
 @mcp.tool()
 async def evaluate(rubric: list[dict[str, str | float]]) -> EvaluationResult:
-    resp = await http_client.post("/evaluate", json={"rubric": rubric})
-    return EvaluationResult(**resp.json())
+    try:
+        resp = await http_client.post("/evaluate", json={"rubric": rubric})
+        resp.raise_for_status()
+        return EvaluationResult(**resp.json())
+    except Exception as e:
+        logging.error(f"Evaluation tool error: {e}")
+        return EvaluationResult(
+            reward=0.0, done=True, content=f"Evaluation error: {e}", isError=True
+        )
+
+
+@mcp.tool()
+async def get_filing_sections(ticker: str, accession_number: str) -> Any:
+    resp = await http_client.post(
+        "/get_filing_sections",
+        json={
+            "ticker": ticker,
+            "accession_number": accession_number,
+        },
+    )
+    return resp.json()
+
+
+@mcp.tool()
+async def web_search(query: str) -> List[Dict[str, str]]:
+    resp = await http_client.post("/web_search", json={"query": query})
+    return resp.json()
+
+
+@mcp.tool()
+async def web_fetch(url: str) -> str:
+    resp = await http_client.post("/web_fetch", json={"url": url})
+    data = resp.json()
+    return data.get("content", "")
 
 
 if __name__ == "__main__":

--- a/environments/rubrics/tasks.json
+++ b/environments/rubrics/tasks.json
@@ -1,104 +1,6 @@
 [
 	{
-		"id": "SQA_00001",
-		"prompt": "Using Tesla's FY2024 10-K and Q3-Q4 2024 8-Ks, analyze the YoY change in automotive gross margin excluding regulatory credits on a segment basis. Decompose the change using Shapley attribution based on per-vehicle ASP and manufacturing cost metrics calculated from sales-only data. Present a four-line bridge (Q4 2023 base, price impact, cost impact, Q4 2024 final) and identify the primary driver.",
-		"mcp_config": {
-			"local": {
-				"command": "docker",
-				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
-			}
-		},
-		"setup_tool": {
-			"name": "setup",
-			"arguments": {}
-		},
-		"evaluate_tool": {
-			"name": "evaluate",
-			"arguments": {
-				"rubric": [
-					{
-						"requirement": "States price impact between -6.5pp and -7.0pp",
-						"weight": 12
-					},
-					{
-						"requirement": "States cost impact between +3.0pp and +3.4pp",
-						"weight": 12
-					},
-					{
-						"requirement": "States Q4 2023 base margin as 17.2%",
-						"weight": 10
-					},
-					{
-						"requirement": "Sates Q4 2024 final margin as 13.6%",
-						"weight": 10
-					},
-					{
-						"requirement": "Excludes operating lease deliveries from per-vehicle calculations",
-						"weight": 10
-					},
-					{
-						"requirement": "Explicitly uses symmetric/Shapley attribution for decomposition",
-						"weight": 8
-					},
-					{
-						"requirement": "Sates Q4 2023 cash deliveries as 473.944",
-						"weight": 6
-					},
-					{
-						"requirement": "States Q4 2024 cash deliveries as 468,608",
-						"weight": 6
-					},
-					{
-						"requirement": "Defines margin as (Auto Rev - Credits - VOGS) / (Auto Rev - Credits)",
-						"weight": 5
-					},
-					{
-						"requirement": "Uses total deliveries instead of cash-only deliveries",
-						"weight": -15
-					},
-					{
-						"requirement": "States ASP decline of $4,000-4,500 per vehicle",
-						"weight": 8
-					},
-					{
-						"requirement": "States cost reduction of $1,600-2,000 per unit",
-						"weight": 8
-					},
-					{
-						"requirement": "Mentions Q4 2024 cost per vehicle fell below $35,000",
-						"weight": 4
-					},
-					{
-						"requirement": "Identifies pricing/ASP as the primary margin compression driver",
-						"weight": 10
-					},
-					{
-						"requirement": "States price impact exceeds cost savings by 2:1 or greater",
-						"weight": 5
-					},
-					{
-						"requirement": "Mentions volume-over margin strategy or aggressive pricing",
-						"weight": 4
-					},
-					{
-						"requirement": "References 0% APR financing over other promotional offers",
-						"weight": 3
-					},
-					{
-						"requirement": "Cites Tesla FY 2024 10-K filing as primary data source",
-						"weight": 8
-					},
-					{
-						"requirement": "Cites at least one Q3 or Q4 2025 Tesla 8-K",
-						"weight": 6
-					}
-				]
-			}
-		},
-		"system_prompt": "You are an AI research assistant that can search the web and fetch content to answer questions. You must call the answer tool with your final answer when you have finished your research. Call search tool with the exact search query then fetch tool with the most promising URLs. After calling answer, stop generating - your task is complete. Do not call random urls. Call the urls that are returned by search. If you do not do this you will inevitably get the wrong answer. Call tools one by one and do not call them all at a time. Again, you must call the answer tool with your final answer when you have finished your research, or else the task will not be completed and you will not get a reward. Simply printing your final answer is not enough."
-	},
-	{
-		"id": "SQA_00002",
+		"id": "finance_rubric_00000",
 		"prompt": "I need help analyzing Valero's refining margins in early 2024. Based on its FY2023 10-K and Q1 2024 10-Q, can you calculate the refining margin per barrel? And compare year over year? \n\nIf margins were getting squeezed while throughput volumes were consistent, figure out what drove that - is it because crude differentials were tightening up, or could it be related to how they timed their maintenance schedules? And based on the findings at that time, what would have been implied about their optimization approach heading into Q2 2024?",
 		"mcp_config": {
 			"local": {
@@ -173,6 +75,768 @@
 				]
 			}
 		},
-		"system_prompt": "You are an AI research assistant that can search the web and fetch content to answer questions. You must call the answer tool with your final answer when you have finished your research. Call search tool with the exact search query then fetch tool with the most promising URLs. After calling answer, stop generating - your task is complete. Do not call random urls. Call the urls that are returned by search. If you do not do this you will inevitably get the wrong answer. Call tools one by one and do not call them all at a time. Again, you must call the answer tool with your final answer when you have finished your research, or else the task will not be completed and you will not get a reward. Simply printing your final answer is not enough."
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00001",
+		"prompt": "Using T-Mobile's Q1 2024 and Q3 2024 10-Qs, calculate wireless service margins and ARPU if disclosed in segment data. Should margins compress despite ARPU growth and subscriber additions, would this reflect promotional intensity to defend share or network infrastructure costs outpacing revenue? What does that imply for fixed cost leverage as the network scales?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 12,
+						"requirement": "States Q1 2024 service margin as 83.3% or 84.0% (adjusted for merger costs)"
+					},
+					{
+						"weight": 12,
+						"requirement": "States Q3 2024 service margin as 83.7%"
+					},
+					{
+						"weight": 10,
+						"requirement": "States margins expanded (not compressed) Q1 to Q3 2024"
+					},
+					{
+						"weight": 8,
+						"requirement": "Shows calculation methodology as (Service Revenue - Cost of Services ex-D&A) / Service Revenue"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Q1 2024 service revenues as $16,096 million (+/- $10m)"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Q1 2024 cost of services as $2,688 million (+/- $10m)"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Q3 2024 service revenues as $16,725 million (+/- $10m)"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Q3 2024 cost of services as $2,722 million (+/- $10m)"
+					},
+					{
+						"weight": 6,
+						"requirement": "States Q1 2024 postpaid phone ARPU as $48.79 (+/- $0.10)"
+					},
+					{
+						"weight": 6,
+						"requirement": "States Q3 2024 postpaid phone ARPU as $49.79 (+/- $0.10)"
+					},
+					{
+						"weight": 5,
+						"requirement": "Quantifies postpaid phone ARPU increase as $1.00 or +2.0%"
+					},
+					{
+						"weight": 5,
+						"requirement": "States postpaid ARPA increased from $140.88 to $145.60 (+/- $0.50 each)"
+					},
+					{
+						"weight": 4,
+						"requirement": "Notes prepaid ARPU declined from Q1 to Q3 2024"
+					},
+					{
+						"weight": 12,
+						"requirement": "Identifies network infrastructure costs as primary or dominant driver of margin dynamics"
+					},
+					{
+						"weight": 10,
+						"requirement": "References Q3 10-Q language about higher site costs or 5G network build-out costs"
+					},
+					{
+						"weight": 8,
+						"requirement": "Discusses promotional activity as present but secondary factor or offset to ARPU gains"
+					},
+					{
+						"weight": 6,
+						"requirement": "Notes record-low churn of 0.86% as evidence against defensive promotional intensity"
+					},
+					{
+						"weight": 6,
+						"requirement": "Compares cost of services growth rate to service revenue growth rate Q1 to Q3"
+					},
+					{
+						"weight": 10,
+						"requirement": "References T-Mobile Q1 2024 10-Q"
+					},
+					{
+						"weight": 10,
+						"requirement": "References T-Mobile Q3 2024 10-Q"
+					},
+					{
+						"weight": 8,
+						"requirement": "Explains wireless operating leverage concept as incremental subscribers adding high-margin revenue over fixed network"
+					},
+					{
+						"weight": 7,
+						"requirement": "Discusses transition from network investment phase to operating leverage phase"
+					},
+					{
+						"weight": 5,
+						"requirement": "Explains how network cost step-ups temporarily mute operating leverage realization"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00002",
+		"prompt": "Using PNC Financial's Q2 2024 and Q2 2023 10-Qs, calculate loan growth and operating cash flow if disclosed in the statements. Should loan balances expand while cash generation contracts, would this reflect provision expense buildup or deposit funding cost pressure? What does that imply for capital deployment efficiency and near-term profitability?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 10,
+						"requirement": "States Q2 2024 period-end total loans as $321.0B to $321.9B"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Q2 2023 period-end total loans as $321.0B to $322.5B"
+					},
+					{
+						"weight": 6,
+						"requirement": "Calculates YoY loan change as -0.5% to +0.2% or -$1.0B to +$0.5B"
+					},
+					{
+						"weight": 10,
+						"requirement": "States 2024 six-month operating cash flow as $2.5B to $3.0B"
+					},
+					{
+						"weight": 10,
+						"requirement": "States 2023 six-month operating cash flow as $4.9B to $5.4B"
+					},
+					{
+						"weight": 6,
+						"requirement": "Calculates YoY cash flow decline as -40% to -50% or -$2.0B to -$2.6B"
+					},
+					{
+						"weight": 12,
+						"requirement": "Explicitly identifies funding cost pressure (not provision buildup) as primary driver of CFO decline"
+					},
+					{
+						"weight": 8,
+						"requirement": "States provision expense changed by less than $50M or increased less than 10% YoY"
+					},
+					{
+						"weight": 8,
+						"requirement": "States deposit interest expense increased by $1.0B to $1.5B YoY"
+					},
+					{
+						"weight": 6,
+						"requirement": "Explains why provision expense cannot explain CFO decline (non-cash add-back or similar logic)"
+					},
+					{
+						"weight": 6,
+						"requirement": "Recommends at least 2 of prioritizing capital return over growth, tightening loan pricing, or managing deposit mix"
+					},
+					{
+						"weight": 5,
+						"requirement": "States net interest margin compressed by 15 to 25 basis points YoY"
+					},
+					{
+						"weight": 4,
+						"requirement": "States borrowed-funds interest expense increased by $500M to $800M YoY"
+					},
+					{
+						"weight": 5,
+						"requirement": "References PNC Financial Q2 2024 10-Q"
+					},
+					{
+						"weight": 5,
+						"requirement": "References PNC Financial Q2 2023 10-Q"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00003",
+		"prompt": "Using Boeing's Q3 2024 10-Q, calculate operating margins by segment if disclosed and compare to FY2023 10-K levels. Should defense margins compress while backlog grows, would this reflect fixed-price contract overruns or engineering labor inflation? What does that imply for program profitability and bid discipline on new awards?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 10,
+						"requirement": "States BCA Q3 2024 operating margin as -54.0% within +/- 1 percentage point"
+					},
+					{
+						"weight": 10,
+						"requirement": "States BDS Q3 2024 operating margin as -43.1% within +/- 1 percentage point"
+					},
+					{
+						"weight": 10,
+						"requirement": "States BGS Q3 2024 operating margin as +17.0% within +/- 1 percentage point"
+					},
+					{
+						"weight": 5,
+						"requirement": "Shows or describes margin calculation as operating income divided by revenue"
+					},
+					{
+						"weight": 8,
+						"requirement": "States BCA FY2023 full-year margin as -4.8% within +/- 1 percentage point"
+					},
+					{
+						"weight": 8,
+						"requirement": "States BDS FY2023 full-year margin as -7.1% within +/- 1 percentage point"
+					},
+					{
+						"weight": 8,
+						"requirement": "States BGS FY2023 full-year margin as +17.4% within +/- 1 percentage point"
+					},
+					{
+						"weight": 6,
+						"requirement": "Calculates or states BDS margin deterioration as 35-37 percentage points YoY"
+					},
+					{
+						"weight": 10,
+						"requirement": "Attributes defense margin compression primarily to fixed-price contract overruns not labor inflation"
+					},
+					{
+						"weight": 8,
+						"requirement": "Quantifies Q3 2024 defense charges as $2.0-2.4 billion"
+					},
+					{
+						"weight": 6,
+						"requirement": "Names at least 3 of T-7A, KC-46A, VC-25B, Commercial Crew, or MQ-25 as troubled programs"
+					},
+					{
+						"weight": 6,
+						"requirement": "States defense backlog grew from approx $59B Dec-2023 to $62B Sep-2024"
+					},
+					{
+						"weight": 8,
+						"requirement": "Identifies backlog growth concurrent with margin compression as bid discipline failure red flag"
+					},
+					{
+						"weight": 8,
+						"requirement": "Recommends improved bid discipline or avoiding unprofitable fixed-price development work"
+					},
+					{
+						"weight": 4,
+						"requirement": "Explicitly cites or references Boeing Q3 2024 10-Q filing as data source"
+					},
+					{
+						"weight": 4,
+						"requirement": "Explicitly cites or references Boeing FY2023 10-K filing as data source"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00004",
+		"prompt": "Using Amazon's FY2024 10-K, calculate inventory turnover and fulfillment costs as a percentage of revenue if disclosed in the statements. Should turnover deteriorate while online mix reaches 65% yet fulfillment intensity remains stable, would this reflect assortment expansion or promotional cadence changes? What does that imply for working capital efficiency?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 10,
+						"requirement": "States inventory turnover between 9.5x and 9.8x for FY2024"
+					},
+					{
+						"weight": 10,
+						"requirement": "States fulfillment costs as 15.2% to 15.6% of revenue"
+					},
+					{
+						"weight": 6,
+						"requirement": "Calculates or states Days Inventory Outstanding between 37 and 39 days"
+					},
+					{
+						"weight": 8,
+						"requirement": "References Amazon FY2024 10-K"
+					},
+					{
+						"weight": 10,
+						"requirement": "States assortment expansion or SKU proliferation as primary driver of turnover deterioration"
+					},
+					{
+						"weight": 8,
+						"requirement": "Explains stable fulfillment percentage means same units per revenue dollar ruling out promotional changes"
+					},
+					{
+						"weight": 6,
+						"requirement": "Mentions long-tail items, SKU count growth, or category expansion reducing average turnover"
+					},
+					{
+						"weight": 5,
+						"requirement": "Discusses forward-stocking, regional distribution, or geographic duplication increasing inventory"
+					},
+					{
+						"weight": 8,
+						"requirement": "Explicitly states promotional changes would alter units per revenue and move fulfillment percentage"
+					},
+					{
+						"weight": 10,
+						"requirement": "States each day of inventory ties up approximately $0.8B to $1.0B in working capital"
+					},
+					{
+						"weight": 6,
+						"requirement": "Calculates cash impact for specific turnover deterioration scenario with dollar amounts"
+					},
+					{
+						"weight": 6,
+						"requirement": "Mentions at least 2 of extending DPO, pushing to FBA/3P, or vendor financing as offsets"
+					},
+					{
+						"weight": 5,
+						"requirement": "Discusses impact on cash conversion cycle or free cash flow from inventory build"
+					},
+					{
+						"weight": 5,
+						"requirement": "Recommends tracking SKU count growth or category mix shifts"
+					},
+					{
+						"weight": 4,
+						"requirement": "Recommends monitoring 1P vs 3P mix or FBA share"
+					},
+					{
+						"weight": 4,
+						"requirement": "Recommends tracking aged inventory, obsolescence reserves, or markdown risk"
+					},
+					{
+						"weight": 4,
+						"requirement": "Recommends monitoring Days Payable Outstanding or supplier payment terms"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00005",
+		"prompt": "Using Moderna's Q1, Q2, and Q3 2024 10-Qs, calculate R&D spend as a percentage of revenue and operating cash burn if disclosed in the cash flow statements. Should burn rate accelerate while Phase III programs advance, would this reflect CRO cost inflation or inefficient trial design? What does that imply for runway and financing needs?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 10,
+						"requirement": "States Q1 2024 R&D as percentage of revenue is 636% (+/- 2pp)"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Q2 2024 R&D as percentage of revenue is 507% (+/- 2pp)"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Q3 2024 R&D as percentage of revenue is 61% (+/- 2pp)"
+					},
+					{
+						"weight": 8,
+						"requirement": "Shows underlying revenue and R&D expense amounts for at least 2 quarters"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Q1 2024 operating cash burn is $989M (+/- $20M)"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Q2 2024 operating cash burn is $1,274M (+/- $30M)"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Q3 2024 operating cash burn is $1,566M (+/- $30M)"
+					},
+					{
+						"weight": 5,
+						"requirement": "Explicitly notes operating cash burn accelerated from Q1 to Q3"
+					},
+					{
+						"weight": 10,
+						"requirement": "References Moderna Q1 2024 10-Q"
+					},
+					{
+						"weight": 10,
+						"requirement": "References Moderna Q2 2024 10-Q"
+					},
+					{
+						"weight": 10,
+						"requirement": "References Moderna Q3 2024 10-Q"
+					},
+					{
+						"weight": 10,
+						"requirement": "Attributes burn acceleration to working capital or prepayments not GAAP expense increases"
+					},
+					{
+						"weight": 6,
+						"requirement": "Notes GAAP R&D expense remained stable at approximately $1.1-1.2B per quarter"
+					},
+					{
+						"weight": 8,
+						"requirement": "Concludes burn reflects Phase III scale-up or timing not trial design inefficiency"
+					},
+					{
+						"weight": 8,
+						"requirement": "States cash position as $9.2B (+/- $0.2B) as of September 30, 2024"
+					},
+					{
+						"weight": 10,
+						"requirement": "Calculates mechanical runway showing 15-22 months from September 2024"
+					},
+					{
+						"weight": 5,
+						"requirement": "Notes Q4 seasonal collections or revenue timing affects true runway"
+					},
+					{
+						"weight": 6,
+						"requirement": "Identifies R&D spending exceeds revenue creating structural deficit"
+					},
+					{
+						"weight": 5,
+						"requirement": "Discusses financing pressure timeline within 18-30 months"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00006",
+		"prompt": "Per Netflix's 2024 Proxy Statement (DEF 14A), compile a table of CEO and CFO total compensation (salary, bonus, equity grant-date value) alongside three-year total shareholder return (2022 -2024). Apply the ISS quantitative pay-for-performance test and tabulate percentile ranks plus the overall score. In three sentences, state whether performance-vesting targets exceeded peer median and recommend a Say-on-Pay vote.",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 15,
+						"requirement": "Contains a table with at least 3 columns and 3 rows displaying executive compensation data"
+					},
+					{
+						"weight": 8,
+						"requirement": "Lists Ted Sarandos by name and identifies him as Co-CEO"
+					},
+					{
+						"weight": 8,
+						"requirement": "Lists Greg Peters by name and identifies him as Co-CEO"
+					},
+					{
+						"weight": 8,
+						"requirement": "Lists Spencer Neumann by name and identifies him as CFO"
+					},
+					{
+						"weight": 5,
+						"requirement": "Table includes a column labeled salary or base salary"
+					},
+					{
+						"weight": 5,
+						"requirement": "Table includes a column labeled bonus or annual bonus"
+					},
+					{
+						"weight": 5,
+						"requirement": "Table includes a column labeled equity, stock, or grant-date value"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Ted Sarandos 2024 salary as $3 million or $3.0M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Ted Sarandos 2024 bonus as $12 million or $12.0M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Ted Sarandos 2024 equity grant-date value as $42.7M or $42.71M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Greg Peters 2024 salary as $3 million or $3.0M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Greg Peters 2024 bonus as $12 million or $12.0M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Greg Peters 2024 equity grant-date value as $42.7M or $42.71M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Spencer Neumann 2024 salary as $1.5 million or $1.5M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Spencer Neumann 2024 bonus as $3M, $3.0M, or $6M"
+					},
+					{
+						"weight": 8,
+						"requirement": "States Spencer Neumann 2024 equity grant-date value as $14.5M or $14.47M"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Ted Sarandos 2024 total compensation as $61.9M or $61.92M"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Greg Peters 2024 total compensation as $60.3M or $60.27M"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Spencer Neumann 2024 total compensation as $22.9M or $22.90M"
+					},
+					{
+						"weight": 10,
+						"requirement": "Includes three-year total shareholder return (TSR) data covering 2022-2024"
+					},
+					{
+						"weight": 4,
+						"requirement": "States the 2022 TSR performance value as -51.1%"
+					},
+					{
+						"weight": 4,
+						"requirement": "States the 2023 TSR performance value as 65.1%"
+					},
+					{
+						"weight": 4,
+						"requirement": "States the 2024 TSR performance value as 83.1%"
+					},
+					{
+						"weight": 5,
+						"requirement": "States 3-year cumulative TSR as 48% or 49.21%"
+					},
+					{
+						"weight": 10,
+						"requirement": "Explicitly mentions applying ISS quantitative pay-for-performance test methodology"
+					},
+					{
+						"weight": 6,
+						"requirement": "States RDA score showing CEO pay at 95th percentile and TSR at 80th percentile"
+					},
+					{
+						"weight": 6,
+						"requirement": "States MOM score as 2.0x or above 2x peer median"
+					},
+					{
+						"weight": 6,
+						"requirement": "States PTA assessment as Aligned or indicates pay-TSR alignment"
+					},
+					{
+						"weight": 4,
+						"requirement": "States CEO pay percentile rank as 95th or 85th percentile"
+					},
+					{
+						"weight": 4,
+						"requirement": "States 3-year TSR performance percentile as 80th or 75th percentile"
+					},
+					{
+						"weight": 5,
+						"requirement": "States overall ISS concern level as Medium Concern"
+					},
+					{
+						"weight": 10,
+						"requirement": "States that performance-vesting targets exceeded peer median"
+					},
+					{
+						"weight": 15,
+						"requirement": "Makes clear recommendation to vote FOR or AGAINST Say-on-Pay"
+					},
+					{
+						"weight": 5,
+						"requirement": "Explicitly connects performance results to vote recommendation"
+					},
+					{
+						"weight": 15,
+						"requirement": "State whether performance-vesting targets exceeded peer median and recommend a Say-on-Pay vote in exactly 3 sentences"
+					},
+					{
+						"weight": 20,
+						"requirement": "References Netflix 2024 DEF 14A proxy statement"
+					},
+					{
+						"weight": -50,
+						"requirement": "Does not flag that Netflix has co-CEOs"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00007",
+		"prompt": "Based on Oracle's FY2024 10-K, what were the operating expenses in 2024, broken out by segment? Which segment had the highest operating expenses and which segment had the lowest?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 10,
+						"requirement": "States Cloud Services and License segment operating expenses were $9.4B (or $9,427m)"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Hardware segment operating expenses were $891m"
+					},
+					{
+						"weight": 10,
+						"requirement": "States Services segment operating expenses were $4.8B (or $4,825m)"
+					},
+					{
+						"weight": 10,
+						"requirement": "Correctly identifies Cloud/Cloud & License as highest operating expense segment"
+					},
+					{
+						"weight": 10,
+						"requirement": "Correctly identifies Hardware as lowest operating expense segment"
+					},
+					{
+						"weight": 8,
+						"requirement": "References Oracle's FY2024 Form 10-K"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00008",
+		"prompt": "Per Sun Country Airlines' FY2024 Form 10-K, what were Sun's ASMs and RPMs for 2024, and what was the load factor?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 15,
+						"requirement": "States 2024 ASMs as 6.7 billion or 6,707,308 thousand"
+					},
+					{
+						"weight": 15,
+						"requirement": "States 2024 RPMs as 5.6 billion or 5,648,351 thousand"
+					},
+					{
+						"weight": 12,
+						"requirement": "States 2024 load factor as 84.2%"
+					},
+					{
+						"weight": 8,
+						"requirement": "References Sun Country Airlines' FY2024 Form 10-K"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
+	},
+	{
+		"id": "finance_rubric_00009",
+		"prompt": "Based on ExxonMobil's Q2 2025 10-Q, what were the crude oil and product purchases for the three months ended June 30, 2025, broken out by U.S. vs Non-U.S.? Which was higher and which was lower?",
+		"mcp_config": {
+			"local": {
+				"command": "docker",
+				"args": ["run", "--rm", "-i", "--env-file", ".env", "rubrics:latest"]
+			}
+		},
+		"setup_tool": {
+			"name": "setup",
+			"arguments": {}
+		},
+		"evaluate_tool": {
+			"name": "evaluate",
+			"arguments": {
+				"rubric": [
+					{
+						"weight": 12,
+						"requirement": "States U.S. purchases as $33,257M or $33.257B or within $33.2-33.3B"
+					},
+					{
+						"weight": 12,
+						"requirement": "States Non-U.S. purchases as $40,786M or $40.786B or within $40.7-40.9B"
+					},
+					{
+						"weight": 10,
+						"requirement": "Explicitly states Non-U.S. purchases were higher than U.S. purchases"
+					},
+					{
+						"weight": 8,
+						"requirement": "References ExxonMobil Q2 2025 10-Q"
+					}
+				]
+			}
+		},
+		"system_prompt": "You are an AI finance research assistant specializing in public company filings analysis. You must call the answer tool with your final answer when you have finished your research. Search for companies by ticker or name, then retrieve the relevant SEC filings needed to answer the question. Extract financial data and segment information from filings as needed for your analysis. You have access to tools that you must call one-at-a-time. As an ABSOLUTE last resort you can use web search and fetch if you're unable to use the SEC tools.\n\nPull the relevant documents, analyze them thoroughly, and provide your answer in a well-structured format. Call tools one-at-a-time. When finished, call the answer tool with your final answer or else the task will not be completed. Once you have gathered the information needed to answer the question, call the answer tool."
 	}
 ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add SEC EDGAR-powered research tooling and endpoints, update MCP server, expand finance tasks, and refresh docs/config and deps.
> 
> - **Backend (environment/)**
>   - **SEC EDGAR integration**: Add `edgar_utils.py` and wire EDGAR via `edgartools`; require `EDGAR_IDENTITY`.
>   - **New endpoints**: `search_company`, `get_filings`, `get_filing_content`, `get_financial_data`, `get_segment_data`, `get_filing_sections`.
>   - **Web search**: Factor Exa calls into `exa_utils.py`; expose `web_search`/`web_fetch` with exponential backoff.
>   - **Evaluation**: Normalize reward (`/100`) and improve error/log handling.
> - **MCP Server (server/)**
>   - Rename server to `sec-rubrics`; add tools mirroring new endpoints and increase HTTP timeouts.
> - **Tasks**
>   - Major expansion of `tasks.json` with multiple finance/SEC-focused rubrics and prompts.
> - **Docs & Config**
>   - Update README with SEC workflow, tools, and setup; add `EDGAR_IDENTITY` to `.env.example` and usage.
> - **Dependencies**
>   - Pin `rubric==1.1.8`; add `edgartools>=4.21.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ee8cce8f0c96bf030ee4fd0bfa50fa63046af0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->