### PR TITLE
Migrate hud init to clone from separate repos

### DIFF
--- a/hud/cli/init.py
+++ b/hud/cli/init.py
@@ -23,8 +23,6 @@ PRESET_MAP: dict[str, str | None] = {
     "deep-research": "hud-deepresearch",
     "browser": "hud-browser",
     "rubrics": "hud-rubrics",
-    "remote-browser": "hud-remote-browser",
-    "text-2048": "hud-text-2048",
 }
 
 SKIP_DIR_NAMES = {"node_modules", "__pycache__", "dist", "build", ".next", ".git"}
@@ -93,9 +91,7 @@ def _prompt_for_preset() -> str:
             {"name": "blank", "message": "blank"},
             {"name": "browser", "message": "browser"},
             {"name": "deep-research", "message": "deep-research"},
-            {"name": "remote-browser", "message": "remote-browser"},
             {"name": "rubrics", "message": "rubrics"},
-            {"name": "text-2048", "message": "text-2048"},
         ]
         display_choices = [c["message"] for c in choices]
         selected = questionary.select(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Init now downloads full preset repos from hud-evals instead of a subdirectory, with placeholder replacement for blank and updated UX.
> 
> - **CLI: `hud init`**
>   - Switch presets to separate repositories under `hud-evals` via tarball download of the entire repo (`_download_tarball_repo`), replacing subdirectory extraction.
>   - Update `PRESET_MAP` to repo names (`hud-blank`, `hud-deepresearch`, `hud-browser`, `hud-rubrics`) and adjust preset prompt order.
>   - Improve console output: new source URL, clearer warnings with available presets, top-level file listing, and guided next steps.
>   - Add placeholder replacement for the `blank` preset across template files (e.g., `pyproject.toml`, `README.md`, `server/main.py`).
>   - Hardening: token-based headers, safer path resolution, and extraction guards during untar.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7870ec567638f24df99fa77f833966750e4a9b8d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->