### PR TITLE
HUD-413 Docker builds using ecr buildkit caching

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,7 +29,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "0.4.60",
+        "version": "0.4.61",
         "groups": [
           {
             "group": "Get Started",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,7 +5,7 @@ icon: "book"
 ---
 
 <Note>
-**Version 0.4.60** - Latest stable release
+**Version 0.4.61** - Latest stable release
 </Note>
 
 <CardGroup cols={3}>

--- a/environments/browser/server/pyproject.toml
+++ b/environments/browser/server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "HUD Browser MCP Server"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "hud-python>=0.4.60",
+    "hud-python>=0.4.61",
     "httpx",
     "playwright",
     "pyautogui",

--- a/environments/jupyter/server/pyproject.toml
+++ b/environments/jupyter/server/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP server for XLSX spreadsheet manipulation"
 authors = [{name = "HUD Team"}]
 requires-python = ">=3.11"
 dependencies = [
-    "hud-python==0.4.60",
+    "hud-python==0.4.61",
     "pandas>=2.0.0",
     "openpyxl>=3.1.0",
     "xlsxwriter>=3.1.0",

--- a/environments/online_mind2web/pyproject.toml
+++ b/environments/online_mind2web/pyproject.toml
@@ -3,7 +3,7 @@ name = "hud-om2w"
 version = "0.1.0"
 description = "HUD Remote Browser Controller with MCP tools for cloud browser providers"
 requires-python = ">=3.11,<3.13"
-dependencies = [ "hud-python==0.4.60", "pyautogui", "playwright", "httpx", "typer", "google-api-python-client", "google-auth",]
+dependencies = [ "hud-python==0.4.61", "pyautogui", "playwright", "httpx", "typer", "google-api-python-client", "google-auth",]
 
 [build-system]
 requires = [ "hatchling",]

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -619,7 +619,7 @@ def build(
         hud build . --tag my-env:v1.0 -e VAR1=value1 -e VAR2=value2
         hud build . --no-cache       # Force rebuild
         hud build . --remote-cache my-cache-repo   # Use ECR remote cache (requires AWS_ACCOUNT_ID and AWS_DEFAULT_REGION)[/not dim]
-    """
+    """  # noqa: E501
     # Parse directory and extra arguments
     if params:
         directory = params[0]

--- a/hud/utils/tests/test_version.py
+++ b/hud/utils/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.4.60"
+    assert hud.__version__ == "0.4.61"

--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.4.60"
+__version__ = "0.4.61"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hud-python"
-version = "0.4.60"
+version = "0.4.61"
 description = "SDK for the HUD platform."
 readme = "README.md"
 requires-python = ">=3.11, <3.13"


### PR DESCRIPTION
1. requiring buildx enabled

docker buildx create --name mybuilder --driver docker-container --use --bootstrap

2. Authenticate Docker with ECR using your AWS credentials
aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 156041433621.dkr.ecr.us-east-1.amazonaws.com

3. Also ensure the ECR repository exists
aws ecr create-repository --repository-name hud-build-temp --region us-east-1 2>/dev/null || true

4. Then run hud build
hud build --remote-cache <ecr repo name>

ECR repo name should be identical to github repo name, e.g., alapha23/hud-example-2



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds --remote-cache for ECR-backed BuildKit caching in hud build and bumps version to 0.4.61.
> 
> - **CLI / Build**
>   - Add `--remote-cache <repo>` option to `hud build` and plumb through `build_command` → `build_environment` → `build_docker_image`.
>   - Use `docker buildx build` when remote cache is enabled; configure `--cache-from/--cache-to` to ECR with `:cache` tag and `--load`.
>   - Validate repo name; require `AWS_ACCOUNT_ID` (region defaults to `AWS_DEFAULT_REGION` or `us-east-1`). Applied to both initial and final (label) build steps.
>   - Update help/examples in CLI docstring.
> - **Versioning**
>   - Bump SDK and docs to `0.4.61` (`pyproject.toml`, `hud/version.py`, tests, docs index/navigation).
>   - Update environment servers to depend on `hud-python==/>=0.4.61`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfe6c3de0a199dc043b84f86e68147ed3b43108a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->