### PR TITLE
Allow forward slashes in ECR names

### DIFF
--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import hashlib
 import json
+import os
 import re
 import subprocess
 import time
@@ -390,14 +391,11 @@ def build_docker_image(
     # Add remote cache support for ECR
     if remote_cache:
         try:
-            import os
-            import re
-
             # Validate ECR repo name
-            if not re.match(r"^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?$", remote_cache):
+            if not re.match(r"^[a-z0-9]([a-z0-9\-_/]*[a-z0-9])?$", remote_cache):
                 hud_console.error(f"Invalid ECR repo name: {remote_cache}")
                 hud_console.info(
-                    "ECR repo names must contain only lowercase letters, numbers, hyphens, and underscores"  # noqa: E501
+                    "ECR repo names must contain only lowercase letters, numbers, hyphens, underscores, and forward slashes"  # noqa: E501
                 )
                 return False
 
@@ -714,10 +712,7 @@ def build_environment(
     # Add remote cache support for final build
     if remote_cache:
         try:
-            import os
-            import re
-
-            if not re.match(r"^[a-z0-9]([a-z0-9\-_]*[a-z0-9])?$", remote_cache):
+            if not re.match(r"^[a-z0-9]([a-z0-9\-_/]*[a-z0-9])?$", remote_cache):
                 hud_console.error(f"Invalid ECR repo name: {remote_cache}")
                 raise typer.Exit(1)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Broadens ECR remote cache repo name validation to accept forward slashes and updates related error messaging in both build steps.
> 
> - **Build (CLI)**:
>   - **ECR Remote Cache Validation**: Allow `/` in `remote_cache` repo names by updating the regex and corresponding error message.
>   - Applied in both initial build (`build_docker_image`) and final rebuild (labeling step).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5258af27a04f7defd7dca483abef43e848e00bfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->