### PR TITLE
Send entire error traceback to telemetry service

### DIFF
--- a/hud/otel/context.py
+++ b/hud/otel/context.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import logging
+import traceback
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -531,11 +532,14 @@ class trace:
         # Update task status (sync call - blocking is expected for sync context manager)
         if self.is_root and settings.telemetry_enabled and settings.api_key:
             status = "error" if exc_type else "completed"
+            error_msg = None
+            if exc_type is not None:
+                error_msg = "".join(traceback.format_exception(exc_type, exc_val, exc_tb))
             _update_task_status_sync(
                 self.task_run_id,
                 status,
                 job_id=self.job_id,
-                error_message=str(exc_val) if exc_val else None,
+                error_message=error_msg,
                 trace_name=self.span_name,
                 task_id=self.task_id,
                 group_id=self.group_id,

--- a/hud/telemetry/async_context.py
+++ b/hud/telemetry/async_context.py
@@ -17,6 +17,7 @@ flushed on context exit. No manual cleanup required.
 from __future__ import annotations
 
 import logging
+import traceback
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -125,13 +126,16 @@ class AsyncTrace:
         # Update trace status to "completed" or "error"
         if self.root and settings.telemetry_enabled and settings.api_key:
             status = "error" if exc_type else "completed"
+            error_msg = None
+            if exc_type is not None:
+                error_msg = "".join(traceback.format_exception(exc_type, exc_val, exc_tb))
 
             try:
                 await _update_task_status_async(
                     self.task_run_id,
                     status,
                     job_id=self.job_id,
-                    error_message=str(exc_val) if exc_val else None,
+                    error_message=error_msg,
                     trace_name=self.name,
                     task_id=self.task_id,
                     group_id=self.group_id,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Send full formatted exception traceback with task status updates for both sync and async trace contexts.
> 
> - **Telemetry**:
>   - **Error reporting**: On exception, send full formatted traceback (`traceback.format_exception`) as `error_message` instead of just `str(exc_val)` in `_update_task_status_*` calls.
>   - Applies to:
>     - Sync trace context manager in `hud/otel/context.py`.
>     - Async trace context manager in `hud/telemetry/async_context.py`.
>   - Minor: add `traceback` imports where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a28cf42469027ee3afeca4dcf12af117dde6fc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->