### PR TITLE
add more functionality to find rewards

### DIFF
--- a/hud/agents/base.py
+++ b/hud/agents/base.py
@@ -764,12 +764,12 @@ def find_reward(result: MCPToolResult) -> float:
     If not found, return 0.0
     """
     accept_keys = ["reward", "grade", "score"]
-    
+
     # Check for direct reward/grade/score keys
     for key in accept_keys:
         if isinstance(result.structuredContent, dict) and key in result.structuredContent:
             return result.structuredContent[key]
-    
+
     # Check for subscores and weights format
     if (
         isinstance(result.structuredContent, dict)
@@ -790,7 +790,7 @@ def find_reward(result: MCPToolResult) -> float:
             except (ValueError, TypeError) as e:
                 logger.error("Failed to parse subscores/weights: %s", e)
                 return 0.0
-    
+
     # Check for reward in JSON text content
     if isinstance(result.content, list):
         for content in result.content:
@@ -802,7 +802,7 @@ def find_reward(result: MCPToolResult) -> float:
                             return value
                 except json.JSONDecodeError:
                     pass
-    
+
     logger.error("Couldn't parse reward from result: %s", result)
     return 0.0
 

--- a/hud/utils/mcp.py
+++ b/hud/utils/mcp.py
@@ -19,7 +19,7 @@ class MCPConfigPatch(BaseModel):
 
 def _is_hud_server(url: str) -> bool:
     """Check if a URL is a HUD MCP server.
-    
+
     Matches any mcp.hud.* domain (including .ai, .so, and future domains).
     """
     if not url:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances `find_reward` to compute rewards from weighted subscores and adds error logging for parse failures.
> 
> - **Agent reward parsing (`hud/agents/base.py`)**:
>   - Compute reward from `structuredContent` with `subscores` × `weights` (sum of weighted subscores).
>   - Retains existing support for direct `reward`/`grade`/`score` keys and JSON text parsing.
>   - Adds error logging when subscores/weights parsing fails and when no reward can be parsed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d928843da3aebda0a1835f8dcb277b0f018a0c00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->