### PR TITLE
avoid cache control on tools, since it is applied automatically

### DIFF
--- a/hud/agents/claude.py
+++ b/hud/agents/claude.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import copy
 import logging
-import re
 from inspect import cleandoc
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes explicit cache_control on tools, switches optional params to Omit, and replaces regex-based computer tool detection with prioritized name matching.
> 
> - **Claude Agent (`hud/agents/claude.py`)**:
>   - *API params*: Replace `NotGiven` with `Omit` for `system` and `betas` in `beta.messages.create`.
>   - *Tool conversion*:
>     - Remove regex-based `computer_tool_regex` and its constructor arg; select computer tool by priority names (`anthropic_computer`, `computer_anthropic`, `computer`) with suffix support.
>     - Stop setting `cache_control` on tool definitions; retain prompt caching on messages via `CacheControlEphemeralParam`.
>     - Simplify computer tool detection and mapping (`has_computer_tool` handling).
>   - *Cleanup*: Drop unused `re` and adjust imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ff1c6d2671396a9de451c8d32e925d737726b9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->