### PR TITLE
docs nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ OSS RL environment + evals toolkit. Wrap software as environments, run benchmark
 pip install hud-python
 
 # CLI - RL pipeline, environment design
-uv tool install hud-python
+uv tool install hud-python@latest
 # uv tool update-shell
 ```
 
@@ -298,7 +298,7 @@ Train with the new interactive `hud rl` flow:
 
 ```bash
 # Install CLI
-uv tool install hud-python
+uv tool install hud-python@latest
 
 # Option A: Run directly from a HuggingFace dataset
 hud rl hud-evals/2048-basic

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -36,7 +36,7 @@ pip install "hud-python[agent]"
 <Tab title="CLI Tools">
 ```bash
 # Install CLI in isolated environment
-uv tool install hud-python
+uv tool install hud-python@latest
 ```
 </Tab>
 </Tabs>

--- a/docs/reference/cli/overview.mdx
+++ b/docs/reference/cli/overview.mdx
@@ -30,7 +30,7 @@ The HUD CLI provides a complete toolkit for creating, developing, and running MC
 
 <CodeGroup>
 ```bash uv (Recommended)
-uv tool install hud-python
+uv tool install hud-python@latest
 hud --version
 ```
 

--- a/docs/train-agents/quickstart.mdx
+++ b/docs/train-agents/quickstart.mdx
@@ -20,7 +20,7 @@ hud set HUD_API_KEY=sk-hud-...
 Install and download a taskset:
 
 ```bash
-uv tool install hud-python
+uv tool install hud-python@latest
 hud get hud-evals/2048-basic
 ```
 
@@ -43,7 +43,7 @@ hud eval 2048-basic.json
 Use any provider with at least 2 GPUs (one for inference, one for training). Run locally with the flag `--local`:
 
 ```bash
-uv tool install hud-python
+uv tool install hud-python@latest
 hud get hud-evals/2048-basic
 hud rl 2048-basic.json --local
 ```

--- a/environments/README.md
+++ b/environments/README.md
@@ -60,7 +60,7 @@ The HUD SDK includes a powerful CLI for debugging and analyzing MCP environments
 
 ```bash
 # Install HUD CLI globally with uv (recommended)
-uv tool install hud-python
+uv tool install hud-python@latest
 
 # Or use without installing
 uvx --from hud-python hud --help


### PR DESCRIPTION
updates documentation to recommend installing the latest version of the `hud-python` CLI tool using `uv tool install hud-python@latest`
Related #204

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update docs to install the CLI with `uv tool install hud-python@latest` across README and CLI/RL quickstarts.
> 
> - **Docs**:
>   - Replace `uv tool install hud-python` with `uv tool install hud-python@latest` in:
>     - `README.md` (Installation, RL section)
>     - `docs/quickstart.mdx` (CLI Tools tab)
>     - `docs/reference/cli/overview.mdx` (Installation)
>     - `docs/train-agents/quickstart.mdx` (Quickstart, local run)
>     - `environments/README.md` (Installing the HUD CLI)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9b272f1bcbb5b5c89c6d2141c0b60967b61dcdef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->