### PR TITLE
update test command to exclude 'rl' option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           DISPLAY: :99
           XAUTHORITY: /dev/null
-        run: uv run --python ${{ matrix.python-version }} --with=".[dev]" pytest --rootdir=hud --cov --cov-report=''
+        run: uv run --python ${{ matrix.python-version }} --with=".[dev]" pytest --rootdir=hud --ignore=hud/rl/tests --cov --cov-report=''
 
   lint-ruff:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust CI test step to run pytest without the RL extra and skip `hud/rl/tests`.
> 
> - **CI**:
>   - **Tests**: Update pytest invocation in `.github/workflows/ci.yml` to drop `.[rl]` extra and ignore `hud/rl/tests` (`--with=".[dev]"` and `--ignore=hud/rl/tests`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c7b6c11b4341e8ec460b80f0403cd2359300e6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->