### PR TITLE
Emit scenario spans

### DIFF
--- a/hud/eval/context.py
+++ b/hud/eval/context.py
@@ -400,6 +400,9 @@ class EvalContext(Environment):
         error: str | None = None,
     ) -> None:
         """Emit a scenario lifecycle span for real-time stage visibility."""
+        if not self._trace_enabled:
+            return
+
         span = {
             "name": name,
             "trace_id": _normalize_trace_id(self.trace_id),

--- a/hud/eval/context.py
+++ b/hud/eval/context.py
@@ -476,6 +476,17 @@ class EvalContext(Environment):
 
         try:
             result = await self.run_scenario_evaluate(scenario_name)
+            self.evaluation_result = result
+            self.reward = result.reward
+
+            self._emit_scenario_span(
+                "scenario_evaluate",
+                "completed",
+                scenario_name,
+                start_time,
+                _now_iso(),
+                result={"reward": result.reward},
+            )
         except Exception as e:
             self.error = e
             self._emit_scenario_span(
@@ -486,20 +497,6 @@ class EvalContext(Environment):
                 _now_iso(),
                 error=str(e),
             )
-            return
-
-        self.evaluation_result = result
-        self.reward = result.reward
-
-        # Emit "completed" span with reward
-        self._emit_scenario_span(
-            "scenario_evaluate",
-            "completed",
-            scenario_name,
-            start_time,
-            _now_iso(),
-            result={"reward": result.reward} if result else None,
-        )
 
     # =========================================================================
     # Summary Context - Attribute Access Control


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new telemetry emission during scenario setup/evaluate and changes error handling flow in `_run_task_scenario_evaluate`, which could affect when results/errors are recorded and how they appear in traces.
> 
> **Overview**
> Adds explicit telemetry spans for scenario lifecycle events to improve real-time visibility of `setup` and `evaluate` stages.
> 
> `EvalContext` now emits `scenario_setup`/`scenario_evaluate` spans on start, completion, and error (including timestamps, normalized trace IDs, and optional reward/result metadata) via `queue_span`. Scenario setup now re-raises exceptions after emitting an error span, and scenario evaluate records `evaluation_result`/`reward` before emitting a completion span, while emitting an error span when evaluation fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0983cd58bc1008f5519d5d94fbbaa89af79fe89d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->