### PR TITLE
Don't shorten scenario name in sample task JSON

### DIFF
--- a/hud/cli/utils/build_display.py
+++ b/hud/cli/utils/build_display.py
@@ -206,8 +206,6 @@ def _display_usage_example(
 
     first = prompts[0]
     scenario_name = first.get("name", "default")
-    # scenario_name is typically "env-name:scenario-name"
-    short_name = scenario_name.split(":")[-1] if ":" in scenario_name else scenario_name
 
     args = first.get("arguments", [])
     example_args: dict[str, str] = {}
@@ -217,7 +215,7 @@ def _display_usage_example(
             example_args[arg_name] = "..."
 
     task_example: dict[str, Any] = {
-        "scenario": short_name,
+        "scenario": scenario_name,
         "env": {"name": env_name},
     }
     if example_args:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CLI display output for the quick-start Task JSON example and does not change deploy/build behavior or data handling.
> 
> **Overview**
> The CLI quick-start "Task JSON" example shown after a successful deploy now uses the **full** scenario name from the lock data rather than stripping everything before `:`.
> 
> This makes the displayed `scenario` value match the actual scenario identifier users should pass when running tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ba5d1349d4f002db665b17c9426d59912e6977c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->