### PR TITLE
Builds Refactor

### DIFF
--- a/hud/cli/analyze.py
+++ b/hud/cli/analyze.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from pathlib import Path  # noqa: TC003
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import typer
 from rich.console import Console
@@ -15,6 +16,9 @@ from rich.table import Table
 from rich.tree import Tree
 
 from hud.utils.hud_console import HUDConsole
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 console = Console()
 hud_console = HUDConsole()
@@ -112,19 +116,26 @@ async def analyze_environment(docker_cmd: list[str], output_format: str, verbose
 
         from fastmcp import Client as FastMCPClient
 
-        from hud.cli.utils.mcp import analyze_environment as mcp_analyze
+        from hud.cli.utils.analysis import analyze_environment as mcp_analyze
 
         client = FastMCPClient(transport=mcp_config)
         # Extract server name for display (first key in mcp_config)
         server_name = next(iter(mcp_config.keys()), None)
 
         try:
+            start_time = time.time()
             await client.__aenter__()
+            initialize_ms = int((time.time() - start_time) * 1000)
             progress.update(task, description="[green]✓ Client initialized[/green]")
 
             # Analyze environment
             progress.update(task, description="Analyzing environment...")
-            analysis = await mcp_analyze(client, verbose, server_name=server_name)
+            analysis = await mcp_analyze(
+                client,
+                verbose,
+                server_name=server_name,
+                initialize_ms=initialize_ms,
+            )
             progress.update(task, description="[green]✓ Analysis complete[/green]")
 
         except Exception as e:
@@ -154,7 +165,7 @@ async def analyze_environment(docker_cmd: list[str], output_format: str, verbose
         display_interactive(analysis)
 
 
-def display_interactive(analysis: dict) -> None:
+def display_interactive(analysis: Mapping[str, Any]) -> None:
     """Display analysis results in interactive format."""
     # Server metadata
     hud_console.section_title("📊 Environment Overview")
@@ -201,13 +212,13 @@ def display_interactive(analysis: dict) -> None:
     hud_console.section_title("🔧 Available Tools")
     tools_tree = Tree("[bold bright_white]Tools[/bold bright_white]")
 
-    # Check if we have hub_tools info (live analysis) or not (metadata-only)
-    if "hub_tools" in analysis:
+    # Check if we have hubTools info (live analysis) or not (metadata-only)
+    if "hubTools" in analysis:
         # Live analysis format - separate regular and hub tools
         # Regular tools
         regular_tools = tools_tree.add("[bright_white]Regular Tools[/bright_white]")
         for tool in analysis["tools"]:
-            if tool["name"] not in analysis["hub_tools"]:
+            if tool["name"] not in analysis["hubTools"]:
                 tool_node = regular_tools.add(f"[bright_white]{tool['name']}[/bright_white]")
                 if tool["description"]:
                     tool_node.add(f"[bright_black]{tool['description']}[/bright_black]")
@@ -219,9 +230,9 @@ def display_interactive(analysis: dict) -> None:
                     tool_node.add(syntax)
 
         # Hub tools
-        if analysis["hub_tools"]:
+        if analysis["hubTools"]:
             hub_tools = tools_tree.add("[bright_white]Hub Tools[/bright_white]")
-            for hub_name, functions in analysis["hub_tools"].items():
+            for hub_name, functions in analysis["hubTools"].items():
                 hub_node = hub_tools.add(f"[rgb(181,137,0)]{hub_name}[/rgb(181,137,0)]")
                 for func in functions:
                     hub_node.add(f"[bright_white]{func}[/bright_white]")
@@ -314,7 +325,7 @@ def display_interactive(analysis: dict) -> None:
         console.print(env_table)
 
 
-def display_markdown(analysis: dict) -> None:
+def display_markdown(analysis: Mapping[str, Any]) -> None:
     """Display analysis results in markdown format."""
     md = []
     md.append("# MCP Environment Analysis\n")
@@ -344,19 +355,19 @@ def display_markdown(analysis: dict) -> None:
     # Tools
     md.append("## Available Tools\n")
 
-    # Check if we have hub_tools info (live analysis) or not (metadata-only)
-    if "hub_tools" in analysis:
+    # Check if we have hubTools info (live analysis) or not (metadata-only)
+    if "hubTools" in analysis:
         # Regular tools
         md.append("### Regular Tools")
         for tool in analysis["tools"]:
-            if tool["name"] not in analysis["hub_tools"]:
+            if tool["name"] not in analysis["hubTools"]:
                 md.extend([f"- **{tool['name']}**: {tool.get('description', 'No description')}"])
         md.append("")
 
         # Hub tools
-        if analysis["hub_tools"]:
+        if analysis["hubTools"]:
             md.append("### Hub Tools")
-            for hub_name, functions in analysis["hub_tools"].items():
+            for hub_name, functions in analysis["hubTools"].items():
                 md.extend([f"- **{hub_name}**"])
                 for func in functions:
                     md.extend([f"  - {func}"])
@@ -469,18 +480,26 @@ async def _analyze_with_config(
 
         from fastmcp import Client as FastMCPClient
 
-        from hud.cli.utils.mcp import analyze_environment as mcp_analyze
+        from hud.cli.utils.analysis import analyze_environment as mcp_analyze
 
         config = _prepare_mcp_config(mcp_config)
         client = FastMCPClient(transport=config)
+        server_name = next(iter(config.keys()), None)
 
         try:
+            start_time = time.time()
             await client.__aenter__()
+            initialize_ms = int((time.time() - start_time) * 1000)
             progress.update(task, description="[green]✓ Client initialized[/green]")
 
             # Analyze environment
             progress.update(task, description="Analyzing environment...")
-            analysis = await mcp_analyze(client, verbose)
+            analysis = await mcp_analyze(
+                client,
+                verbose,
+                server_name=server_name,
+                initialize_ms=initialize_ms,
+            )
             progress.update(task, description="[green]✓ Analysis complete[/green]")
 
         except Exception as e:

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -1211,28 +1211,18 @@ def build_command(
         hud build . --no-cache       # Force rebuild
         hud build . --build-arg NODE_ENV=production  # Pass Docker build args
         hud build . --secret id=MY_KEY,env=MY_KEY  # Pass build secrets
-        hud build . -- --push        # Push to registry after build[/not dim]
+        hud build . --push                         # Push to registry after build[/not dim]
     """
     if params:
-        # Split at -- separator: everything after goes to Docker as passthrough
-        if "--" in params:
-            sep_idx = params.index("--")
-            hud_params = params[:sep_idx]
-            docker_args: list[str] | None = params[sep_idx + 1 :] or None
-        else:
-            hud_params = params
-            docker_args = None
-
-        directory = hud_params[0] if hud_params else "."
-        extra_args = hud_params[1:] if len(hud_params) > 1 else []
+        directory = params[0]
+        extra_args = params[1:] if len(params) > 1 else []
     else:
         directory = "."
         extra_args = []
-        docker_args = None
 
     from hud.cli.utils.args import split_docker_passthrough
 
-    env_vars, build_args, _ = split_docker_passthrough(extra_args)
+    env_vars, build_args, docker_args = split_docker_passthrough(extra_args)
 
     build_environment(
         directory,
@@ -1243,5 +1233,5 @@ def build_command(
         platform,
         secrets,
         build_args=build_args or None,
-        docker_args=docker_args,
+        docker_args=docker_args or None,
     )

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -656,25 +656,30 @@ def build_docker_image(
     build_args: dict[str, str] | None = None,
     platform: str | None = None,
     secrets: list[str] | None = None,
-    remote_cache: str | None = None,
+    docker_args: list[str] | None = None,
 ) -> bool:
-    """Build a Docker image from a directory."""
+    """Build a Docker image from a directory.
+
+    Wraps ``docker build`` (or ``docker buildx build`` when Docker-specific
+    flags are passed via *docker_args*).  Any flags that Docker understands
+    (``--cache-from``, ``--push``, ``--load``, etc.) belong in *docker_args*
+    and are appended to the command as-is.
+    """
     hud_console = HUDConsole()
     build_args = build_args or {}
     secrets = secrets or []
+    docker_args = docker_args or []
 
-    # Check if Dockerfile exists (prefer Dockerfile.hud)
     dockerfile = find_dockerfile(directory)
     if dockerfile is None:
         hud_console.error(f"No Dockerfile found in {directory}")
         hud_console.info("Expected: Dockerfile.hud or Dockerfile")
         return False
 
-    # Build command - use buildx when remote cache is enabled
+    needs_buildx = any(a.startswith("--cache") or a in ("--push", "--load") for a in docker_args)
     effective_platform = platform if platform is not None else "linux/amd64"
-    cmd = ["docker", "buildx", "build"] if remote_cache else ["docker", "build"]
+    cmd = ["docker", "buildx", "build"] if needs_buildx else ["docker", "build"]
 
-    # Specify dockerfile explicitly if not the default name
     if dockerfile.name != "Dockerfile":
         cmd.extend(["-f", str(dockerfile)])
 
@@ -684,64 +689,24 @@ def build_docker_image(
     if no_cache:
         cmd.append("--no-cache")
 
-    # Add remote cache support for ECR
-    if remote_cache:
-        try:
-            # Validate ECR repo name
-            if not re.match(r"^[a-z0-9]([a-z0-9\-_/]*[a-z0-9])?$", remote_cache):
-                hud_console.error(f"Invalid ECR repo name: {remote_cache}")
-                hud_console.info(
-                    "ECR repo names must contain only lowercase letters, numbers, hyphens, underscores, and forward slashes"  # noqa: E501
-                )
-                return False
+    # Passthrough: cache, push, and any other Docker-native flags
+    cmd.extend(docker_args)
 
-            # Get required environment variables
-            aws_account_id = os.getenv("AWS_ACCOUNT_ID")
-            aws_region = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+    # Auto-add --load for buildx when caller didn't specify an output mode
+    if needs_buildx and "--push" not in docker_args and "--load" not in docker_args:
+        cmd.append("--load")
 
-            if not aws_account_id:
-                hud_console.error("AWS_ACCOUNT_ID environment variable not set")
-                return False
-
-            # ECR cache image reference
-            cache_image = (
-                f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/{remote_cache}:cache"
-            )
-
-            # Add cache arguments with proper ECR format
-            cmd.extend(
-                [
-                    "--cache-from",
-                    f"type=registry,ref={cache_image}",
-                    "--cache-to",
-                    f"mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref={cache_image}",
-                    "--load",  # Load image to local Docker after build
-                ]
-            )
-
-            hud_console.success(f"Remote cache configured: {cache_image}")
-
-        except typer.Exit:
-            raise
-        except Exception as e:
-            hud_console.error(f"Remote cache setup error: {e}")
-            return False
-
-    # Add build args
     for key, value in build_args.items():
         cmd.extend(["--build-arg", f"{key}={value}"])
 
-    # Add secrets
     for secret in secrets:
         cmd.extend(["--secret", secret])
 
     cmd.append(str(directory))
 
-    # Always show build output
     hud_console.info(f"Running: {' '.join(cmd)}")
 
     try:
-        # Use Docker's native output formatting - no capture, let Docker handle display
         env = os.environ.copy()
         if secrets:
             env["DOCKER_BUILDKIT"] = "1"
@@ -760,8 +725,8 @@ def build_environment(
     env_vars: dict[str, str] | None = None,
     platform: str | None = None,
     secrets: list[str] | None = None,
-    remote_cache: str | None = None,
     build_args: dict[str, str] | None = None,
+    docker_args: list[str] | None = None,
 ) -> None:
     """Build a HUD environment and generate lock file."""
     hud_console = HUDConsole()
@@ -822,26 +787,58 @@ def build_environment(
         # No tag provided - we'll add version later
         image_tag = None
 
-    # Build temporary image first
-    temp_tag = f"hud-build-temp:{int(time.time())}"
+    # Compute version before building (needed for image tags when --push is used)
+    existing_version = get_existing_version(lock_path)
+    if existing_version:
+        new_version = increment_version(existing_version)
+        hud_console.info(f"Incrementing version: {existing_version} → {new_version}")
+    else:
+        new_version = "0.1.0"
+        hud_console.info(f"Setting initial version: {new_version}")
 
-    hud_console.progress_message(f"Building Docker image: {temp_tag}")
+    # Detect --push in docker passthrough args
+    pushing = "--push" in (docker_args or [])
+
+    # Set up build tags
+    if pushing:
+        if not tag:
+            hud_console.error("--push requires --tag with a registry-qualified image name")
+            raise typer.Exit(1)
+        build_tag = tag
+        hud_console.progress_message("Building and pushing Docker image...")
+    else:
+        build_tag = f"hud-build-temp:{int(time.time())}"
+        hud_console.progress_message(f"Building Docker image: {build_tag}")
 
     # Build the image (env vars are for runtime, not build time)
     if not build_docker_image(
         env_dir,
-        temp_tag,
+        build_tag,
         no_cache,
         verbose,
         build_args=build_args or None,
         platform=platform,
         secrets=secrets,
-        remote_cache=remote_cache,
+        docker_args=docker_args,
     ):
         hud_console.error("Docker build failed")
         raise typer.Exit(1)
 
-    hud_console.success(f"Built temporary image: {temp_tag}")
+    # Get image locally for analysis
+    if pushing:
+        hud_console.success(f"Pushed image: {build_tag}")
+        hud_console.progress_message("Pulling image for analysis...")
+        pull_result = subprocess.run(
+            ["docker", "pull", build_tag],  # noqa: S607
+            check=False,
+        )
+        if pull_result.returncode != 0:
+            hud_console.error(f"Failed to pull image: {build_tag}")
+            raise typer.Exit(1)
+        analysis_image = build_tag
+    else:
+        analysis_image = build_tag
+        hud_console.success(f"Built temporary image: {build_tag}")
 
     # Analyze the environment (merge folder .env if present)
     hud_console.progress_message("Analyzing MCP environment...")
@@ -859,13 +856,13 @@ def build_environment(
         merged_env_for_analysis = {**env_from_file, **(env_vars or {})}
 
         analysis = loop.run_until_complete(
-            analyze_mcp_environment(temp_tag, verbose, merged_env_for_analysis)
+            analyze_mcp_environment(analysis_image, verbose, merged_env_for_analysis)
         )
     except Exception as e:
         hud_console.error(f"Failed to analyze MCP environment: {e}")
         hud_console.info("")
         hud_console.info("To debug this issue, run:")
-        hud_console.command_example(f"hud debug {temp_tag}")
+        hud_console.command_example(f"hud debug {analysis_image}")
         hud_console.info("")
         raise typer.Exit(1) from e
     finally:
@@ -913,25 +910,12 @@ def build_environment(
     if secret_vars:
         display_secrets_warning(secret_vars)
 
-    # Check for existing version and increment
-    lock_path = env_dir / "hud.lock.yaml"
-    existing_version = get_existing_version(lock_path)
-
-    if existing_version:
-        # Increment existing version
-        new_version = increment_version(existing_version)
-        hud_console.info(f"Incrementing version: {existing_version} → {new_version}")
-    else:
-        # Start with 0.1.0 for new environments
-        new_version = "0.1.0"
-        hud_console.info(f"Setting initial version: {new_version}")
-
     # Determine base name for image references
     if image_tag:
         base_name = image_tag.split(":")[0] if ":" in image_tag else image_tag
 
     # Collect runtime metadata and compute base image/platform
-    runtime_info = collect_runtime_metadata(temp_tag, verbose=verbose)
+    runtime_info = collect_runtime_metadata(analysis_image, verbose=verbose)
     base_image = parse_base_image(dockerfile_path)
     effective_platform = platform if platform is not None else "linux/amd64"
 
@@ -1054,129 +1038,101 @@ def build_environment(
     lock_hash = hashlib.sha256(lock_content_str.encode()).hexdigest()
     lock_size = len(lock_content_str)
 
-    # Rebuild with label containing lock file hash
-    hud_console.progress_message("Rebuilding with lock file metadata...")
-
-    # Build final image with label (uses cache from first build)
-    # Create tags: versioned and latest (and custom tag if provided)
     version_tag = f"{base_name}:{new_version}"
     latest_tag = f"{base_name}:latest"
 
-    # Build command - use buildx when remote cache is enabled
-    label_cmd = ["docker", "buildx", "build"] if remote_cache else ["docker", "build"]
-
-    # Specify dockerfile explicitly if not the default name
-    if dockerfile_path and dockerfile_path.name != "Dockerfile":
-        label_cmd.extend(["-f", str(dockerfile_path)])
-
-    # Use same defaulting for the second build step
-    label_platform = platform if platform is not None else "linux/amd64"
-    if label_platform:
-        label_cmd.extend(["--platform", label_platform])
-
-    # Add remote cache support for final build
-    if remote_cache:
-        try:
-            if not re.match(r"^[a-z0-9]([a-z0-9\-_/]*[a-z0-9])?$", remote_cache):
-                hud_console.error(f"Invalid ECR repo name: {remote_cache}")
-                raise typer.Exit(1)
-
-            aws_account_id = os.getenv("AWS_ACCOUNT_ID")
-            aws_region = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
-
-            if not aws_account_id:
-                hud_console.error("AWS_ACCOUNT_ID environment variable not set")
-                raise typer.Exit(1)
-
-            cache_image = (
-                f"{aws_account_id}.dkr.ecr.{aws_region}.amazonaws.com/{remote_cache}:cache"
-            )
-
-            label_cmd.extend(
-                [
-                    "--cache-from",
-                    f"type=registry,ref={cache_image}",
-                    "--cache-to",
-                    f"mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref={cache_image}",
-                    "--load",  # Load image to local Docker after build
-                ]
-            )
-        except typer.Exit:
-            raise
-        except Exception as e:
-            hud_console.error(f"Remote cache setup error: {e}")
-            raise typer.Exit(1) from e
-
-    label_cmd.extend(
-        [
-            "--label",
-            f"org.hud.manifest.head={lock_hash}:{lock_size}",
-            "--label",
-            f"org.hud.version={new_version}",
-            "-t",
-            version_tag,  # Always tag with new version
-            "-t",
-            latest_tag,  # Always tag with latest
-        ]
-    )
-
-    # Add custom tag if user provided one
-    if image_tag and image_tag not in [version_tag, latest_tag]:
-        label_cmd.extend(["-t", image_tag])
-
-    # Add build args to final image build (same as initial build)
-    for key, value in build_args.items():
-        label_cmd.extend(["--build-arg", f"{key}={value}"])
-
-    # Add secrets to final image build (same as initial build)
-    for secret in secrets or []:
-        label_cmd.extend(["--secret", secret])
-
-    label_cmd.append(str(env_dir))
-
-    # Run rebuild using Docker's native output formatting
-    env = os.environ.copy()
-    if secrets:
-        env["DOCKER_BUILDKIT"] = "1"
-    if verbose:
-        # Show Docker's native output when verbose
-        result = subprocess.run(label_cmd, check=False, env=env)
-    else:
-        # Capture output for error reporting, but don't show unless it fails
-        result = subprocess.run(label_cmd, capture_output=True, text=True, check=False, env=env)
-
-    if result.returncode != 0:
-        hud_console.error("Failed to rebuild with label")
-        if not verbose and result.stderr:
-            hud_console.info("Error output:")
-            hud_console.info(str(result.stderr))
-        if not verbose:
-            hud_console.info("")
-            hud_console.info("Run with --verbose to see full build output:")
-            hud_console.command_example("hud build --verbose")
-        raise typer.Exit(1)
-
-    hud_console.success("Built final image with lock file metadata")
-
-    # NOW get the image ID after the final build
-    image_id = get_docker_image_id(version_tag)
-    if image_id:
-        # Store full reference with digest
-        if image_id.startswith("sha256:"):
-            lock_content["images"]["full"] = f"{version_tag}@{image_id}"
+    if pushing:
+        # Image already pushed — get digest from pulled image
+        image_id = get_docker_image_id(analysis_image)
+        if image_id:
+            if image_id.startswith("sha256:"):
+                lock_content["images"]["full"] = f"{analysis_image}@{image_id}"
+            else:
+                lock_content["images"]["full"] = f"{analysis_image}@sha256:{image_id}"
+            with open(lock_path, "w") as f:
+                yaml.dump(lock_content, f, default_flow_style=False, sort_keys=False)
+            hud_console.success("Updated lock file with image digest")
         else:
-            lock_content["images"]["full"] = f"{version_tag}@sha256:{image_id}"
-
-        # Update the lock file with the full image reference
-        with open(lock_path, "w") as f:
-            yaml.dump(lock_content, f, default_flow_style=False, sort_keys=False)
-
-        hud_console.success("Updated lock file with image digest")
+            hud_console.warning("Could not retrieve image digest")
+        subprocess.run(["docker", "rmi", "-f", analysis_image], capture_output=True)  # noqa: S607
     else:
-        hud_console.warning("Could not retrieve image digest")
+        # Rebuild with label containing lock file hash
+        hud_console.progress_message("Rebuilding with lock file metadata...")
 
-    # Remove temp image after we're done
-    subprocess.run(["docker", "rmi", "-f", temp_tag], capture_output=True)  # noqa: S607
+        # Reuse cache flags from docker_args for the label rebuild, but never --push
+        label_docker_args = [a for a in (docker_args or []) if a != "--push"]
+        needs_buildx = any(a.startswith("--cache") or a == "--load" for a in label_docker_args)
+        label_cmd = ["docker", "buildx", "build"] if needs_buildx else ["docker", "build"]
+
+        if dockerfile_path and dockerfile_path.name != "Dockerfile":
+            label_cmd.extend(["-f", str(dockerfile_path)])
+
+        label_platform = platform if platform is not None else "linux/amd64"
+        if label_platform:
+            label_cmd.extend(["--platform", label_platform])
+
+        label_cmd.extend(label_docker_args)
+        if needs_buildx and "--load" not in label_docker_args:
+            label_cmd.append("--load")
+
+        label_cmd.extend(
+            [
+                "--label",
+                f"org.hud.manifest.head={lock_hash}:{lock_size}",
+                "--label",
+                f"org.hud.version={new_version}",
+                "-t",
+                version_tag,
+                "-t",
+                latest_tag,
+            ]
+        )
+
+        if image_tag and image_tag not in [version_tag, latest_tag]:
+            label_cmd.extend(["-t", image_tag])
+
+        for key, value in build_args.items():
+            label_cmd.extend(["--build-arg", f"{key}={value}"])
+
+        for secret in secrets or []:
+            label_cmd.extend(["--secret", secret])
+
+        label_cmd.append(str(env_dir))
+
+        env = os.environ.copy()
+        if secrets:
+            env["DOCKER_BUILDKIT"] = "1"
+        if verbose:
+            result = subprocess.run(label_cmd, check=False, env=env)
+        else:
+            result = subprocess.run(label_cmd, capture_output=True, text=True, check=False, env=env)
+
+        if result.returncode != 0:
+            hud_console.error("Failed to rebuild with label")
+            if not verbose and result.stderr:
+                hud_console.info("Error output:")
+                hud_console.info(str(result.stderr))
+            if not verbose:
+                hud_console.info("")
+                hud_console.info("Run with --verbose to see full build output:")
+                hud_console.command_example("hud build --verbose")
+            raise typer.Exit(1)
+
+        hud_console.success("Built final image with lock file metadata")
+
+        image_id = get_docker_image_id(version_tag)
+        if image_id:
+            if image_id.startswith("sha256:"):
+                lock_content["images"]["full"] = f"{version_tag}@{image_id}"
+            else:
+                lock_content["images"]["full"] = f"{version_tag}@sha256:{image_id}"
+            with open(lock_path, "w") as f:
+                yaml.dump(lock_content, f, default_flow_style=False, sort_keys=False)
+            hud_console.success("Updated lock file with image digest")
+        else:
+            hud_console.warning("Could not retrieve image digest")
+
+        subprocess.run(["docker", "rmi", "-f", build_tag], capture_output=True)  # noqa: S607
 
     # Update tasks.json files with new version
     hud_console.progress_message("Updating task files with new version...")
@@ -1238,9 +1194,6 @@ def build_command(
         "--secret",
         help=("Docker build secret (repeatable), e.g. --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN"),
     ),
-    remote_cache: str | None = typer.Option(
-        None, "--remote-cache", help="Enable remote cache using Amazon ECR with specified repo name"
-    ),
 ) -> None:
     """🏗️ Build a HUD environment and generate lock file.
 
@@ -1249,22 +1202,33 @@ def build_command(
     - Analyzes the MCP server to extract metadata
     - Generates a hud.lock.yaml file for reproducibility
 
+    Docker flags (--cache-from, --push, etc.) can be passed after --.
+
     Examples:
         hud build                    # Build current directory
         hud build environments/text_2048 -e API_KEY=secret
         hud build . --tag my-env:v1.0 -e VAR1=value1 -e VAR2=value2
         hud build . --no-cache       # Force rebuild
-        hud build . --remote-cache my-cache-repo   # Use ECR remote cache (requires AWS_ACCOUNT_ID and AWS_DEFAULT_REGION)
         hud build . --build-arg NODE_ENV=production  # Pass Docker build args
-        hud build . --secret id=MY_KEY,env=MY_KEY  # Pass build secrets, reading $MY_KEY env var. These will be encrypted at rest.
-        hud build . --secret id=MY_KEY,src=./my_key.txt  # Pass build secret from file.[/not dim]
-    """  # noqa: E501
+        hud build . --secret id=MY_KEY,env=MY_KEY  # Pass build secrets
+        hud build . -- --push        # Push to registry after build[/not dim]
+    """
     if params:
-        directory = params[0]
-        extra_args = params[1:] if len(params) > 1 else []
+        # Split at -- separator: everything after goes to Docker as passthrough
+        if "--" in params:
+            sep_idx = params.index("--")
+            hud_params = params[:sep_idx]
+            docker_args: list[str] | None = params[sep_idx + 1 :] or None
+        else:
+            hud_params = params
+            docker_args = None
+
+        directory = hud_params[0] if hud_params else "."
+        extra_args = hud_params[1:] if len(hud_params) > 1 else []
     else:
         directory = "."
         extra_args = []
+        docker_args = None
 
     from hud.cli.utils.args import split_docker_passthrough
 
@@ -1278,6 +1242,6 @@ def build_command(
         env_vars or None,
         platform,
         secrets,
-        remote_cache,
-        build_args or None,
+        build_args=build_args or None,
+        docker_args=docker_args,
     )

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -10,18 +10,21 @@ import os
 import re
 import subprocess
 import time
-from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import typer
-import yaml
 
 from hud.cli.utils.environment import find_dockerfile
-from hud.cli.utils.source_hash import compute_source_hash, list_source_files
+from hud.cli.utils.lockfile import (
+    build_lock_data,
+    dump_lock_data,
+)
 from hud.shared.hints import render_hints, secrets_in_build_args
 from hud.utils.hud_console import HUDConsole
-from hud.version import __version__ as hud_version
+
+if TYPE_CHECKING:
+    from hud.cli.utils.analysis import BuildAnalysis
 
 
 def parse_version(version_str: str) -> tuple[int, int, int]:
@@ -372,9 +375,17 @@ def display_secrets_warning(secret_vars: list[str]) -> None:
     hud_console.print("")
 
 
+def _has_build_output_arg(docker_args: list[str]) -> bool:
+    """Return True when *docker_args* already choose a build output mode."""
+    return any(
+        arg in ("--push", "--load", "--output", "-o") or arg.startswith(("--output=", "-o="))
+        for arg in docker_args
+    )
+
+
 async def analyze_mcp_environment(
     image: str, verbose: bool = False, env_vars: dict[str, str] | None = None
-) -> dict[str, Any]:
+) -> BuildAnalysis:
     """Analyze an MCP environment to extract metadata.
 
     Supports both stdio (default) and HTTP transport.  The transport is
@@ -382,27 +393,28 @@ async def analyze_mcp_environment(
     """
     from fastmcp import Client as FastMCPClient
 
+    from hud.cli.utils.analysis import analyze_environment
     from hud.cli.utils.docker import (
         DEFAULT_HTTP_PORT,
         build_env_flags,
         detect_transport,
         stop_container,
     )
-    from hud.cli.utils.mcp import analyze_environment
 
     hud_console = HUDConsole()
     env_vars = env_vars or {}
     transport_mode, container_port = detect_transport(image)
     is_http = transport_mode == "http"
     container_name: str | None = None
+    server_url: str | None = None
     initialized = False
     client: Any = None
 
     try:
         # --- transport-specific setup ---
         if is_http:
+            from hud.cli.utils.analysis import wait_for_http_server
             from hud.cli.utils.logging import find_free_port
-            from hud.cli.utils.mcp import wait_for_http_server
 
             port = container_port or DEFAULT_HTTP_PORT
             host_port = find_free_port(port)
@@ -468,6 +480,7 @@ async def analyze_mcp_environment(
             hud_console.info("Initializing MCP client...")
 
         if is_http:
+            assert server_url is not None
             await wait_for_http_server(  # type: ignore[possibly-undefined]
                 server_url, timeout_seconds=60.0
             )
@@ -478,8 +491,12 @@ async def analyze_mcp_environment(
         initialized = True
         initialize_ms = int((time.time() - start_time) * 1000)
 
-        full_analysis = await analyze_environment(client, verbose, server_name=server_name)
-        return _build_analysis_result(full_analysis, initialize_ms)
+        return await analyze_environment(
+            client,
+            verbose,
+            server_name=server_name,
+            initialize_ms=initialize_ms,
+        )
     except TimeoutError:
         from hud.shared.exceptions import HudException
 
@@ -507,61 +524,6 @@ async def analyze_mcp_environment(
             stop_container(container_name)
 
 
-def _build_analysis_result(full_analysis: dict[str, Any], initialize_ms: int) -> dict[str, Any]:
-    """Normalize the raw analysis dict into the build-lock result format."""
-    tools_list = full_analysis.get("tools", [])
-    hub_map = full_analysis.get("hub_tools", {}) or full_analysis.get("hubTools", {})
-
-    normalized_tools: list[dict[str, Any]] = []
-    internal_total = 0
-    for t in tools_list:
-        if hasattr(t, "name"):
-            name = getattr(t, "name", None)
-            description = getattr(t, "description", None)
-            input_schema = getattr(t, "inputSchema", None)
-            existing_internal = getattr(t, "internalTools", None)
-        else:
-            name = t.get("name")
-            description = t.get("description")
-            input_schema = t.get("inputSchema") or t.get("input_schema")
-            existing_internal = t.get("internalTools") or t.get("internal_tools")
-
-        tool_entry: dict[str, Any] = {"name": name}
-        if description:
-            tool_entry["description"] = description
-        if input_schema:
-            tool_entry["inputSchema"] = input_schema
-
-        merged_internal: list[str] = []
-        if isinstance(existing_internal, list):
-            merged_internal.extend([str(x) for x in existing_internal])
-        if isinstance(hub_map, dict) and name in hub_map and isinstance(hub_map[name], list):
-            merged_internal.extend([str(x) for x in hub_map[name]])
-        if merged_internal:
-            merged_internal = list(dict.fromkeys(merged_internal))
-            tool_entry["internalTools"] = merged_internal
-            internal_total += len(merged_internal)
-
-        normalized_tools.append(tool_entry)
-
-    result: dict[str, Any] = {
-        "initializeMs": initialize_ms,
-        "toolCount": len(tools_list),
-        "internalToolCount": internal_total,
-        "tools": normalized_tools,
-        "success": True,
-    }
-    if hub_map:
-        result["hub_tools"] = hub_map
-    if full_analysis.get("prompts"):
-        result["prompts"] = full_analysis["prompts"]
-    if full_analysis.get("resources"):
-        result["resources"] = full_analysis["resources"]
-    if "scenarios" in full_analysis:
-        result["scenarios"] = full_analysis["scenarios"]
-    return result
-
-
 def build_docker_image(
     directory: Path,
     tag: str,
@@ -574,10 +536,11 @@ def build_docker_image(
 ) -> bool:
     """Build a Docker image from a directory.
 
-    Wraps ``docker build`` (or ``docker buildx build`` when Docker-specific
-    flags are passed via *docker_args*).  Any flags that Docker understands
+    Wraps ``docker buildx build``. Any flags that Docker understands
     (``--cache-from``, ``--push``, ``--load``, etc.) belong in *docker_args*
-    and are appended to the command as-is.
+    and are appended to the command as-is. Unless the caller explicitly picks
+    an output mode, the result is loaded into the host daemon for local
+    analysis/debugging.
     """
     hud_console = HUDConsole()
     build_args = build_args or {}
@@ -590,9 +553,8 @@ def build_docker_image(
         hud_console.info("Expected: Dockerfile.hud or Dockerfile")
         return False
 
-    needs_buildx = any(a.startswith("--cache") or a in ("--push", "--load") for a in docker_args)
     effective_platform = platform if platform is not None else "linux/amd64"
-    cmd = ["docker", "buildx", "build"] if needs_buildx else ["docker", "build"]
+    cmd = ["docker", "buildx", "build"]
 
     if dockerfile.name != "Dockerfile":
         cmd.extend(["-f", str(dockerfile)])
@@ -606,8 +568,9 @@ def build_docker_image(
     # Passthrough: cache, push, and any other Docker-native flags
     cmd.extend(docker_args)
 
-    # Auto-add --load for buildx when caller didn't specify an output mode
-    if needs_buildx and "--push" not in docker_args and "--load" not in docker_args:
+    # Local hud build expects a daemon-loaded image unless the caller explicitly
+    # selects another buildx output mode such as --push/--output.
+    if not _has_build_output_arg(docker_args):
         cmd.append("--load")
 
     for key, value in build_args.items():
@@ -798,7 +761,7 @@ def build_environment(
 
     # Extract environment variables from Dockerfile
     dockerfile_path = find_dockerfile(env_dir) or env_dir / "Dockerfile"
-    required_env, optional_env = extract_env_vars_from_dockerfile(dockerfile_path)
+    required_env, _optional_env = extract_env_vars_from_dockerfile(dockerfile_path)
 
     # Show env vars detected from .env file
     if env_from_file:
@@ -828,124 +791,30 @@ def build_environment(
     if image_tag:
         base_name = image_tag.split(":")[0] if ":" in image_tag else image_tag
 
-    # Collect base image/platform metadata for the lock file
-    base_image = parse_base_image(dockerfile_path)
     effective_platform = platform if platform is not None else "linux/amd64"
 
-    # Create lock file content with images subsection at top
-    lock_content = {
-        "version": "1.3",  # Lock file format version
-        "images": {
-            "local": f"{base_name}:{new_version}",  # Local tag with version
-            "full": None,  # Will be set with digest after build
-            "pushed": None,  # Will be set by hud push
-        },
-        "build": {
-            "generatedAt": datetime.now(UTC).isoformat() + "Z",
-            "hudVersion": hud_version,
-            "directory": str(env_dir.name),
-            "version": new_version,
-            # Fast source fingerprint for change detection
-            "sourceHash": compute_source_hash(env_dir),
-            "baseImage": base_image,
-            "platform": effective_platform,
-        },
-        "environment": {
-            "initializeMs": analysis["initializeMs"],
-            "toolCount": analysis["toolCount"],
-        },
-    }
-
-    internal_count = int(analysis.get("internalToolCount", 0) or 0)
-    lock_content["environment"]["internalToolCount"] = internal_count
-
-    # Add environment variables section if any exist
-    # Include env vars from .env file as well
     env_vars_from_file = set(env_from_file.keys()) if env_from_file else set()
-
-    # Check if we have any env vars to document
-    has_env_vars = bool(required_env or optional_env or env_vars or env_vars_from_file)
-
-    if has_env_vars:
-        lock_content["environment"]["variables"] = {}
-
-        # Add note about editing environment variables
-        lock_content["environment"]["variables"]["_note"] = (
-            "You can edit this section to add or modify environment variables. "
-            "Provided variables will be used when running the environment."
-        )
-
-        # Combine all required variables: from Dockerfile, .env file, and provided vars
-        all_required = set(required_env)
-
-        # Add all env vars from .env file to required
-        all_required.update(env_vars_from_file)
-
-        # Add all provided env vars to required
-        if env_vars:
-            all_required.update(env_vars.keys())
-
-        # Remove any that are optional - they stay in optional
-        all_required = all_required - set(optional_env)
-
-        if all_required:
-            lock_content["environment"]["variables"]["required"] = sorted(list(all_required))
-        if optional_env:
-            lock_content["environment"]["variables"]["optional"] = optional_env
-
-    # Add tools with full schemas for RL config generation
-    if analysis["tools"]:
-        tools_serialized: list[dict[str, Any]] = []
-        for tool in analysis["tools"]:
-            entry: dict[str, Any] = {
-                "name": tool["name"],
-                # Preserve legacy shape: always include description/inputSchema
-                "description": tool.get("description", ""),
-                "inputSchema": tool.get("inputSchema", {}),
-            }
-            if tool.get("internalTools"):
-                entry["internalTools"] = tool.get("internalTools")
-            tools_serialized.append(entry)
-        lock_content["tools"] = tools_serialized
-
-    # Add hub tools if present (analyze_environment returns hub_tools with snake_case)
-    hub_tools = analysis.get("hub_tools") or analysis.get("hubTools")
-    if hub_tools:
-        lock_content["hubTools"] = hub_tools
-
-    # Add prompts if present
-    prompts = analysis.get("prompts")
-    if prompts:
-        lock_content["prompts"] = prompts
-
-    # Add resources if present
-    resources = analysis.get("resources")
-    if resources:
-        lock_content["resources"] = resources
-
-    # Add scenarios if present
-    if "scenarios" in analysis:
-        lock_content["scenarios"] = analysis["scenarios"]
+    lock_content = build_lock_data(
+        source_dir=env_dir,
+        analysis=analysis,
+        version=new_version,
+        image_name=base_name,
+        full_image_ref=None,
+        pushed_image_ref=None,
+        env_vars=env_vars or None,
+        additional_required_env_vars=env_vars_from_file,
+        platform=effective_platform,
+    )
 
     # Write lock file
     lock_path = env_dir / "hud.lock.yaml"
     with open(lock_path, "w") as f:
-        yaml.dump(lock_content, f, default_flow_style=False, sort_keys=False)
-
-    # Also write the file list we hashed for transparency (non-essential)
-    with contextlib.suppress(Exception):
-        files = [
-            str(p.resolve().relative_to(env_dir)).replace("\\", "/")
-            for p in list_source_files(env_dir)
-        ]
-        lock_content["build"]["sourceFiles"] = files
-        with open(lock_path, "w") as f:
-            yaml.dump(lock_content, f, default_flow_style=False, sort_keys=False)
+        f.write(dump_lock_data(lock_content))
 
     hud_console.success("Created lock file: hud.lock.yaml")
 
     # Calculate lock file hash
-    lock_content_str = yaml.dump(lock_content, default_flow_style=False, sort_keys=True)
+    lock_content_str = dump_lock_data(lock_content, sort_keys=True)
     lock_hash = hashlib.sha256(lock_content_str.encode()).hexdigest()
     lock_size = len(lock_content_str)
 
@@ -961,7 +830,7 @@ def build_environment(
             else:
                 lock_content["images"]["full"] = f"{analysis_image}@sha256:{image_id}"
             with open(lock_path, "w") as f:
-                yaml.dump(lock_content, f, default_flow_style=False, sort_keys=False)
+                f.write(dump_lock_data(lock_content))
             hud_console.success("Updated lock file with image digest")
         else:
             hud_console.warning("Could not retrieve image digest")
@@ -970,10 +839,9 @@ def build_environment(
         # Rebuild with label containing lock file hash
         hud_console.progress_message("Rebuilding with lock file metadata...")
 
-        # Reuse cache flags from docker_args for the label rebuild, but never --push
+        # Reuse Docker flags for the label rebuild, but never --push.
         label_docker_args = [a for a in (docker_args or []) if a != "--push"]
-        needs_buildx = any(a.startswith("--cache") or a == "--load" for a in label_docker_args)
-        label_cmd = ["docker", "buildx", "build"] if needs_buildx else ["docker", "build"]
+        label_cmd = ["docker", "buildx", "build"]
 
         if dockerfile_path and dockerfile_path.name != "Dockerfile":
             label_cmd.extend(["-f", str(dockerfile_path)])
@@ -983,7 +851,7 @@ def build_environment(
             label_cmd.extend(["--platform", label_platform])
 
         label_cmd.extend(label_docker_args)
-        if needs_buildx and "--load" not in label_docker_args:
+        if not _has_build_output_arg(label_docker_args):
             label_cmd.append("--load")
 
         label_cmd.extend(
@@ -1038,7 +906,7 @@ def build_environment(
             else:
                 lock_content["images"]["full"] = f"{version_tag}@sha256:{image_id}"
             with open(lock_path, "w") as f:
-                yaml.dump(lock_content, f, default_flow_style=False, sort_keys=False)
+                f.write(dump_lock_data(lock_content))
             hud_console.success("Updated lock file with image digest")
         else:
             hud_console.warning("Could not retrieve image digest")

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -688,6 +688,14 @@ def build_environment(
     # Detect --push in docker passthrough args
     pushing = "--push" in (docker_args or [])
 
+    if not pushing and _has_non_daemon_output(docker_args or []):
+        hud_console.error(
+            "A custom --output was specified without --load; "
+            "the image would not be available in the local Docker daemon for analysis."
+        )
+        hud_console.info("Add --load alongside your --output flag, or use --push instead.")
+        raise typer.Exit(1)
+
     # Set up build tags
     if pushing:
         if not tag:
@@ -726,13 +734,6 @@ def build_environment(
             raise typer.Exit(1)
         analysis_image = build_tag
     else:
-        if _has_non_daemon_output(docker_args or []):
-            hud_console.error(
-                "A custom --output was specified without --load; "
-                "the image is not available in the local Docker daemon for analysis."
-            )
-            hud_console.info("Add --load alongside your --output flag, or use --push instead.")
-            raise typer.Exit(1)
         analysis_image = build_tag
         hud_console.success(f"Built temporary image: {build_tag}")
 

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -383,6 +383,18 @@ def _has_build_output_arg(docker_args: list[str]) -> bool:
     )
 
 
+def _has_non_daemon_output(docker_args: list[str]) -> bool:
+    """Return True when *docker_args* route build output away from the local daemon.
+
+    Detects ``--output``/``-o`` without an accompanying ``--load``, meaning
+    the built image won't be available for local analysis.
+    """
+    has_custom = any(
+        arg in ("--output", "-o") or arg.startswith(("--output=", "-o=")) for arg in docker_args
+    )
+    return has_custom and "--load" not in docker_args
+
+
 async def analyze_mcp_environment(
     image: str, verbose: bool = False, env_vars: dict[str, str] | None = None
 ) -> BuildAnalysis:
@@ -714,6 +726,13 @@ def build_environment(
             raise typer.Exit(1)
         analysis_image = build_tag
     else:
+        if _has_non_daemon_output(docker_args or []):
+            hud_console.error(
+                "A custom --output was specified without --load; "
+                "the image is not available in the local Docker daemon for analysis."
+            )
+            hud_console.info("Add --load alongside your --output flag, or use --push instead.")
+            raise typer.Exit(1)
         analysis_image = build_tag
         hud_console.success(f"Built temporary image: {build_tag}")
 
@@ -800,10 +819,11 @@ def build_environment(
         version=new_version,
         image_name=base_name,
         full_image_ref=None,
-        pushed_image_ref=None,
+        pushed_image_ref=build_tag if pushing else None,
         env_vars=env_vars or None,
         additional_required_env_vars=env_vars_from_file,
         platform=effective_platform,
+        local_image_ref=build_tag if pushing else None,
     )
 
     # Write lock file
@@ -915,8 +935,15 @@ def build_environment(
 
     # Update tasks.json files with new version
     hud_console.progress_message("Updating task files with new version...")
+    if pushing:
+        # Use the tag portion from the user's push tag so task references match
+        # what was actually pushed (e.g. "v1.0" from "registry.com/image:v1.0").
+        _lc, _ls = build_tag.rfind(":"), build_tag.rfind("/")
+        effective_version = build_tag[_lc + 1 :] if _lc > _ls else new_version
+    else:
+        effective_version = new_version
     updated_task_files = update_tasks_json_versions(
-        env_dir, base_name, existing_version, new_version
+        env_dir, base_name, existing_version, effective_version
     )
 
     if updated_task_files:
@@ -927,27 +954,30 @@ def build_environment(
     # Print summary
     hud_console.section_title("Build Complete")
 
-    # Show the version tag as primary since that's what will be pushed
-    hud_console.status_item("Built image", version_tag, primary=True)
-
-    # Show additional tags
-    additional_tags = [latest_tag]
-    if image_tag and image_tag not in [version_tag, latest_tag]:
-        additional_tags.append(image_tag)
-    hud_console.status_item("Also tagged", ", ".join(additional_tags))
+    if pushing:
+        hud_console.status_item("Pushed image", build_tag, primary=True)
+    else:
+        hud_console.status_item("Built image", version_tag, primary=True)
+        additional_tags = [latest_tag]
+        if image_tag and image_tag not in [version_tag, latest_tag]:
+            additional_tags.append(image_tag)
+        hud_console.status_item("Also tagged", ", ".join(additional_tags))
 
     hud_console.status_item("Version", new_version)
     hud_console.status_item("Lock file", "hud.lock.yaml")
     hud_console.status_item("Tools found", str(analysis["toolCount"]))
 
-    # Show the digest info separately if we have it
     if image_id:
         hud_console.dim_info("\nImage digest", image_id)
 
     hud_console.section_title("Next Steps")
-    hud_console.info("Test locally:")
-    hud_console.command_example("hud dev", "Hot-reload development")
-    hud_console.command_example(f"hud debug {version_tag}", "Test MCP compliance")
+    if pushing:
+        hud_console.info("Test the pushed image:")
+        hud_console.command_example(f"hud debug {build_tag}", "Test MCP compliance")
+    else:
+        hud_console.info("Test locally:")
+        hud_console.command_example("hud dev", "Hot-reload development")
+        hud_console.command_example(f"hud debug {version_tag}", "Test MCP compliance")
     hud_console.info("")
     hud_console.info("Deploy to platform:")
     hud_console.command_example("hud deploy", "Build remotely and deploy")

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -372,92 +372,6 @@ def display_secrets_warning(secret_vars: list[str]) -> None:
     hud_console.print("")
 
 
-def collect_runtime_metadata(image: str, *, verbose: bool = False) -> dict[str, str | None]:
-    """Probe container to capture Python/CUDA/cuDNN/PyTorch versions.
-
-    Runs a tiny Python snippet inside the built image using docker run.
-    """
-    hud_console = HUDConsole()
-
-    runtime_script = (
-        "import json, platform\n"
-        "info = {'python': platform.python_version()}\n"
-        "try:\n"
-        "    import torch\n"
-        "    info['pytorch'] = getattr(torch, '__version__', None)\n"
-        "    cuda_version = None\n"
-        "    try:\n"
-        "        cuda_version = getattr(getattr(torch, 'version', None), 'cuda', None)\n"
-        "    except Exception:\n"
-        "        cuda_version = None\n"
-        "    if cuda_version:\n"
-        "        info['cuda'] = cuda_version\n"
-        "    try:\n"
-        "        cudnn_version = torch.backends.cudnn.version()\n"
-        "    except Exception:\n"
-        "        cudnn_version = None\n"
-        "    if cudnn_version:\n"
-        "        info['cudnn'] = str(cudnn_version)\n"
-        "except Exception:\n"
-        "    pass\n"
-        "info.setdefault('pytorch', None)\n"
-        "info.setdefault('cuda', None)\n"
-        "info.setdefault('cudnn', None)\n"
-        "print(json.dumps(info))\n"
-    )
-
-    for binary in ("python", "python3"):
-        cmd = [
-            "docker",
-            "run",
-            "--rm",
-            image,
-            binary,
-            "-c",
-            runtime_script,
-        ]
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)
-        except FileNotFoundError:
-            return {}
-
-        if result.returncode != 0:
-            if verbose:
-                hud_console.debug(
-                    f"Runtime probe failed with {binary}: {result.stderr.strip() or 'no stderr'}"
-                )
-            continue
-
-        output = (result.stdout or "").strip()
-        if not output:
-            return {}
-
-        try:
-            data = json.loads(output.splitlines()[-1])
-        except json.JSONDecodeError:
-            if verbose:
-                hud_console.debug(
-                    "Runtime probe returned non-JSON output; skipping metadata capture"
-                )
-            return {}
-
-        if not isinstance(data, dict):
-            if verbose:
-                hud_console.debug(
-                    "Runtime probe returned JSON that is not an object; skipping metadata capture"
-                )
-            return {}
-
-        return {
-            "python": data.get("python"),
-            "cuda": data.get("cuda"),
-            "cudnn": data.get("cudnn"),
-            "pytorch": data.get("pytorch"),
-        }
-
-    return {}
-
-
 async def analyze_mcp_environment(
     image: str, verbose: bool = False, env_vars: dict[str, str] | None = None
 ) -> dict[str, Any]:
@@ -914,8 +828,7 @@ def build_environment(
     if image_tag:
         base_name = image_tag.split(":")[0] if ":" in image_tag else image_tag
 
-    # Collect runtime metadata and compute base image/platform
-    runtime_info = collect_runtime_metadata(analysis_image, verbose=verbose)
+    # Collect base image/platform metadata for the lock file
     base_image = parse_base_image(dockerfile_path)
     effective_platform = platform if platform is not None else "linux/amd64"
 
@@ -943,8 +856,6 @@ def build_environment(
         },
     }
 
-    if runtime_info:
-        lock_content["environment"]["runtime"] = runtime_info
     internal_count = int(analysis.get("internalToolCount", 0) or 0)
     lock_content["environment"]["internalToolCount"] = internal_count
 

--- a/hud/cli/debug.py
+++ b/hud/cli/debug.py
@@ -23,7 +23,7 @@ console = Console()
 def debug_command(
     params: list[str] = typer.Argument(  # type: ignore[arg-type]  # noqa: B008
         None,
-        help="Docker image, environment directory, or config file followed by optional Docker arguments",  # noqa: E501
+        help="Docker image or environment directory. Docker flags go after --",
     ),
     config: Path | None = typer.Option(  # noqa: B008
         None,
@@ -51,12 +51,14 @@ def debug_command(
 ) -> None:
     """🐛 Debug MCP environment - test initialization, tools, and readiness.
 
-    [not dim]Examples:
+    [not dim]Docker flags (e.g. -e, -p, -v) go after --.
+
+    Examples:
         hud debug .                              # Debug current directory
         hud debug environments/browser           # Debug specific directory
         hud debug . --build                      # Build then debug
         hud debug hud-text-2048:latest          # Debug Docker image
-        hud debug my-mcp-server:v1 -e API_KEY=xxx
+        hud debug my-image -- -e API_KEY=xxx     # Pass env to Docker
         hud debug --config mcp-config.json
         hud debug . --max-phase 3               # Stop after phase 3[/not dim]
     """
@@ -80,8 +82,19 @@ def debug_command(
         server_config = mcp_config[server_name]
         command = [server_config["command"], *server_config.get("args", [])]
     elif params:
-        first_param = params[0]
-        docker_args = params[1:] if len(params) > 1 else []
+        if "--" in params:
+            sep_idx = params.index("--")
+            hud_params = params[:sep_idx]
+            docker_args = params[sep_idx + 1 :]
+        else:
+            hud_params = params
+            docker_args = []
+
+        if not hud_params:
+            console.print("[red]Error: Must specify a directory or Docker image before --[/red]")
+            raise typer.Exit(1)
+
+        first_param = hud_params[0]
 
         p = Path(first_param)
         if is_environment_directory(p):

--- a/hud/cli/debug.py
+++ b/hud/cli/debug.py
@@ -23,7 +23,7 @@ console = Console()
 def debug_command(
     params: list[str] = typer.Argument(  # type: ignore[arg-type]  # noqa: B008
         None,
-        help="Docker image or environment directory. Docker flags go after --",
+        help="Docker image or environment directory, followed by optional Docker args",
     ),
     config: Path | None = typer.Option(  # noqa: B008
         None,
@@ -51,14 +51,14 @@ def debug_command(
 ) -> None:
     """🐛 Debug MCP environment - test initialization, tools, and readiness.
 
-    [not dim]Docker flags (e.g. -e, -p, -v) go after --.
+    [not dim]Extra arguments after the image/directory are passed to Docker.
 
     Examples:
         hud debug .                              # Debug current directory
         hud debug environments/browser           # Debug specific directory
         hud debug . --build                      # Build then debug
         hud debug hud-text-2048:latest          # Debug Docker image
-        hud debug my-image -- -e API_KEY=xxx     # Pass env to Docker
+        hud debug my-image -e API_KEY=xxx        # Pass env to Docker
         hud debug --config mcp-config.json
         hud debug . --max-phase 3               # Stop after phase 3[/not dim]
     """
@@ -82,19 +82,8 @@ def debug_command(
         server_config = mcp_config[server_name]
         command = [server_config["command"], *server_config.get("args", [])]
     elif params:
-        if "--" in params:
-            sep_idx = params.index("--")
-            hud_params = params[:sep_idx]
-            docker_args = params[sep_idx + 1 :]
-        else:
-            hud_params = params
-            docker_args = []
-
-        if not hud_params:
-            console.print("[red]Error: Must specify a directory or Docker image before --[/red]")
-            raise typer.Exit(1)
-
-        first_param = hud_params[0]
+        first_param = params[0]
+        docker_args = params[1:] if len(params) > 1 else []
 
         p = Path(first_param)
         if is_environment_directory(p):

--- a/hud/cli/deploy.py
+++ b/hud/cli/deploy.py
@@ -46,7 +46,7 @@ def _handle_name_conflict(
     error: Any,
     console: HUDConsole,
 ) -> str | None:
-    """Handle a 409 name conflict from trigger-direct. Returns registry_id to rebuild, or None."""
+    """Handle a 409 name conflict from build trigger. Returns registry_id or None."""
     try:
         detail = error.response.json().get("detail", {})
     except Exception:
@@ -474,6 +474,7 @@ async def _deploy_async(
 
         try:
             trigger_payload = {
+                "source": "direct",
                 "build_id": build_id,
                 "name": name,
                 "no_cache": no_cache,
@@ -488,7 +489,7 @@ async def _deploy_async(
                 trigger_payload["build_secrets"] = build_secrets
 
             trigger_response = await client.post(
-                f"{api_url.rstrip('/')}/builds/trigger-direct",
+                f"{api_url.rstrip('/')}/builds/trigger",
                 json=trigger_payload,
                 headers=headers,
             )
@@ -501,7 +502,7 @@ async def _deploy_async(
                     trigger_payload["registry_id"] = conflict
                     try:
                         trigger_response = await client.post(
-                            f"{api_url.rstrip('/')}/builds/trigger-direct",
+                            f"{api_url.rstrip('/')}/builds/trigger",
                             json=trigger_payload,
                             headers=headers,
                         )

--- a/hud/cli/dev.py
+++ b/hud/cli/dev.py
@@ -959,7 +959,7 @@ def run_docker_dev_server(
 def dev_command(
     params: list[str] = typer.Argument(  # type: ignore[arg-type]  # noqa: B008
         None,
-        help="Module path or extra Docker args (when using --docker)",
+        help="Module path. Docker flags go after --",
     ),
     docker: bool = typer.Option(
         False,
@@ -1020,8 +1020,15 @@ def dev_command(
         Terminal 1: hud dev -w 'tools env.py' --port 8000
         Terminal 2: python local_test.py  # Uses connect_url()[/not dim]
     """
-    module = params[0] if params and not docker else None
-    docker_args = params if docker else []
+    if params and "--" in params:
+        sep_idx = params.index("--")
+        hud_params = params[:sep_idx]
+        docker_args = params[sep_idx + 1 :]
+    else:
+        hud_params = params or []
+        docker_args = []
+
+    module = hud_params[0] if hud_params and not docker else None
     watch_paths = watch if watch else None
 
     run_mcp_dev_server(

--- a/hud/cli/dev.py
+++ b/hud/cli/dev.py
@@ -959,7 +959,7 @@ def run_docker_dev_server(
 def dev_command(
     params: list[str] = typer.Argument(  # type: ignore[arg-type]  # noqa: B008
         None,
-        help="Module path. Docker flags go after --",
+        help="Module path or extra Docker args (when using --docker)",
     ),
     docker: bool = typer.Option(
         False,
@@ -1020,15 +1020,8 @@ def dev_command(
         Terminal 1: hud dev -w 'tools env.py' --port 8000
         Terminal 2: python local_test.py  # Uses connect_url()[/not dim]
     """
-    if params and "--" in params:
-        sep_idx = params.index("--")
-        hud_params = params[:sep_idx]
-        docker_args = params[sep_idx + 1 :]
-    else:
-        hud_params = params or []
-        docker_args = []
-
-    module = hud_params[0] if hud_params and not docker else None
+    module = params[0] if params and not docker else None
+    docker_args = params if docker else []
     watch_paths = watch if watch else None
 
     run_mcp_dev_server(

--- a/hud/cli/tests/test_analysis_utils.py
+++ b/hud/cli/tests/test_analysis_utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from hud.cli.utils.analysis import analyze_environment
+
+
+@pytest.mark.asyncio
+async def test_analyze_environment_returns_build_ready_shape() -> None:
+    client = MagicMock()
+    client.list_tools = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                name="setup",
+                description="Calls internal functions.",
+                inputSchema={"type": "object"},
+            )
+        ]
+    )
+    client.read_resource = AsyncMock(return_value=[SimpleNamespace(text='["prepare", "seed"]')])
+    client.list_resources = AsyncMock(return_value=[])
+    client.list_prompts = AsyncMock(return_value=[])
+
+    analysis = await analyze_environment(client, server_name="local", initialize_ms=321)
+
+    assert analysis["initializeMs"] == 321
+    assert analysis["toolCount"] == 1
+    assert analysis["internalToolCount"] == 2
+    assert analysis["hubTools"] == {"setup": ["prepare", "seed"]}
+    assert analysis["success"] is True
+    assert analysis["metadata"] == {"initialized": True, "servers": ["local"]}
+    assert analysis["prompts"] == []
+    assert analysis["resources"] == []
+    assert analysis["scenarios"] == []
+    assert analysis["tools"][0]["internalTools"] == ["prepare", "seed"]

--- a/hud/cli/tests/test_analyze.py
+++ b/hud/cli/tests/test_analyze.py
@@ -44,7 +44,7 @@ class TestAnalyzeEnvironment:
         mock_analysis = {
             "metadata": {"servers": ["test"], "initialized": True},
             "tools": [{"name": "tool1", "description": "Test tool"}],
-            "hub_tools": {},
+            "hubTools": {},
             "resources": [],
             "telemetry": {},
         }
@@ -52,7 +52,7 @@ class TestAnalyzeEnvironment:
         with (
             patch("fastmcp.Client") as MockClient,
             patch(
-                "hud.cli.utils.mcp.analyze_environment", new_callable=AsyncMock
+                "hud.cli.utils.analysis.analyze_environment", new_callable=AsyncMock
             ) as mock_mcp_analyze,
             patch("hud.cli.analyze.console"),
             patch("hud.cli.analyze.display_interactive") as mock_interactive,
@@ -116,7 +116,7 @@ class TestAnalyzeEnvironment:
         mock_analysis = {
             "metadata": {"servers": ["test"], "initialized": True},
             "tools": [],
-            "hub_tools": {},
+            "hubTools": {},
             "resources": [],
             "telemetry": {},
             "verbose": False,
@@ -126,7 +126,7 @@ class TestAnalyzeEnvironment:
             with (
                 patch("fastmcp.Client") as MockClient,
                 patch(
-                    "hud.cli.utils.mcp.analyze_environment", new_callable=AsyncMock
+                    "hud.cli.utils.analysis.analyze_environment", new_callable=AsyncMock
                 ) as mock_mcp_analyze,
                 patch("hud.cli.analyze.console") as mock_console,
                 patch("hud.cli.analyze.display_interactive") as mock_interactive,
@@ -166,7 +166,7 @@ class TestAnalyzeWithConfig:
         mock_analysis = {
             "metadata": {"servers": ["server"], "initialized": True},
             "tools": [],
-            "hub_tools": {},
+            "hubTools": {},
             "resources": [],
             "telemetry": {},
         }
@@ -174,7 +174,7 @@ class TestAnalyzeWithConfig:
         with (
             patch("fastmcp.Client") as MockClient,
             patch(
-                "hud.cli.utils.mcp.analyze_environment", new_callable=AsyncMock
+                "hud.cli.utils.analysis.analyze_environment", new_callable=AsyncMock
             ) as mock_mcp_analyze,
             patch("hud.cli.analyze.console"),
             patch("hud.cli.analyze.display_interactive") as mock_interactive,
@@ -255,7 +255,7 @@ class TestDisplayFunctions:
         analysis = {
             "metadata": {"servers": ["test"], "initialized": True},
             "tools": [{"name": "tool1", "description": "Test tool"}],
-            "hub_tools": {"hub1": ["func1", "func2"]},
+            "hubTools": {"hub1": ["func1", "func2"]},
             "resources": [{"uri": "file:///test", "name": "Test", "description": "Resource"}],
             "telemetry": {"status": "running", "live_url": "http://test"},
         }
@@ -276,7 +276,7 @@ class TestDisplayFunctions:
                 {"name": "tool1", "description": "Tool 1"},
                 {"name": "setup", "description": "Hub tool"},
             ],
-            "hub_tools": {"setup": ["init", "config"]},
+            "hubTools": {"setup": ["init", "config"]},
             "resources": [{"uri": "telemetry://live", "name": "Telemetry"}],
             "telemetry": {"status": "active"},
         }

--- a/hud/cli/tests/test_analyze_module.py
+++ b/hud/cli/tests/test_analyze_module.py
@@ -30,7 +30,7 @@ def test_parse_docker_command():
 
 
 @pytest.mark.asyncio
-@patch("hud.cli.utils.mcp.analyze_environment")
+@patch("hud.cli.utils.analysis.analyze_environment")
 @patch("fastmcp.Client")
 @patch("hud.cli.analyze.console")
 async def test_analyze_environment_success_json(mock_console, MockClient, mock_mcp_analyze):
@@ -97,7 +97,7 @@ def test_display_markdown_both_paths(capsys):
     assert "MCP Environment Analysis" in captured.out
 
 
-@patch("hud.cli.utils.mcp.analyze_environment")
+@patch("hud.cli.utils.analysis.analyze_environment")
 @patch("fastmcp.Client")
 async def test_analyze_environment_from_config(MockClient, mock_mcp_analyze, tmp_path: Path):
     client = MagicMock()
@@ -113,7 +113,7 @@ async def test_analyze_environment_from_config(MockClient, mock_mcp_analyze, tmp
     assert client.__aenter__.awaited and client.close.awaited
 
 
-@patch("hud.cli.utils.mcp.analyze_environment")
+@patch("hud.cli.utils.analysis.analyze_environment")
 @patch("fastmcp.Client")
 async def test_analyze_environment_from_mcp_config(MockClient, mock_mcp_analyze):
     client = MagicMock()
@@ -128,7 +128,7 @@ async def test_analyze_environment_from_mcp_config(MockClient, mock_mcp_analyze)
     assert client.__aenter__.awaited and client.close.awaited
 
 
-@patch("hud.cli.utils.mcp.analyze_environment")
+@patch("hud.cli.utils.analysis.analyze_environment")
 @patch("fastmcp.Client")
 async def test_analyze_environment_from_mcp_config_http(MockClient, mock_mcp_analyze):
     """HTTP transport (hud dev) should inject auth=None to skip OAuth discovery."""

--- a/hud/cli/tests/test_build.py
+++ b/hud/cli/tests/test_build.py
@@ -208,7 +208,7 @@ class TestAnalyzeMcpEnvironment:
     """Test analyzing MCP environment."""
 
     @mock.patch("hud.cli.utils.docker.detect_transport", return_value=("stdio", None))
-    @mock.patch("hud.cli.utils.mcp.analyze_environment")
+    @mock.patch("hud.cli.utils.analysis.analyze_environment")
     @mock.patch("fastmcp.Client")
     async def test_analyze_success(self, mock_client_class, mock_mcp_analyze, _mock_detect):
         """Test successful environment analysis."""
@@ -221,10 +221,16 @@ class TestAnalyzeMcpEnvironment:
 
         # Mock analyze_environment return value
         mock_mcp_analyze.return_value = {
+            "initializeMs": 123,
+            "toolCount": 1,
+            "internalToolCount": 0,
+            "success": True,
             "metadata": {"servers": ["local"], "initialized": True},
             "tools": [{"name": "test_tool", "description": "Test tool"}],
-            "hub_tools": {},
+            "hubTools": {},
+            "prompts": [],
             "resources": [],
+            "scenarios": [],
             "telemetry": {},
         }
 
@@ -253,7 +259,7 @@ class TestAnalyzeMcpEnvironment:
             await analyze_mcp_environment("test:latest")
 
     @mock.patch("hud.cli.utils.docker.detect_transport", return_value=("stdio", None))
-    @mock.patch("hud.cli.utils.mcp.analyze_environment")
+    @mock.patch("hud.cli.utils.analysis.analyze_environment")
     @mock.patch("fastmcp.Client")
     async def test_analyze_verbose_mode(self, mock_client_class, mock_mcp_analyze, _mock_detect):
         """Test analysis in verbose mode."""
@@ -263,10 +269,16 @@ class TestAnalyzeMcpEnvironment:
         mock_client.close = mock.AsyncMock()
         mock_client_class.return_value = mock_client
         mock_mcp_analyze.return_value = {
+            "initializeMs": 123,
+            "toolCount": 0,
+            "internalToolCount": 0,
+            "success": True,
             "metadata": {"servers": ["local"], "initialized": True},
             "tools": [],
-            "hub_tools": {},
+            "hubTools": {},
+            "prompts": [],
             "resources": [],
+            "scenarios": [],
             "telemetry": {},
         }
 
@@ -444,10 +456,10 @@ class TestAnalyzeMcpHttp:
     """Test HTTP-mode analysis in analyze_mcp_environment."""
 
     @mock.patch("hud.cli.utils.docker.stop_container")
-    @mock.patch("hud.cli.utils.mcp.wait_for_http_server", new_callable=mock.AsyncMock)
+    @mock.patch("hud.cli.utils.analysis.wait_for_http_server", new_callable=mock.AsyncMock)
     @mock.patch("subprocess.run")
     @mock.patch("hud.cli.utils.docker.detect_transport", return_value=("http", 8765))
-    @mock.patch("hud.cli.utils.mcp.analyze_environment")
+    @mock.patch("hud.cli.utils.analysis.analyze_environment")
     @mock.patch("fastmcp.Client")
     async def test_http_analysis_success(
         self,
@@ -470,9 +482,15 @@ class TestAnalyzeMcpHttp:
         mock_subprocess.return_value = mock_proc
 
         mock_mcp_analyze.return_value = {
+            "initializeMs": 456,
+            "toolCount": 1,
+            "internalToolCount": 0,
+            "success": True,
             "tools": [{"name": "tool1", "description": "A tool"}],
-            "hub_tools": {},
+            "hubTools": {},
+            "prompts": [],
             "resources": [],
+            "scenarios": [],
         }
 
         result = await analyze_mcp_environment("http-img:latest")
@@ -515,7 +533,7 @@ class TestAnalyzeMcpHttp:
         _mock_stop.assert_called_once()
 
     @mock.patch("hud.cli.utils.docker.stop_container")
-    @mock.patch("hud.cli.utils.mcp.wait_for_http_server", new_callable=mock.AsyncMock)
+    @mock.patch("hud.cli.utils.analysis.wait_for_http_server", new_callable=mock.AsyncMock)
     @mock.patch("subprocess.run")
     @mock.patch("hud.cli.utils.docker.detect_transport", return_value=("http", 8765))
     async def test_http_server_timeout(self, _mock_detect, mock_subprocess, mock_wait, _mock_stop):
@@ -566,6 +584,9 @@ class TestBuildDockerImage:
 
         result = build_docker_image(tmp_path, "test:latest")
         assert result is True
+        call_args = mock_run.call_args[0][0]
+        assert call_args[:3] == ["docker", "buildx", "build"]
+        assert "--load" in call_args
 
     @mock.patch("subprocess.run")
     def test_build_failure(self, mock_run, tmp_path):
@@ -601,6 +622,44 @@ class TestBuildDockerImage:
         # Check that --no-cache was included
         call_args = mock_run.call_args[0][0]
         assert "--no-cache" in call_args
+
+    @mock.patch("subprocess.run")
+    def test_build_with_push_does_not_add_load(self, mock_run, tmp_path):
+        """Pushed builds should stay on the push output mode."""
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM python:3.11")
+
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        build_docker_image(tmp_path, "registry.example/test:latest", docker_args=["--push"])
+
+        call_args = mock_run.call_args[0][0]
+        assert call_args[:3] == ["docker", "buildx", "build"]
+        assert "--push" in call_args
+        assert "--load" not in call_args
+
+    @mock.patch("subprocess.run")
+    def test_build_with_explicit_output_does_not_add_load(self, mock_run, tmp_path):
+        """Explicit buildx outputs should not be combined with auto --load."""
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text("FROM python:3.11")
+
+        mock_result = mock.Mock()
+        mock_result.returncode = 0
+        mock_run.return_value = mock_result
+
+        build_docker_image(
+            tmp_path,
+            "test:latest",
+            docker_args=["--output", "type=oci,dest=out.tar"],
+        )
+
+        call_args = mock_run.call_args[0][0]
+        assert call_args[:3] == ["docker", "buildx", "build"]
+        assert "--output" in call_args
+        assert "--load" not in call_args
 
 
 class TestBuildEnvironment:

--- a/hud/cli/tests/test_build.py
+++ b/hud/cli/tests/test_build.py
@@ -607,7 +607,6 @@ class TestBuildEnvironment:
     """Test the main build_environment function."""
 
     @mock.patch("hud.cli.build.build_docker_image")
-    @mock.patch("hud.cli.build.collect_runtime_metadata")
     @mock.patch("hud.cli.build.analyze_mcp_environment")
     @mock.patch("hud.cli.build.get_docker_image_id")
     @mock.patch("subprocess.run")
@@ -616,7 +615,6 @@ class TestBuildEnvironment:
         mock_run,
         mock_get_id,
         mock_analyze,
-        mock_collect_runtime,
         mock_build_docker,
         tmp_path,
     ):
@@ -651,12 +649,6 @@ ENV API_KEY
             ],
         }
         mock_get_id.return_value = "sha256:abc123"
-        mock_collect_runtime.return_value = {
-            "python": "3.11.6",
-            "cuda": None,
-            "cudnn": None,
-            "pytorch": None,
-        }
 
         # Mock final rebuild
         mock_result = mock.Mock()
@@ -683,11 +675,10 @@ ENV API_KEY
         assert lock_data["build"]["baseImage"] == "python:3.11"
         assert lock_data["build"]["platform"] == "linux/amd64"
         assert lock_data["environment"]["toolCount"] == 2
-        assert lock_data["environment"]["runtime"]["python"] == "3.11.6"
+        assert "runtime" not in lock_data["environment"]
         assert len(lock_data["tools"]) == 2
 
     @mock.patch("hud.cli.build.build_docker_image")
-    @mock.patch("hud.cli.build.collect_runtime_metadata")
     @mock.patch("hud.cli.build.analyze_mcp_environment")
     @mock.patch("hud.cli.build.get_docker_image_id")
     @mock.patch("subprocess.run")
@@ -696,7 +687,6 @@ ENV API_KEY
         mock_run,
         mock_get_id,
         mock_analyze,
-        mock_collect_runtime,
         mock_build_docker,
         tmp_path,
     ):
@@ -728,12 +718,6 @@ FROM python:3.11
             ],
         }
         mock_get_id.return_value = "sha256:fff111"
-        mock_collect_runtime.return_value = {
-            "python": "3.11.6",
-            "cuda": None,
-            "cudnn": None,
-            "pytorch": None,
-        }
 
         mock_result = mock.Mock()
         mock_result.returncode = 0

--- a/hud/cli/tests/test_build_failure.py
+++ b/hud/cli/tests/test_build_failure.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-@patch("hud.cli.build.compute_source_hash", return_value="deadbeef")
+@patch("hud.cli.utils.lockfile.compute_source_hash", return_value="deadbeef")
 @patch(
     "hud.cli.build.analyze_mcp_environment",
     return_value={"initializeMs": 10, "toolCount": 0, "tools": []},
@@ -29,7 +29,7 @@ def test_build_label_rebuild_failure(_bd, _an, _hash, tmp_path: Path, monkeypatc
 
     def run_side_effect(cmd, *a, **k):
         # Return 0 for first docker build, 1 for label build
-        if isinstance(cmd, list) and cmd[:2] == ["docker", "build"] and "--label" in cmd:
+        if isinstance(cmd, list) and cmd[:3] == ["docker", "buildx", "build"] and "--label" in cmd:
             return types.SimpleNamespace(returncode=1, stderr="boom")
         return types.SimpleNamespace(returncode=0, stdout="")
 

--- a/hud/cli/tests/test_lockfile_utils.py
+++ b/hud/cli/tests/test_lockfile_utils.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from hud.cli.utils.lockfile import build_lock_data
+
+
+def test_build_lock_data_builds_shared_lock_shape(tmp_path) -> None:
+    (tmp_path / "Dockerfile.hud").write_text(
+        "FROM python:3.11\nENV OPENAI_API_KEY=\n",
+        encoding="utf-8",
+    )
+    controller_dir = tmp_path / "controller"
+    controller_dir.mkdir()
+    (controller_dir / "server.py").write_text("print('ok')\n", encoding="utf-8")
+
+    lock_data = build_lock_data(
+        source_dir=tmp_path,
+        analysis={
+            "initializeMs": 123,
+            "toolCount": 1,
+            "internalToolCount": 1,
+            "tools": [
+                {
+                    "name": "setup",
+                    "description": "Calls internal functions.",
+                    "inputSchema": {"type": "object"},
+                    "internalTools": ["prepare"],
+                }
+            ],
+            "prompts": [],
+            "resources": [],
+            "scenarios": [],
+            "hubTools": {"setup": ["prepare"]},
+        },
+        version="1.2.3",
+        image_name="acme/repo",
+        build_id="build-1",
+        build_method="modal",
+        full_image_ref="acme/repo:1.2.3@sha256:abc",
+        env_vars={"ANTHROPIC_API_KEY": "secret"},
+        hud_version_value="modal-native",
+    )
+
+    assert lock_data["images"] == {
+        "local": "acme/repo:1.2.3",
+        "full": "acme/repo:1.2.3@sha256:abc",
+        "pushed": None,
+    }
+    assert lock_data["build"]["buildId"] == "build-1"
+    assert lock_data["build"]["buildMethod"] == "modal"
+    assert lock_data["build"]["hudVersion"] == "modal-native"
+    assert lock_data["build"]["baseImage"] == "python:3.11"
+    assert lock_data["build"]["sourceHash"]
+    assert lock_data["build"]["sourceFiles"] == [
+        "Dockerfile.hud",
+        "controller/server.py",
+    ]
+    assert lock_data["environment"]["initializeMs"] == 123
+    assert lock_data["environment"]["toolCount"] == 1
+    assert lock_data["environment"]["internalToolCount"] == 1
+    assert lock_data["environment"]["variables"]["required"] == [
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+    ]
+    assert lock_data["tools"] == [
+        {
+            "name": "setup",
+            "description": "Calls internal functions.",
+            "inputSchema": {"type": "object"},
+            "internalTools": ["prepare"],
+        }
+    ]
+    assert lock_data["hubTools"] == {"setup": ["prepare"]}

--- a/hud/cli/utils/analysis.py
+++ b/hud/cli/utils/analysis.py
@@ -1,4 +1,4 @@
-"""MCP utilities for CLI commands."""
+"""Live MCP analysis helpers for CLI commands."""
 
 from __future__ import annotations
 
@@ -6,12 +6,31 @@ import asyncio
 import json
 import logging
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from fastmcp import Client
 
 logger = logging.getLogger(__name__)
+
+
+class BuildAnalysis(TypedDict):
+    """Shared live MCP analysis payload for build and inspect flows."""
+
+    initializeMs: int
+    toolCount: int
+    internalToolCount: int
+    tools: list[dict[str, Any]]
+    prompts: list[dict[str, Any]]
+    resources: list[dict[str, Any]]
+    scenarios: list[dict[str, Any]]
+    success: bool
+    hubTools: dict[str, list[str]]
+    metadata: dict[str, Any]
+    telemetry: NotRequired[dict[str, Any]]
+    verbose: NotRequired[bool]
 
 
 async def wait_for_http_server(
@@ -35,40 +54,54 @@ async def wait_for_http_server(
 
 
 async def analyze_environment(
-    client: Client, verbose: bool = False, server_name: str | None = None
-) -> dict[str, Any]:
-    """Analyze an MCP environment via a connected client.
+    client: Client,
+    verbose: bool = False,
+    server_name: str | None = None,
+    initialize_ms: int = 0,
+) -> BuildAnalysis:
+    """Analyze an MCP environment into the shared build-ready shape.
 
     Args:
         client: An initialized fastmcp.Client
         verbose: Enable verbose logging
         server_name: Optional server name for display
+        initialize_ms: Time spent initializing the MCP client
 
     Returns:
-        Dictionary containing tools, hub_tools, resources, prompts, scenarios, telemetry
+        Build-ready analysis payload plus optional display metadata
     """
     servers = [server_name] if server_name else []
-    analysis: dict[str, Any] = {
+    hub_tools: dict[str, list[str]] = {}
+    analysis: BuildAnalysis = {
+        "initializeMs": initialize_ms,
+        "toolCount": 0,
+        "internalToolCount": 0,
         "tools": [],
-        "hub_tools": {},
+        "hubTools": hub_tools,
         "resources": [],
         "prompts": [],
         "scenarios": [],
+        "success": True,
         "verbose": verbose,
         "metadata": {"initialized": True, "servers": servers},
     }
 
-    # Get all tools with schemas
+    # Get all tools with schemas, merging hub subtools into each dispatcher.
     tools = await client.list_tools()
+    normalized_tools: list[dict[str, Any]] = []
+    internal_total = 0
     for tool in tools:
-        tool_info = {
+        tool_info: dict[str, Any] = {
             "name": tool.name,
             "description": tool.description,
             "inputSchema": tool.inputSchema,
         }
-        analysis["tools"].append(tool_info)
-
-        # Check if this is a hub tool (like setup, evaluate)
+        merged_internal: list[str] = []
+        existing_internal = getattr(tool, "internalTools", None) or getattr(
+            tool, "internal_tools", None
+        )
+        if isinstance(existing_internal, list):
+            merged_internal.extend([str(item) for item in existing_internal])
         if (
             tool.description
             and "internal" in tool.description.lower()
@@ -76,7 +109,16 @@ async def analyze_environment(
         ):
             hub_functions = await _get_hub_tools(client, tool.name, verbose)
             if hub_functions:
-                analysis["hub_tools"][tool.name] = hub_functions
+                hub_tools[tool.name] = hub_functions
+                merged_internal.extend(hub_functions)
+        if merged_internal:
+            deduped_internal = list(dict.fromkeys(merged_internal))
+            tool_info["internalTools"] = deduped_internal
+            internal_total += len(deduped_internal)
+        normalized_tools.append(tool_info)
+    analysis["tools"] = normalized_tools
+    analysis["toolCount"] = len(normalized_tools)
+    analysis["internalToolCount"] = internal_total
 
     # Get all resources
     try:
@@ -156,7 +198,7 @@ async def _get_hub_tools(client: Client, hub_name: str, verbose: bool) -> list[s
     return []
 
 
-def _derive_scenarios(analysis: dict[str, Any]) -> list[dict[str, Any]]:
+def _derive_scenarios(analysis: Mapping[str, Any]) -> list[dict[str, Any]]:
     """Derive scenarios from prompt/resource pairs."""
     scenarios_by_id: dict[str, dict[str, Any]] = {}
 

--- a/hud/cli/utils/lockfile.py
+++ b/hud/cli/utils/lockfile.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import contextlib
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from .analysis import BuildAnalysis
+
 import yaml
+
+from hud.cli.utils.environment import find_dockerfile
+from hud.cli.utils.source_hash import compute_source_hash, list_source_files
+from hud.version import __version__ as hud_version
 
 LOCK_FILENAME = "hud.lock.yaml"
 
@@ -34,3 +42,128 @@ def get_local_image(lock_data: dict[str, Any]) -> str:
     Returns empty string if neither exists.
     """
     return lock_data.get("images", {}).get("local") or lock_data.get("image", "")
+
+
+def dump_lock_data(lock_data: dict[str, Any], *, sort_keys: bool = False) -> str:
+    """Serialize lock data to YAML with stable formatting."""
+    return yaml.dump(lock_data, default_flow_style=False, sort_keys=sort_keys)
+
+
+def build_lock_data(
+    *,
+    source_dir: Path | None,
+    analysis: BuildAnalysis | dict[str, Any],
+    version: str,
+    image_name: str,
+    full_image_ref: str | None = None,
+    pushed_image_ref: str | None = None,
+    env_vars: dict[str, str] | None = None,
+    additional_required_env_vars: set[str] | list[str] | None = None,
+    hud_version_value: str | None = None,
+    platform: str = "linux/amd64",
+    build_id: str | None = None,
+    build_method: str | None = None,
+    directory_name: str | None = None,
+    local_image_ref: str | None = None,
+) -> dict[str, Any]:
+    """Build a `hud.lock.yaml`-compatible dict from shared analysis data."""
+    from hud.cli.build import extract_env_vars_from_dockerfile, parse_base_image
+
+    resolved_source_dir = source_dir.resolve() if source_dir is not None else None
+    dockerfile_path = (
+        find_dockerfile(resolved_source_dir) if resolved_source_dir is not None else None
+    )
+    required_env, optional_env = (
+        extract_env_vars_from_dockerfile(dockerfile_path)
+        if dockerfile_path is not None
+        else ([], [])
+    )
+    resolved_directory_name = directory_name or (
+        resolved_source_dir.name
+        if resolved_source_dir is not None
+        else image_name.rsplit("/", 1)[-1].split(":", 1)[0]
+    )
+    resolved_local_image_ref = local_image_ref or f"{image_name}:{version}"
+
+    lock_content: dict[str, Any] = {
+        "version": "1.3",
+        "images": {
+            "local": resolved_local_image_ref,
+            "full": full_image_ref,
+            "pushed": pushed_image_ref,
+        },
+        "build": {
+            "generatedAt": datetime.now(UTC).isoformat() + "Z",
+            "hudVersion": hud_version_value or hud_version,
+            "directory": resolved_directory_name,
+            "version": version,
+            "platform": platform,
+        },
+        "environment": {
+            "initializeMs": int(analysis.get("initializeMs", 0) or 0),
+            "toolCount": int(analysis.get("toolCount", 0) or 0),
+            "internalToolCount": int(analysis.get("internalToolCount", 0) or 0),
+        },
+    }
+    if build_id is not None:
+        lock_content["build"]["buildId"] = build_id
+    if build_method is not None:
+        lock_content["build"]["buildMethod"] = build_method
+
+    if dockerfile_path is not None:
+        base_image = parse_base_image(dockerfile_path)
+        if base_image:
+            lock_content["build"]["baseImage"] = base_image
+
+    if resolved_source_dir is not None:
+        with contextlib.suppress(Exception):
+            lock_content["build"]["sourceHash"] = compute_source_hash(resolved_source_dir)
+        with contextlib.suppress(Exception):
+            lock_content["build"]["sourceFiles"] = [
+                str(path.resolve().relative_to(resolved_source_dir)).replace("\\", "/")
+                for path in list_source_files(resolved_source_dir)
+            ]
+
+    required_from_extra = set(additional_required_env_vars or [])
+    provided_env_vars = set((env_vars or {}).keys())
+    all_required = (set(required_env) | required_from_extra | provided_env_vars) - set(optional_env)
+    if all_required or optional_env:
+        variables: dict[str, Any] = {
+            "_note": (
+                "You can edit this section to add or modify environment variables. "
+                "Provided variables will be used when running the environment."
+            )
+        }
+        if all_required:
+            variables["required"] = sorted(all_required)
+        if optional_env:
+            variables["optional"] = optional_env
+        lock_content["environment"]["variables"] = variables
+
+    tools = analysis.get("tools") or []
+    if tools:
+        tools_serialized: list[dict[str, Any]] = []
+        for tool in tools:
+            entry: dict[str, Any] = {
+                "name": tool["name"],
+                "description": tool.get("description", ""),
+                "inputSchema": tool.get("inputSchema", {}),
+            }
+            if tool.get("internalTools"):
+                entry["internalTools"] = tool["internalTools"]
+            tools_serialized.append(entry)
+        lock_content["tools"] = tools_serialized
+
+    hub_tools = analysis.get("hubTools")
+    if hub_tools:
+        lock_content["hubTools"] = hub_tools
+    prompts = analysis.get("prompts")
+    if prompts:
+        lock_content["prompts"] = prompts
+    resources = analysis.get("resources")
+    if resources:
+        lock_content["resources"] = resources
+    if "scenarios" in analysis:
+        lock_content["scenarios"] = analysis.get("scenarios") or []
+
+    return lock_content


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core `hud build` flow and lockfile generation, including new `--push`/buildx output handling, which could affect image availability for analysis and produced lock contents. Also updates deploy build trigger endpoint/payload, which may break compatibility if backend expectations differ.
> 
> **Overview**
> **Build and analysis output has been standardized and refactored.** A new shared `hud.cli.utils.analysis.analyze_environment` returns a build-ready `BuildAnalysis` shape (adds `initializeMs`, `toolCount`, `internalToolCount`, `success`, `hubTools`, and scenario derivation) and `hud analyze` now measures client init time and consumes `hubTools` (camelCase) instead of `hub_tools`.
> 
> **`hud build` now always uses `docker buildx build` with passthrough Docker flags** (provided after `--`), auto-adds `--load` unless an output mode is explicitly chosen, and supports `--push` by pushing, then pulling for local analysis. Lockfile generation is centralized in new `hud.cli.utils.lockfile.build_lock_data`/`dump_lock_data`, and runtime probing metadata capture was removed.
> 
> **Deploy trigger API updated.** The direct deploy flow now POSTs to `/builds/trigger` (with `source: "direct"`) instead of `/builds/trigger-direct`. Tests were updated and new unit tests were added for the shared analysis/lockfile helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e7f151f220a00a8168399eed0163360c2f70682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->