### PR TITLE
Fix importlib module name collision in _collect_from_package

### DIFF
--- a/hud/cli/utils/collect.py
+++ b/hud/cli/utils/collect.py
@@ -92,8 +92,17 @@ def _collect_from_package(directory: Path) -> list[Any]:
     """
     from hud.eval.task import Task
 
-    pkg_name = directory.name
+    pkg_name = f"_hud_collect_pkg_{directory.name}"
+    init_path = directory / "__init__.py"
     parent_dir = str(directory.parent)
+
+    spec = importlib.util.spec_from_file_location(
+        pkg_name,
+        init_path,
+        submodule_search_locations=[str(directory)],
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot import package '{directory.name}': failed to create module spec")
 
     inserted = False
     if parent_dir not in sys.path:
@@ -101,13 +110,18 @@ def _collect_from_package(directory: Path) -> list[Any]:
         inserted = True
 
     try:
-        module = importlib.import_module(pkg_name)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[pkg_name] = module
+        spec.loader.exec_module(module)
     except Exception as e:
-        raise ImportError(f"Failed to import package '{pkg_name}': {type(e).__name__}: {e}") from e
+        raise ImportError(
+            f"Failed to import package '{directory.name}': {type(e).__name__}: {e}"
+        ) from e
     finally:
         if inserted:
             with contextlib.suppress(ValueError):
                 sys.path.remove(parent_dir)
+        sys.modules.pop(pkg_name, None)
 
     found: list[Task] = []
 

--- a/hud/cli/utils/tests/test_collect.py
+++ b/hud/cli/utils/tests/test_collect.py
@@ -107,51 +107,6 @@ class TestPackageImport:
             _cleanup(pkg)
 
 
-class TestPackageNameCollision:
-    """_collect_from_package must not return a cached sys.modules entry."""
-
-    def test_colliding_name_does_not_use_cached_module(self, tmp_path: Path) -> None:
-        """If sys.modules already has a module named 'tasks', a directory
-        called 'tasks' with __init__.py must still import from disk, not
-        from the cached module."""
-        import types
-
-        from hud.cli.utils.collect import _collect_from_package
-
-        fake_mod = types.ModuleType("tasks")
-        fake_mod.tasks = []  # type: ignore[attr-defined]
-        sys.modules["tasks"] = fake_mod
-
-        try:
-            _write(
-                tmp_path / "tasks" / "__init__.py",
-                """\
-                from hud.eval.task import Task
-                tasks = [Task(env={"name": "e"}, scenario="e:s", args={}, slug="real")]
-                """,
-            )
-            result = _collect_from_package(tmp_path / "tasks")
-            assert len(result) == 1
-            assert result[0].slug == "real"
-        finally:
-            sys.modules.pop("tasks", None)
-            _cleanup("_hud_collect_pkg_tasks")
-
-    def test_sys_modules_cleaned_up_after_import(self, tmp_path: Path) -> None:
-        """The synthetic module name must not linger in sys.modules."""
-        from hud.cli.utils.collect import _collect_from_package
-
-        _write(
-            tmp_path / "mypkg" / "__init__.py",
-            """\
-            from hud.eval.task import Task
-            tasks = [Task(env={"name": "e"}, scenario="e:s", args={}, slug="t")]
-            """,
-        )
-        _collect_from_package(tmp_path / "mypkg")
-        assert "_hud_collect_pkg_mypkg" not in sys.modules
-
-
 class TestRecursiveDiscovery:
     """_collect_from_directory with recursive rglob for task.py files."""
 

--- a/hud/cli/utils/tests/test_collect.py
+++ b/hud/cli/utils/tests/test_collect.py
@@ -107,6 +107,51 @@ class TestPackageImport:
             _cleanup(pkg)
 
 
+class TestPackageNameCollision:
+    """_collect_from_package must not return a cached sys.modules entry."""
+
+    def test_colliding_name_does_not_use_cached_module(self, tmp_path: Path) -> None:
+        """If sys.modules already has a module named 'tasks', a directory
+        called 'tasks' with __init__.py must still import from disk, not
+        from the cached module."""
+        import types
+
+        from hud.cli.utils.collect import _collect_from_package
+
+        fake_mod = types.ModuleType("tasks")
+        fake_mod.tasks = []  # type: ignore[attr-defined]
+        sys.modules["tasks"] = fake_mod
+
+        try:
+            _write(
+                tmp_path / "tasks" / "__init__.py",
+                """\
+                from hud.eval.task import Task
+                tasks = [Task(env={"name": "e"}, scenario="e:s", args={}, slug="real")]
+                """,
+            )
+            result = _collect_from_package(tmp_path / "tasks")
+            assert len(result) == 1
+            assert result[0].slug == "real"
+        finally:
+            sys.modules.pop("tasks", None)
+            _cleanup("_hud_collect_pkg_tasks")
+
+    def test_sys_modules_cleaned_up_after_import(self, tmp_path: Path) -> None:
+        """The synthetic module name must not linger in sys.modules."""
+        from hud.cli.utils.collect import _collect_from_package
+
+        _write(
+            tmp_path / "mypkg" / "__init__.py",
+            """\
+            from hud.eval.task import Task
+            tasks = [Task(env={"name": "e"}, scenario="e:s", args={}, slug="t")]
+            """,
+        )
+        _collect_from_package(tmp_path / "mypkg")
+        assert "_hud_collect_pkg_mypkg" not in sys.modules
+
+
 class TestRecursiveDiscovery:
     """_collect_from_directory with recursive rglob for task.py files."""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`_collect_from_package` calls `importlib.import_module(pkg_name)` using only `directory.name` (e.g., `"tasks"`). Since `importlib.import_module` checks `sys.modules` first, if any previously imported module shares that name, the cached module is returned regardless of the `sys.path` manipulation — yielding wrong or zero tasks silently.

Unlike `_import_tasks_from_module`, which uses a unique synthetic name (`_hud_collect_{stem}`) and cleans up `sys.modules`, `_collect_from_package` did neither, making common directory names like `tasks` prone to collision.

## Fix

Replace `importlib.import_module(directory.name)` with `importlib.util.spec_from_file_location` using a unique synthetic module name (`_hud_collect_pkg_{name}`), matching the pattern already used by `_import_tasks_from_module`:

- Use `importlib.util.spec_from_file_location` to load the package's `__init__.py` directly from disk
- Pass `submodule_search_locations=[str(directory)]` so sub-package imports still work
- Register the module under a unique synthetic name in `sys.modules` during execution
- Clean up the synthetic name from `sys.modules` in a `finally` block

All 13 existing tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-364aad8b-1bcb-4106-9e7a-53faad619114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-364aad8b-1bcb-4106-9e7a-53faad619114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

