### PR TITLE
sync adjustments

### DIFF
--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -619,7 +619,7 @@ async def _run_evaluation(cfg: EvalConfig) -> tuple[list[Any], list[Any]]:
             tasks = _load_from_file(path)
         else:
             from hud.cli.utils.api import hud_headers
-            from hud.cli.utils.evalset import fetch_remote_tasks, resolve_taskset_id
+            from hud.cli.utils.taskset import fetch_remote_tasks, resolve_taskset_id
             from hud.settings import settings
 
             resolved_id, _resolved_name, _ = resolve_taskset_id(
@@ -646,7 +646,7 @@ async def _run_evaluation(cfg: EvalConfig) -> tuple[list[Any], list[Any]]:
 
     if cfg.taskset:
         from hud.cli.utils.api import hud_headers as _hud_headers
-        from hud.cli.utils.evalset import resolve_taskset_id as _resolve_ts
+        from hud.cli.utils.taskset import resolve_taskset_id as _resolve_ts
         from hud.settings import settings as _settings
 
         try:

--- a/hud/cli/sync.py
+++ b/hud/cli/sync.py
@@ -13,12 +13,12 @@ import typer
 
 from hud.cli.utils.api import hud_headers, require_api_key
 from hud.cli.utils.collect import collect_tasks
-from hud.cli.utils.evalset import fetch_remote_tasks, resolve_taskset_id
 from hud.cli.utils.project_config import (
     get_taskset_id,
     load_project_config,
     save_project_config,
 )
+from hud.cli.utils.taskset import fetch_remote_tasks, resolve_taskset_id
 from hud.settings import settings
 from hud.utils.hud_console import HUDConsole
 
@@ -174,6 +174,9 @@ def _diff_and_display(
     taskset_id: str,
     taskset_exists: bool,
     hud_console: HUDConsole,
+    *,
+    collection_failures: list[tuple[str, str]] | None = None,
+    switching_from: str | None = None,
 ) -> list[dict[str, Any]]:
     """Diff local vs remote, display plan, return tasks to upload."""
     remote_by_slug: dict[str, dict[str, Any]] = {}
@@ -207,6 +210,13 @@ def _diff_and_display(
 
     if not taskset_exists:
         hud_console.info("  Taskset will be created")
+    if switching_from:
+        hud_console.warning(f"  Switching from previously stored taskset ({switching_from[:8]}...)")
+
+    if collection_failures:
+        hud_console.info(f"\n  Skipped ({len(collection_failures)}):")
+        for rel_path, error in collection_failures:
+            hud_console.info(f"    ! {rel_path}: {error}")
 
     if to_create:
         hud_console.info(f"\n  Create ({len(to_create)}):")
@@ -362,20 +372,16 @@ def sync_tasks_command(
 
     if taskset and not resolved_taskset_id:
         hud_console.progress_message("Resolving taskset...")
-        resolved_taskset_id, taskset_display, evalset_created = resolve_taskset_id(
+        resolved_taskset_id, taskset_display, _ = resolve_taskset_id(
             taskset,
             api_url,
             headers,
+            create=False,
         )
-        if evalset_created:
-            hud_console.success(f"Created new evalset '{taskset_display}'")
+        if resolved_taskset_id:
+            hud_console.success(f"Found taskset '{taskset_display}'")
         else:
-            hud_console.success(f"Found evalset '{taskset_display}'")
-
-        if previously_stored_id and previously_stored_id != resolved_taskset_id:
-            hud_console.warning(
-                f"Switching from previously stored taskset ({previously_stored_id[:8]}...)"
-            )
+            taskset_display = taskset
 
     # Resolve the taskset name from platform (for display + upload)
     if resolved_taskset_id and not taskset_display:
@@ -414,9 +420,10 @@ def sync_tasks_command(
             pass
 
     # Collect local tasks
+    collection_failures: list[tuple[str, str]] = []
     hud_console.progress_message(f"Collecting tasks from {source}...")
     try:
-        raw_tasks = collect_tasks(source)
+        raw_tasks = collect_tasks(source, failures=collection_failures)
     except (ImportError, FileNotFoundError, ValueError) as e:
         hud_console.error(str(e))
         raise typer.Exit(1) from e
@@ -451,7 +458,8 @@ def sync_tasks_command(
                 fixed = check_and_fix_env_name(source_dir, platform_env_name, hud_console)
                 if fixed:
                     hud_console.progress_message("Re-collecting tasks after name fix...")
-                    raw_tasks = collect_tasks(source)
+                    collection_failures = []
+                    raw_tasks = collect_tasks(source, failures=collection_failures)
                     local_specs = _build_local_specs(raw_tasks, hud_console)
 
     # Apply filters
@@ -467,7 +475,7 @@ def sync_tasks_command(
             hud_console.error("No tasks left after exclusions")
             raise typer.Exit(1)
 
-    # Fetch remote state (always by UUID — resolve-evalset already created it if needed)
+    # Fetch remote state (skip if taskset doesn't exist yet)
     taskset_exists = bool(resolved_taskset_id)
     taskset_name = taskset_display
     remote_tasks: list[dict[str, Any]] = []
@@ -490,6 +498,12 @@ def sync_tasks_command(
     if not taskset_name and taskset:
         taskset_name = taskset
 
+    switching_from = (
+        previously_stored_id
+        if previously_stored_id and previously_stored_id != resolved_taskset_id
+        else None
+    )
+
     # Force mode: skip diff, upload everything
     if force:
         to_upload = local_specs
@@ -502,6 +516,8 @@ def sync_tasks_command(
             resolved_taskset_id,
             taskset_exists,
             hud_console,
+            collection_failures=collection_failures,
+            switching_from=switching_from,
         )
 
     if not to_upload:

--- a/hud/cli/tests/test_sync.py
+++ b/hud/cli/tests/test_sync.py
@@ -1020,7 +1020,7 @@ class TestEnvironmentNameResolution:
 class TestTasksetResolution:
     def test_T1_name_resolves_to_id(self) -> None:
         """T1: Taskset name resolves to UUID via POST resolve-evalset."""
-        from hud.cli.utils.evalset import resolve_taskset_id
+        from hud.cli.utils.taskset import resolve_taskset_id
 
         resp = _mock_response(200, {"evalset_id": "uuid-123", "name": "my-taskset"})
         with patch("httpx.post", return_value=resp):
@@ -1030,7 +1030,7 @@ class TestTasksetResolution:
 
     def test_T1_creates_new_taskset(self) -> None:
         """T1: New taskset name creates it and returns UUID."""
-        from hud.cli.utils.evalset import resolve_taskset_id
+        from hud.cli.utils.taskset import resolve_taskset_id
 
         resp = _mock_response(200, {"evalset_id": "new-uuid", "name": "new-ts", "created": True})
         with patch("httpx.post", return_value=resp):
@@ -1039,7 +1039,7 @@ class TestTasksetResolution:
 
     def test_uuid_passed_directly(self) -> None:
         """UUID input skips API resolution."""
-        from hud.cli.utils.evalset import resolve_taskset_id
+        from hud.cli.utils.taskset import resolve_taskset_id
 
         ts_id, _ts_name, _ = resolve_taskset_id(
             "550e8400-e29b-41d4-a716-446655440000",
@@ -1056,7 +1056,7 @@ class TestTasksetResolution:
 
 class TestFetchRemoteTasks:
     def test_fetch_existing_taskset(self) -> None:
-        from hud.cli.utils.evalset import fetch_remote_tasks
+        from hud.cli.utils.taskset import fetch_remote_tasks
 
         resp = _mock_response(
             200,
@@ -1075,7 +1075,7 @@ class TestFetchRemoteTasks:
 
     def test_E4_fetch_nonexistent_taskset(self) -> None:
         """Taskset doesn't exist → empty results."""
-        from hud.cli.utils.evalset import fetch_remote_tasks
+        from hud.cli.utils.taskset import fetch_remote_tasks
 
         resp = _mock_response(404)
         with patch("httpx.get", return_value=resp):
@@ -1083,7 +1083,7 @@ class TestFetchRemoteTasks:
         assert tasks == []
 
     def test_fetch_empty_taskset(self) -> None:
-        from hud.cli.utils.evalset import fetch_remote_tasks
+        from hud.cli.utils.taskset import fetch_remote_tasks
 
         resp = _mock_response(
             200,
@@ -1112,7 +1112,7 @@ class TestFullSyncFlow:
             _upload_tasks,
         )
         from hud.cli.utils.collect import collect_tasks
-        from hud.cli.utils.evalset import fetch_remote_tasks
+        from hud.cli.utils.taskset import fetch_remote_tasks
         from hud.utils.hud_console import HUDConsole
 
         tasks = collect_tasks(str(project_dir / "tasks.py"))

--- a/hud/cli/utils/collect.py
+++ b/hud/cli/utils/collect.py
@@ -187,11 +187,14 @@ def _collect_from_directory(
     found: list[Task] = []
     skip_names = {"env", "conftest", "setup", "__init__", "__main__"}
 
-    def _record_failure(rel_path: str, error: ImportError) -> None:
+    def _record_failure(rel_path: str, error: Exception) -> None:
         LOGGER.warning("Failed to import %s: %s", rel_path, error)
         if failures is not None:
             cause = error.__cause__
-            short = f"{type(cause).__name__}: {cause}" if cause else str(error)
+            if cause:
+                short = f"{type(cause).__name__}: {cause}"
+            else:
+                short = f"{type(error).__name__}: {error}"
             failures.append((rel_path, short))
 
     # Priority 0: directory is a Python package — use package imports
@@ -218,7 +221,7 @@ def _collect_from_directory(
                 if result:
                     LOGGER.info("Collected %d task(s) from %s", len(result), candidate.name)
                     found.extend(result)
-            except ImportError as e:
+            except Exception as e:
                 _record_failure(candidate.name, e)
     if found:
         return found
@@ -236,7 +239,7 @@ def _collect_from_directory(
                 rel = task_file.relative_to(directory)
                 LOGGER.info("Collected %d task(s) from %s", len(result), rel)
                 found.extend(result)
-        except ImportError as e:
+        except Exception as e:
             rel = str(task_file.relative_to(directory))
             _record_failure(rel, e)
     if found:
@@ -251,7 +254,7 @@ def _collect_from_directory(
             if result:
                 LOGGER.info("Collected %d task(s) from %s", len(result), py_file.name)
                 found.extend(result)
-        except ImportError as e:
+        except Exception as e:
             LOGGER.debug("Skipping %s: %s", py_file.name, e)
 
     return found

--- a/hud/cli/utils/collect.py
+++ b/hud/cli/utils/collect.py
@@ -167,7 +167,11 @@ def _find_project_root(directory: Path) -> str | None:
     return None
 
 
-def _collect_from_directory(directory: Path) -> list[Any]:
+def _collect_from_directory(
+    directory: Path,
+    *,
+    failures: list[tuple[str, str]] | None = None,
+) -> list[Any]:
     """Walk a directory and collect Task objects from Python files.
 
     Checks in this order:
@@ -182,6 +186,13 @@ def _collect_from_directory(directory: Path) -> list[Any]:
 
     found: list[Task] = []
     skip_names = {"env", "conftest", "setup", "__init__", "__main__"}
+
+    def _record_failure(rel_path: str, error: ImportError) -> None:
+        LOGGER.warning("Failed to import %s: %s", rel_path, error)
+        if failures is not None:
+            cause = error.__cause__
+            short = f"{type(cause).__name__}: {cause}" if cause else str(error)
+            failures.append((rel_path, short))
 
     # Priority 0: directory is a Python package — use package imports
     if (directory / "__init__.py").is_file():
@@ -207,8 +218,8 @@ def _collect_from_directory(directory: Path) -> list[Any]:
                 if result:
                     LOGGER.info("Collected %d task(s) from %s", len(result), candidate.name)
                     found.extend(result)
-            except ImportError:
-                LOGGER.warning("Failed to import %s, skipping", candidate.name)
+            except ImportError as e:
+                _record_failure(candidate.name, e)
     if found:
         return found
 
@@ -226,8 +237,8 @@ def _collect_from_directory(directory: Path) -> list[Any]:
                 LOGGER.info("Collected %d task(s) from %s", len(result), rel)
                 found.extend(result)
         except ImportError as e:
-            rel = task_file.relative_to(directory)
-            LOGGER.warning("Failed to import %s: %s", rel, e)
+            rel = str(task_file.relative_to(directory))
+            _record_failure(rel, e)
     if found:
         return found
 
@@ -246,7 +257,11 @@ def _collect_from_directory(directory: Path) -> list[Any]:
     return found
 
 
-def collect_tasks(source: str) -> list[Any]:
+def collect_tasks(
+    source: str,
+    *,
+    failures: list[tuple[str, str]] | None = None,
+) -> list[Any]:
     """Collect Task objects from a source path.
 
     Supports:
@@ -255,6 +270,7 @@ def collect_tasks(source: str) -> list[Any]:
     - JSON/JSONL file: loads task dicts and converts to Task objects
 
     Returns an empty list if no tasks are found (caller should error).
+    If *failures* is provided, import errors are appended as ``(path, error)`` tuples.
     """
     path = Path(source).resolve()
 
@@ -268,6 +284,6 @@ def collect_tasks(source: str) -> list[Any]:
                 f"Unsupported file type: {path.suffix} (expected .py, .json, or .jsonl)"
             )
     elif path.is_dir():
-        return _collect_from_directory(path)
+        return _collect_from_directory(path, failures=failures)
     else:
         raise FileNotFoundError(f"Source not found: {source}")

--- a/hud/cli/utils/taskset.py
+++ b/hud/cli/utils/taskset.py
@@ -1,4 +1,4 @@
-"""Shared evalset resolution utilities used by ``hud sync`` and ``hud eval``."""
+"""Shared taskset resolution utilities used by ``hud sync`` and ``hud eval``."""
 
 from __future__ import annotations
 
@@ -21,10 +21,10 @@ def resolve_taskset_id(
     """Resolve a taskset name to its UUID.
 
     Args:
-        create: If True (default), creates the evalset if it doesn't exist.
+        create: If True (default), creates the taskset if it doesn't exist.
             Set to False for read-only operations like ``hud eval``.
 
-    Returns (evalset_id, evalset_name, created).
+    Returns (taskset_id, taskset_name, created).
     Returns ("", name, False) if not found and create=False.
     """
     try:
@@ -63,13 +63,13 @@ def resolve_taskset_id(
 
 
 def fetch_remote_tasks(
-    evalset_id: str,
+    taskset_id: str,
     api_url: str,
     headers: dict[str, str],
 ) -> list[dict[str, Any]]:
-    """Fetch remote tasks for an evalset by UUID."""
+    """Fetch remote tasks for a taskset by UUID."""
     response = httpx.get(
-        f"{api_url}/tasks/evalsets/{evalset_id}/tasks-by-id",
+        f"{api_url}/tasks/evalsets/{taskset_id}/tasks-by-id",
         headers=headers,
         timeout=30.0,
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes sync/eval taskset resolution behavior (no auto-create during resolve) and alters task collection to tolerate/record import failures, which could affect which tasks get uploaded if some modules fail to import.
> 
> **Overview**
> Updates `hud sync`/`hud eval` to use the renamed shared `taskset` utilities (replacing `evalset` imports) and adjusts taskset resolution messaging/behavior to be *read-only* during resolve (`create=False`).
> 
> Improves task collection robustness by capturing per-file import failures when scanning directories and surfacing them in the sync plan (including a warning when switching away from a previously stored taskset), while continuing with successfully collected tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc8cb600e3c307a91952664283f7e0ee4e55c7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->