### PR TITLE
Add GeminiWriteTool and GeminiReadManyTool implementations

### DIFF
--- a/hud/tools/__init__.py
+++ b/hud/tools/__init__.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
         EditTool,
         GeminiEditTool,
         GeminiShellTool,
+        GeminiWriteTool,
         ShellTool,
     )
     from .computer import (
@@ -54,6 +55,7 @@ if TYPE_CHECKING:
         QwenComputerTool,
     )
     from .filesystem import (
+        GeminiReadManyTool,
         GlobTool,
         GrepTool,
         ListTool,
@@ -74,7 +76,9 @@ __all__ = [
     "GeminiComputerTool",
     "GeminiEditTool",
     "GeminiMemoryTool",
+    "GeminiReadManyTool",
     "GeminiShellTool",
+    "GeminiWriteTool",
     "GlobTool",
     "GoogleSearchTool",
     "GrepTool",
@@ -121,6 +125,7 @@ def __getattr__(name: str) -> Any:
         "ApplyPatchTool",
         "GeminiShellTool",
         "GeminiEditTool",
+        "GeminiWriteTool",
     ):
         from . import coding
 
@@ -132,6 +137,7 @@ def __getattr__(name: str) -> Any:
         "GrepTool",
         "GlobTool",
         "ListTool",
+        "GeminiReadManyTool",
     ):
         from . import filesystem
 

--- a/hud/tools/coding/__init__.py
+++ b/hud/tools/coding/__init__.py
@@ -23,6 +23,7 @@ from hud.tools.coding.bash import BashTool, ClaudeBashSession, _BashSession
 from hud.tools.coding.edit import Command, EditTool
 from hud.tools.coding.gemini_edit import GeminiEditTool
 from hud.tools.coding.gemini_shell import GeminiShellOutput, GeminiShellTool
+from hud.tools.coding.gemini_write import GeminiWriteTool
 from hud.tools.coding.session import BashSession, ShellCallOutcome, ShellCommandOutput
 from hud.tools.coding.shell import ShellResult, ShellTool
 from hud.tools.coding.utils import (
@@ -49,6 +50,7 @@ __all__ = [
     "GeminiEditTool",
     "GeminiShellOutput",
     "GeminiShellTool",
+    "GeminiWriteTool",
     "ShellCallOutcome",
     "ShellCommandOutput",
     "ShellResult",

--- a/hud/tools/coding/gemini_edit.py
+++ b/hud/tools/coding/gemini_edit.py
@@ -23,9 +23,6 @@ from .utils import (
     write_file_sync,
 )
 
-# Delimiters that get split into separate tokens for regex matching
-_DELIMITERS = set("():[]{}><= ")
-
 
 def _escape_regex(s: str) -> str:
     """Escape regex special characters."""

--- a/hud/tools/coding/gemini_edit.py
+++ b/hud/tools/coding/gemini_edit.py
@@ -23,21 +23,90 @@ from .utils import (
     write_file_sync,
 )
 
+# Delimiters that get split into separate tokens for regex matching
+_DELIMITERS = set("():[]{}><= ")
+
 
 def _escape_regex(s: str) -> str:
     """Escape regex special characters."""
     return re.sub(r"[.*+?^${}()|[\]\\]", r"\\\g<0>", s)
 
 
+def _tokenize_for_regex(s: str) -> list[str]:
+    """Tokenize string by splitting on delimiters (matching Gemini CLI).
+
+    Pads delimiters with spaces before splitting so each delimiter
+    becomes its own token. E.g., "foo(bar)" -> ["foo", "(", "bar", ")"].
+    """
+    processed = s
+    for delim in "():[]{}><= ":
+        processed = processed.replace(delim, f" {delim} ")
+    return [t for t in processed.split() if t]
+
+
+def _detect_line_ending(content: str) -> str:
+    """Detect the dominant line ending in content."""
+    crlf = content.count("\r\n")
+    lf = content.count("\n") - crlf
+    return "\r\n" if crlf > lf else "\n"
+
+
+def _restore_trailing_newline(new_content: str, original_content: str) -> str:
+    """Preserve the original file's trailing newline state."""
+    had_trailing = original_content.endswith("\n")
+    has_trailing = new_content.endswith("\n")
+    if had_trailing and not has_trailing:
+        return new_content + "\n"
+    if not had_trailing and has_trailing:
+        return new_content.rstrip("\n")
+    return new_content
+
+
+def _apply_relative_indentation(
+    base_indent: str,
+    old_lines: list[str],
+    new_lines: list[str],
+) -> list[str]:
+    """Apply indentation preserving relative indent levels.
+
+    Uses the first old line's indent as reference, computes each
+    new line's relative indent, then applies base_indent + relative.
+    """
+    if not new_lines:
+        return new_lines
+
+    # Determine reference indent from old_lines
+    if old_lines:
+        ref_match = re.match(r"^(\s*)", old_lines[0])
+        ref_indent = ref_match.group(1) if ref_match else ""
+    else:
+        ref_indent = ""
+
+    result = []
+    for j, line in enumerate(new_lines):
+        if not line.strip():
+            result.append("")
+            continue
+        if j == 0:
+            result.append(f"{base_indent}{line.lstrip()}")
+        else:
+            line_match = re.match(r"^(\s*)", line)
+            line_indent = line_match.group(1) if line_match else ""
+            extra = line_indent[len(ref_indent) :] if len(line_indent) > len(ref_indent) else ""
+            result.append(f"{base_indent}{extra}{line.lstrip()}")
+    return result
+
+
 def _flexible_match(content: str, old_string: str, new_string: str) -> tuple[str, int]:
     """Attempt flexible whitespace-insensitive matching.
 
     Matches Gemini CLI behavior: strips each line and compares,
-    preserves original indentation in replacement.
+    preserves relative indentation in replacement.
     """
     source_lines = content.split("\n")
     search_lines = [line.strip() for line in old_string.split("\n")]
     replace_lines = new_string.split("\n")
+    old_lines = old_string.split("\n")
 
     occurrences = 0
     i = 0
@@ -47,13 +116,11 @@ def _flexible_match(content: str, old_string: str, new_string: str) -> tuple[str
 
         if window_stripped == search_lines:
             occurrences += 1
-            # Get indentation from first matching line
             indent_match = re.match(r"^(\s*)", window[0])
-            indentation = indent_match.group(1) if indent_match else ""
-            # Apply indentation to replacement
-            indented_replace = [f"{indentation}{line}" for line in replace_lines]
-            source_lines[i : i + len(search_lines)] = indented_replace
-            i += len(replace_lines)
+            base_indent = indent_match.group(1) if indent_match else ""
+            indented = _apply_relative_indentation(base_indent, old_lines, replace_lines)
+            source_lines[i : i + len(search_lines)] = indented
+            i += len(indented)
         else:
             i += 1
 
@@ -68,8 +135,8 @@ class GeminiEditTool(BaseTool):
     2. Flexible matching (whitespace-insensitive line comparison)
     3. Regex-based flexible matching
 
-    By default replaces a single occurrence, but can replace multiple
-    when expected_replacements is specified.
+    When old_string is empty and the file does not exist, creates a new file
+    with new_string as content.
 
     Parameters (matching Gemini CLI exactly):
         file_path: Path to the file to modify (required)
@@ -78,15 +145,11 @@ class GeminiEditTool(BaseTool):
         new_string: Exact literal text to replace with (required)
         allow_multiple: If true, replace all occurrences (default: false)
 
-    Error messages match Gemini CLI format for consistency.
-
     Native specs: Uses function calling (no native API), but has role="editor"
                   for mutual exclusion with EditTool/ApplyPatchTool.
     """
 
     native_specs: ClassVar[NativeToolSpecs] = {
-        # No api_type - uses standard function calling
-        # Role ensures mutual exclusion with other editor tools
         AgentType.GEMINI: NativeToolSpec(role="editor"),
     }
 
@@ -94,20 +157,16 @@ class GeminiEditTool(BaseTool):
     _file_history: dict[Path, list[str]]
 
     def __init__(self, base_directory: str = ".") -> None:
-        """Initialize GeminiEditTool.
-
-        Args:
-            base_directory: Base directory for relative paths
-        """
         super().__init__(
             env=None,
-            name="replace",  # Match Gemini CLI tool name
+            name="replace",
             title="Edit",
             description=(
                 "Replaces text within a file. Requires providing significant context "
                 "around the change. Always use read_file to examine content before editing. "
                 "old_string MUST be exact literal text including whitespace and indentation. "
-                "new_string MUST be exact literal text for the replacement."
+                "new_string MUST be exact literal text for the replacement. "
+                "To create a new file, set old_string to empty string."
             ),
         )
         self._base_directory = str(Path(base_directory).resolve())
@@ -128,17 +187,12 @@ class GeminiEditTool(BaseTool):
         new_string: str,
         allow_multiple: bool = False,
     ) -> list[ContentBlock]:
-        """Edit a file by replacing text.
-
-        Uses three matching strategies (like Gemini CLI):
-        1. Exact string matching
-        2. Flexible matching (whitespace-insensitive)
-        3. Regex-based flexible matching
+        """Edit a file by replacing text, or create a new file.
 
         Args:
             file_path: Path to the file to modify
             instruction: Clear description of the change purpose
-            old_string: Exact literal text to replace
+            old_string: Exact literal text to replace (empty = create file)
             new_string: Exact literal text to replace with
             allow_multiple: If true, replace all occurrences (default: false)
 
@@ -156,6 +210,18 @@ class GeminiEditTool(BaseTool):
 
         path = self._resolve_path(file_path)
 
+        # File creation: empty old_string on non-existent file
+        if old_string == "" and not path.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            write_file_sync(path, new_string)
+            return ContentResult(output=f"Created new file: {file_path}").to_content_blocks()
+
+        if old_string == "" and path.exists():
+            raise ToolError(
+                f"File already exists, cannot create: {file_path}. "
+                "Use a non-empty old_string to edit an existing file."
+            )
+
         if not path.exists():
             raise ToolError(f"File not found: {file_path}")
         if path.is_dir():
@@ -165,10 +231,11 @@ class GeminiEditTool(BaseTool):
         file_content = read_file_sync(path)
         original_content = file_content
 
-        # Normalize line endings and tabs
-        file_content = file_content.replace("\r\n", "\n").expandtabs()
-        old_string_norm = old_string.replace("\r\n", "\n").expandtabs()
-        new_string_norm = new_string.replace("\r\n", "\n").expandtabs()
+        # Detect and normalize line endings (restore later)
+        original_ending = _detect_line_ending(file_content)
+        file_content = file_content.replace("\r\n", "\n")
+        old_string_norm = old_string.replace("\r\n", "\n")
+        new_string_norm = new_string.replace("\r\n", "\n")
 
         # Strategy 1: Exact matching
         occurrences = file_content.count(old_string_norm)
@@ -182,9 +249,10 @@ class GeminiEditTool(BaseTool):
                 new_content = file_content.replace(old_string_norm, new_string_norm, 1)
             else:
                 raise ToolError(
-                    f"Multiple occurrences ({occurrences}) found for old_string in {file_path}. "
-                    "Use allow_multiple: true to replace all, or provide more context "
-                    "to match a single occurrence."
+                    f"Multiple occurrences ({occurrences}) found for "
+                    f"old_string in {file_path}. "
+                    "Use allow_multiple: true to replace all, or provide "
+                    "more context to match a single occurrence."
                 )
 
         # Strategy 2: Flexible matching (whitespace-insensitive)
@@ -199,40 +267,65 @@ class GeminiEditTool(BaseTool):
                     match_strategy = "flexible"
                 else:
                     raise ToolError(
-                        f"Multiple occurrences ({flex_occurrences}) found for old_string "
-                        f"in {file_path}. Use allow_multiple: true to replace all."
+                        f"Multiple occurrences ({flex_occurrences}) found "
+                        f"for old_string in {file_path}. "
+                        "Use allow_multiple: true to replace all."
                     )
 
-        # Strategy 3: Regex-based flexible matching (for single replacements)
-        if new_content is None and not allow_multiple:
-            tokens = old_string_norm.split()
+        # Strategy 3: Regex-based flexible matching
+        if new_content is None:
+            tokens = _tokenize_for_regex(old_string_norm)
             if tokens:
                 escaped_tokens = [_escape_regex(t) for t in tokens]
-                pattern = r"\s*".join(escaped_tokens)
-                regex_match = re.search(pattern, file_content, re.MULTILINE)
-                if regex_match:
-                    new_content = (
-                        file_content[: regex_match.start()]
-                        + new_string_norm
-                        + file_content[regex_match.end() :]
-                    )
-                    occurrences = 1
-                    match_strategy = "regex"
+                pattern = r"^([ \t]*)" + r"\s*".join(escaped_tokens)
+                if allow_multiple:
+                    regex_matches = list(re.finditer(pattern, file_content, re.MULTILINE))
+                    if regex_matches:
+                        # Replace from end to start to preserve offsets
+                        new_content = file_content
+                        for m in reversed(regex_matches):
+                            new_content = (
+                                new_content[: m.start()]
+                                + m.group(1)
+                                + new_string_norm
+                                + new_content[m.end() :]
+                            )
+                        occurrences = len(regex_matches)
+                        match_strategy = "regex"
+                else:
+                    regex_match = re.search(pattern, file_content, re.MULTILINE)
+                    if regex_match:
+                        indent = regex_match.group(1)
+                        new_content = (
+                            file_content[: regex_match.start()]
+                            + indent
+                            + new_string_norm
+                            + file_content[regex_match.end() :]
+                        )
+                        occurrences = 1
+                        match_strategy = "regex"
 
         # Handle no match found
         if new_content is None or occurrences == 0:
             raise ToolError(
-                f"Failed to edit, 0 occurrences found for old_string in {file_path}. "
-                "Ensure you're not escaping content incorrectly and check whitespace, "
-                "indentation, and context. Use read_file tool to verify."
+                f"Failed to edit, 0 occurrences found for old_string "
+                f"in {file_path}. "
+                "Ensure you're not escaping content incorrectly and "
+                "check whitespace, indentation, and context. "
+                "Use read_file tool to verify."
             )
 
         # Check if old_string equals new_string
         if old_string_norm == new_string_norm:
             raise ToolError(
-                f"No changes to apply. The old_string and new_string are identical "
-                f"in file: {file_path}"
+                "No changes to apply. The old_string and new_string "
+                f"are identical in file: {file_path}"
             )
+
+        # Restore trailing newline state and line endings
+        new_content = _restore_trailing_newline(new_content, file_content)
+        if original_ending == "\r\n":
+            new_content = new_content.replace("\n", "\r\n")
 
         # Write new content
         write_file_sync(path, new_content)
@@ -240,7 +333,6 @@ class GeminiEditTool(BaseTool):
         # Save to history for potential undo
         self._file_history[path].append(original_content)
 
-        # Build Gemini CLI-style success response
         result = f"Successfully modified file: {file_path} ({occurrences} replacements)."
         if match_strategy != "exact":
             result += f" [matched using {match_strategy} strategy]"

--- a/hud/tools/coding/gemini_edit.py
+++ b/hud/tools/coding/gemini_edit.py
@@ -76,7 +76,7 @@ class GeminiEditTool(BaseTool):
         instruction: Semantic description of the change (required)
         old_string: Exact literal text to replace (required)
         new_string: Exact literal text to replace with (required)
-        expected_replacements: Number of replacements expected (default: 1)
+        allow_multiple: If true, replace all occurrences (default: false)
 
     Error messages match Gemini CLI format for consistency.
 
@@ -126,7 +126,7 @@ class GeminiEditTool(BaseTool):
         instruction: str,
         old_string: str,
         new_string: str,
-        expected_replacements: int = 1,
+        allow_multiple: bool = False,
     ) -> list[ContentBlock]:
         """Edit a file by replacing text.
 
@@ -140,7 +140,7 @@ class GeminiEditTool(BaseTool):
             instruction: Clear description of the change purpose
             old_string: Exact literal text to replace
             new_string: Exact literal text to replace with
-            expected_replacements: Number of replacements expected (default: 1)
+            allow_multiple: If true, replace all occurrences (default: false)
 
         Returns:
             List of ContentBlocks with Gemini CLI-style result
@@ -153,13 +153,10 @@ class GeminiEditTool(BaseTool):
             raise ToolError("The 'old_string' parameter is required.")
         if new_string is None:
             raise ToolError("The 'new_string' parameter is required.")
-        if expected_replacements < 1:
-            raise ToolError("expected_replacements must be >= 1")
 
         path = self._resolve_path(file_path)
 
         if not path.exists():
-            # Match Gemini CLI error format
             raise ToolError(f"File not found: {file_path}")
         if path.is_dir():
             raise ToolError(f"Path is a directory: {file_path}")
@@ -179,24 +176,35 @@ class GeminiEditTool(BaseTool):
         match_strategy = "exact"
 
         if occurrences > 0:
-            if occurrences == expected_replacements:
+            if allow_multiple:
                 new_content = file_content.replace(old_string_norm, new_string_norm)
-            elif occurrences == 1 and expected_replacements == 1:
+            elif occurrences == 1:
                 new_content = file_content.replace(old_string_norm, new_string_norm, 1)
+            else:
+                raise ToolError(
+                    f"Multiple occurrences ({occurrences}) found for old_string in {file_path}. "
+                    "Use allow_multiple: true to replace all, or provide more context "
+                    "to match a single occurrence."
+                )
 
         # Strategy 2: Flexible matching (whitespace-insensitive)
         if new_content is None:
             flex_content, flex_occurrences = _flexible_match(
                 file_content, old_string_norm, new_string_norm
             )
-            if flex_occurrences == expected_replacements:
-                new_content = flex_content
-                occurrences = flex_occurrences
-                match_strategy = "flexible"
+            if flex_occurrences > 0:
+                if allow_multiple or flex_occurrences == 1:
+                    new_content = flex_content
+                    occurrences = flex_occurrences
+                    match_strategy = "flexible"
+                else:
+                    raise ToolError(
+                        f"Multiple occurrences ({flex_occurrences}) found for old_string "
+                        f"in {file_path}. Use allow_multiple: true to replace all."
+                    )
 
         # Strategy 3: Regex-based flexible matching (for single replacements)
-        if new_content is None and expected_replacements == 1:
-            # Build flexible regex pattern
+        if new_content is None and not allow_multiple:
             tokens = old_string_norm.split()
             if tokens:
                 escaped_tokens = [_escape_regex(t) for t in tokens]
@@ -213,19 +221,10 @@ class GeminiEditTool(BaseTool):
 
         # Handle no match found
         if new_content is None or occurrences == 0:
-            # Match Gemini CLI error format
             raise ToolError(
                 f"Failed to edit, 0 occurrences found for old_string in {file_path}. "
                 "Ensure you're not escaping content incorrectly and check whitespace, "
                 "indentation, and context. Use read_file tool to verify."
-            )
-
-        # Handle occurrence count mismatch
-        if occurrences != expected_replacements:
-            occurrence_term = "occurrence" if expected_replacements == 1 else "occurrences"
-            raise ToolError(
-                f"Failed to edit, Expected {expected_replacements} {occurrence_term} "
-                f"but found {occurrences} for old_string in file: {file_path}"
             )
 
         # Check if old_string equals new_string

--- a/hud/tools/coding/gemini_write.py
+++ b/hud/tools/coding/gemini_write.py
@@ -16,7 +16,7 @@ from hud.tools.native_types import NativeToolSpec, NativeToolSpecs
 from hud.tools.types import ContentResult, ToolError
 from hud.types import AgentType
 
-from .utils import write_file_sync
+from .utils import resolve_path_safely, write_file_sync
 
 
 class GeminiWriteTool(BaseTool):
@@ -54,11 +54,8 @@ class GeminiWriteTool(BaseTool):
         self._base_directory = str(Path(base_directory).resolve())
 
     def _resolve_path(self, file_path: str) -> Path:
-        """Resolve file path relative to base directory."""
-        path = Path(file_path)
-        if path.is_absolute():
-            return path
-        return Path(self._base_directory) / path
+        """Resolve file path relative to base directory with containment check."""
+        return resolve_path_safely(file_path, Path(self._base_directory))
 
     async def __call__(
         self,

--- a/hud/tools/coding/gemini_write.py
+++ b/hud/tools/coding/gemini_write.py
@@ -1,0 +1,95 @@
+"""Gemini-style write_file tool implementation.
+
+Based on Gemini CLI's write_file tool:
+https://github.com/google-gemini/gemini-cli
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+
+from mcp.types import ContentBlock  # noqa: TC002 - used at runtime by FunctionTool
+
+from hud.tools.base import BaseTool
+from hud.tools.native_types import NativeToolSpec, NativeToolSpecs
+from hud.tools.types import ContentResult, ToolError
+from hud.types import AgentType
+
+from .utils import write_file_sync
+
+
+class GeminiWriteTool(BaseTool):
+    """Gemini CLI-style file writing tool.
+
+    Creates or overwrites a file with the provided content.
+    Creates parent directories if they don't exist.
+
+    Parameters (matching Gemini CLI):
+        file_path: Path to the file to write (required)
+        content: The content to write to the file (required)
+
+    Native specs: Uses function calling (no native API), role="writer"
+                  for mutual exclusion with other write tools.
+    """
+
+    native_specs: ClassVar[NativeToolSpecs] = {
+        AgentType.GEMINI: NativeToolSpec(role="writer"),
+    }
+
+    _base_directory: str
+
+    def __init__(self, base_directory: str = ".") -> None:
+        super().__init__(
+            env=None,
+            name="write_file",
+            title="WriteFile",
+            description=(
+                "Creates a new file or overwrites an existing file with the provided content. "
+                "Creates parent directories if they don't exist. "
+                "Use this for creating new files. "
+                "For editing existing files, prefer the replace tool."
+            ),
+        )
+        self._base_directory = str(Path(base_directory).resolve())
+
+    def _resolve_path(self, file_path: str) -> Path:
+        """Resolve file path relative to base directory."""
+        path = Path(file_path)
+        if path.is_absolute():
+            return path
+        return Path(self._base_directory) / path
+
+    async def __call__(
+        self,
+        file_path: str,
+        content: str,
+    ) -> list[ContentBlock]:
+        """Write content to a file.
+
+        Args:
+            file_path: Path to the file to write
+            content: The content to write to the file
+
+        Returns:
+            List of ContentBlocks with result message
+        """
+        if not file_path or not file_path.strip():
+            raise ToolError("The 'file_path' parameter must be non-empty.")
+
+        path = self._resolve_path(file_path)
+
+        if path.exists() and path.is_dir():
+            raise ToolError(f"Path is a directory: {file_path}")
+
+        is_new = not path.exists()
+        write_file_sync(path, content)
+
+        action = "Created" if is_new else "Overwrote"
+        line_count = content.count("\n") + (1 if content else 0)
+        result = f"{action} file: {file_path} ({line_count} lines)"
+
+        return ContentResult(output=result).to_content_blocks()
+
+
+__all__ = ["GeminiWriteTool"]

--- a/hud/tools/coding/tests/test_gemini_tools.py
+++ b/hud/tools/coding/tests/test_gemini_tools.py
@@ -10,6 +10,7 @@ import pytest
 
 from hud.tools.coding.gemini_edit import GeminiEditTool
 from hud.tools.coding.gemini_shell import GeminiShellTool
+from hud.tools.coding.gemini_write import GeminiWriteTool
 from hud.tools.types import ToolError
 
 
@@ -152,22 +153,20 @@ class TestGeminiEditTool:
                 )
 
     @pytest.mark.asyncio
-    async def test_call_multiple_occurrences_no_expected(self) -> None:
-        """Test call with multiple occurrences without expected_replacements replaces first only."""
+    async def test_call_multiple_occurrences_no_allow_multiple(self) -> None:
+        """Test call with multiple occurrences without allow_multiple raises error."""
         with tempfile.TemporaryDirectory() as tmpdir:
             test_file = Path(tmpdir) / "test.txt"
             test_file.write_text("hello hello hello")
 
             tool = GeminiEditTool(base_directory=tmpdir)
-            # Without expected_replacements, it replaces only the first occurrence
-            result = await tool(
-                file_path="test.txt",
-                instruction="test edit",
-                old_string="hello",
-                new_string="world",
-            )
-            assert test_file.read_text() == "world hello hello"
-            assert "1 replacements" in result[0].text  # type: ignore[union-attr]
+            with pytest.raises(ToolError, match="Multiple occurrences"):
+                await tool(
+                    file_path="test.txt",
+                    instruction="test edit",
+                    old_string="hello",
+                    new_string="world",
+                )
 
     @pytest.mark.asyncio
     async def test_call_successful_edit(self) -> None:
@@ -193,8 +192,8 @@ class TestGeminiEditTool:
             assert "Successfully modified" in result[0].text  # type: ignore[union-attr]
 
     @pytest.mark.asyncio
-    async def test_call_multiple_replacements(self) -> None:
-        """Test multiple replacements with expected_replacements."""
+    async def test_call_allow_multiple(self) -> None:
+        """Test replacing all occurrences with allow_multiple=True."""
         with tempfile.TemporaryDirectory() as tmpdir:
             test_file = Path(tmpdir) / "test.txt"
             test_file.write_text("hello hello hello")
@@ -205,10 +204,9 @@ class TestGeminiEditTool:
                 instruction="Replace all hello with world",
                 old_string="hello",
                 new_string="world",
-                expected_replacements=3,
+                allow_multiple=True,
             )
 
-            # Verify file was modified
             assert test_file.read_text() == "world world world"
 
     @pytest.mark.asyncio
@@ -229,3 +227,68 @@ class TestGeminiEditTool:
             # Check history was saved
             assert len(tool._file_history[test_file]) == 1
             assert tool._file_history[test_file][0] == "original content"
+
+
+class TestGeminiWriteTool:
+    """Tests for GeminiWriteTool."""
+
+    def test_init(self) -> None:
+        """Test initialization."""
+        tool = GeminiWriteTool()
+        assert tool.name == "write_file"
+
+    def test_init_with_base_directory(self) -> None:
+        """Test initialization with custom base directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tool = GeminiWriteTool(base_directory=tmpdir)
+            assert tool._base_directory == str(Path(tmpdir).resolve())
+
+    @pytest.mark.asyncio
+    async def test_write_new_file(self) -> None:
+        """Test writing a new file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tool = GeminiWriteTool(base_directory=tmpdir)
+            result = await tool(file_path="new.txt", content="hello world")
+
+            written = (Path(tmpdir) / "new.txt").read_text()
+            assert written == "hello world"
+            assert "Created" in result[0].text  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_overwrite_file(self) -> None:
+        """Test overwriting an existing file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            existing = Path(tmpdir) / "existing.txt"
+            existing.write_text("old content")
+
+            tool = GeminiWriteTool(base_directory=tmpdir)
+            result = await tool(file_path="existing.txt", content="new content")
+
+            assert existing.read_text() == "new content"
+            assert "Overwrote" in result[0].text  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_create_parent_dirs(self) -> None:
+        """Test that parent directories are created."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tool = GeminiWriteTool(base_directory=tmpdir)
+            await tool(file_path="sub/deep/file.txt", content="nested")
+
+            assert (Path(tmpdir) / "sub" / "deep" / "file.txt").read_text() == "nested"
+
+    @pytest.mark.asyncio
+    async def test_empty_file_path_error(self) -> None:
+        """Test empty file_path raises error."""
+        tool = GeminiWriteTool()
+        with pytest.raises(ToolError, match="non-empty"):
+            await tool(file_path="", content="content")
+
+    @pytest.mark.asyncio
+    async def test_write_to_directory_error(self) -> None:
+        """Test writing to a directory path raises error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tool = GeminiWriteTool(base_directory=tmpdir)
+            subdir = Path(tmpdir) / "adir"
+            subdir.mkdir()
+            with pytest.raises(ToolError, match="directory"):
+                await tool(file_path="adir", content="content")

--- a/hud/tools/filesystem/__init__.py
+++ b/hud/tools/filesystem/__init__.py
@@ -56,6 +56,7 @@ from hud.tools.filesystem.gemini import (
     GeminiReadTool,
     GeminiSearchTool,
 )
+from hud.tools.filesystem.gemini_read_many import GeminiReadManyTool
 
 # OpenCode-style tools (default)
 from hud.tools.filesystem.glob import GlobTool
@@ -72,6 +73,7 @@ __all__ = [
     "FileMatch",
     "GeminiGlobTool",
     "GeminiListTool",
+    "GeminiReadManyTool",
     "GeminiReadTool",
     "GeminiSearchTool",
     "GlobTool",

--- a/hud/tools/filesystem/base.py
+++ b/hud/tools/filesystem/base.py
@@ -383,11 +383,12 @@ class BaseSearchTool(BaseFilesystemTool):
         self._max_results = max_results
         self._max_files = max_files
 
-    def compile_pattern(self, pattern: str) -> re.Pattern[str]:
+    def compile_pattern(self, pattern: str, case_insensitive: bool = False) -> re.Pattern[str]:
         """Compile a regex pattern.
 
         Args:
             pattern: Regex pattern string
+            case_insensitive: Whether to compile with IGNORECASE flag
 
         Returns:
             Compiled regex pattern
@@ -399,7 +400,8 @@ class BaseSearchTool(BaseFilesystemTool):
             raise ToolError("pattern is required")
 
         try:
-            return re.compile(pattern)
+            flags = re.IGNORECASE if case_insensitive else 0
+            return re.compile(pattern, flags)
         except re.error as e:
             raise ToolError(f"Invalid regex pattern: {e}") from None
 
@@ -446,7 +448,7 @@ class BaseSearchTool(BaseFilesystemTool):
 
             for i, line in enumerate(content.split("\n"), 1):
                 if regex.search(line):
-                    line_text = self.truncate_line(line.strip())
+                    line_text = self.truncate_line(line.rstrip())
                     matches.append(
                         FileMatch(
                             path=rel_path,
@@ -509,6 +511,8 @@ class BaseGlobTool(BaseFilesystemTool):
         directory: Path,
         pattern: str,
         include_ignored: bool = False,
+        include_hidden: bool = False,
+        case_sensitive: bool = True,
     ) -> list[tuple[Path, float]]:
         """Find files matching a glob pattern.
 
@@ -516,6 +520,8 @@ class BaseGlobTool(BaseFilesystemTool):
             directory: Directory to search
             pattern: Glob pattern
             include_ignored: Whether to include ignored directories
+            include_hidden: Whether to include hidden/dot files
+            case_sensitive: Whether matching is case-sensitive
 
         Returns:
             List of (path, mtime) tuples
@@ -526,8 +532,18 @@ class BaseGlobTool(BaseFilesystemTool):
         matches: list[tuple[Path, float]] = []
 
         try:
+            # Case-insensitive: convert pattern to match any case
+            if not case_sensitive:
+                ci_pattern = ""
+                for c in pattern:
+                    if c.isalpha():
+                        ci_pattern += f"[{c.lower()}{c.upper()}]"
+                    else:
+                        ci_pattern += c
+                pattern = ci_pattern
+
             for match in directory.glob(pattern):
-                if self.is_hidden(match):
+                if not include_hidden and self.is_hidden(match):
                     continue
 
                 if not include_ignored and self.is_ignored_dir(match):

--- a/hud/tools/filesystem/gemini.py
+++ b/hud/tools/filesystem/gemini.py
@@ -12,6 +12,7 @@ Key differences from OpenCode-style tools:
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
@@ -68,8 +69,8 @@ class GeminiReadTool(BaseReadTool):
             title="ReadFile",
             description=(
                 "Reads and returns the content of a specified file. If the file is large, "
-                "the content will be truncated. Use 'offset' and 'limit' parameters to "
-                "paginate through large files."
+                "the content will be truncated. Use 'start_line' and 'end_line' parameters "
+                "to read specific line ranges."
             ),
         )
 
@@ -92,13 +93,13 @@ class GeminiReadTool(BaseReadTool):
         is_partial = (result.start_offset > 0) or has_more or result.truncated_by_bytes
 
         if is_partial:
-            next_offset = lines_shown_end
+            next_start = lines_shown_end + 1
             return (
                 f"IMPORTANT: The file content has been truncated.\n"
                 f"Status: Showing lines {lines_shown_start}-{lines_shown_end} "
                 f"of {result.total_lines} total lines.\n"
-                f"Action: To read more, use 'offset' and 'limit' parameters. "
-                f"Example: offset: {next_offset}.\n\n"
+                f"Action: To read more, use 'start_line' and 'end_line' parameters. "
+                f"Example: start_line: {next_start}.\n\n"
                 f"--- FILE CONTENT (truncated) ---\n{file_content}"
             )
         else:
@@ -107,15 +108,15 @@ class GeminiReadTool(BaseReadTool):
     async def __call__(
         self,
         file_path: str,
-        offset: int | None = None,
-        limit: int | None = None,
+        start_line: int | None = None,
+        end_line: int | None = None,
     ) -> list[TextContent | ImageContent]:
-        """Read file contents with optional pagination.
+        """Read file contents with optional line range.
 
         Args:
             file_path: Path to the file to read
-            offset: 0-based line number to start reading from
-            limit: Maximum number of lines to read
+            start_line: 1-based line number to start reading from
+            end_line: 1-based line number to stop reading at (inclusive)
 
         Returns:
             List of TextContent (or ImageContent for images) with file contents
@@ -130,17 +131,23 @@ class GeminiReadTool(BaseReadTool):
         if path.is_dir():
             raise ToolError(f"Path is a directory, not a file: {file_path}")
 
-        if offset is not None and offset < 0:
-            raise ToolError("Offset must be a non-negative number")
-        if limit is not None and limit <= 0:
-            raise ToolError("Limit must be a positive number")
+        if start_line is not None and start_line < 1:
+            raise ToolError("start_line must be >= 1")
+        if end_line is not None and end_line < 1:
+            raise ToolError("end_line must be >= 1")
+        if start_line is not None and end_line is not None and end_line < start_line:
+            raise ToolError("end_line must be >= start_line")
 
         # Handle images
         if self.is_image(path):
             result = self.read_image(path)
             return result.to_content_blocks()  # type: ignore[return-value]
 
-        result = self.read_with_pagination(path, offset=offset or 0, limit=limit)
+        # Convert 1-based start_line/end_line to 0-based offset/limit
+        offset = (start_line - 1) if start_line is not None else 0
+        limit = (end_line - offset) if (start_line is not None and end_line is not None) else None
+
+        result = self.read_with_pagination(path, offset=offset, limit=limit)
         output = self.format_output(result, file_path)
 
         return list(ContentResult(output=output).to_text_blocks())
@@ -150,12 +157,16 @@ class GeminiSearchTool(BaseSearchTool):
     """Gemini CLI-style file content search tool.
 
     Searches file contents using regex patterns.
-    Matches Gemini CLI's search_file_content tool interface.
+    Matches Gemini CLI's grep_search tool interface.
 
     Parameters:
         pattern: Regex pattern to search for (required)
         dir_path: Directory to search in (optional, defaults to project root)
-        include: Glob pattern to filter files (e.g., "*.py")
+        include_pattern: Glob pattern to filter files (e.g., "*.py")
+        exclude_pattern: Regex pattern to exclude from results
+        names_only: If true, return only file paths without line content
+        max_matches_per_file: Maximum matches per file
+        total_max_matches: Maximum total matches (default: 100)
     """
 
     native_specs: ClassVar[NativeToolSpecs] = {
@@ -179,20 +190,26 @@ class GeminiSearchTool(BaseSearchTool):
             base_path=base_path,
             max_results=max_results,
             max_files=max_files,
-            name="search_file_content",
-            title="Search",
+            name="grep_search",
+            title="SearchText",
             description=(
-                "Search file contents using a regex pattern. "
-                "Returns matching lines grouped by file with line numbers."
+                "Searches for a regular expression pattern within file contents. "
+                "Returns matching lines grouped by file with line numbers. Max 100 matches."
             ),
         )
 
-    def format_output(self, matches: list[FileMatch], pattern: str) -> str:
+    def format_output(
+        self,
+        matches: list[FileMatch],
+        pattern: str,
+        names_only: bool = False,
+    ) -> str:
         """Format output in Gemini CLI style (grouped by file).
 
         Args:
             matches: List of FileMatch objects
             pattern: Original search pattern
+            names_only: If true, return only file paths
 
         Returns:
             Formatted output grouped by file
@@ -208,6 +225,12 @@ class GeminiSearchTool(BaseSearchTool):
             if match.path not in file_matches:
                 file_matches[match.path] = []
             file_matches[match.path].append(match)
+
+        if names_only:
+            lines = list(file_matches.keys())
+            if truncated:
+                lines.append("\n(Results are truncated. Consider using a more specific pattern.)")
+            return "\n".join(lines)
 
         lines = [f"Found {len(matches)} matches in {len(file_matches)} files"]
         lines.append("")
@@ -226,14 +249,22 @@ class GeminiSearchTool(BaseSearchTool):
         self,
         pattern: str,
         dir_path: str | None = None,
-        include: str | None = None,
+        include_pattern: str | None = None,
+        exclude_pattern: str | None = None,
+        names_only: bool = False,
+        max_matches_per_file: int | None = None,
+        total_max_matches: int | None = None,
     ) -> list[TextContent]:
         """Search file contents for a pattern.
 
         Args:
             pattern: Regex pattern to search for
             dir_path: Directory to search in (defaults to base path)
-            include: Glob pattern to filter files (e.g., "*.py")
+            include_pattern: Glob pattern to filter which files are searched
+            exclude_pattern: Regex pattern to exclude from results
+            names_only: If true, return only file paths
+            max_matches_per_file: Maximum matches per file
+            total_max_matches: Maximum total matches (overrides default 100)
 
         Returns:
             List of TextContent with matching lines grouped by file
@@ -244,8 +275,40 @@ class GeminiSearchTool(BaseSearchTool):
         if not search_path.exists():
             raise ToolError(f"Directory not found: {dir_path or '.'}")
 
-        matches = self.search_files(search_path, regex, include)
-        output = self.format_output(matches, pattern)
+        # Validate exclude_pattern if provided
+        exclude_regex = None
+        if exclude_pattern:
+            try:
+                exclude_regex = re.compile(exclude_pattern)
+            except re.error as e:
+                raise ToolError(f"Invalid exclude_pattern regex: {e}") from None
+
+        # Use per-call max if provided
+        orig_max = self._max_results
+        if total_max_matches is not None:
+            self._max_results = total_max_matches
+
+        try:
+            matches = self.search_files(search_path, regex, include_pattern)
+        finally:
+            self._max_results = orig_max
+
+        # Apply exclude_pattern filter
+        if exclude_regex:
+            matches = [m for m in matches if not exclude_regex.search(m.line_text)]
+
+        # Apply max_matches_per_file limit
+        if max_matches_per_file is not None:
+            file_counts: dict[str, int] = {}
+            filtered: list[FileMatch] = []
+            for m in matches:
+                count = file_counts.get(m.path, 0)
+                if count < max_matches_per_file:
+                    filtered.append(m)
+                    file_counts[m.path] = count + 1
+            matches = filtered
+
+        output = self.format_output(matches, pattern, names_only=names_only)
 
         return ContentResult(output=output).to_text_blocks()
 
@@ -322,6 +385,7 @@ class GeminiGlobTool(BaseGlobTool):
         dir_path: str | None = None,
         case_sensitive: bool = True,
         respect_git_ignore: bool = True,
+        respect_gemini_ignore: bool = True,
     ) -> list[TextContent]:
         """Find files matching a glob pattern.
 
@@ -330,6 +394,7 @@ class GeminiGlobTool(BaseGlobTool):
             dir_path: Directory to search in (defaults to base path)
             case_sensitive: Whether matching is case-sensitive
             respect_git_ignore: Whether to respect .gitignore
+            respect_gemini_ignore: Whether to respect .geminiignore (accepted, not yet implemented)
 
         Returns:
             List of TextContent with matching file paths

--- a/hud/tools/filesystem/gemini.py
+++ b/hud/tools/filesystem/gemini.py
@@ -4,15 +4,17 @@ These tools match the interface and output format of Gemini CLI:
 https://github.com/google-gemini/gemini-cli
 
 Key differences from OpenCode-style tools:
-- read_file: Uses offset/limit (0-based), different truncation message
-- search_file_content: Named differently, grouped output by file
-- glob: Adds case_sensitive, respect_git_ignore options, absolute paths
-- list_directory: Uses dir_path, ignore[] params, DIR/file output format
+- read_file: Uses start_line/end_line (1-based inclusive)
+- grep_search: Case-insensitive by default, grouped output by file
+- glob: Case-insensitive by default, sorted by recency, includes dot files
+- list_directory: Uses dir_path, ignore[] params, [DIR]/size output format
 """
 
 from __future__ import annotations
 
+import os
 import re
+import time
 from typing import TYPE_CHECKING, ClassVar
 
 if TYPE_CHECKING:
@@ -36,13 +38,13 @@ from hud.types import AgentType
 class GeminiReadTool(BaseReadTool):
     """Gemini CLI-style file reading tool.
 
-    Reads file contents with offset/limit pagination (0-based).
+    Reads file contents with start_line/end_line (1-based, inclusive).
     Matches Gemini CLI's read_file tool interface.
 
     Parameters:
         file_path: Path to the file to read (required)
-        offset: 0-based line number to start reading from (optional)
-        limit: Maximum number of lines to read (optional)
+        start_line: 1-based line number to start reading from (optional)
+        end_line: 1-based line number to stop reading at, inclusive (optional)
 
     Output includes truncation warnings with pagination hints.
     """
@@ -145,7 +147,7 @@ class GeminiReadTool(BaseReadTool):
 
         # Convert 1-based start_line/end_line to 0-based offset/limit
         offset = (start_line - 1) if start_line is not None else 0
-        limit = (end_line - offset) if (start_line is not None and end_line is not None) else None
+        limit = (end_line - offset) if end_line is not None else None
 
         result = self.read_with_pagination(path, offset=offset, limit=limit)
         output = self.format_output(result, file_path)
@@ -269,7 +271,8 @@ class GeminiSearchTool(BaseSearchTool):
         Returns:
             List of TextContent with matching lines grouped by file
         """
-        regex = self.compile_pattern(pattern)
+        # Gemini CLI uses case-insensitive search by default
+        regex = self.compile_pattern(pattern, case_insensitive=True)
         search_path = self.resolve_path(dir_path or ".")
 
         if not search_path.exists():
@@ -283,9 +286,15 @@ class GeminiSearchTool(BaseSearchTool):
             except re.error as e:
                 raise ToolError(f"Invalid exclude_pattern regex: {e}") from None
 
-        # Use per-call max if provided
+        effective_max = total_max_matches if total_max_matches is not None else self._max_results
+        needs_post_filter = exclude_regex is not None or max_matches_per_file is not None
+
+        # When post-filters are active, remove the scan cap so filtered-out
+        # matches don't prevent valid later matches from being found.
         orig_max = self._max_results
-        if total_max_matches is not None:
+        if needs_post_filter:
+            self._max_results = self._max_files  # scan all files
+        elif total_max_matches is not None:
             self._max_results = total_max_matches
 
         try:
@@ -307,6 +316,9 @@ class GeminiSearchTool(BaseSearchTool):
                     filtered.append(m)
                     file_counts[m.path] = count + 1
             matches = filtered
+
+        # Cap at the effective maximum after all filtering
+        matches = matches[:effective_max]
 
         output = self.format_output(matches, pattern, names_only=names_only)
 
@@ -367,8 +379,15 @@ class GeminiGlobTool(BaseGlobTool):
 
         truncated = len(matches) >= self._max_results
 
-        # Sort alphabetically (Gemini CLI behavior, not by mtime)
-        sorted_matches = sorted(matches, key=lambda x: str(x[0]))
+        # Sort by recency: files modified within 24h first (newest to oldest),
+        # then older files alphabetically (matches Gemini CLI behavior)
+        now = time.time()
+        day_ago = now - 86400
+        recent = [(m, mt) for m, mt in matches if mt >= day_ago]
+        older = [(m, mt) for m, mt in matches if mt < day_ago]
+        recent.sort(key=lambda x: x[1], reverse=True)
+        older.sort(key=lambda x: str(x[0]))
+        sorted_matches = recent + older
 
         # Return absolute paths (Gemini CLI format)
         abs_paths = [str(m.resolve()) for m, _mtime in sorted_matches]
@@ -383,7 +402,7 @@ class GeminiGlobTool(BaseGlobTool):
         self,
         pattern: str,
         dir_path: str | None = None,
-        case_sensitive: bool = True,
+        case_sensitive: bool = False,
         respect_git_ignore: bool = True,
         respect_gemini_ignore: bool = True,
     ) -> list[TextContent]:
@@ -406,7 +425,13 @@ class GeminiGlobTool(BaseGlobTool):
         if not base.is_dir():
             raise ToolError(f"Not a directory: {dir_path or '.'}")
 
-        matches = self.find_files(base, pattern, include_ignored=not respect_git_ignore)
+        matches = self.find_files(
+            base,
+            pattern,
+            include_ignored=not respect_git_ignore,
+            include_hidden=True,  # Gemini CLI uses dot: true
+            case_sensitive=case_sensitive,
+        )
         output = self.format_output(matches, pattern)
 
         return ContentResult(output=output).to_text_blocks()
@@ -470,15 +495,18 @@ class GeminiListTool(BaseListTool):
 
         truncated = len(entries) >= self._max_entries
 
-        # Format as DIR/filename (Gemini CLI format)
+        # Format as [DIR]/filename with size (Gemini CLI format)
         lines = []
         for name, is_dir in entries:
-            # Extract just the name (not full relative path)
             simple_name = name.rstrip("/").split("/")[-1]
             if is_dir:
-                lines.append(f"DIR  {simple_name}")
+                lines.append(f"[DIR] {simple_name}")
             else:
-                lines.append(f"     {simple_name}")
+                try:
+                    size = os.path.getsize(directory / simple_name)
+                    lines.append(f"{simple_name} ({size} bytes)")
+                except OSError:
+                    lines.append(simple_name)
 
         output = "\n".join(lines)
 

--- a/hud/tools/filesystem/gemini.py
+++ b/hud/tools/filesystem/gemini.py
@@ -205,6 +205,7 @@ class GeminiSearchTool(BaseSearchTool):
         matches: list[FileMatch],
         pattern: str,
         names_only: bool = False,
+        truncated: bool = False,
     ) -> str:
         """Format output in Gemini CLI style (grouped by file).
 
@@ -212,14 +213,13 @@ class GeminiSearchTool(BaseSearchTool):
             matches: List of FileMatch objects
             pattern: Original search pattern
             names_only: If true, return only file paths
+            truncated: Whether results were capped
 
         Returns:
             Formatted output grouped by file
         """
         if not matches:
             return f"No matches found for pattern: {pattern}"
-
-        truncated = len(matches) >= self._max_results
 
         # Group by file
         file_matches: dict[str, list[FileMatch]] = {}
@@ -318,9 +318,12 @@ class GeminiSearchTool(BaseSearchTool):
             matches = filtered
 
         # Cap at the effective maximum after all filtering
+        was_truncated = len(matches) > effective_max
         matches = matches[:effective_max]
 
-        output = self.format_output(matches, pattern, names_only=names_only)
+        output = self.format_output(
+            matches, pattern, names_only=names_only, truncated=was_truncated
+        )
 
         return ContentResult(output=output).to_text_blocks()
 

--- a/hud/tools/filesystem/gemini_read_many.py
+++ b/hud/tools/filesystem/gemini_read_many.py
@@ -84,10 +84,13 @@ class GeminiReadManyTool(BaseFilesystemTool):
                     files.append(resolved)
                 continue
 
-            # Glob pattern
+            # Glob pattern -- strip recursive ** when recursive=False
             base = self._base_path
+            effective_pattern = pattern
+            if not recursive and "**" in effective_pattern:
+                effective_pattern = effective_pattern.replace("**/", "").replace("**", "*")
 
-            for match in base.glob(pattern):
+            for match in base.glob(effective_pattern):
                 if not match.is_file():
                     continue
                 if match in seen:

--- a/hud/tools/filesystem/gemini_read_many.py
+++ b/hud/tools/filesystem/gemini_read_many.py
@@ -86,8 +86,6 @@ class GeminiReadManyTool(BaseFilesystemTool):
 
             # Glob pattern
             base = self._base_path
-            if recursive and "**" not in pattern:
-                pattern = f"**/{pattern}"
 
             for match in base.glob(pattern):
                 if not match.is_file():

--- a/hud/tools/filesystem/gemini_read_many.py
+++ b/hud/tools/filesystem/gemini_read_many.py
@@ -1,0 +1,206 @@
+"""Gemini CLI-style read_many_files tool.
+
+Based on Gemini CLI's read_many_files tool:
+https://github.com/google-gemini/gemini-cli
+
+Reads content from multiple files specified by glob patterns,
+concatenating results with file path separators.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from mcp.types import TextContent  # noqa: TC002
+
+from hud.tools.filesystem.base import BaseFilesystemTool
+from hud.tools.native_types import NativeToolSpec, NativeToolSpecs
+from hud.tools.types import ContentResult, ToolError
+from hud.types import AgentType
+
+
+class GeminiReadManyTool(BaseFilesystemTool):
+    """Gemini CLI-style multi-file reading tool.
+
+    Reads content from multiple files specified by glob patterns or paths.
+    Concatenates results with file path separators.
+
+    Parameters (matching Gemini CLI):
+        include: Array of glob patterns or file paths to read (required)
+        exclude: Array of glob patterns to exclude (optional)
+        recursive: Whether to search recursively (default: True)
+        useDefaultExcludes: Whether to apply default exclusions (default: True)
+    """
+
+    native_specs: ClassVar[NativeToolSpecs] = {
+        AgentType.GEMINI: NativeToolSpec(role="batch_reader"),
+    }
+
+    _max_files: int
+    _max_total_lines: int
+
+    def __init__(
+        self,
+        base_path: str = ".",
+        max_files: int = 100,
+        max_total_lines: int = 10000,
+    ) -> None:
+        super().__init__(
+            base_path=base_path,
+            name="read_many_files",
+            title="ReadManyFiles",
+            description=(
+                "Reads and concatenates content from multiple files. "
+                "Accepts arrays of glob patterns and file paths to include and exclude. "
+                "Returns concatenated file contents separated by file path headers."
+            ),
+        )
+        self._max_files = max_files
+        self._max_total_lines = max_total_lines
+
+    def _collect_files(
+        self,
+        include: list[str],
+        exclude: list[str] | None,
+        recursive: bool,
+        use_default_excludes: bool,
+    ) -> list[Path]:
+        """Resolve include/exclude patterns into a deduplicated file list."""
+        exclude_patterns = exclude or []
+        seen: set[Path] = set()
+        files: list[Path] = []
+
+        for pattern in include:
+            resolved = self.resolve_path(pattern)
+
+            # Literal file path
+            if resolved.is_file():
+                if resolved not in seen:
+                    seen.add(resolved)
+                    files.append(resolved)
+                continue
+
+            # Glob pattern
+            base = self._base_path
+            if recursive and "**" not in pattern:
+                pattern = f"**/{pattern}"
+
+            for match in base.glob(pattern):
+                if not match.is_file():
+                    continue
+                if match in seen:
+                    continue
+                if self.is_hidden(match):
+                    continue
+                if use_default_excludes and self.is_ignored_dir(match):
+                    continue
+                seen.add(match)
+                files.append(match)
+
+                if len(files) >= self._max_files:
+                    break
+
+            if len(files) >= self._max_files:
+                break
+
+        # Apply exclude patterns
+        if exclude_patterns:
+            files = [
+                f
+                for f in files
+                if not any(fnmatch.fnmatch(str(f), ep) for ep in exclude_patterns)
+                and not any(fnmatch.fnmatch(f.name, ep) for ep in exclude_patterns)
+            ]
+
+        return files
+
+    async def __call__(
+        self,
+        include: list[str],
+        exclude: list[str] | None = None,
+        recursive: bool = True,
+        useDefaultExcludes: bool = True,
+    ) -> list[TextContent]:
+        """Read content from multiple files.
+
+        Args:
+            include: Array of glob patterns or file paths to read
+            exclude: Array of glob patterns to exclude
+            recursive: Whether to search recursively
+            useDefaultExcludes: Whether to apply default exclusions
+
+        Returns:
+            List of TextContent with concatenated file contents
+        """
+        if not include:
+            raise ToolError("The 'include' parameter must be a non-empty array.")
+
+        files = self._collect_files(include, exclude, recursive, useDefaultExcludes)
+
+        if not files:
+            return ContentResult(
+                output="No files found matching the specified patterns."
+            ).to_text_blocks()
+
+        parts: list[str] = []
+        total_lines = 0
+        files_read = 0
+        skipped: list[str] = []
+        truncated = False
+
+        for path in files:
+            try:
+                content = self.read_file_content(path)
+            except Exception:
+                skipped.append(str(path))
+                continue
+
+            line_count = content.count("\n") + 1
+            if total_lines + line_count > self._max_total_lines:
+                truncated = True
+                remaining = self._max_total_lines - total_lines
+                if remaining > 0:
+                    truncated_content = "\n".join(content.split("\n")[:remaining])
+                    try:
+                        rel = str(path.relative_to(self._base_path))
+                    except ValueError:
+                        rel = str(path)
+                    parts.append(f"--- {rel} ---")
+                    parts.append(truncated_content)
+                    parts.append(
+                        "[WARNING: This file was truncated. Use 'read_file' for full content.]"
+                    )
+                    files_read += 1
+                break
+
+            try:
+                rel = str(path.relative_to(self._base_path))
+            except ValueError:
+                rel = str(path)
+
+            parts.append(f"--- {rel} ---")
+            parts.append(content)
+            total_lines += line_count
+            files_read += 1
+
+        parts.append("--- End of content ---")
+
+        if skipped:
+            parts.append(f"\nSkipped {len(skipped)} files (read errors): {', '.join(skipped)}")
+
+        if truncated:
+            parts.append(
+                f"\n[Truncated: showing {files_read} of {len(files)} files, "
+                f"{total_lines} lines. Use more specific patterns or "
+                f"read_file for individual files.]"
+            )
+
+        output = "\n".join(parts)
+        return ContentResult(output=output).to_text_blocks()
+
+
+__all__ = ["GeminiReadManyTool"]

--- a/hud/tools/filesystem/tests/test_glob.py
+++ b/hud/tools/filesystem/tests/test_glob.py
@@ -98,3 +98,12 @@ class TestGeminiGlobTool:
         lines = [line for line in text.strip().split("\n") if line and not line.startswith("(")]
         # Should be sorted alphabetically
         assert lines == sorted(lines)
+
+    @pytest.mark.asyncio
+    async def test_glob_respect_gemini_ignore_param(self, workspace: Path) -> None:
+        """Test that respect_gemini_ignore param is accepted."""
+        tool = GeminiGlobTool(base_path=str(workspace))
+        result = await tool(pattern="**/*.py", respect_gemini_ignore=True)
+
+        text = result[0].text
+        assert "main.py" in text

--- a/hud/tools/filesystem/tests/test_glob.py
+++ b/hud/tools/filesystem/tests/test_glob.py
@@ -89,15 +89,15 @@ class TestGeminiGlobTool:
                 assert Path(line).is_absolute() or str(workspace) in line
 
     @pytest.mark.asyncio
-    async def test_glob_alphabetical_sort(self, workspace: Path) -> None:
-        """Test that results are sorted alphabetically."""
+    async def test_glob_recency_sort(self, workspace: Path) -> None:
+        """Test that results are sorted by recency (recently modified first)."""
         tool = GeminiGlobTool(base_path=str(workspace))
         result = await tool(pattern="**/*.py")
 
         text = result[0].text
         lines = [line for line in text.strip().split("\n") if line and not line.startswith("(")]
-        # Should be sorted alphabetically
-        assert lines == sorted(lines)
+        # All files in test workspace are recent, so they should be sorted newest first
+        assert len(lines) == 3
 
     @pytest.mark.asyncio
     async def test_glob_respect_gemini_ignore_param(self, workspace: Path) -> None:

--- a/hud/tools/filesystem/tests/test_grep.py
+++ b/hud/tools/filesystem/tests/test_grep.py
@@ -83,7 +83,12 @@ class TestGrepTool:
 
 
 class TestGeminiSearchTool:
-    """Tests for Gemini CLI-style GeminiSearchTool."""
+    """Tests for Gemini CLI-style GeminiSearchTool (grep_search)."""
+
+    def test_tool_name(self) -> None:
+        """Test that tool name is grep_search."""
+        tool = GeminiSearchTool(base_path=".")
+        assert tool.name == "grep_search"
 
     @pytest.mark.asyncio
     async def test_search_simple_pattern(self, workspace: Path) -> None:
@@ -112,3 +117,44 @@ class TestGeminiSearchTool:
         result = await tool(pattern="nonexistent_pattern_xyz")
 
         assert "No matches found" in result[0].text
+
+    @pytest.mark.asyncio
+    async def test_search_with_include_pattern(self, workspace: Path) -> None:
+        """Test searching with include_pattern filter."""
+        tool = GeminiSearchTool(base_path=str(workspace))
+        result = await tool(pattern="Hello", include_pattern="*.py")
+
+        text = result[0].text
+        assert "example.py" in text
+        assert "app.js" not in text
+
+    @pytest.mark.asyncio
+    async def test_search_with_exclude_pattern(self, workspace: Path) -> None:
+        """Test searching with exclude_pattern."""
+        tool = GeminiSearchTool(base_path=str(workspace))
+        result = await tool(pattern="TODO", exclude_pattern="later")
+
+        text = result[0].text
+        assert "fix this" in text
+        assert "later" not in text
+
+    @pytest.mark.asyncio
+    async def test_search_names_only(self, workspace: Path) -> None:
+        """Test names_only returns only file paths."""
+        tool = GeminiSearchTool(base_path=str(workspace))
+        result = await tool(pattern="TODO", names_only=True)
+
+        text = result[0].text
+        assert "notes.txt" in text
+        # Should not contain "Line" or "Found" prefix
+        assert "Line" not in text
+        assert "Found" not in text
+
+    @pytest.mark.asyncio
+    async def test_search_total_max_matches(self, workspace: Path) -> None:
+        """Test total_max_matches limits results."""
+        tool = GeminiSearchTool(base_path=str(workspace))
+        result = await tool(pattern="TODO", total_max_matches=1)
+
+        text = result[0].text
+        assert "Found 1 match" in text

--- a/hud/tools/filesystem/tests/test_list.py
+++ b/hud/tools/filesystem/tests/test_list.py
@@ -103,7 +103,7 @@ class TestGeminiListTool:
         result = await tool(dir_path=str(workspace))
 
         text = result[0].text
-        assert "DIR  src" in text or "DIR  docs" in text
+        assert "[DIR] src" in text or "[DIR] docs" in text
 
     @pytest.mark.asyncio
     async def test_list_empty_path_error(self, workspace: Path) -> None:

--- a/hud/tools/filesystem/tests/test_read.py
+++ b/hud/tools/filesystem/tests/test_read.py
@@ -99,19 +99,32 @@ class TestGeminiReadTool:
         assert "line 1" in result[0].text
 
     @pytest.mark.asyncio
-    async def test_read_with_pagination(self, workspace: Path) -> None:
-        """Test reading with offset and limit."""
+    async def test_read_with_start_end_line(self, workspace: Path) -> None:
+        """Test reading with start_line and end_line (1-based, inclusive)."""
         tool = GeminiReadTool(base_path=str(workspace))
         result = await tool(
             file_path=str(workspace / "long.txt"),
-            offset=10,
-            limit=5,
+            start_line=11,
+            end_line=15,
         )
 
         assert isinstance(result[0], TextContent)
         text = result[0].text
         assert "IMPORTANT" in text  # Truncation warning
         assert "line 11" in text
+
+    @pytest.mark.asyncio
+    async def test_read_with_start_line_only(self, workspace: Path) -> None:
+        """Test reading from a start_line without end_line."""
+        tool = GeminiReadTool(base_path=str(workspace), max_lines=5)
+        result = await tool(
+            file_path=str(workspace / "long.txt"),
+            start_line=50,
+        )
+
+        assert isinstance(result[0], TextContent)
+        text = result[0].text
+        assert "line 50" in text
 
     @pytest.mark.asyncio
     async def test_read_empty_path_error(self, workspace: Path) -> None:
@@ -123,10 +136,19 @@ class TestGeminiReadTool:
             await tool(file_path="")
 
     @pytest.mark.asyncio
-    async def test_read_negative_offset_error(self, workspace: Path) -> None:
-        """Test negative offset raises error."""
+    async def test_read_invalid_start_line_error(self, workspace: Path) -> None:
+        """Test start_line < 1 raises error."""
         from hud.tools.types import ToolError
 
         tool = GeminiReadTool(base_path=str(workspace))
-        with pytest.raises(ToolError, match="non-negative"):
-            await tool(file_path=str(workspace / "test.txt"), offset=-1)
+        with pytest.raises(ToolError, match="start_line must be >= 1"):
+            await tool(file_path=str(workspace / "test.txt"), start_line=0)
+
+    @pytest.mark.asyncio
+    async def test_read_end_before_start_error(self, workspace: Path) -> None:
+        """Test end_line < start_line raises error."""
+        from hud.tools.types import ToolError
+
+        tool = GeminiReadTool(base_path=str(workspace))
+        with pytest.raises(ToolError, match="end_line must be >= start_line"):
+            await tool(file_path=str(workspace / "test.txt"), start_line=5, end_line=2)

--- a/hud/tools/filesystem/tests/test_read.py
+++ b/hud/tools/filesystem/tests/test_read.py
@@ -127,6 +127,22 @@ class TestGeminiReadTool:
         assert "line 50" in text
 
     @pytest.mark.asyncio
+    async def test_read_with_end_line_only(self, workspace: Path) -> None:
+        """Test reading with only end_line (first N lines)."""
+        tool = GeminiReadTool(base_path=str(workspace))
+        result = await tool(
+            file_path=str(workspace / "long.txt"),
+            end_line=3,
+        )
+
+        assert isinstance(result[0], TextContent)
+        text = result[0].text
+        assert "line 1" in text
+        assert "line 3" in text
+        # Should not contain line 4+
+        assert "line 4\n" not in text
+
+    @pytest.mark.asyncio
     async def test_read_empty_path_error(self, workspace: Path) -> None:
         """Test empty path raises error."""
         from hud.tools.types import ToolError

--- a/hud/tools/filesystem/tests/test_read_many.py
+++ b/hud/tools/filesystem/tests/test_read_many.py
@@ -1,0 +1,121 @@
+"""Tests for GeminiReadManyTool."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from mcp.types import TextContent
+
+from hud.tools.filesystem import GeminiReadManyTool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def workspace(tmp_path: Path) -> Path:
+    """Create a temporary workspace with test files."""
+    src = tmp_path / "src"
+    src.mkdir()
+
+    (src / "main.py").write_text("def main():\n    pass\n")
+    (src / "utils.py").write_text("def helper():\n    return 1\n")
+    (tmp_path / "readme.txt").write_text("Hello world\n")
+    (tmp_path / "config.json").write_text('{"key": "value"}\n')
+
+    # Create a node_modules dir to test default excludes
+    nm = tmp_path / "node_modules"
+    nm.mkdir()
+    (nm / "pkg.js").write_text("// package\n")
+
+    return tmp_path
+
+
+class TestGeminiReadManyTool:
+    """Tests for GeminiReadManyTool."""
+
+    def test_init(self) -> None:
+        """Test initialization."""
+        tool = GeminiReadManyTool(base_path=".")
+        assert tool.name == "read_many_files"
+
+    @pytest.mark.asyncio
+    async def test_read_single_file(self, workspace: Path) -> None:
+        """Test reading a single literal file path."""
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        result = await tool(include=["readme.txt"])
+
+        assert len(result) == 1
+        assert isinstance(result[0], TextContent)
+        text = result[0].text
+        assert "readme.txt" in text
+        assert "Hello world" in text
+
+    @pytest.mark.asyncio
+    async def test_read_glob_pattern(self, workspace: Path) -> None:
+        """Test reading files by glob pattern."""
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        result = await tool(include=["**/*.py"])
+
+        text = result[0].text
+        assert "main.py" in text
+        assert "utils.py" in text
+        assert "def main" in text
+        assert "def helper" in text
+
+    @pytest.mark.asyncio
+    async def test_read_with_exclude(self, workspace: Path) -> None:
+        """Test excluding files by pattern."""
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        result = await tool(include=["**/*.py"], exclude=["**/utils.py"])
+
+        text = result[0].text
+        assert "main.py" in text
+        assert "utils.py" not in text
+
+    @pytest.mark.asyncio
+    async def test_default_excludes(self, workspace: Path) -> None:
+        """Test that node_modules is excluded by default."""
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        result = await tool(include=["**/*.js"])
+
+        text = result[0].text
+        assert "pkg.js" not in text
+
+    @pytest.mark.asyncio
+    async def test_no_default_excludes(self, workspace: Path) -> None:
+        """Test disabling default excludes."""
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        result = await tool(include=["**/*.js"], useDefaultExcludes=False)
+
+        text = result[0].text
+        assert "pkg.js" in text
+
+    @pytest.mark.asyncio
+    async def test_no_matches(self, workspace: Path) -> None:
+        """Test when no files match."""
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        result = await tool(include=["**/*.xyz"])
+
+        text = result[0].text
+        assert "No files found" in text
+
+    @pytest.mark.asyncio
+    async def test_file_separators(self, workspace: Path) -> None:
+        """Test output has file path separators."""
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        result = await tool(include=["**/*.py"])
+
+        text = result[0].text
+        assert "---" in text
+        assert "End of content" in text
+
+    @pytest.mark.asyncio
+    async def test_empty_include_error(self, workspace: Path) -> None:
+        """Test empty include raises error."""
+        from hud.tools.types import ToolError
+
+        tool = GeminiReadManyTool(base_path=str(workspace))
+        with pytest.raises(ToolError, match="non-empty"):
+            await tool(include=[])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Behavior and interface changes to Gemini tools (notably parameter renames/defaults and stricter multi-match handling) can break existing callers or subtly change file/search results. New write/multi-read capabilities touch filesystem I/O, so containment and truncation logic should be reviewed for edge cases.
> 
> **Overview**
> Adds new Gemini CLI-style tools: `GeminiWriteTool` for creating/overwriting files (with base-directory containment checks) and `GeminiReadManyTool` for concatenated multi-file reads via include/exclude globs with truncation limits; both are exported via `hud.tools` and `hud.tools.filesystem`.
> 
> Updates Gemini tool semantics to closer match Gemini CLI: `GeminiEditTool` now supports new-file creation when `old_string==""`, preserves line endings/trailing newline, improves indentation handling, and replaces `expected_replacements` with an explicit `allow_multiple` flag that errors on ambiguous multi-matches by default.
> 
> Aligns Gemini filesystem tools and outputs: `GeminiReadTool` switches to `start_line`/`end_line` (1-based), `GeminiSearchTool` is renamed to `grep_search` with case-insensitive search by default and adds include/exclude/names-only/limit options, `GeminiGlobTool` becomes case-insensitive by default, includes dotfiles, and sorts by recency, and `GeminiListTool` outputs `[DIR]` plus file sizes. Tests are updated/added accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8202bfeee87041834a05b3ada078f6bfd4960e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->