### PR TITLE
fix ascii color and path based assertions for macos local runs

### DIFF
--- a/hud/cli/tests/test_cli_init.py
+++ b/hud/cli/tests/test_cli_init.py
@@ -131,10 +131,14 @@ class TestCLICommands:
 
     def test_version_import_error(self) -> None:
         """Test version command when version unavailable."""
+        import re
+
+        ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
         with patch.dict("sys.modules", {"hud": None}):
             result = runner.invoke(app, ["version"])
             assert result.exit_code == 0
-            assert "HUD CLI version: unknown" in result.output
+            clean_output = ansi_escape.sub("", result.output)
+            assert "HUD CLI version: unknown" in clean_output
 
     def test_mcp_command(self) -> None:
         """Test mcp server command."""

--- a/hud/tools/coding/tests/test_gemini_tools.py
+++ b/hud/tools/coding/tests/test_gemini_tools.py
@@ -86,7 +86,8 @@ class TestGeminiEditTool:
         with tempfile.TemporaryDirectory() as tmpdir:
             tool = GeminiEditTool(base_directory=tmpdir)
             result = tool._resolve_path("test.txt")
-            assert result == Path(tmpdir) / "test.txt"
+            expected = Path(tmpdir).resolve() / "test.txt"
+            assert result == expected
 
     def test_resolve_path_absolute(self) -> None:
         """Test path resolution with absolute path."""
@@ -213,7 +214,7 @@ class TestGeminiEditTool:
     async def test_file_history_saved(self) -> None:
         """Test that file history is saved for potential undo."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            test_file = Path(tmpdir) / "test.txt"
+            test_file = Path(tmpdir).resolve() / "test.txt"
             test_file.write_text("original content")
 
             tool = GeminiEditTool(base_directory=tmpdir)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates are test-only and primarily adjust assertions for ANSI-colored output and resolved paths, with no production logic changes.
> 
> **Overview**
> Improves test robustness for local/macOS runs by stripping ANSI color codes before asserting `hud version` output (including the import-error `unknown` case).
> 
> Updates `GeminiEditTool` tests to compare against fully resolved `Path` values (and resolved temp file keys) to avoid platform-dependent path normalization failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5aa4c94a3da4e7fb9e533ab2a50b707a7c2bdd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->