### PR TITLE
Add hud export, harbor support

### DIFF
--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -32,6 +32,7 @@ from .analyze import analyze_command  # noqa: E402
 from .build import build_command  # noqa: E402
 from .cancel import cancel_command  # noqa: E402
 from .convert import convert_command  # noqa: E402
+from .export import export_app  # noqa: E402
 from .debug import debug_command  # noqa: E402
 from .deploy import deploy_command  # noqa: E402
 from .dev import dev_command  # noqa: E402
@@ -116,6 +117,9 @@ app.add_typer(scenario_app, name="scenario")
 
 # Sync subcommand group
 app.add_typer(sync_app, name="sync")
+
+# Export subcommand group (HUD → Harbor / ...)
+app.add_typer(export_app, name="export")
 
 # RL subcommand group
 rl_app = typer.Typer(help="🚀 RL training commands\n\nExample: hud rl run my-taskset -m <model-id>")

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -32,11 +32,11 @@ from .analyze import analyze_command  # noqa: E402
 from .build import build_command  # noqa: E402
 from .cancel import cancel_command  # noqa: E402
 from .convert import convert_command  # noqa: E402
-from .export import export_app  # noqa: E402
 from .debug import debug_command  # noqa: E402
 from .deploy import deploy_command  # noqa: E402
 from .dev import dev_command  # noqa: E402
 from .eval import eval_command  # noqa: E402
+from .export import export_app  # noqa: E402
 from .init import init_command  # noqa: E402
 from .link import link_command  # noqa: E402
 from .login import login_command  # noqa: E402

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 import typer
 
-from hud.cli.utils.docker import get_docker_cmd, get_docker_entrypoint
+from hud.cli.utils.docker import _inspect_config
 from hud.cli.utils.environment import find_dockerfile
 from hud.cli.utils.lockfile import (
     build_lock_data,
@@ -815,8 +815,9 @@ def build_environment(
     effective_platform = platform if platform is not None else "linux/amd64"
 
     env_vars_from_file = set(env_from_file.keys()) if env_from_file else set()
-    runtime_command = (get_docker_entrypoint(analysis_image) or []) + (
-        get_docker_cmd(analysis_image) or []
+    image_config = _inspect_config(analysis_image) or {}
+    runtime_command = (
+        (image_config.get("Entrypoint") or []) + (image_config.get("Cmd") or [])
     ) or None
     lock_content = build_lock_data(
         source_dir=env_dir,

--- a/hud/cli/build.py
+++ b/hud/cli/build.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 
 import typer
 
+from hud.cli.utils.docker import get_docker_cmd, get_docker_entrypoint
 from hud.cli.utils.environment import find_dockerfile
 from hud.cli.utils.lockfile import (
     build_lock_data,
@@ -814,6 +815,9 @@ def build_environment(
     effective_platform = platform if platform is not None else "linux/amd64"
 
     env_vars_from_file = set(env_from_file.keys()) if env_from_file else set()
+    runtime_command = (get_docker_entrypoint(analysis_image) or []) + (
+        get_docker_cmd(analysis_image) or []
+    ) or None
     lock_content = build_lock_data(
         source_dir=env_dir,
         analysis=analysis,
@@ -825,6 +829,7 @@ def build_environment(
         additional_required_env_vars=env_vars_from_file,
         platform=effective_platform,
         local_image_ref=build_tag if pushing else None,
+        runtime_command=runtime_command,
     )
 
     # Write lock file

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -320,7 +320,7 @@ def _run_remote_export(
         console.section_title("Try it")
         console.command_example(
             f"cd {out_path} && {sample_cmd}",
-            "Build and run the first task locally",
+            "Run all tasks",
         )
 
     rendered_count = int(manifest.get("rendered_prompt_count", 0))
@@ -484,7 +484,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
         hud_console.section_title("Try it")
         hud_console.command_example(
             f"cd {out_path} && {result.manifest['sample_run_command']}",
-            "Build and run the first task locally",
+            "Run all tasks",
         )
         rendered_count = result.manifest.get("rendered_prompt_count", 0)
         total = result.manifest.get("task_count", 0)

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -378,7 +378,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
             f"cd {out_path} && {result.manifest['sample_run_command']}",
             "Build and run the first task locally",
         )
-        rendered_count = len(rendered)
+        rendered_count = result.manifest.get("rendered_prompt_count", 0)
         total = result.manifest.get("task_count", 0)
         if render_prompts == "skip":
             hud_console.info("")

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -16,7 +16,7 @@ import contextlib
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import typer
 
@@ -245,6 +245,95 @@ def _resolve_prompts(
     raise typer.BadParameter(f"Unknown render-prompts mode: {mode}")
 
 
+def _run_remote_export(
+    *,
+    exporter: BaseExporter,
+    taskset: str,
+    output: Path,
+    private: bool,
+    path: Path,
+    tasks: str | None,
+    image: str | None,
+    render_prompts: str,
+    prompts_file: Path | None,
+    env_var: list[str] | None,
+    task_subset: list[str] | None,
+    console: HUDConsole,
+) -> None:
+    """Delegate the export to the platform; download + extract to ``output``.
+
+    Local-mode flags don't apply in remote mode (the platform owns task
+    discovery, image, prompts, env), so reject any of them up front.
+    """
+    from .remote import remote_export
+
+    conflicting: list[str] = []
+    if path != Path("."):
+        conflicting.append("path argument")
+    if tasks:
+        conflicting.append("--tasks")
+    if image:
+        conflicting.append("--image")
+    if render_prompts != "auto":
+        conflicting.append("--render-prompts")
+    if prompts_file:
+        conflicting.append("--prompts-file")
+    if env_var:
+        conflicting.append("--env")
+    if task_subset:
+        conflicting.append("--task")
+    if conflicting:
+        console.error(
+            "--taskset (remote mode) cannot be combined with: "
+            + ", ".join(conflicting)
+            + ". Remove these flags, or run without --taskset to export from "
+            "a local repo."
+        )
+        raise typer.Exit(1)
+
+    out_path = remote_export(
+        taskset_name=taskset,
+        output_dir=output,
+        fmt=exporter.name,
+        private=private,
+        console=console,
+    )
+
+    manifest_path = out_path / "manifest.json"
+    manifest: dict[str, Any] = {}
+    if manifest_path.is_file():
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            manifest = {}
+
+    console.header(f"Exported to {exporter.name}")
+    console.section_title("Output")
+    console.status_item("Directory", str(out_path))
+    console.status_item("Tasks", str(manifest.get("task_count", 0)))
+    if manifest.get("base_image"):
+        console.status_item("Base image", str(manifest["base_image"]))
+    console.info("")
+
+    sample_cmd = manifest.get("sample_run_command")
+    if sample_cmd:
+        console.section_title("Try it")
+        console.command_example(
+            f"cd {out_path} && {sample_cmd}",
+            "Build and run the first task locally",
+        )
+
+    rendered_count = int(manifest.get("rendered_prompt_count", 0))
+    total = int(manifest.get("task_count", 0))
+    if total and rendered_count < total:
+        missing = total - rendered_count
+        console.info("")
+        console.info(
+            f"{missing} of {total} prompt(s) could not be rendered; "
+            "those instruction.md files fall back to args.description."
+        )
+
+
 def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
     """Build the per-format Typer command function."""
 
@@ -262,7 +351,16 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
         taskset: str | None = typer.Option(
             None,
             "--taskset",
-            help="Taskset name; reserved for future remote-mode support",
+            help=(
+                "Taskset name (or UUID) — runs the export on the HUD platform "
+                "and downloads the result. Required for users behind private "
+                "ECR who can't pull env images locally."
+            ),
+        ),
+        private: bool = typer.Option(
+            False,
+            "--private",
+            help="(remote-mode only) Push mirrored images to private Docker Hub repos.",
         ),
         tasks: str | None = typer.Option(
             None,
@@ -300,11 +398,21 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
         hud_console = HUDConsole()
 
         if taskset:
-            hud_console.error(
-                "--taskset (remote mode) is not yet supported in the CLI. "
-                "Use the platform pipeline, or run from a local repo."
+            _run_remote_export(
+                exporter=exporter,
+                taskset=taskset,
+                output=output,
+                private=private,
+                path=path,
+                tasks=tasks,
+                image=image,
+                render_prompts=render_prompts,
+                prompts_file=prompts_file,
+                env_var=env_var,
+                task_subset=task_subset,
+                console=hud_console,
             )
-            raise typer.Exit(1)
+            return
 
         repo_path = path.resolve()
 

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -245,6 +245,17 @@ def _resolve_prompts(
     raise typer.BadParameter(f"Unknown render-prompts mode: {mode}")
 
 
+def _strip_extract_prefix(sample_run_command: str) -> str:
+    """Drop the ``tar xzf … && cd …`` prefix from ``manifest.sample_run_command``.
+
+    The platform stamps a tar+cd prefix for browser users who download
+    the raw tarball. The CLI (local and remote modes) already has the
+    files extracted in ``out_path``, so only the trailing run command
+    after the last ``&&`` is meaningful.
+    """
+    return sample_run_command.rsplit(" && ", 1)[-1]
+
+
 def _run_remote_export(
     *,
     exporter: BaseExporter,
@@ -319,7 +330,7 @@ def _run_remote_export(
     if sample_cmd:
         console.section_title("Try it")
         console.command_example(
-            f"cd {out_path} && {sample_cmd}",
+            f"cd {out_path} && {_strip_extract_prefix(sample_cmd)}",
             "Run all tasks",
         )
 
@@ -483,7 +494,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
 
         hud_console.section_title("Try it")
         hud_console.command_example(
-            f"cd {out_path} && {result.manifest['sample_run_command']}",
+            f"cd {out_path} && {_strip_extract_prefix(result.manifest['sample_run_command'])}",
             "Run all tasks",
         )
         rendered_count = result.manifest.get("rendered_prompt_count", 0)

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -289,6 +289,15 @@ def _run_remote_export(
         )
         raise typer.Exit(1)
 
+    if not private:
+        prompt = (
+            "--remote will mirror env image(s) to your Docker Hub "
+            "(public by default; pass --private to force private). Continue?"
+        )
+        if not console.confirm(prompt, default=False):
+            console.info("Aborted.")
+            raise typer.Exit(0)
+
     out_path = remote_export(
         taskset_name=taskset_name,
         output_dir=output,

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -1,0 +1,401 @@
+"""HUD → external format exporter.
+
+Public surface:
+  * ``export_app`` — Typer subgroup; one subcommand per registered exporter.
+  * ``export()`` — programmatic entry used by the platform pipeline.
+  * ``write_result()`` — writes an ExportResult to a directory on disk.
+  * ``BaseExporter`` / ``ExportInput`` / ``ExportResult`` — data model.
+
+Add a new format by subclassing ``BaseExporter`` and registering it in
+``_load_exporters()``. The Typer subcommand is generated automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import typer
+
+from hud.utils.hud_console import HUDConsole
+
+from .base import BaseExporter, ExportInput, ExportResult
+from .harbor import HarborExporter
+from .render import render_prompts_via_image, render_prompts_via_url
+
+__all__ = [
+    "BaseExporter",
+    "ExportInput",
+    "ExportResult",
+    "export",
+    "export_app",
+    "get_exporter",
+    "list_formats",
+    "render_prompts_via_image",
+    "render_prompts_via_url",
+    "write_result",
+]
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_exporters: list[BaseExporter] | None = None
+
+
+def _load_exporters() -> list[BaseExporter]:
+    global _exporters
+    if _exporters is None:
+        _exporters = [HarborExporter()]
+    return _exporters
+
+
+def get_exporter(name: str) -> BaseExporter | None:
+    for e in _load_exporters():
+        if e.name == name:
+            return e
+    return None
+
+
+def list_formats() -> list[tuple[str, str]]:
+    return [(e.name, e.description) for e in _load_exporters()]
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+
+def write_result(result: ExportResult, output_dir: Path) -> Path:
+    """Materialize an ExportResult to disk. Returns the output dir."""
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for rel_path, content in result.files.items():
+        target = output_dir / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(content, encoding="utf-8")
+        # Mark shell scripts executable so `./sample-run.sh` works.
+        if target.suffix in {".sh", ".bash"}:
+            target.chmod(0o755)
+    return output_dir
+
+
+# ---------------------------------------------------------------------------
+# Programmatic entry
+# ---------------------------------------------------------------------------
+
+
+def export(format_name: str, inp: ExportInput) -> ExportResult:
+    """Run an exporter by name. Used by the platform pipeline."""
+    exporter = get_exporter(format_name)
+    if exporter is None:
+        available = ", ".join(name for name, _ in list_formats())
+        raise ValueError(f"Unknown export format: {format_name}. Available: {available}")
+    return exporter.export(inp)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+export_app = typer.Typer(
+    help="Export HUD taskset+envs to external formats (Harbor)",
+    rich_markup_mode="rich",
+    no_args_is_help=True,
+)
+
+
+def _resolve_repo_inputs(
+    path: Path,
+    image_override: str | None,
+    tasks_override: str | None,
+) -> tuple[list, str, list[str], str | None]:
+    """Load tasks and image ref from a local repo.
+
+    Returns (tasks, image_ref, required_env, platform).
+    """
+    import sys
+
+    from hud.cli.utils.collect import collect_tasks
+    from hud.cli.utils.environment import find_dockerfile
+    from hud.cli.utils.lockfile import find_lock, get_local_image, load_lock
+
+    if not path.exists() or not path.is_dir():
+        raise typer.BadParameter(f"Not a directory: {path}")
+
+    if find_dockerfile(path) is None:
+        raise typer.BadParameter(
+            f"{path} does not look like a HUD environment (no Dockerfile.hud or Dockerfile found)"
+        )
+
+    # Add common Python source roots to sys.path so user task modules
+    # can resolve their package imports without requiring hud-python's
+    # venv to also have the user's package installed. Covers:
+    #   <repo>/        — flat layout (env.py at root, etc.)
+    #   <repo>/src     — src layout (hud_controller/, …)
+    extra_paths = [str(path), str(path / "src")]
+    inserted: list[str] = []
+    for p in extra_paths:
+        if Path(p).is_dir() and p not in sys.path:
+            sys.path.insert(0, p)
+            inserted.append(p)
+    try:
+        tasks_source = tasks_override or str(path)
+        tasks = collect_tasks(tasks_source)
+    finally:
+        for p in inserted:
+            try:
+                sys.path.remove(p)
+            except ValueError:
+                pass
+    if not tasks:
+        raise typer.BadParameter(
+            f"No tasks found at {tasks_source}. Pass --tasks <file> if your "
+            "taskset lives elsewhere."
+        )
+
+    platform: str | None = None
+    if image_override:
+        image_ref = image_override
+        required_env: list[str] = []
+    else:
+        lock_path = find_lock(path)
+        if lock_path is None:
+            raise typer.BadParameter(
+                f"No hud.lock.yaml found near {path}. Run `hud build` and "
+                "`hud push` first, or pass --image <ref>."
+            )
+        lock_data = load_lock(lock_path)
+        image_ref = lock_data.get("images", {}).get("pushed") or get_local_image(lock_data)
+        if not image_ref:
+            raise typer.BadParameter(
+                "Lock file has no pushed/local image. Run `hud push` first, or pass --image <ref>."
+            )
+        env_block = lock_data.get("environment", {}).get("variables", {}) or {}
+        required_env = list(env_block.get("required") or [])
+        platform = lock_data.get("build", {}).get("platform")
+
+    return tasks, image_ref, required_env, platform
+
+
+def _resolve_prompts(
+    tasks: list,
+    mode: str,
+    prompts_file: Path | None,
+    *,
+    image: str,
+    taskset_name: str,
+    env_vars: dict[str, str] | None = None,
+    platform: str | None = None,
+) -> dict[str, str]:
+    """Return a slug → rendered-prompt dict per the chosen mode."""
+    if prompts_file:
+        data = json.loads(prompts_file.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise typer.BadParameter(f"--prompts-file must contain a JSON object, got {type(data)}")
+        return {str(k): str(v) for k, v in data.items()}
+
+    if mode == "skip":
+        return {}
+    if mode == "live":
+        import asyncio
+
+        return asyncio.run(
+            render_prompts_via_image(
+                image,
+                tasks,
+                taskset_name,
+                env_vars=env_vars or None,
+                platform=platform,
+            )
+        )
+    if mode == "trace":
+        # Trace mode reads pre-recorded prompt spans from the platform's
+        # trace store. The platform pipeline performs this lookup itself
+        # and supplies rendered_prompts via ExportInput; the local CLI
+        # has no trace store to query.
+        raise NotImplementedError(
+            "--render-prompts trace requires the platform pipeline. "
+            "Use --render-prompts live (Docker), --prompts-file <json>, "
+            "or --render-prompts skip from the CLI."
+        )
+    if mode == "auto":
+        # No trace store available locally; auto == live for the CLI.
+        return _resolve_prompts(
+            tasks,
+            "live",
+            None,
+            image=image,
+            taskset_name=taskset_name,
+            env_vars=env_vars,
+            platform=platform,
+        )
+    raise typer.BadParameter(f"Unknown render-prompts mode: {mode}")
+
+
+def _make_format_command(exporter: BaseExporter):
+    """Build the per-format Typer command function."""
+
+    def _cmd(
+        path: Path = typer.Argument(  # noqa: B008
+            Path("."),
+            help="Path to the HUD environment repo (default: current directory)",
+        ),
+        output: Path = typer.Option(  # noqa: B008
+            Path("./hud_exported"),
+            "--output",
+            "-o",
+            help="Output directory",
+        ),
+        taskset: str | None = typer.Option(
+            None,
+            "--taskset",
+            help="Taskset name; reserved for future remote-mode support",
+        ),
+        tasks: str | None = typer.Option(
+            None,
+            "--tasks",
+            help="Explicit path to a tasks file (.py / .json / .jsonl)",
+        ),
+        image: str | None = typer.Option(
+            None,
+            "--image",
+            help="Override the base image reference",
+        ),
+        render_prompts: str = typer.Option(
+            "auto",
+            "--render-prompts",
+            help="How to render prompts: auto (default) | live | trace | skip",
+        ),
+        prompts_file: Path | None = typer.Option(  # noqa: B008
+            None,
+            "--prompts-file",
+            help="JSON object mapping task slug → rendered prompt",
+        ),
+        env_var: list[str] | None = typer.Option(  # noqa: B008
+            None,
+            "--env",
+            "-e",
+            help="KEY=VALUE env vars for live render container (repeatable)",
+        ),
+        task_subset: list[str] | None = typer.Option(  # noqa: B008
+            None,
+            "--task",
+            help="Restrict export to specific task slugs (repeatable)",
+        ),
+    ) -> None:
+        f"""Export to {exporter.name}."""  # noqa: B021
+        hud_console = HUDConsole()
+
+        if taskset:
+            hud_console.error(
+                "--taskset (remote mode) is not yet supported in the CLI. "
+                "Use the platform pipeline, or run from a local repo."
+            )
+            raise typer.Exit(1)
+
+        repo_path = path.resolve()
+
+        try:
+            collected, image_ref, required_env, platform = _resolve_repo_inputs(
+                repo_path, image, tasks
+            )
+        except typer.BadParameter as exc:
+            hud_console.error(str(exc))
+            raise typer.Exit(1) from None
+
+        env_vars: dict[str, str] = {}
+        for raw in env_var or []:
+            if "=" not in raw:
+                hud_console.error(f"Invalid --env (expected KEY=VALUE): {raw}")
+                raise typer.Exit(1)
+            key, value = raw.split("=", 1)
+            env_vars[key.strip()] = value
+
+        try:
+            rendered = _resolve_prompts(
+                collected,
+                render_prompts,
+                prompts_file,
+                image=image_ref,
+                taskset_name=taskset or repo_path.name,
+                env_vars=env_vars,
+                platform=platform,
+            )
+        except (NotImplementedError, typer.BadParameter) as exc:
+            hud_console.error(str(exc))
+            raise typer.Exit(1) from None
+        except (RuntimeError, OSError) as exc:
+            hud_console.error(f"Live render failed: {exc}")
+            raise typer.Exit(1) from None
+
+        taskset_name = taskset or repo_path.name
+
+        inp = ExportInput(
+            tasks=collected,
+            env_image=image_ref,
+            env_platform=platform,
+            env_required_env=required_env,
+            repo_root=repo_path,
+            rendered_prompts=rendered,
+            taskset_name=taskset_name,
+            taskset_id=None,
+            task_subset=list(task_subset) if task_subset else None,
+        )
+
+        try:
+            result = exporter.export(inp)
+        except NotImplementedError as exc:
+            hud_console.error(str(exc))
+            raise typer.Exit(1) from None
+        except ValueError as exc:
+            hud_console.error(str(exc))
+            raise typer.Exit(1) from None
+
+        out_path = write_result(result, output)
+
+        hud_console.header(f"Exported to {exporter.name}")
+        hud_console.section_title("Output")
+        hud_console.status_item("Directory", str(out_path))
+        hud_console.status_item("Tasks", str(result.manifest.get("task_count", 0)))
+        hud_console.status_item("Base image", image_ref)
+        hud_console.info("")
+
+        hud_console.section_title("Try it")
+        hud_console.command_example(
+            f"cd {out_path} && {result.manifest['sample_run_command']}",
+            "Build and run the first task locally",
+        )
+        rendered_count = len(rendered)
+        total = result.manifest.get("task_count", 0)
+        if render_prompts == "skip":
+            hud_console.info("")
+            hud_console.info(
+                "Prompts not rendered (--render-prompts skip). "
+                "instruction.md files contain placeholders."
+            )
+        elif rendered_count < total:
+            missing = total - rendered_count
+            hud_console.info("")
+            hud_console.info(
+                f"{missing} of {total} prompt(s) could not be rendered; "
+                "those instruction.md files fall back to args.description."
+            )
+
+    _cmd.__name__ = f"export_{exporter.name}"
+    _cmd.__doc__ = f"Export HUD taskset+envs to {exporter.description}."
+    return _cmd
+
+
+# Auto-register one subcommand per exporter.
+for _exp in _load_exporters():
+    export_app.command(name=_exp.name)(_make_format_command(_exp))

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -123,10 +123,10 @@ def _resolve_repo_inputs(
     path: Path,
     image_override: str | None,
     tasks_override: str | None,
-) -> tuple[list, str, list[str], str | None]:
+) -> tuple[list, str, list[str], str | None, list[str] | None]:
     """Load tasks and image ref from a local repo.
 
-    Returns (tasks, image_ref, required_env, platform).
+    Returns (tasks, image_ref, required_env, platform, runtime_command).
     """
     import sys
 
@@ -167,6 +167,7 @@ def _resolve_repo_inputs(
         )
 
     platform: str | None = None
+    runtime_command: list[str] | None = None
     if image_override:
         image_ref = image_override
         required_env: list[str] = []
@@ -183,11 +184,15 @@ def _resolve_repo_inputs(
             raise typer.BadParameter(
                 "Lock file has no pushed/local image. Run `hud push` first, or pass --image <ref>."
             )
-        env_block = lock_data.get("environment", {}).get("variables", {}) or {}
+        env_section = lock_data.get("environment", {}) or {}
+        env_block = env_section.get("variables", {}) or {}
         required_env = list(env_block.get("required") or [])
         platform = lock_data.get("build", {}).get("platform")
+        cmd = env_section.get("command")
+        if isinstance(cmd, list) and cmd:
+            runtime_command = [str(arg) for arg in cmd]
 
-    return tasks, image_ref, required_env, platform
+    return tasks, image_ref, required_env, platform, runtime_command
 
 
 def _resolve_prompts(
@@ -262,7 +267,6 @@ def _run_remote_export(
     taskset: str,
     output: Path,
     private: bool,
-    path: Path,
     tasks: str | None,
     image: str | None,
     render_prompts: str,
@@ -279,8 +283,6 @@ def _run_remote_export(
     from .remote import remote_export
 
     conflicting: list[str] = []
-    if path != Path("."):
-        conflicting.append("path argument")
     if tasks:
         conflicting.append("--tasks")
     if image:
@@ -414,7 +416,6 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
                 taskset=taskset,
                 output=output,
                 private=private,
-                path=path,
                 tasks=tasks,
                 image=image,
                 render_prompts=render_prompts,
@@ -428,7 +429,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
         repo_path = path.resolve()
 
         try:
-            collected, image_ref, required_env, platform = _resolve_repo_inputs(
+            collected, image_ref, required_env, platform, runtime_command = _resolve_repo_inputs(
                 repo_path, image, tasks
             )
         except typer.BadParameter as exc:
@@ -466,6 +467,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
             tasks=collected,
             env_image=image_ref,
             env_platform=platform,
+            env_runtime_command=runtime_command,
             env_required_env=required_env,
             repo_root=repo_path,
             rendered_prompts=rendered,
@@ -476,10 +478,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
 
         try:
             result = exporter.export(inp)
-        except NotImplementedError as exc:
-            hud_console.error(str(exc))
-            raise typer.Exit(1) from None
-        except ValueError as exc:
+        except (NotImplementedError, ValueError) as exc:
             hud_console.error(str(exc))
             raise typer.Exit(1) from None
 

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -12,9 +12,11 @@ Add a new format by subclassing ``BaseExporter`` and registering it in
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 
@@ -23,6 +25,9 @@ from hud.utils.hud_console import HUDConsole
 from .base import BaseExporter, ExportInput, ExportResult
 from .harbor import HarborExporter
 from .render import render_prompts_via_image, render_prompts_via_url
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = [
     "BaseExporter",
@@ -153,10 +158,8 @@ def _resolve_repo_inputs(
         tasks = collect_tasks(tasks_source)
     finally:
         for p in inserted:
-            try:
+            with contextlib.suppress(ValueError):
                 sys.path.remove(p)
-            except ValueError:
-                pass
     if not tasks:
         raise typer.BadParameter(
             f"No tasks found at {tasks_source}. Pass --tasks <file> if your "
@@ -242,7 +245,7 @@ def _resolve_prompts(
     raise typer.BadParameter(f"Unknown render-prompts mode: {mode}")
 
 
-def _make_format_command(exporter: BaseExporter):
+def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
     """Build the per-format Typer command function."""
 
     def _cmd(

--- a/hud/cli/export/__init__.py
+++ b/hud/cli/export/__init__.py
@@ -23,7 +23,7 @@ import typer
 from hud.utils.hud_console import HUDConsole
 
 from .base import BaseExporter, ExportInput, ExportResult
-from .harbor import HarborExporter
+from .harbor import HarborExporter, _slugify
 from .render import render_prompts_via_image, render_prompts_via_url
 
 if TYPE_CHECKING:
@@ -205,7 +205,11 @@ def _resolve_prompts(
     env_vars: dict[str, str] | None = None,
     platform: str | None = None,
 ) -> dict[str, str]:
-    """Return a slug → rendered-prompt dict per the chosen mode."""
+    """Return a slug → rendered-prompt dict per the chosen mode.
+
+    ``--prompts-file`` always wins over ``mode``: if a file is supplied,
+    skip Docker entirely and load the dict from disk.
+    """
     if prompts_file:
         data = json.loads(prompts_file.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
@@ -226,28 +230,9 @@ def _resolve_prompts(
                 platform=platform,
             )
         )
-    if mode == "trace":
-        # Trace mode reads pre-recorded prompt spans from the platform's
-        # trace store. The platform pipeline performs this lookup itself
-        # and supplies rendered_prompts via ExportInput; the local CLI
-        # has no trace store to query.
-        raise NotImplementedError(
-            "--render-prompts trace requires the platform pipeline. "
-            "Use --render-prompts live (Docker), --prompts-file <json>, "
-            "or --render-prompts skip from the CLI."
-        )
-    if mode == "auto":
-        # No trace store available locally; auto == live for the CLI.
-        return _resolve_prompts(
-            tasks,
-            "live",
-            None,
-            image=image,
-            taskset_name=taskset_name,
-            env_vars=env_vars,
-            platform=platform,
-        )
-    raise typer.BadParameter(f"Unknown render-prompts mode: {mode}")
+    raise typer.BadParameter(
+        f"Unknown --render-prompts mode: {mode!r}. Use 'live' (default) or 'skip'."
+    )
 
 
 def _strip_extract_prefix(sample_run_command: str) -> str:
@@ -264,7 +249,7 @@ def _strip_extract_prefix(sample_run_command: str) -> str:
 def _run_remote_export(
     *,
     exporter: BaseExporter,
-    taskset: str,
+    taskset_name: str,
     output: Path,
     private: bool,
     tasks: str | None,
@@ -287,7 +272,7 @@ def _run_remote_export(
         conflicting.append("--tasks")
     if image:
         conflicting.append("--image")
-    if render_prompts != "auto":
+    if render_prompts != "live":
         conflicting.append("--render-prompts")
     if prompts_file:
         conflicting.append("--prompts-file")
@@ -297,15 +282,15 @@ def _run_remote_export(
         conflicting.append("--task")
     if conflicting:
         console.error(
-            "--taskset (remote mode) cannot be combined with: "
+            "--remote cannot be combined with: "
             + ", ".join(conflicting)
-            + ". Remove these flags, or run without --taskset to export from "
+            + ". Remove these flags, or run without --remote to export from "
             "a local repo."
         )
         raise typer.Exit(1)
 
     out_path = remote_export(
-        taskset_name=taskset,
+        taskset_name=taskset_name,
         output_dir=output,
         fmt=exporter.name,
         private=private,
@@ -351,29 +336,41 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
     """Build the per-format Typer command function."""
 
     def _cmd(
-        path: Path = typer.Argument(  # noqa: B008
-            Path("."),
-            help="Path to the HUD environment repo (default: current directory)",
+        name: str | None = typer.Argument(
+            None,
+            help=(
+                "Bundle name — used in task.toml, README, manifest, and the "
+                "default output directory. Defaults to the source directory "
+                "name locally. Required with --remote (becomes the platform "
+                "taskset name to fetch)."
+            ),
         ),
-        output: Path = typer.Option(  # noqa: B008
-            Path("./hud_exported"),
+        source: str = typer.Argument(
+            ".",
+            help=(
+                "Path to the HUD environment repo (default: current directory). "
+                "Ignored when --remote is set."
+            ),
+        ),
+        output: Path | None = typer.Option(  # noqa: B008
+            None,
             "--output",
             "-o",
-            help="Output directory",
+            help="Output directory (default: ./<name>)",
         ),
-        taskset: str | None = typer.Option(
-            None,
-            "--taskset",
+        remote: bool = typer.Option(
+            False,
+            "--remote",
             help=(
-                "Taskset name (or UUID) — runs the export on the HUD platform "
-                "and downloads the result. Required for users behind private "
-                "ECR who can't pull env images locally."
+                "Run the export on the HUD platform instead of locally and "
+                "download the result. Required for users behind private ECR "
+                "who can't pull env images locally."
             ),
         ),
         private: bool = typer.Option(
             False,
             "--private",
-            help="(remote-mode only) Push mirrored images to private Docker Hub repos.",
+            help="(--remote only) Push mirrored images to private Docker Hub repos.",
         ),
         tasks: str | None = typer.Option(
             None,
@@ -386,20 +383,24 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
             help="Override the base image reference",
         ),
         render_prompts: str = typer.Option(
-            "auto",
+            "live",
             "--render-prompts",
-            help="How to render prompts: auto (default) | live | trace | skip",
+            help=(
+                "How to render prompts: live (default; boots the env image "
+                "in Docker and queries MCP) | skip (use placeholders). "
+                "Overridden by --prompts-file when set."
+            ),
         ),
         prompts_file: Path | None = typer.Option(  # noqa: B008
             None,
             "--prompts-file",
-            help="JSON object mapping task slug → rendered prompt",
+            help="JSON object mapping task slug → rendered prompt (overrides --render-prompts)",
         ),
         env_var: list[str] | None = typer.Option(  # noqa: B008
             None,
             "--env",
             "-e",
-            help="KEY=VALUE env vars for live render container (repeatable)",
+            help="KEY=VALUE env vars for the live render container (repeatable)",
         ),
         task_subset: list[str] | None = typer.Option(  # noqa: B008
             None,
@@ -410,11 +411,17 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
         f"""Export to {exporter.name}."""  # noqa: B021
         hud_console = HUDConsole()
 
-        if taskset:
+        if remote:
+            if not name:
+                hud_console.error(
+                    "--remote requires a taskset name as the first positional "
+                    "argument (e.g. `hud export harbor my-taskset --remote`)."
+                )
+                raise typer.Exit(1)
             _run_remote_export(
                 exporter=exporter,
-                taskset=taskset,
-                output=output,
+                taskset_name=name,
+                output=output or Path(f"./{_slugify(name)}"),
                 private=private,
                 tasks=tasks,
                 image=image,
@@ -426,7 +433,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
             )
             return
 
-        repo_path = path.resolve()
+        repo_path = Path(source).resolve()
 
         try:
             collected, image_ref, required_env, platform, runtime_command = _resolve_repo_inputs(
@@ -444,13 +451,15 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
             key, value = raw.split("=", 1)
             env_vars[key.strip()] = value
 
+        taskset_name = name or repo_path.name
+
         try:
             rendered = _resolve_prompts(
                 collected,
                 render_prompts,
                 prompts_file,
                 image=image_ref,
-                taskset_name=taskset or repo_path.name,
+                taskset_name=taskset_name,
                 env_vars=env_vars,
                 platform=platform,
             )
@@ -460,8 +469,6 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
         except (RuntimeError, OSError) as exc:
             hud_console.error(f"Live render failed: {exc}")
             raise typer.Exit(1) from None
-
-        taskset_name = taskset or repo_path.name
 
         inp = ExportInput(
             tasks=collected,
@@ -482,7 +489,7 @@ def _make_format_command(exporter: BaseExporter) -> Callable[..., None]:
             hud_console.error(str(exc))
             raise typer.Exit(1) from None
 
-        out_path = write_result(result, output)
+        out_path = write_result(result, output or Path(f"./{_slugify(taskset_name)}"))
 
         hud_console.header(f"Exported to {exporter.name}")
         hud_console.section_title("Output")

--- a/hud/cli/export/base.py
+++ b/hud/cli/export/base.py
@@ -40,6 +40,7 @@ class ExportInput(BaseModel):
     taskset_name: str
     taskset_id: str | None = None
     task_subset: list[str] | None = None
+    bundle_name: str | None = None
 
 
 class ExportResult(BaseModel):

--- a/hud/cli/export/base.py
+++ b/hud/cli/export/base.py
@@ -34,6 +34,7 @@ class ExportInput(BaseModel):
     tasks: list[Task]
     env_image: str
     env_platform: str | None = None
+    env_runtime_command: list[str] | None = None
     env_required_env: list[str] = Field(default_factory=list)
     repo_root: Path | None = None
     rendered_prompts: dict[str, str] = Field(default_factory=dict)

--- a/hud/cli/export/base.py
+++ b/hud/cli/export/base.py
@@ -1,0 +1,67 @@
+"""Abstract base classes for format exporters.
+
+Mirrors the structure of hud/cli/convert/base.py but goes the inverse
+direction: HUD environments + tasksets → external benchmark format.
+
+BaseExporter.export() is pure: it takes a structured ExportInput and
+returns an ExportResult containing files-to-write plus a manifest.
+The CLI shell writes the result to disk; the platform pipeline streams
+it to S3/Supabase.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from hud.eval.task import Task
+
+__all__ = ["BaseExporter", "ExportInput", "ExportResult"]
+
+
+class ExportInput(BaseModel):
+    """Structured input for an export run.
+
+    Constructed by the CLI (from a local repo) or by the platform
+    pipeline (from taskset API + image registry + trace store).
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    tasks: list[Task]
+    env_image: str
+    env_platform: str | None = None
+    env_required_env: list[str] = Field(default_factory=list)
+    repo_root: Path | None = None
+    rendered_prompts: dict[str, str] = Field(default_factory=dict)
+    taskset_name: str
+    taskset_id: str | None = None
+    task_subset: list[str] | None = None
+
+
+class ExportResult(BaseModel):
+    """Files-to-write plus a manifest.
+
+    `files` keys are POSIX-style relative paths under the export root.
+    Values may be str (text) or bytes (binary). The CLI's write_result()
+    materializes these to disk; the platform streams them into a tarball.
+    """
+
+    files: dict[str, str | bytes]
+    manifest: dict[str, Any]
+    sample_run_script: str
+    summary: list[str] = Field(default_factory=list)
+
+
+class BaseExporter(ABC):
+    """Abstract base for HUD-to-external format exporters."""
+
+    name: str
+    description: str
+
+    @abstractmethod
+    def export(self, inp: ExportInput) -> ExportResult:
+        """Produce an ExportResult from the given input. Must be pure."""

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -349,6 +349,11 @@ class HarborExporter(BaseExporter):
         files["README.md"] = readme
         files["sample-run.sh"] = sample_run
 
+        bundle_name = inp.bundle_name or _slugify(inp.taskset_name)
+        sample_run_command = (
+            f"tar xzf {bundle_name}.tar.gz\ncd {bundle_name}\n./sample-run.sh {ordered_slugs[0]}"
+        )
+
         manifest: dict[str, Any] = {
             "format": "harbor",
             "taskset_name": inp.taskset_name,
@@ -358,7 +363,8 @@ class HarborExporter(BaseExporter):
             "rendered_prompt_count": rendered_prompt_count,
             "base_image": inp.env_image,
             "required_env": sorted(inp.env_required_env),
-            "sample_run_command": f"./sample-run.sh {ordered_slugs[0]}",
+            "bundle_name": bundle_name,
+            "sample_run_command": sample_run_command,
         }
         files["manifest.json"] = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
 

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -56,6 +56,27 @@ def _task_slug(task: Task, fallback_index: int) -> str:
     return _slugify(candidate)
 
 
+def _dedupe_slugs(tasks: list[Task]) -> list[str]:
+    """Return per-task slugs with collisions disambiguated as ``slug-2``, ``slug-3``, ...
+
+    Single source of truth for the export pipeline: ``HarborExporter.export``
+    and ``render_prompts_via_url`` both use this so the slug a prompt is
+    rendered against is the same key the exporter looks up later.
+    """
+    used: set[str] = set()
+    out: list[str] = []
+    for index, task in enumerate(tasks):
+        base = _task_slug(task, index)
+        slug = base
+        n = 1
+        while slug in used:
+            n += 1
+            slug = f"{base}-{n}"
+        used.add(slug)
+        out.append(slug)
+    return out
+
+
 def _toml_escape(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
@@ -276,28 +297,21 @@ class HarborExporter(BaseExporter):
 
         files: dict[str, str | bytes] = {}
         summary: list[str] = []
-        slugs_used: set[str] = set()
-        ordered_slugs: list[str] = []
+        ordered_slugs = _dedupe_slugs(tasks)
+        rendered_prompt_count = 0
 
         bake_setup = _read_template("bake-setup.sh")
         entrypoint_py = _read_template("entrypoint.py")
         test_sh = _read_template("test.sh")
 
-        for index, task in enumerate(tasks):
-            slug = _task_slug(task, index)
-            base_slug = slug
-            dedupe = 1
-            while slug in slugs_used:
-                dedupe += 1
-                slug = f"{base_slug}-{dedupe}"
-            slugs_used.add(slug)
-            ordered_slugs.append(slug)
-
+        for task, slug in zip(tasks, ordered_slugs, strict=True):
             scenario_full = _full_scenario_name(task, inp.taskset_name)
             args_json = json.dumps(task.args or {}, sort_keys=True)
             prompt_was_rendered = bool(
                 inp.rendered_prompts.get(slug) or inp.rendered_prompts.get(task.slug or "")
             )
+            if prompt_was_rendered:
+                rendered_prompt_count += 1
             rendered = inp.rendered_prompts.get(slug) or inp.rendered_prompts.get(
                 task.slug or "", ""
             )
@@ -341,6 +355,7 @@ class HarborExporter(BaseExporter):
             "taskset_id": inp.taskset_id,
             "task_count": len(ordered_slugs),
             "task_slugs": ordered_slugs,
+            "rendered_prompt_count": rendered_prompt_count,
             "base_image": inp.env_image,
             "required_env": sorted(inp.env_required_env),
             "sample_run_command": f"./sample-run.sh {ordered_slugs[0]}",

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -38,10 +38,51 @@ if TYPE_CHECKING:
 __all__ = ["HarborExporter"]
 
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
+_HARBOR_MCP_PORT = 8765
 
 
 def _read_template(name: str) -> str:
     return (_TEMPLATES_DIR / name).read_text(encoding="utf-8")
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_float(value: Any, default: float) -> float:
+    try:
+        return float(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _rewrite_stdio_to_port(cmd: list[Any], port: int) -> list[str]:
+    """Replace ``--stdio`` with ``--port <port>`` in an argv-style command.
+
+    The env image's launch command (from the build's lock yaml) typically
+    runs ``hud dev … --stdio`` for MCP-over-stdio. Harbor's compose driver
+    needs HTTP, so the exporter rewrites the command once at build time
+    and stamps the result as ``HUD_LAUNCH_COMMAND``. Both bake-setup.sh
+    and entrypoint.py consume the rewritten value verbatim — no runtime
+    rewriting.
+
+    Handles both standalone ``--stdio`` tokens and ``--stdio`` embedded
+    inside shell-string args (e.g. ``sh -c "uvicorn … & exec hud dev … --stdio"``).
+    """
+    port_str = str(port)
+    out: list[str] = []
+    for arg in cmd:
+        s = str(arg)
+        if s == "--stdio":
+            out.extend(["--port", port_str])
+        elif "--stdio" in s:
+            out.append(s.replace("--stdio", f"--port {port_str}"))
+        else:
+            out.append(s)
+    return out
 
 
 def _slugify(value: str) -> str:
@@ -100,10 +141,7 @@ def _system_prompt(task: Task) -> str | None:
 def _agent_timeout(task: Task) -> int:
     cfg = task.agent_config
     val = cfg.get("timeout") if isinstance(cfg, dict) else getattr(cfg, "timeout", None)
-    try:
-        return int(val) if val else 1800
-    except (TypeError, ValueError):
-        return 1800
+    return _coerce_int(val, 1800)
 
 
 def _build_instruction_md(task: Task, rendered_prompt: str) -> str:
@@ -148,11 +186,11 @@ def _build_task_toml(
 
     difficulty = task.metadata.get("difficulty")
     category = task.metadata.get("category")
-    verifier_timeout = float(task.metadata.get("verifier_timeout", 1800))
-    agent_timeout = float(_agent_timeout(task))
-    build_timeout = float(task.metadata.get("build_timeout", 2400))
-    cpus = int(task.metadata.get("cpus", 4))
-    memory_mb = int(task.metadata.get("memory_mb", 16384))
+    verifier_timeout = _coerce_float(task.metadata.get("verifier_timeout"), 1800)
+    agent_timeout = _coerce_float(_agent_timeout(task), 1800)
+    build_timeout = _coerce_float(task.metadata.get("build_timeout"), 2400)
+    cpus = _coerce_int(task.metadata.get("cpus"), 4)
+    memory_mb = _coerce_int(task.metadata.get("memory_mb"), 16384)
 
     lines: list[str] = [
         "[task]",
@@ -236,7 +274,9 @@ def _build_task_dockerfile(
 
     ``runtime_command`` is the env image's *full* launch command from
     the build's lock yaml (e.g. ``["sh", "-c", "uvicorn ... & sleep 5
-    && exec hud dev env:env --stdio"]``).
+    && exec hud dev env:env --stdio"]``). The exporter rewrites
+    ``--stdio`` to ``--port <_HARBOR_MCP_PORT>`` once here so the runtime
+    scripts (bake-setup.sh, entrypoint.py) can consume the value verbatim.
     """
     safe_args = args_json.replace("'", "'\\''")
     from_line = f"FROM --platform={platform} {base_image}" if platform else f"FROM {base_image}"
@@ -247,9 +287,10 @@ def _build_task_dockerfile(
         f"ENV HUD_TASK_ARGS='{safe_args}'",
     ]
     if runtime_command:
+        rewritten = _rewrite_stdio_to_port(list(runtime_command), _HARBOR_MCP_PORT)
         # JSON-encode and shell-escape single quotes so the docker ENV
         # value survives both Dockerfile parsing and bash dequoting.
-        launch_json = json.dumps(list(runtime_command))
+        launch_json = json.dumps(rewritten)
         safe_launch = launch_json.replace("'", "'\\''")
         parts.append(f"ENV HUD_LAUNCH_COMMAND='{safe_launch}'")
     parts.extend(
@@ -347,15 +388,13 @@ class HarborExporter(BaseExporter):
         for task, slug in zip(tasks, ordered_slugs, strict=True):
             scenario_full = _full_scenario_name(task, inp.taskset_name)
             args_json = json.dumps(task.args or {}, sort_keys=True)
-            prompt_was_rendered = bool(
-                inp.rendered_prompts.get(slug) or inp.rendered_prompts.get(task.slug or "")
+            rendered = (
+                inp.rendered_prompts.get(slug) or inp.rendered_prompts.get(task.slug or "") or ""
             )
+            prompt_was_rendered = bool(rendered)
             if prompt_was_rendered:
                 rendered_prompt_count += 1
-            rendered = inp.rendered_prompts.get(slug) or inp.rendered_prompts.get(
-                task.slug or "", ""
-            )
-            if not rendered:
+            else:
                 rendered = (
                     f"[Prompt for scenario {scenario_full!r} was not rendered "
                     f"during export. Run with --render-prompts live or trace.]"

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -219,8 +219,7 @@ def _build_compose_override(required_env: list[str]) -> str | None:
     if not required_env:
         return None
     lines = ["services:", "  main:", "    environment:"]
-    for var in sorted(required_env):
-        lines.append(f"      {var}: ${{{var}}}")
+    lines.extend(f"      {var}: ${{{var}}}" for var in sorted(required_env))
     lines.append("")
     return "\n".join(lines)
 

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -162,6 +162,18 @@ def _build_task_toml(
             f"cpus = {cpus}",
             f"memory_mb = {memory_mb}",
             "",
+            "[[environment.mcp_servers]]",
+            'name = "hud_env"',
+            'transport = "streamable-http"',
+            'url = "http://localhost:8765/mcp"',
+            "",
+            "[environment.healthcheck]",
+            'command = "curl -fsS http://localhost:8765/mcp >/dev/null 2>&1"',
+            "interval_sec = 2.0",
+            "timeout_sec = 5.0",
+            "start_period_sec = 5.0",
+            "retries = 30",
+            "",
         ]
     )
     return "\n".join(lines)
@@ -188,7 +200,13 @@ def _build_task_dockerfile(
     if required_env:
         parts.append("")
         parts.extend(f"# {var} must be supplied at run time" for var in sorted(required_env))
-    parts.extend(["", 'CMD ["/bin/bash"]', ""])
+    parts.extend(
+        [
+            "",
+            'CMD ["sh", "-c", "exec hud dev env:env --port 8765"]',
+            "",
+        ]
+    )
     return "\n".join(parts)
 
 

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -138,6 +138,7 @@ def _build_task_toml(
     taskset_name: str,
     instruction: str,
     prompt_was_rendered: bool,
+    required_env: list[str] | None = None,
 ) -> str:
     name = f"{_slugify(taskset_name)}/{slug}"
     description_seed = _derive_description(task, slug, instruction, prompt_was_rendered)
@@ -195,32 +196,33 @@ def _build_task_toml(
             "timeout_sec = 5.0",
             "start_period_sec = 5.0",
             "retries = 30",
-            "",
         ]
     )
+    if required_env:
+        lines.extend(["", "[environment.env]"])
+        lines.extend(f'{var} = "${{{var}}}"' for var in sorted(required_env))
+    lines.append("")
     return "\n".join(lines)
 
 
-def _extract_hud_dev_module(runtime_command: list[str] | None) -> str | None:
-    """Pull the ``module:attr`` token out of an env's launch command."""
-    if not runtime_command:
+def _build_compose_override(required_env: list[str]) -> str | None:
+    """Render a docker-compose override that forwards host-resolved env
+    vars into the running ``main`` container.
+
+    Harbor's base compose YAML has no ``environment:`` block, so values
+    that ``task.toml``'s ``[environment.env]`` resolves into the compose
+    subprocess's env never reach the running container without an
+    override. Emit one whenever the env declared any required vars.
+    Returns ``None`` for empty ``required_env`` so the bundle stays
+    minimal.
+    """
+    if not required_env:
         return None
-    import shlex
-
-    tokens: list[str] = []
-    for arg in runtime_command:
-        if arg in {"sh", "bash", "/bin/sh", "/bin/bash", "-c", "-lc", "exec"}:
-            continue
-        tokens.extend(shlex.split(arg) if (" " in arg or "$" in arg) else [arg])
-
-    for index, token in enumerate(tokens):
-        if token == "hud" and index + 1 < len(tokens) and tokens[index + 1] == "dev":  # noqa: S105
-            for candidate in tokens[index + 2 :]:
-                if candidate.startswith("-"):
-                    continue
-                return candidate
-            return None
-    return None
+    lines = ["services:", "  main:", "    environment:"]
+    for var in sorted(required_env):
+        lines.append(f"      {var}: ${{{var}}}")
+    lines.append("")
+    return "\n".join(lines)
 
 
 def _build_task_dockerfile(
@@ -229,8 +231,14 @@ def _build_task_dockerfile(
     args_json: str,
     required_env: list[str],
     platform: str | None = None,
-    hud_dev_args: str | None = None,
+    runtime_command: list[str] | None = None,
 ) -> str:
+    """Render a per-task Dockerfile.
+
+    ``runtime_command`` is the env image's *full* launch command from
+    the build's lock yaml (e.g. ``["sh", "-c", "uvicorn ... & sleep 5
+    && exec hud dev env:env --stdio"]``).
+    """
     safe_args = args_json.replace("'", "'\\''")
     from_line = f"FROM --platform={platform} {base_image}" if platform else f"FROM {base_image}"
     parts = [
@@ -239,8 +247,12 @@ def _build_task_dockerfile(
         f"ENV HUD_TASK_SCENARIO={scenario_full}",
         f"ENV HUD_TASK_ARGS='{safe_args}'",
     ]
-    if hud_dev_args:
-        parts.append(f"ENV HUD_DEV_ARGS={hud_dev_args}")
+    if runtime_command:
+        # JSON-encode and shell-escape single quotes so the docker ENV
+        # value survives both Dockerfile parsing and bash dequoting.
+        launch_json = json.dumps(list(runtime_command))
+        safe_launch = launch_json.replace("'", "'\\''")
+        parts.append(f"ENV HUD_LAUNCH_COMMAND='{safe_launch}'")
     parts.extend(
         [
             "",
@@ -332,7 +344,6 @@ class HarborExporter(BaseExporter):
         bake_setup = _read_template("bake-setup.sh")
         entrypoint_py = _read_template("entrypoint.py")
         test_sh = _read_template("test.sh")
-        hud_dev_args = _extract_hud_dev_module(inp.env_runtime_command)
 
         for task, slug in zip(tasks, ordered_slugs, strict=True):
             scenario_full = _full_scenario_name(task, inp.taskset_name)
@@ -353,7 +364,12 @@ class HarborExporter(BaseExporter):
 
             instruction = _build_instruction_md(task, rendered)
             task_toml = _build_task_toml(
-                task, slug, inp.taskset_name, instruction, prompt_was_rendered
+                task,
+                slug,
+                inp.taskset_name,
+                instruction,
+                prompt_was_rendered,
+                required_env=inp.env_required_env,
             )
             dockerfile = _build_task_dockerfile(
                 base_image=inp.env_image,
@@ -361,7 +377,7 @@ class HarborExporter(BaseExporter):
                 args_json=args_json,
                 required_env=inp.env_required_env,
                 platform=inp.env_platform,
-                hud_dev_args=hud_dev_args,
+                runtime_command=inp.env_runtime_command,
             )
 
             base = f"tasks/{slug}"
@@ -370,6 +386,9 @@ class HarborExporter(BaseExporter):
             files[f"{base}/environment/Dockerfile"] = dockerfile
             files[f"{base}/environment/bake-setup.sh"] = bake_setup
             files[f"{base}/environment/entrypoint.py"] = entrypoint_py
+            compose_override = _build_compose_override(inp.env_required_env)
+            if compose_override:
+                files[f"{base}/environment/docker-compose.yaml"] = compose_override
             files[f"{base}/tests/test.sh"] = test_sh
 
             summary.append(f"{slug} ({scenario_full})")

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -168,7 +168,11 @@ def _build_task_toml(
             'url = "http://localhost:8765/mcp"',
             "",
             "[environment.healthcheck]",
-            'command = "curl -fsS http://localhost:8765/mcp >/dev/null 2>&1"',
+            # MCP at /mcp speaks streamable-http (needs POST + handshake),
+            # so a plain ``curl -fsS GET /mcp`` 400s and curl exits 22.
+            # Use a TCP-level connect check instead: any successful
+            # connection means ``hud dev`` is bound and ready.
+            'command = "python3 -c \\"import socket;socket.create_connection((\'localhost\',8765),timeout=2).close()\\""',  # noqa: E501
             "interval_sec = 2.0",
             "timeout_sec = 5.0",
             "start_period_sec = 5.0",
@@ -196,6 +200,9 @@ def _build_task_dockerfile(
         "",
         "COPY bake-setup.sh /opt/hud/bake-setup.sh",
         "RUN chmod +x /opt/hud/bake-setup.sh && /opt/hud/bake-setup.sh",
+        "",
+        "COPY entrypoint.py /opt/hud/entrypoint.py",
+        "RUN chmod +x /opt/hud/entrypoint.py",
     ]
     if required_env:
         parts.append("")
@@ -203,7 +210,8 @@ def _build_task_dockerfile(
     parts.extend(
         [
             "",
-            'CMD ["sh", "-c", "exec hud dev env:env --port 8765"]',
+            'ENTRYPOINT ["python3", "/opt/hud/entrypoint.py"]',
+            'CMD ["sleep", "infinity"]',
             "",
         ]
     )
@@ -275,6 +283,7 @@ class HarborExporter(BaseExporter):
         ordered_slugs: list[str] = []
 
         bake_setup = _read_template("bake-setup.sh")
+        entrypoint_py = _read_template("entrypoint.py")
         test_sh = _read_template("test.sh")
 
         for index, task in enumerate(tasks):
@@ -318,6 +327,7 @@ class HarborExporter(BaseExporter):
             files[f"{base}/task.toml"] = task_toml
             files[f"{base}/environment/Dockerfile"] = dockerfile
             files[f"{base}/environment/bake-setup.sh"] = bake_setup
+            files[f"{base}/environment/entrypoint.py"] = entrypoint_py
             files[f"{base}/tests/test.sh"] = test_sh
 
             summary.append(f"{slug} ({scenario_full})")

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -214,7 +214,7 @@ def _extract_hud_dev_module(runtime_command: list[str] | None) -> str | None:
         tokens.extend(shlex.split(arg) if (" " in arg or "$" in arg) else [arg])
 
     for index, token in enumerate(tokens):
-        if token == "hud" and index + 1 < len(tokens) and tokens[index + 1] == "dev":
+        if token == "hud" and index + 1 < len(tokens) and tokens[index + 1] == "dev":  # noqa: S105
             for candidate in tokens[index + 2 :]:
                 if candidate.startswith("-"):
                     continue

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -1,0 +1,330 @@
+"""HUD → Harbor exporter.
+
+Produces a Harbor-format directory tree from a HUD taskset+environment.
+
+Output layout (per ../outline-harbor-coding):
+    <root>/
+    ├── README.md
+    ├── sample-run.sh
+    ├── tasks/
+    │   └── <task-slug>/
+    │       ├── instruction.md            # rendered system + user prompt
+    │       ├── task.toml                 # metadata, timeouts, resources
+    │       ├── environment/
+    │       │   ├── Dockerfile            # FROM <base> + bake-setup
+    │       │   └── bake-setup.sh
+    │       └── tests/
+    │           └── test.sh               # generic; calls `hud scenario grade`
+    └── manifest.json                     # taskset metadata + sample command
+
+Setup is baked into each per-task image via `hud scenario setup` at
+docker-build time (see bake-setup.sh). Grading shells to `hud scenario
+grade` at runtime (see test.sh). One generic test.sh handles every
+HUD scenario type.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .base import BaseExporter, ExportInput, ExportResult
+
+if TYPE_CHECKING:
+    from hud.eval.task import Task
+
+__all__ = ["HarborExporter"]
+
+_TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+
+def _read_template(name: str) -> str:
+    return (_TEMPLATES_DIR / name).read_text(encoding="utf-8")
+
+
+def _slugify(value: str) -> str:
+    """Normalize an arbitrary identifier to a Harbor-safe slug."""
+    s = value.strip().lower()
+    s = re.sub(r"[^a-z0-9]+", "-", s)
+    return s.strip("-") or "task"
+
+
+def _task_slug(task: Task, fallback_index: int) -> str:
+    candidate = task.slug or task.id or task.scenario or f"task-{fallback_index}"
+    return _slugify(candidate)
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _render_keywords(keywords: list[Any]) -> str:
+    parts = [f'"{_toml_escape(str(k))}"' for k in keywords]
+    return "[" + ", ".join(parts) + "]"
+
+
+def _system_prompt(task: Task) -> str | None:
+    cfg = task.agent_config
+    if cfg is None:
+        return None
+    if isinstance(cfg, dict):
+        prompt = cfg.get("system_prompt")
+    else:
+        prompt = getattr(cfg, "system_prompt", None)
+    return prompt or None
+
+
+def _agent_timeout(task: Task) -> int:
+    cfg = task.agent_config
+    if isinstance(cfg, dict):
+        val = cfg.get("timeout")
+    else:
+        val = getattr(cfg, "timeout", None)
+    try:
+        return int(val) if val else 1800
+    except (TypeError, ValueError):
+        return 1800
+
+
+def _build_instruction_md(task: Task, rendered_prompt: str) -> str:
+    system = _system_prompt(task)
+    if system:
+        return f"{system.strip()}\n\n---\n\n{rendered_prompt.strip()}\n"
+    return f"{rendered_prompt.strip()}\n"
+
+
+def _derive_description(task: Task, slug: str, instruction: str, prompt_was_rendered: bool) -> str:
+    """Pick a short, human-readable description for task.toml.
+
+    Prefers the first line of a rendered instruction; falls back to
+    args.description (a common convention) and finally the slug.
+    """
+    if prompt_was_rendered:
+        first_line = next((ln for ln in instruction.splitlines() if ln.strip()), "")
+        if first_line:
+            return first_line[:200]
+    args = task.args or {}
+    if isinstance(args, dict):
+        for key in ("description", "task_description", "prompt"):
+            value = args.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip().splitlines()[0][:200]
+    return slug
+
+
+def _build_task_toml(
+    task: Task,
+    slug: str,
+    taskset_name: str,
+    instruction: str,
+    prompt_was_rendered: bool,
+) -> str:
+    name = f"{_slugify(taskset_name)}/{slug}"
+    description_seed = _derive_description(task, slug, instruction, prompt_was_rendered)
+    keywords = task.metadata.get("keywords") or []
+    if not isinstance(keywords, list):
+        keywords = [keywords]
+
+    difficulty = task.metadata.get("difficulty")
+    category = task.metadata.get("category")
+    verifier_timeout = float(task.metadata.get("verifier_timeout", 1800))
+    agent_timeout = float(_agent_timeout(task))
+    build_timeout = float(task.metadata.get("build_timeout", 2400))
+    cpus = int(task.metadata.get("cpus", 4))
+    memory_mb = int(task.metadata.get("memory_mb", 16384))
+
+    lines: list[str] = [
+        "[task]",
+        f'name = "{_toml_escape(name)}"',
+        f'description = "{_toml_escape(description_seed)}"',
+        f"keywords = {_render_keywords(keywords)}",
+        "",
+        "[metadata]",
+    ]
+    if difficulty:
+        lines.append(f'difficulty = "{_toml_escape(str(difficulty))}"')
+    if category:
+        lines.append(f'category = "{_toml_escape(str(category))}"')
+    lines.extend(
+        [
+            "",
+            "[verifier]",
+            f"timeout_sec = {verifier_timeout}",
+            'user = "root"',
+            "",
+            "[agent]",
+            f"timeout_sec = {agent_timeout}",
+            "",
+            "[environment]",
+            f"build_timeout_sec = {build_timeout}",
+            f"cpus = {cpus}",
+            f"memory_mb = {memory_mb}",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _build_task_dockerfile(
+    base_image: str,
+    scenario_full: str,
+    args_json: str,
+    required_env: list[str],
+    platform: str | None = None,
+) -> str:
+    safe_args = args_json.replace("'", "'\\''")
+    from_line = f"FROM --platform={platform} {base_image}" if platform else f"FROM {base_image}"
+    parts = [
+        from_line,
+        "",
+        f"ENV HUD_TASK_SCENARIO={scenario_full}",
+        f"ENV HUD_TASK_ARGS='{safe_args}'",
+        "",
+        "COPY bake-setup.sh /opt/hud/bake-setup.sh",
+        "RUN chmod +x /opt/hud/bake-setup.sh && /opt/hud/bake-setup.sh",
+    ]
+    if required_env:
+        parts.append("")
+        parts.extend(f"# {var} must be supplied at run time" for var in sorted(required_env))
+    parts.extend(["", 'CMD ["/bin/bash"]', ""])
+    return "\n".join(parts)
+
+
+def _full_scenario_name(task: Task, taskset_name: str) -> str:
+    """Compose env:scenario form for `hud scenario` lookups."""
+    if not task.scenario:
+        raise ValueError(f"Task {task.slug or task.id!r} has no scenario; cannot export")
+    if ":" in task.scenario:
+        return task.scenario
+    env_name: str | None = None
+    env = task.env
+    if env is not None:
+        env_name = getattr(env, "name", None)
+        if env_name is None and isinstance(env, dict):
+            env_name = env.get("name")
+    if not env_name:
+        env_name = _slugify(taskset_name)
+    return f"{env_name}:{task.scenario}"
+
+
+def _select_tasks(inp: ExportInput) -> list[Task]:
+    if not inp.task_subset:
+        return list(inp.tasks)
+    wanted = set(inp.task_subset)
+    return [
+        t for t in inp.tasks if (t.slug in wanted) or (t.id in wanted) or (t.scenario in wanted)
+    ]
+
+
+def _render_readme(taskset_name: str, task_slugs: list[str], base_image: str) -> str:
+    listing = "\n".join(f"- `tasks/{s}/`" for s in task_slugs)
+    return (
+        f"# {taskset_name} (Harbor export)\n"
+        f"\n"
+        f"Auto-generated by `hud export harbor`. Each task is a self-contained\n"
+        f"Harbor task directory under `tasks/`.\n"
+        f"\n"
+        f"## Base image\n"
+        f"\n"
+        f"    {base_image}\n"
+        f"\n"
+        f"## Tasks ({len(task_slugs)})\n"
+        f"\n"
+        f"{listing}\n"
+        f"\n"
+        f"## Run a task\n"
+        f"\n"
+        f"    ./sample-run.sh <task-slug>\n"
+        f"\n"
+        f"Reward is written to `logs/<task-slug>/verifier/reward.txt`.\n"
+    )
+
+
+class HarborExporter(BaseExporter):
+    name = "harbor"
+    description = "Harbor framework task layout (instruction.md + task.toml + tests/test.sh)"
+
+    def export(self, inp: ExportInput) -> ExportResult:
+        tasks = _select_tasks(inp)
+        if not tasks:
+            raise ValueError("No tasks selected for export")
+
+        files: dict[str, str | bytes] = {}
+        summary: list[str] = []
+        slugs_used: set[str] = set()
+        ordered_slugs: list[str] = []
+
+        bake_setup = _read_template("bake-setup.sh")
+        test_sh = _read_template("test.sh")
+
+        for index, task in enumerate(tasks):
+            slug = _task_slug(task, index)
+            base_slug = slug
+            dedupe = 1
+            while slug in slugs_used:
+                dedupe += 1
+                slug = f"{base_slug}-{dedupe}"
+            slugs_used.add(slug)
+            ordered_slugs.append(slug)
+
+            scenario_full = _full_scenario_name(task, inp.taskset_name)
+            args_json = json.dumps(task.args or {}, sort_keys=True)
+            prompt_was_rendered = bool(
+                inp.rendered_prompts.get(slug) or inp.rendered_prompts.get(task.slug or "")
+            )
+            rendered = inp.rendered_prompts.get(slug) or inp.rendered_prompts.get(
+                task.slug or "", ""
+            )
+            if not rendered:
+                rendered = (
+                    f"[Prompt for scenario {scenario_full!r} was not rendered "
+                    f"during export. Run with --render-prompts live or trace.]"
+                )
+
+            instruction = _build_instruction_md(task, rendered)
+            task_toml = _build_task_toml(
+                task, slug, inp.taskset_name, instruction, prompt_was_rendered
+            )
+            dockerfile = _build_task_dockerfile(
+                base_image=inp.env_image,
+                scenario_full=scenario_full,
+                args_json=args_json,
+                required_env=inp.env_required_env,
+                platform=inp.env_platform,
+            )
+
+            base = f"tasks/{slug}"
+            files[f"{base}/instruction.md"] = instruction
+            files[f"{base}/task.toml"] = task_toml
+            files[f"{base}/environment/Dockerfile"] = dockerfile
+            files[f"{base}/environment/bake-setup.sh"] = bake_setup
+            files[f"{base}/tests/test.sh"] = test_sh
+
+            summary.append(f"{slug} ({scenario_full})")
+
+        readme = _render_readme(inp.taskset_name, ordered_slugs, inp.env_image)
+        sample_run = _read_template("sample-run.sh").replace("__FIRST_TASK__", ordered_slugs[0])
+
+        files["README.md"] = readme
+        files["sample-run.sh"] = sample_run
+
+        manifest: dict[str, Any] = {
+            "format": "harbor",
+            "taskset_name": inp.taskset_name,
+            "taskset_id": inp.taskset_id,
+            "task_count": len(ordered_slugs),
+            "task_slugs": ordered_slugs,
+            "base_image": inp.env_image,
+            "required_env": sorted(inp.env_required_env),
+            "sample_run_command": f"./sample-run.sh {ordered_slugs[0]}",
+        }
+        files["manifest.json"] = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+
+        return ExportResult(
+            files=files,
+            manifest=manifest,
+            sample_run_script=sample_run,
+            summary=summary,
+        )

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -78,10 +78,7 @@ def _system_prompt(task: Task) -> str | None:
 
 def _agent_timeout(task: Task) -> int:
     cfg = task.agent_config
-    if isinstance(cfg, dict):
-        val = cfg.get("timeout")
-    else:
-        val = getattr(cfg, "timeout", None)
+    val = cfg.get("timeout") if isinstance(cfg, dict) else getattr(cfg, "timeout", None)
     try:
         return int(val) if val else 1800
     except (TypeError, ValueError):

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -201,12 +201,35 @@ def _build_task_toml(
     return "\n".join(lines)
 
 
+def _extract_hud_dev_module(runtime_command: list[str] | None) -> str | None:
+    """Pull the ``module:attr`` token out of an env's launch command."""
+    if not runtime_command:
+        return None
+    import shlex
+
+    tokens: list[str] = []
+    for arg in runtime_command:
+        if arg in {"sh", "bash", "/bin/sh", "/bin/bash", "-c", "-lc", "exec"}:
+            continue
+        tokens.extend(shlex.split(arg) if (" " in arg or "$" in arg) else [arg])
+
+    for index, token in enumerate(tokens):
+        if token == "hud" and index + 1 < len(tokens) and tokens[index + 1] == "dev":
+            for candidate in tokens[index + 2 :]:
+                if candidate.startswith("-"):
+                    continue
+                return candidate
+            return None
+    return None
+
+
 def _build_task_dockerfile(
     base_image: str,
     scenario_full: str,
     args_json: str,
     required_env: list[str],
     platform: str | None = None,
+    hud_dev_args: str | None = None,
 ) -> str:
     safe_args = args_json.replace("'", "'\\''")
     from_line = f"FROM --platform={platform} {base_image}" if platform else f"FROM {base_image}"
@@ -215,13 +238,19 @@ def _build_task_dockerfile(
         "",
         f"ENV HUD_TASK_SCENARIO={scenario_full}",
         f"ENV HUD_TASK_ARGS='{safe_args}'",
-        "",
-        "COPY bake-setup.sh /opt/hud/bake-setup.sh",
-        "RUN chmod +x /opt/hud/bake-setup.sh && /opt/hud/bake-setup.sh",
-        "",
-        "COPY entrypoint.py /opt/hud/entrypoint.py",
-        "RUN chmod +x /opt/hud/entrypoint.py",
     ]
+    if hud_dev_args:
+        parts.append(f"ENV HUD_DEV_ARGS={hud_dev_args}")
+    parts.extend(
+        [
+            "",
+            "COPY bake-setup.sh /opt/hud/bake-setup.sh",
+            "RUN chmod +x /opt/hud/bake-setup.sh && /opt/hud/bake-setup.sh",
+            "",
+            "COPY entrypoint.py /opt/hud/entrypoint.py",
+            "RUN chmod +x /opt/hud/entrypoint.py",
+        ]
+    )
     if required_env:
         parts.append("")
         parts.extend(f"# {var} must be supplied at run time" for var in sorted(required_env))
@@ -303,6 +332,7 @@ class HarborExporter(BaseExporter):
         bake_setup = _read_template("bake-setup.sh")
         entrypoint_py = _read_template("entrypoint.py")
         test_sh = _read_template("test.sh")
+        hud_dev_args = _extract_hud_dev_module(inp.env_runtime_command)
 
         for task, slug in zip(tasks, ordered_slugs, strict=True):
             scenario_full = _full_scenario_name(task, inp.taskset_name)
@@ -331,6 +361,7 @@ class HarborExporter(BaseExporter):
                 args_json=args_json,
                 required_env=inp.env_required_env,
                 platform=inp.env_platform,
+                hud_dev_args=hud_dev_args,
             )
 
             base = f"tasks/{slug}"

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -351,7 +351,7 @@ class HarborExporter(BaseExporter):
 
         bundle_name = inp.bundle_name or _slugify(inp.taskset_name)
         sample_run_command = (
-            f"tar xzf {bundle_name}.tar.gz\ncd {bundle_name}\n./sample-run.sh {ordered_slugs[0]}"
+            f"tar xzf {bundle_name}.tar.gz\ncd {bundle_name}\nharbor run -p tasks"
         )
 
         manifest: dict[str, Any] = {

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -350,7 +350,9 @@ class HarborExporter(BaseExporter):
         files["sample-run.sh"] = sample_run
 
         bundle_name = inp.bundle_name or _slugify(inp.taskset_name)
-        sample_run_command = f"tar xzf {bundle_name}.tar.gz\ncd {bundle_name}\nharbor run -p tasks"
+        sample_run_command = (
+            f"tar xzf {bundle_name}.tar.gz && cd {bundle_name} && harbor run -p tasks"
+        )
 
         manifest: dict[str, Any] = {
             "format": "harbor",

--- a/hud/cli/export/harbor.py
+++ b/hud/cli/export/harbor.py
@@ -350,9 +350,7 @@ class HarborExporter(BaseExporter):
         files["sample-run.sh"] = sample_run
 
         bundle_name = inp.bundle_name or _slugify(inp.taskset_name)
-        sample_run_command = (
-            f"tar xzf {bundle_name}.tar.gz\ncd {bundle_name}\nharbor run -p tasks"
-        )
+        sample_run_command = f"tar xzf {bundle_name}.tar.gz\ncd {bundle_name}\nharbor run -p tasks"
 
         manifest: dict[str, Any] = {
             "format": "harbor",

--- a/hud/cli/export/remote.py
+++ b/hud/cli/export/remote.py
@@ -1,0 +1,191 @@
+"""Remote-mode export client.
+
+When ``hud export <fmt> --taskset NAME`` is invoked, the platform owns
+the entire export pipeline (Harbor build, image mirroring, S3 upload).
+This module just resolves the name → evalset_id, kicks off the job,
+polls until done, and extracts the resulting tarball.
+
+Required because users behind private ECR can't pull env images
+locally — all docker pull/push must happen server-side.
+"""
+
+from __future__ import annotations
+
+import logging
+import tarfile
+import tempfile
+import time
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import typer
+
+from hud.cli.utils.api import hud_headers, require_api_key
+from hud.cli.utils.taskset import resolve_taskset_id
+from hud.settings import settings
+from hud.utils.hud_console import HUDConsole
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+LOGGER = logging.getLogger(__name__)
+
+_TERMINAL_STATES = {"completed", "error"}
+
+
+def remote_export(
+    *,
+    taskset_name: str,
+    output_dir: Path,
+    fmt: str = "harbor",
+    private: bool = False,
+    poll_interval: float = 3.0,
+    timeout: float = 3600.0,
+    console: HUDConsole | None = None,
+) -> Path:
+    """Run an export on the platform and extract the result locally.
+
+    Args:
+        taskset_name: Name (or UUID) of the taskset on the platform.
+        output_dir: Directory to extract the resulting tarball into.
+        fmt: Export format (e.g. ``harbor``).
+        private: Push mirrored images to private Docker Hub repos.
+        poll_interval: Seconds between status polls.
+        timeout: Max seconds to wait for the export to complete.
+
+    Returns:
+        ``output_dir`` (resolved, absolute).
+
+    Raises ``typer.Exit(1)`` on any failure with a user-facing message.
+    """
+    hud_console = console or HUDConsole()
+    require_api_key("export a taskset")
+
+    api_url = settings.hud_api_url.rstrip("/")
+    headers = hud_headers()
+
+    hud_console.progress_message(f"Resolving taskset '{taskset_name}'...")
+    evalset_id, _, _ = resolve_taskset_id(taskset_name, api_url, headers, create=False)
+    if not evalset_id:
+        hud_console.error(f"Taskset '{taskset_name}' not found on platform")
+        raise typer.Exit(1)
+
+    hud_console.progress_message(f"Requesting {fmt} export...")
+    try:
+        response = httpx.post(
+            f"{api_url}/exports/tasksets/{evalset_id}",
+            json={"format": fmt, "private": private},
+            headers=headers,
+            timeout=60.0,
+        )
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        _surface_http_error(exc, hud_console)
+        raise typer.Exit(1) from None
+    export_id = response.json()["export_id"]
+    hud_console.success(f"Export queued: {export_id}")
+
+    row = _poll_until_terminal(
+        api_url=api_url,
+        headers=headers,
+        export_id=export_id,
+        poll_interval=poll_interval,
+        timeout=timeout,
+        console=hud_console,
+    )
+    if row.get("status") == "error":
+        hud_console.error(f"Export failed: {row.get('error') or 'unknown error'}")
+        raise typer.Exit(1)
+
+    hud_console.progress_message("Fetching download URL...")
+    try:
+        dl_response = httpx.get(
+            f"{api_url}/exports/{export_id}/download",
+            headers=headers,
+            timeout=30.0,
+        )
+        dl_response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        _surface_http_error(exc, hud_console)
+        raise typer.Exit(1) from None
+    presigned_url = dl_response.json()["url"]
+
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    hud_console.progress_message(f"Downloading and extracting to {output_dir}...")
+    _download_and_extract(presigned_url, output_dir)
+
+    hud_console.success(f"Extracted to {output_dir}")
+    return output_dir
+
+
+def _poll_until_terminal(
+    *,
+    api_url: str,
+    headers: dict[str, str],
+    export_id: str,
+    poll_interval: float,
+    timeout: float,
+    console: HUDConsole,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last_status = ""
+    while True:
+        if time.monotonic() > deadline:
+            console.error(f"Export {export_id} timed out after {timeout:.0f}s")
+            raise typer.Exit(1)
+        try:
+            poll_response = httpx.get(
+                f"{api_url}/exports/{export_id}",
+                headers=headers,
+                timeout=30.0,
+            )
+            poll_response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            _surface_http_error(exc, console)
+            raise typer.Exit(1) from None
+        row = poll_response.json()
+        status = row.get("status", "")
+        if status != last_status:
+            console.progress_message(f"Status: {status}")
+            last_status = status
+        if status in _TERMINAL_STATES:
+            return row
+        time.sleep(poll_interval)
+
+
+def _download_and_extract(url: str, output_dir: Path) -> None:
+    """Stream the presigned URL to a temp tarball, then extract."""
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=True) as tmp:
+        with httpx.stream("GET", url, timeout=300.0) as stream:
+            stream.raise_for_status()
+            for chunk in stream.iter_bytes():
+                tmp.write(chunk)
+        tmp.flush()
+        with tarfile.open(tmp.name, "r:gz") as tar:
+            tar.extractall(output_dir, filter="data")
+
+
+def _surface_http_error(exc: httpx.HTTPStatusError, console: HUDConsole) -> None:
+    """Translate an HTTP error from the platform into a user-facing message."""
+    code = exc.response.status_code
+    try:
+        body = exc.response.json()
+    except Exception:
+        body = exc.response.text
+
+    detail: Any = body.get("detail") if isinstance(body, dict) else body
+
+    if code == 401:
+        console.error("Authentication failed. Run `hud login` or set HUD_API_KEY.")
+    elif code == 403:
+        console.error(f"Forbidden: {detail}")
+    elif code == 404:
+        console.error(f"Not found: {detail}")
+    elif code == 409:
+        if isinstance(detail, dict) and detail.get("message"):
+            console.error(f"Export precheck failed: {detail['message']}")
+        else:
+            console.error(f"Conflict: {detail}")
+    else:
+        console.error(f"HTTP {code}: {detail}")

--- a/hud/cli/export/render.py
+++ b/hud/cli/export/render.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING, Any
 from .harbor import _full_scenario_name, _slugify, _task_slug
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from hud.eval.task import Task
 
 LOGGER = logging.getLogger(__name__)
@@ -65,7 +67,7 @@ def _extract_text(messages: list[Any]) -> str:
 
 
 @contextlib.contextmanager
-def _quiet_mcp_retry_logs():
+def _quiet_mcp_retry_logs() -> Iterator[None]:
     """Suppress hud.patches.mcp_patches retry warnings during a block.
 
     These fire on every transient ReadError from the streamable-http
@@ -123,7 +125,7 @@ async def render_prompts_via_url(
                         rendered[slug] = text
                     else:
                         LOGGER.warning("Empty prompt for %s", slug)
-                except Exception as exc:  # noqa: BLE001 — best-effort per-task
+                except Exception as exc:
                     LOGGER.warning("Failed to render prompt for %s: %s", slug, exc)
         finally:
             await client.__aexit__(None, None, None)
@@ -209,16 +211,17 @@ async def render_prompts_via_image(
     )
 
     LOGGER.info("Booting image %s for prompt rendering", image)
-    proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+    proc = await asyncio.to_thread(subprocess.run, cmd, capture_output=True, text=True)
     if proc.returncode != 0:
         raise RuntimeError(f"docker run failed: {proc.stderr.strip() or proc.stdout.strip()}")
     container_id = proc.stdout.strip()
 
     try:
         url = f"http://localhost:{host_port}/mcp"
-        if not _wait_for_port("localhost", host_port, boot_timeout):
-            logs = subprocess.run(  # noqa: S603
-                ["docker", "logs", "--tail", "60", container_id],  # noqa: S607
+        if not await asyncio.to_thread(_wait_for_port, "localhost", host_port, boot_timeout):
+            logs = await asyncio.to_thread(
+                subprocess.run,
+                ["docker", "logs", "--tail", "60", container_id],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -233,8 +236,9 @@ async def render_prompts_via_image(
         )
     finally:
         with contextlib.suppress(Exception):
-            subprocess.run(  # noqa: S603
-                ["docker", "rm", "-f", container_id],  # noqa: S607
+            await asyncio.to_thread(
+                subprocess.run,
+                ["docker", "rm", "-f", container_id],
                 capture_output=True,
                 timeout=15,
             )

--- a/hud/cli/export/render.py
+++ b/hud/cli/export/render.py
@@ -27,7 +27,7 @@ import subprocess
 import time
 from typing import TYPE_CHECKING, Any
 
-from .harbor import _full_scenario_name, _slugify, _task_slug
+from .harbor import _dedupe_slugs, _full_scenario_name, _slugify
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -35,10 +35,6 @@ if TYPE_CHECKING:
     from hud.eval.task import Task
 
 LOGGER = logging.getLogger(__name__)
-
-
-def _slug_for_task(task: Task, index: int) -> str:
-    return _task_slug(task, index)
 
 
 def _serialize_args(args: dict[str, Any] | None) -> dict[str, str]:
@@ -106,13 +102,13 @@ async def render_prompts_via_url(
     from fastmcp.client.transports.http import StreamableHttpTransport
 
     rendered: dict[str, str] = {}
+    slugs = _dedupe_slugs(tasks)
     with _quiet_mcp_retry_logs():
         transport = StreamableHttpTransport(url)
         client = Client(transport)
         await client.__aenter__()
         try:
-            for index, task in enumerate(tasks):
-                slug = _slug_for_task(task, index)
+            for task, slug in zip(tasks, slugs, strict=True):
                 try:
                     full_name = _full_scenario_name(task, taskset_name)
                     args = _serialize_args(task.args)

--- a/hud/cli/export/render.py
+++ b/hud/cli/export/render.py
@@ -1,0 +1,240 @@
+"""Prompt rendering helpers for export.
+
+Two layers, both async and reusable:
+
+* ``render_prompts_via_url(url, tasks, taskset_name)`` — renders against
+  an already-running MCP server. The platform pipeline reuses this
+  against its running env containers; the CLI's docker mode wraps it.
+
+* ``render_prompts_via_image(image, tasks, taskset_name, env_vars)`` —
+  boots a container from the pushed image, waits for the MCP endpoint,
+  calls the URL-based helper, then stops the container.
+
+Both return ``{slug: rendered_text}``. Failures per task are logged and
+that slug is omitted from the dict — callers can decide whether to fall
+back to placeholder text.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import secrets
+import shutil
+import socket
+import subprocess
+import time
+from typing import TYPE_CHECKING, Any
+
+from .harbor import _full_scenario_name, _slugify, _task_slug
+
+if TYPE_CHECKING:
+    from hud.eval.task import Task
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _slug_for_task(task: Task, index: int) -> str:
+    return _task_slug(task, index)
+
+
+def _serialize_args(args: dict[str, Any] | None) -> dict[str, str]:
+    """MCP prompts only accept string args; JSON-encode non-strings."""
+    import json
+
+    if not args:
+        return {}
+    return {k: v if isinstance(v, str) else json.dumps(v) for k, v in args.items()}
+
+
+def _extract_text(messages: list[Any]) -> str:
+    parts: list[str] = []
+    for msg in messages:
+        content = getattr(msg, "content", None)
+        if content is None and isinstance(msg, dict):
+            content = msg.get("content")
+        text = getattr(content, "text", None)
+        if text is None and isinstance(content, dict):
+            text = content.get("text")
+        if text is None and isinstance(content, str):
+            text = content
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts).strip()
+
+
+@contextlib.contextmanager
+def _quiet_mcp_retry_logs():
+    """Suppress hud.patches.mcp_patches retry warnings during a block.
+
+    These fire on every transient ReadError from the streamable-http
+    transport, which is normal during connection setup/teardown. They
+    add no signal during export; just noise.
+    """
+    target = logging.getLogger("hud.patches.mcp_patches")
+    previous = target.level
+    target.setLevel(logging.ERROR)
+    try:
+        yield
+    finally:
+        target.setLevel(previous)
+
+
+async def render_prompts_via_url(
+    url: str,
+    tasks: list[Task],
+    taskset_name: str,
+    *,
+    timeout_per_task: float = 60.0,
+) -> dict[str, str]:
+    """Render prompts for each task against an already-running MCP server.
+
+    Args:
+        url: MCP HTTP URL (e.g. ``http://localhost:8080/mcp``).
+        tasks: Tasks whose prompts to render.
+        taskset_name: Used to resolve unqualified scenario names.
+        timeout_per_task: Per-task timeout in seconds.
+
+    Returns:
+        ``{task_slug: rendered_prompt_text}``. Tasks whose render fails
+        are omitted.
+    """
+    from fastmcp import Client
+    from fastmcp.client.transports.http import StreamableHttpTransport
+
+    rendered: dict[str, str] = {}
+    with _quiet_mcp_retry_logs():
+        transport = StreamableHttpTransport(url)
+        client = Client(transport)
+        await client.__aenter__()
+        try:
+            for index, task in enumerate(tasks):
+                slug = _slug_for_task(task, index)
+                try:
+                    full_name = _full_scenario_name(task, taskset_name)
+                    args = _serialize_args(task.args)
+                    result = await asyncio.wait_for(
+                        client.get_prompt(full_name, args),
+                        timeout=timeout_per_task,
+                    )
+                    text = _extract_text(getattr(result, "messages", []))
+                    if text:
+                        rendered[slug] = text
+                    else:
+                        LOGGER.warning("Empty prompt for %s", slug)
+                except Exception as exc:  # noqa: BLE001 — best-effort per-task
+                    LOGGER.warning("Failed to render prompt for %s: %s", slug, exc)
+        finally:
+            await client.__aexit__(None, None, None)
+    return rendered
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_port(host: str, port: int, timeout: float) -> bool:
+    """Return True once a TCP connect to (host, port) succeeds."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+async def render_prompts_via_image(
+    image: str,
+    tasks: list[Task],
+    taskset_name: str,
+    *,
+    env_vars: dict[str, str] | None = None,
+    server_command: list[str] | None = None,
+    container_port: int = 8765,
+    platform: str | None = None,
+    boot_timeout: float = 90.0,
+    timeout_per_task: float = 60.0,
+) -> dict[str, str]:
+    """Boot ``image`` in Docker, render prompts via MCP, then stop it.
+
+    Designed for the export CLI. Platforms with already-running env
+    containers should call ``render_prompts_via_url`` directly.
+
+    Args:
+        image: Pushed image reference (e.g. ``ghcr.io/...@sha256:...``).
+        tasks: Tasks whose prompts to render.
+        taskset_name: Used to resolve unqualified scenario names.
+        env_vars: Optional env vars passed to the container.
+        server_command: Override the container's CMD. Defaults to
+            ``["hud", "dev", "env:env", "--port", "<container_port>"]``,
+            which forces HTTP mode regardless of how the image was
+            originally built (many HUD images CMD with ``--stdio``).
+        container_port: Port the MCP server listens on inside the image.
+            Default 8765 matches ``hud dev``'s HTTP default.
+        boot_timeout: Seconds to wait for the MCP server to be reachable.
+        timeout_per_task: Per-task render timeout.
+
+    Returns:
+        ``{task_slug: rendered_prompt_text}``.
+    """
+    if shutil.which("docker") is None:
+        raise RuntimeError("docker CLI not found on PATH; required for --render-prompts live")
+
+    host_port = _free_port()
+    name = f"hud-export-render-{_slugify(taskset_name)}-{secrets.token_hex(4)}"
+    cmd: list[str] = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        name,
+        "-p",
+        f"{host_port}:{container_port}",
+    ]
+    if platform:
+        cmd.extend(["--platform", platform])
+    for key, value in (env_vars or {}).items():
+        cmd.extend(["-e", f"{key}={value}"])
+    cmd.append(image)
+    cmd.extend(
+        server_command
+        if server_command is not None
+        else ["hud", "dev", "env:env", "--port", str(container_port)]
+    )
+
+    LOGGER.info("Booting image %s for prompt rendering", image)
+    proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603
+    if proc.returncode != 0:
+        raise RuntimeError(f"docker run failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    container_id = proc.stdout.strip()
+
+    try:
+        url = f"http://localhost:{host_port}/mcp"
+        if not _wait_for_port("localhost", host_port, boot_timeout):
+            logs = subprocess.run(  # noqa: S603
+                ["docker", "logs", "--tail", "60", container_id],  # noqa: S607
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            tail = (logs.stdout + logs.stderr).strip()
+            tail_block = f"\n--- container logs (tail) ---\n{tail}" if tail else ""
+            raise RuntimeError(
+                f"MCP server at {url} did not become ready within {boot_timeout}s.{tail_block}"
+            )
+        return await render_prompts_via_url(
+            url, tasks, taskset_name, timeout_per_task=timeout_per_task
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            subprocess.run(  # noqa: S603
+                ["docker", "rm", "-f", container_id],  # noqa: S607
+                capture_output=True,
+                timeout=15,
+            )

--- a/hud/cli/export/templates/bake-setup.sh
+++ b/hud/cli/export/templates/bake-setup.sh
@@ -25,8 +25,7 @@ ARGS=${HUD_TASK_ARGS-}
 # ``--port`` — required for envs that wrap ``hud dev`` in a multi-
 # process startup (e.g. ``sh -c "uvicorn sidecars... & exec hud dev
 # env:env --stdio"``); skip the prefix and the sidecars never run.
-# Falls back to the legacy ``HUD_DEV_ARGS`` (just the ``module:attr``
-# token) for older bundles.
+# Falls back to a bare ``hud dev env:env`` when not set.
 LAUNCH_SHELL=$(python3 - <<'PY'
 import json, os, shlex
 raw = os.environ.get("HUD_LAUNCH_COMMAND") or ""
@@ -43,8 +42,7 @@ if raw:
             out.append(str(arg))
     print(shlex.join(out))
 else:
-    dev_args = os.environ.get("HUD_DEV_ARGS") or "env:env"
-    print(f"hud dev {shlex.quote(dev_args)} --port {shlex.quote(port)}")
+    print(f"hud dev env:env --port {shlex.quote(port)}")
 PY
 )
 

--- a/hud/cli/export/templates/bake-setup.sh
+++ b/hud/cli/export/templates/bake-setup.sh
@@ -12,21 +12,54 @@ if [[ -z "${HUD_TASK_SCENARIO:-}" ]]; then
     exit 1
 fi
 
-HUD_MCP_PORT=${HUD_MCP_PORT:-8765}
+export HUD_MCP_PORT=${HUD_MCP_PORT:-8765}
 HUD_MCP_URL=${HUD_MCP_URL:-http://localhost:$HUD_MCP_PORT/mcp}
-HUD_DEV_ARGS=${HUD_DEV_ARGS:-env:env}
 
 # Bash parameter expansion stops at the first '}', so '${X:-{}}' doesn't
 # default to '{}'. Use an explicit fallback instead.
 ARGS=${HUD_TASK_ARGS-}
 [[ -z "$ARGS" ]] && ARGS='{}'
 
-hud dev $HUD_DEV_ARGS --port "$HUD_MCP_PORT" &
-SERVER_PID=$!
-trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+# Render the env's launch command. ``HUD_LAUNCH_COMMAND`` (JSON list)
+# is the env image's full original CMD with ``--stdio`` rewritten to
+# ``--port`` — required for envs that wrap ``hud dev`` in a multi-
+# process startup (e.g. ``sh -c "uvicorn sidecars... & exec hud dev
+# env:env --stdio"``); skip the prefix and the sidecars never run.
+# Falls back to the legacy ``HUD_DEV_ARGS`` (just the ``module:attr``
+# token) for older bundles.
+LAUNCH_SHELL=$(python3 - <<'PY'
+import json, os, shlex
+raw = os.environ.get("HUD_LAUNCH_COMMAND") or ""
+port = os.environ["HUD_MCP_PORT"]
+if raw:
+    cmd = json.loads(raw)
+    out = []
+    for arg in cmd:
+        if arg == "--stdio":
+            out.extend(["--port", port])
+        elif "--stdio" in arg:
+            out.append(arg.replace("--stdio", f"--port {port}"))
+        else:
+            out.append(str(arg))
+    print(shlex.join(out))
+else:
+    dev_args = os.environ.get("HUD_DEV_ARGS") or "env:env"
+    print(f"hud dev {shlex.quote(dev_args)} --port {shlex.quote(port)}")
+PY
+)
 
-# Wait for the MCP port to start accepting connections.
-for _ in $(seq 1 60); do
+# ``setsid`` puts the launch tree in its own process group so we can
+# kill the whole tree on EXIT — envs that fork sidecars (uvicorn,
+# Xvfb, chromium, etc.) leave orphans behind a plain ``kill $!`` and
+# leak zombie processes into the next docker layer.
+setsid bash -c "$LAUNCH_SHELL" &
+SERVER_PID=$!
+trap 'kill -- -"$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+
+# Wait for the MCP port to start accepting connections. Bumped from 60s
+# because some envs do significant pre-MCP setup (uvicorn boot, Xvfb,
+# chrome warmup) that easily exceeds 60s on a cold build cache.
+for _ in $(seq 1 240); do
     if (echo > "/dev/tcp/127.0.0.1/$HUD_MCP_PORT") 2>/dev/null; then
         break
     fi

--- a/hud/cli/export/templates/bake-setup.sh
+++ b/hud/cli/export/templates/bake-setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Image-build-time setup baker for HUD-exported tasks.
+# Runs during `docker build` of a per-task environment Dockerfile:
+#   1. Boots the HUD MCP server in the background (HTTP transport).
+#   2. Calls `hud scenario setup` to perform task-specific setup.
+#   3. Stops the server. The mutated filesystem is committed by Docker
+#      as the next image layer, so the agent gets a pre-baked env.
+set -euo pipefail
+
+if [[ -z "${HUD_TASK_SCENARIO:-}" ]]; then
+    echo "HUD_TASK_SCENARIO not set; nothing to bake" >&2
+    exit 1
+fi
+
+HUD_MCP_PORT=${HUD_MCP_PORT:-8765}
+HUD_MCP_URL=${HUD_MCP_URL:-http://localhost:$HUD_MCP_PORT/mcp}
+HUD_DEV_ARGS=${HUD_DEV_ARGS:-env:env}
+
+# Bash parameter expansion stops at the first '}', so '${X:-{}}' doesn't
+# default to '{}'. Use an explicit fallback instead.
+ARGS=${HUD_TASK_ARGS-}
+[[ -z "$ARGS" ]] && ARGS='{}'
+
+hud dev $HUD_DEV_ARGS --port "$HUD_MCP_PORT" &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
+
+# Wait for the MCP port to start accepting connections.
+for _ in $(seq 1 60); do
+    if (echo > "/dev/tcp/127.0.0.1/$HUD_MCP_PORT") 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+hud scenario setup "$HUD_TASK_SCENARIO" --args "$ARGS" --url "$HUD_MCP_URL"

--- a/hud/cli/export/templates/bake-setup.sh
+++ b/hud/cli/export/templates/bake-setup.sh
@@ -21,26 +21,15 @@ ARGS=${HUD_TASK_ARGS-}
 [[ -z "$ARGS" ]] && ARGS='{}'
 
 # Render the env's launch command. ``HUD_LAUNCH_COMMAND`` (JSON list)
-# is the env image's full original CMD with ``--stdio`` rewritten to
-# ``--port`` — required for envs that wrap ``hud dev`` in a multi-
-# process startup (e.g. ``sh -c "uvicorn sidecars... & exec hud dev
-# env:env --stdio"``); skip the prefix and the sidecars never run.
-# Falls back to a bare ``hud dev env:env`` when not set.
+# is the env image's full original CMD already rewritten by the exporter
+# (``--stdio`` → ``--port <HARBOR_MCP_PORT>``); shells just shlex-join
+# and run. Falls back to a bare ``hud dev env:env`` when unset.
 LAUNCH_SHELL=$(python3 - <<'PY'
 import json, os, shlex
 raw = os.environ.get("HUD_LAUNCH_COMMAND") or ""
 port = os.environ["HUD_MCP_PORT"]
 if raw:
-    cmd = json.loads(raw)
-    out = []
-    for arg in cmd:
-        if arg == "--stdio":
-            out.extend(["--port", port])
-        elif "--stdio" in arg:
-            out.append(arg.replace("--stdio", f"--port {port}"))
-        else:
-            out.append(str(arg))
-    print(shlex.join(out))
+    print(shlex.join(str(a) for a in json.loads(raw)))
 else:
     print(f"hud dev env:env --port {shlex.quote(port)}")
 PY

--- a/hud/cli/export/templates/entrypoint.py
+++ b/hud/cli/export/templates/entrypoint.py
@@ -26,14 +26,17 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import signal
 import subprocess
 import sys
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
 
-async def _wait_port(port: int, timeout: int = 30) -> bool:
+
+async def _wait_port(port: int, timeout: int = 30) -> bool:  # noqa: ASYNC109
     """Return True once ``localhost:port`` accepts TCP connections."""
     for _ in range(timeout * 2):
         try:
@@ -61,23 +64,27 @@ async def _register_session(url: str, scenario: str, args_dict: dict) -> str | N
         read_stream,
         write_stream,
         get_session_id,
-    ):
-        async with ClientSession(read_stream, write_stream) as session:
-            await session.initialize()
-            await session.get_prompt(scenario, arguments=args_for_mcp)
-            return get_session_id()
+    ), ClientSession(read_stream, write_stream) as session:
+        await session.initialize()
+        await session.get_prompt(scenario, arguments=args_for_mcp)
+        return get_session_id()
 
 
 def _spawn_hud_dev(port: int) -> subprocess.Popen[bytes]:
-    log_fd = open("/tmp/hud-dev.log", "wb")
-    return subprocess.Popen(
-        ["hud", "dev", "env:env", "--port", str(port)],
-        stdout=log_fd,
-        stderr=subprocess.STDOUT,
-    )
+    with open("/tmp/hud-dev.log", "wb") as log_fd:  # noqa: S108
+        return subprocess.Popen(
+            ["hud", "dev", "env:env", "--port", str(port)],  # noqa: S607
+            stdout=log_fd,
+            stderr=subprocess.STDOUT,
+        )
 
 
 def _main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="entrypoint: %(message)s",
+        stream=sys.stderr,
+    )
     port = int(os.environ.get("HUD_MCP_PORT", "8765"))
     scenario = os.environ.get("HUD_TASK_SCENARIO") or ""
     args_json = os.environ.get("HUD_TASK_ARGS") or "{}"
@@ -86,31 +93,31 @@ def _main() -> None:
     _spawn_hud_dev(port)
 
     if not asyncio.run(_wait_port(port)):
-        print(f"entrypoint: hud dev did not bind :{port}", file=sys.stderr)
+        logger.error("hud dev did not bind :%d", port)
 
     if scenario:
         try:
             try:
                 args_dict = json.loads(args_json) if args_json else {}
             except json.JSONDecodeError as exc:
-                print(f"entrypoint: invalid HUD_TASK_ARGS: {exc}", file=sys.stderr)
+                logger.error("invalid HUD_TASK_ARGS: %s", exc)
                 args_dict = {}
             session_id = asyncio.run(
                 _register_session(url, scenario, args_dict if isinstance(args_dict, dict) else {})
             )
             if session_id:
-                Path("/tmp/.hud_scenario_session").write_text(session_id)
-                print(f"entrypoint: scenario session {session_id}")
+                Path("/tmp/.hud_scenario_session").write_text(session_id)  # noqa: S108
+                logger.info("scenario session %s", session_id)
             else:
-                print("entrypoint: scenario setup returned no session id", file=sys.stderr)
-        except Exception as exc:  # noqa: BLE001
-            print(f"entrypoint: scenario setup failed: {exc}", file=sys.stderr)
+                logger.error("scenario setup returned no session id")
+        except Exception as exc:
+            logger.error("scenario setup failed: %s", exc)
 
     # Hand off PID 1 to whatever harbor's compose ``command:`` was
     # (typically ``sh -c "sleep infinity"``).
     cmd = sys.argv[1:]
     if cmd:
-        os.execvp(cmd[0], cmd)
+        os.execvp(cmd[0], cmd)  # noqa: S606
     else:
         signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
         signal.pause()

--- a/hud/cli/export/templates/entrypoint.py
+++ b/hud/cli/export/templates/entrypoint.py
@@ -74,12 +74,77 @@ async def _register_session(url: str, scenario: str, args_dict: dict) -> str | N
 
 
 def _spawn_hud_dev(port: int) -> subprocess.Popen[bytes]:
+    dev_args = os.environ.get("HUD_DEV_ARGS") or "env:env"
     with open("/tmp/hud-dev.log", "wb") as log_fd:  # noqa: S108
         return subprocess.Popen(
-            ["hud", "dev", "env:env", "--port", str(port)],  # noqa: S607
+            ["hud", "dev", dev_args, "--port", str(port)],  # noqa: S607
             stdout=log_fd,
             stderr=subprocess.STDOUT,
         )
+
+
+_KEEPALIVE_INTERVAL_SEC = 30
+_KEEPALIVE_LOG_PATH = "/logs/agent/keepalive.log"
+
+
+def _spawn_session_keepalive(url: str, session_id: str) -> subprocess.Popen[bytes]:
+    """Background-ping the registered MCP session to keep it alive.
+
+    The agent runs on its OWN MCP session (claude-code/codex/etc. each
+    open one when they connect), so the session entrypoint registered
+    here sits idle the entire time the agent is doing work. Without
+    keepalive, the verifier's ``hud scenario grade`` fails with
+    ``McpError: Session terminated`` because the session was reaped
+    mid-trial. A cheap ``list_tools`` every 30s keeps it warm.
+
+    The script runs as a detached subprocess so PID 1 is free to
+    ``exec`` into Harbor's compose command. ``streamablehttp_client``
+    is used with ``terminate_on_close=False`` so the keepalive doesn't
+    accidentally DELETE the session it's trying to preserve. Logs are
+    timestamped + flushed eagerly so a missing keepalive process is
+    obvious in /logs/keepalive.log.
+    """
+    script = (
+        "import asyncio, sys, time, os\n"
+        "URL = " + repr(url) + "\n"
+        "SID = " + repr(session_id) + "\n"
+        "INTERVAL = " + repr(_KEEPALIVE_INTERVAL_SEC) + "\n"
+        "def _log(msg):\n"
+        "    sys.stdout.write(f\"[{time.strftime('%H:%M:%S')}] keepalive: {msg}\\n\")\n"
+        "    sys.stdout.flush()\n"
+        '_log(f"started; session={SID[:8]}... interval={INTERVAL}s")\n'
+        "async def _ping_loop():\n"
+        "    from mcp import ClientSession\n"
+        "    from mcp.client.streamable_http import streamablehttp_client\n"
+        "    n = 0\n"
+        "    while True:\n"
+        "        try:\n"
+        "            async with streamablehttp_client(\n"
+        '                URL, terminate_on_close=False, headers={"mcp-session-id": SID}\n'
+        "            ) as (r, w, _gid):\n"
+        "                async with ClientSession(r, w) as session:\n"
+        "                    await session.initialize()\n"
+        "                    tools = await session.list_tools()\n"
+        "                    n += 1\n"
+        '                    _log(f"ping #{n} ok ({len(tools.tools)} tools)")\n'
+        "        except Exception as exc:\n"
+        '            _log(f"ping #{n} failed: {type(exc).__name__}: {exc}")\n'
+        "        await asyncio.sleep(INTERVAL)\n"
+        "asyncio.run(_ping_loop())\n"
+    )
+    # Open the log under /logs for post-mortem visibility; if /logs
+    # isn't writable yet (Harbor sometimes lazily mounts), fall back
+    # to /tmp.
+    try:
+        log_fd = open(_KEEPALIVE_LOG_PATH, "wb")  # noqa: SIM115
+    except OSError:
+        log_fd = open("/tmp/hud-keepalive.log", "wb")  # noqa: S108, SIM115
+    return subprocess.Popen(
+        ["python3", "-u", "-c", script],  # noqa: S607
+        stdout=log_fd,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
 
 
 def _main() -> None:
@@ -111,6 +176,8 @@ def _main() -> None:
             if session_id:
                 Path("/tmp/.hud_scenario_session").write_text(session_id)  # noqa: S108
                 logger.info("scenario session %s", session_id)
+                _spawn_session_keepalive(url, session_id)
+                logger.info("session keepalive started (every %ds)", _KEEPALIVE_INTERVAL_SEC)
             else:
                 logger.error("scenario setup returned no session id")
         except Exception as exc:

--- a/hud/cli/export/templates/entrypoint.py
+++ b/hud/cli/export/templates/entrypoint.py
@@ -60,11 +60,14 @@ async def _register_session(url: str, scenario: str, args_dict: dict) -> str | N
 
     args_for_mcp = {k: json.dumps(v) if not isinstance(v, str) else v for k, v in args_dict.items()}
 
-    async with streamablehttp_client(url, terminate_on_close=False) as (
-        read_stream,
-        write_stream,
-        get_session_id,
-    ), ClientSession(read_stream, write_stream) as session:
+    async with (
+        streamablehttp_client(url, terminate_on_close=False) as (
+            read_stream,
+            write_stream,
+            get_session_id,
+        ),
+        ClientSession(read_stream, write_stream) as session,
+    ):
         await session.initialize()
         await session.get_prompt(scenario, arguments=args_for_mcp)
         return get_session_id()

--- a/hud/cli/export/templates/entrypoint.py
+++ b/hud/cli/export/templates/entrypoint.py
@@ -36,8 +36,13 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-async def _wait_port(port: int, timeout: int = 30) -> bool:  # noqa: ASYNC109
-    """Return True once ``localhost:port`` accepts TCP connections."""
+async def _wait_port(port: int, timeout: int = 180) -> bool:  # noqa: ASYNC109
+    """Return True once ``localhost:port`` accepts TCP connections.
+
+    Default 180s because some env packages do significant work at
+    import time. A too-short timeout here makes the entrypoint barrel into
+    ``_register_session`` before the MCP server is listening.
+    """
     for _ in range(timeout * 2):
         try:
             _, writer = await asyncio.open_connection("127.0.0.1", port)
@@ -73,13 +78,50 @@ async def _register_session(url: str, scenario: str, args_dict: dict) -> str | N
         return get_session_id()
 
 
-def _spawn_hud_dev(port: int) -> subprocess.Popen[bytes]:
+def _build_launch_command(port: int) -> list[str]:
+    """Return the env's launch command, with ``--stdio`` rewritten to
+    ``--port <port>`` so MCP speaks HTTP for Harbor's compose driver.
+
+    Order of preference:
+
+    1. ``HUD_LAUNCH_COMMAND`` (JSON list) — the env image's full original
+       CMD, captured at build time and threaded through the export's
+       lock yaml. Required for envs that wrap ``hud dev`` in a multi-
+       process startup.
+    2. ``HUD_DEV_ARGS`` (legacy) — just the ``module:attr`` token. Older
+       bundles that only know about the simple form still work.
+    3. ``env:env`` fallback.
+    """
+    raw = os.environ.get("HUD_LAUNCH_COMMAND")
+    if raw:
+        cmd = json.loads(raw)
+        rewritten: list[str] = []
+        for arg in cmd:
+            if arg == "--stdio":
+                rewritten.extend(["--port", str(port)])
+            elif "--stdio" in arg:
+                # ``sh -c`` shell-string forms — rewrite inside the string
+                rewritten.append(arg.replace("--stdio", f"--port {port}"))
+            else:
+                rewritten.append(str(arg))
+        return rewritten
     dev_args = os.environ.get("HUD_DEV_ARGS") or "env:env"
+    return ["hud", "dev", dev_args, "--port", str(port)]
+
+
+def _spawn_hud_dev(port: int) -> subprocess.Popen[bytes]:
+    cmd = _build_launch_command(port)
     with open("/tmp/hud-dev.log", "wb") as log_fd:  # noqa: S108
+        # ``start_new_session=True`` puts the launch tree in its own
+        # process group so envs that fork sub-processes (uvicorn, Xvfb,
+        # chrome, ...) survive ``os.execvp`` into Harbor's compose
+        # ``sleep infinity`` below — and also so a future graceful
+        # shutdown could ``killpg`` the whole tree if needed.
         return subprocess.Popen(
-            ["hud", "dev", dev_args, "--port", str(port)],  # noqa: S607
+            cmd,
             stdout=log_fd,
             stderr=subprocess.STDOUT,
+            start_new_session=True,
         )
 
 
@@ -164,6 +206,16 @@ def _main() -> None:
         logger.error("hud dev did not bind :%d", port)
 
     if scenario:
+        # Bake-time ``hud scenario setup`` already wrote a session id
+        # into the image at /tmp/.hud_scenario_session. That id belongs
+        # to a server that no longer exists. If runtime registration
+        # below fails (slow env init, transient error, etc.) we want
+        # the verifier's ``hud scenario grade`` to fall through to a
+        # *new* session rather than try to resume the dead bake-time
+        # one and crash with "Session terminated". So clear the stale
+        # value upfront and only repopulate on a confirmed re-register.
+        session_file = Path("/tmp/.hud_scenario_session")  # noqa: S108
+        session_file.unlink(missing_ok=True)
         try:
             try:
                 args_dict = json.loads(args_json) if args_json else {}
@@ -174,7 +226,7 @@ def _main() -> None:
                 _register_session(url, scenario, args_dict if isinstance(args_dict, dict) else {})
             )
             if session_id:
-                Path("/tmp/.hud_scenario_session").write_text(session_id)  # noqa: S108
+                session_file.write_text(session_id)
                 logger.info("scenario session %s", session_id)
                 _spawn_session_keepalive(url, session_id)
                 logger.info("session keepalive started (every %ds)", _KEEPALIVE_INTERVAL_SEC)

--- a/hud/cli/export/templates/entrypoint.py
+++ b/hud/cli/export/templates/entrypoint.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Harbor entrypoint for HUD-exported task images.
+
+Two jobs:
+
+1. Start ``hud dev`` in the background so the harbor agent's
+   ``[[environment.mcp_servers]]`` config can connect to it.
+
+2. Register the scenario session against that ``hud dev`` and persist
+   the session id to ``/tmp/.hud_scenario_session`` so the harbor
+   verifier's ``hud scenario grade`` can resume the *same* session
+   later — without re-running ``setup_task`` and clobbering the
+   agent's filesystem edits.
+
+The trick is calling MCP's lower-level ``streamablehttp_client`` with
+``terminate_on_close=False`` here. fastmcp's ``Client`` defaults to
+sending a DELETE on close, which would kill the session as soon as our
+``setup`` call returns — leaving the verifier with a "Session
+terminated" error. With ``terminate_on_close=False`` the session stays
+alive on the server after we disconnect, until either the verifier
+explicitly closes it (default fastmcp behaviour) or the container
+shuts down.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+
+async def _wait_port(port: int, timeout: int = 30) -> bool:
+    """Return True once ``localhost:port`` accepts TCP connections."""
+    for _ in range(timeout * 2):
+        try:
+            _, writer = await asyncio.open_connection("127.0.0.1", port)
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except OSError:
+            await asyncio.sleep(0.5)
+    return False
+
+
+async def _register_session(url: str, scenario: str, args_dict: dict) -> str | None:
+    """Run scenario setup against ``url`` and return the resulting MCP
+    session id. The session is intentionally NOT terminated on close.
+    """
+    # Imported lazily so a missing fastmcp install doesn't crash before
+    # we've at least booted ``hud dev``.
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    args_for_mcp = {k: json.dumps(v) if not isinstance(v, str) else v for k, v in args_dict.items()}
+
+    async with streamablehttp_client(url, terminate_on_close=False) as (
+        read_stream,
+        write_stream,
+        get_session_id,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            await session.get_prompt(scenario, arguments=args_for_mcp)
+            return get_session_id()
+
+
+def _spawn_hud_dev(port: int) -> subprocess.Popen[bytes]:
+    log_fd = open("/tmp/hud-dev.log", "wb")
+    return subprocess.Popen(
+        ["hud", "dev", "env:env", "--port", str(port)],
+        stdout=log_fd,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def _main() -> None:
+    port = int(os.environ.get("HUD_MCP_PORT", "8765"))
+    scenario = os.environ.get("HUD_TASK_SCENARIO") or ""
+    args_json = os.environ.get("HUD_TASK_ARGS") or "{}"
+    url = f"http://localhost:{port}/mcp"
+
+    _spawn_hud_dev(port)
+
+    if not asyncio.run(_wait_port(port)):
+        print(f"entrypoint: hud dev did not bind :{port}", file=sys.stderr)
+
+    if scenario:
+        try:
+            try:
+                args_dict = json.loads(args_json) if args_json else {}
+            except json.JSONDecodeError as exc:
+                print(f"entrypoint: invalid HUD_TASK_ARGS: {exc}", file=sys.stderr)
+                args_dict = {}
+            session_id = asyncio.run(
+                _register_session(url, scenario, args_dict if isinstance(args_dict, dict) else {})
+            )
+            if session_id:
+                Path("/tmp/.hud_scenario_session").write_text(session_id)
+                print(f"entrypoint: scenario session {session_id}")
+            else:
+                print("entrypoint: scenario setup returned no session id", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001
+            print(f"entrypoint: scenario setup failed: {exc}", file=sys.stderr)
+
+    # Hand off PID 1 to whatever harbor's compose ``command:`` was
+    # (typically ``sh -c "sleep infinity"``).
+    cmd = sys.argv[1:]
+    if cmd:
+        os.execvp(cmd[0], cmd)
+    else:
+        signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
+        signal.pause()
+
+
+if __name__ == "__main__":
+    _main()

--- a/hud/cli/export/templates/entrypoint.py
+++ b/hud/cli/export/templates/entrypoint.py
@@ -79,27 +79,15 @@ async def _register_session(url: str, scenario: str, args_dict: dict) -> str | N
 
 
 def _build_launch_command(port: int) -> list[str]:
-    """Return the env's launch command, with ``--stdio`` rewritten to
-    ``--port <port>`` so MCP speaks HTTP for Harbor's compose driver.
+    """Return the env's launch command for ``hud dev`` over HTTP.
 
     ``HUD_LAUNCH_COMMAND`` (JSON list) is the env image's full original
-    CMD, captured at build time and threaded through the export's lock
-    yaml. Required for envs that wrap ``hud dev`` in a multi-process
-    startup. Falls back to a bare ``hud dev env:env`` when not set.
+    CMD, already rewritten by the exporter (``--stdio`` → ``--port``).
+    Falls back to a bare ``hud dev env:env`` when not set.
     """
     raw = os.environ.get("HUD_LAUNCH_COMMAND")
     if raw:
-        cmd = json.loads(raw)
-        rewritten: list[str] = []
-        for arg in cmd:
-            if arg == "--stdio":
-                rewritten.extend(["--port", str(port)])
-            elif "--stdio" in arg:
-                # ``sh -c`` shell-string forms — rewrite inside the string
-                rewritten.append(arg.replace("--stdio", f"--port {port}"))
-            else:
-                rewritten.append(str(arg))
-        return rewritten
+        return [str(arg) for arg in json.loads(raw)]
     return ["hud", "dev", "env:env", "--port", str(port)]
 
 
@@ -123,60 +111,66 @@ _KEEPALIVE_INTERVAL_SEC = 30
 _KEEPALIVE_LOG_PATH = "/logs/agent/keepalive.log"
 
 
-def _spawn_session_keepalive(url: str, session_id: str) -> subprocess.Popen[bytes]:
-    """Background-ping the registered MCP session to keep it alive.
+def _keepalive_main(url: str, session_id: str) -> None:
+    """Ping ``url`` every ``_KEEPALIVE_INTERVAL_SEC`` to keep ``session_id`` warm.
 
-    The agent runs on its OWN MCP session (claude-code/codex/etc. each
-    open one when they connect), so the session entrypoint registered
-    here sits idle the entire time the agent is doing work. Without
+    Invoked as ``entrypoint.py --keepalive <url> <session_id>`` from
+    ``_spawn_session_keepalive``. The agent runs on its OWN MCP session
+    (claude-code/codex/etc. each open one when they connect), so the
+    session registered at boot sits idle the entire time. Without this
     keepalive, the verifier's ``hud scenario grade`` fails with
     ``McpError: Session terminated`` because the session was reaped
-    mid-trial. A cheap ``list_tools`` every 30s keeps it warm.
-
-    The script runs as a detached subprocess so PID 1 is free to
-    ``exec`` into Harbor's compose command. ``streamablehttp_client``
-    is used with ``terminate_on_close=False`` so the keepalive doesn't
-    accidentally DELETE the session it's trying to preserve. Logs are
-    timestamped + flushed eagerly so a missing keepalive process is
-    obvious in /logs/keepalive.log.
+    mid-trial. ``terminate_on_close=False`` ensures the keepalive
+    doesn't accidentally DELETE the session it's preserving.
     """
-    script = (
-        "import asyncio, sys, time, os\n"
-        "URL = " + repr(url) + "\n"
-        "SID = " + repr(session_id) + "\n"
-        "INTERVAL = " + repr(_KEEPALIVE_INTERVAL_SEC) + "\n"
-        "def _log(msg):\n"
-        "    sys.stdout.write(f\"[{time.strftime('%H:%M:%S')}] keepalive: {msg}\\n\")\n"
-        "    sys.stdout.flush()\n"
-        '_log(f"started; session={SID[:8]}... interval={INTERVAL}s")\n'
-        "async def _ping_loop():\n"
-        "    from mcp import ClientSession\n"
-        "    from mcp.client.streamable_http import streamablehttp_client\n"
-        "    n = 0\n"
-        "    while True:\n"
-        "        try:\n"
-        "            async with streamablehttp_client(\n"
-        '                URL, terminate_on_close=False, headers={"mcp-session-id": SID}\n'
-        "            ) as (r, w, _gid):\n"
-        "                async with ClientSession(r, w) as session:\n"
-        "                    await session.initialize()\n"
-        "                    tools = await session.list_tools()\n"
-        "                    n += 1\n"
-        '                    _log(f"ping #{n} ok ({len(tools.tools)} tools)")\n'
-        "        except Exception as exc:\n"
-        '            _log(f"ping #{n} failed: {type(exc).__name__}: {exc}")\n'
-        "        await asyncio.sleep(INTERVAL)\n"
-        "asyncio.run(_ping_loop())\n"
-    )
-    # Open the log under /logs for post-mortem visibility; if /logs
-    # isn't writable yet (Harbor sometimes lazily mounts), fall back
-    # to /tmp.
+    import time as _time
+
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    def _log(msg: str) -> None:
+        sys.stdout.write(f"[{_time.strftime('%H:%M:%S')}] keepalive: {msg}\n")
+        sys.stdout.flush()
+
+    _log(f"started; session={session_id[:8]}... interval={_KEEPALIVE_INTERVAL_SEC}s")
+
+    async def _ping_loop() -> None:
+        n = 0
+        while True:
+            try:
+                async with (
+                    streamablehttp_client(
+                        url,
+                        terminate_on_close=False,
+                        headers={"mcp-session-id": session_id},
+                    ) as (r, w, _gid),
+                    ClientSession(r, w) as session,
+                ):
+                    await session.initialize()
+                    tools = await session.list_tools()
+                    n += 1
+                    _log(f"ping #{n} ok ({len(tools.tools)} tools)")
+            except Exception as exc:
+                _log(f"ping #{n} failed: {type(exc).__name__}: {exc}")
+            await asyncio.sleep(_KEEPALIVE_INTERVAL_SEC)
+
+    asyncio.run(_ping_loop())
+
+
+def _spawn_session_keepalive(url: str, session_id: str) -> subprocess.Popen[bytes]:
+    """Spawn ``_keepalive_main`` as a detached subprocess.
+
+    Detached so PID 1 is free to ``exec`` into Harbor's compose command.
+    Logs go to ``/logs/agent/keepalive.log`` for post-mortem visibility;
+    if ``/logs`` isn't writable yet (Harbor sometimes lazily mounts),
+    fall back to ``/tmp``.
+    """
     try:
         log_fd = open(_KEEPALIVE_LOG_PATH, "wb")  # noqa: SIM115
     except OSError:
         log_fd = open("/tmp/hud-keepalive.log", "wb")  # noqa: S108, SIM115
     return subprocess.Popen(
-        ["python3", "-u", "-c", script],  # noqa: S607
+        [sys.executable, "-u", __file__, "--keepalive", url, session_id],
         stdout=log_fd,
         stderr=subprocess.STDOUT,
         start_new_session=True,
@@ -184,6 +178,13 @@ def _spawn_session_keepalive(url: str, session_id: str) -> subprocess.Popen[byte
 
 
 def _main() -> None:
+    # Self-dispatch: ``_spawn_session_keepalive`` re-execs us with
+    # ``--keepalive <url> <session_id>`` so the keepalive runs as its
+    # own detached process without us shipping a second .py file.
+    if len(sys.argv) >= 4 and sys.argv[1] == "--keepalive":
+        _keepalive_main(sys.argv[2], sys.argv[3])
+        return
+
     logging.basicConfig(
         level=logging.INFO,
         format="entrypoint: %(message)s",

--- a/hud/cli/export/templates/entrypoint.py
+++ b/hud/cli/export/templates/entrypoint.py
@@ -82,15 +82,10 @@ def _build_launch_command(port: int) -> list[str]:
     """Return the env's launch command, with ``--stdio`` rewritten to
     ``--port <port>`` so MCP speaks HTTP for Harbor's compose driver.
 
-    Order of preference:
-
-    1. ``HUD_LAUNCH_COMMAND`` (JSON list) — the env image's full original
-       CMD, captured at build time and threaded through the export's
-       lock yaml. Required for envs that wrap ``hud dev`` in a multi-
-       process startup.
-    2. ``HUD_DEV_ARGS`` (legacy) — just the ``module:attr`` token. Older
-       bundles that only know about the simple form still work.
-    3. ``env:env`` fallback.
+    ``HUD_LAUNCH_COMMAND`` (JSON list) is the env image's full original
+    CMD, captured at build time and threaded through the export's lock
+    yaml. Required for envs that wrap ``hud dev`` in a multi-process
+    startup. Falls back to a bare ``hud dev env:env`` when not set.
     """
     raw = os.environ.get("HUD_LAUNCH_COMMAND")
     if raw:
@@ -105,8 +100,7 @@ def _build_launch_command(port: int) -> list[str]:
             else:
                 rewritten.append(str(arg))
         return rewritten
-    dev_args = os.environ.get("HUD_DEV_ARGS") or "env:env"
-    return ["hud", "dev", dev_args, "--port", str(port)]
+    return ["hud", "dev", "env:env", "--port", str(port)]
 
 
 def _spawn_hud_dev(port: int) -> subprocess.Popen[bytes]:

--- a/hud/cli/export/templates/sample-run.sh
+++ b/hud/cli/export/templates/sample-run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Build and run one task from this Harbor-format export.
+#   ./sample-run.sh                # run first task
+#   ./sample-run.sh <task-slug>    # run a specific task
+set -euo pipefail
+
+EXPORT_ROOT=$(cd "$(dirname "$0")" && pwd)
+TASK=${1:-__FIRST_TASK__}
+
+if [[ ! -d "$EXPORT_ROOT/tasks/$TASK" ]]; then
+    echo "Task not found: $TASK" >&2
+    echo "Available:" >&2
+    ls "$EXPORT_ROOT/tasks" >&2
+    exit 1
+fi
+
+IMG="hud-export-task:$TASK"
+docker build -t "$IMG" "$EXPORT_ROOT/tasks/$TASK/environment"
+
+LOG_DIR="$EXPORT_ROOT/logs/$TASK"
+mkdir -p "$LOG_DIR"
+
+set +e
+docker run --rm \
+    -v "$EXPORT_ROOT/tasks/$TASK/tests:/tests:ro" \
+    -v "$LOG_DIR:/logs" \
+    "$IMG" \
+    bash /tests/test.sh
+RUN_RC=$?
+set -e
+
+REWARD_FILE="$LOG_DIR/verifier/reward.txt"
+echo
+if [[ -f "$REWARD_FILE" ]]; then
+    echo "Reward: $(cat "$REWARD_FILE")  (test.sh exit=$RUN_RC)"
+else
+    echo "No reward.txt produced (test.sh exit=$RUN_RC). See container logs above."
+fi
+exit "$RUN_RC"

--- a/hud/cli/export/templates/test.sh
+++ b/hud/cli/export/templates/test.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 # Generic Harbor verifier for HUD-exported tasks.
-# Boots the HUD MCP server inside the running container, registers a fresh
-# scenario session against the (pre-baked) filesystem state, then calls
-# `hud scenario grade` and writes the reward to /logs/verifier/reward.txt.
 #
-# Per-task config comes from environment variables baked into the image:
+# By the time this runs, the image's ENTRYPOINT (entrypoint.py) has
+# already:
+#   - booted ``hud dev`` on $HUD_MCP_PORT,
+#   - registered a scenario session against it (running ``setup_task``
+#     once), and
+#   - persisted the session id to /tmp/.hud_scenario_session.
+#
+# So all we need is ``hud scenario grade`` — which loads the saved
+# session id, calls ``_hud_submit``, reads the grader resource, and
+# returns the reward. No need to call ``setup`` again here, which
+# would re-run the env's destructive ``setup_task`` and wipe the
+# agent's edits.
+#
+# Per-task config from environment variables:
 #   HUD_TASK_SCENARIO  — full scenario name (env:scenario)
-#   HUD_TASK_ARGS      — JSON args (may be "{}")
 set -euo pipefail
 
 REWARD_DIR=${REWARD_DIR:-/logs/verifier}
@@ -20,27 +29,23 @@ fi
 
 HUD_MCP_PORT=${HUD_MCP_PORT:-8765}
 HUD_MCP_URL=${HUD_MCP_URL:-http://localhost:$HUD_MCP_PORT/mcp}
-HUD_DEV_ARGS=${HUD_DEV_ARGS:-env:env}
 
-# Bash parameter expansion stops at the first '}', so '${X:-{}}' doesn't
-# default to '{}'. Use an explicit fallback instead.
-ARGS=${HUD_TASK_ARGS-}
-[[ -z "$ARGS" ]] && ARGS='{}'
+# Confirm hud dev is up. If not (entrypoint.py died, or this image was
+# built without one), surface a clear error rather than letting hud
+# scenario grade fail with an obscure connect error.
+if ! (echo > "/dev/tcp/127.0.0.1/$HUD_MCP_PORT") 2>/dev/null; then
+    echo "hud dev is not running on :$HUD_MCP_PORT — entrypoint may have failed" >&2
+    cat /tmp/hud-dev.log >&2 2>/dev/null || true
+    echo 0 > "$REWARD_DIR/reward.txt"
+    exit 1
+fi
 
-hud dev $HUD_DEV_ARGS --port "$HUD_MCP_PORT" &
-SERVER_PID=$!
-trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
-
-for _ in $(seq 1 30); do
-    if (echo > "/dev/tcp/127.0.0.1/$HUD_MCP_PORT") 2>/dev/null; then
-        break
-    fi
-    sleep 1
-done
-
-# Re-register session against the baked filesystem state.
-# Setup must be idempotent on already-set-up state.
-hud scenario setup "$HUD_TASK_SCENARIO" --args "$ARGS" --url "$HUD_MCP_URL" >/dev/null
+# Confirm the entrypoint registered a session.
+if [[ ! -s /tmp/.hud_scenario_session ]]; then
+    echo "/tmp/.hud_scenario_session is missing — entrypoint scenario setup failed" >&2
+    echo 0 > "$REWARD_DIR/reward.txt"
+    exit 1
+fi
 
 RESULT=$(hud scenario grade "$HUD_TASK_SCENARIO" --answer "${ANSWER:-}" --url "$HUD_MCP_URL")
 # Parse with the Python that ships with `hud` — avoids depending on jq.

--- a/hud/cli/export/templates/test.sh
+++ b/hud/cli/export/templates/test.sh
@@ -5,8 +5,10 @@
 # already:
 #   - booted ``hud dev`` on $HUD_MCP_PORT,
 #   - registered a scenario session against it (running ``setup_task``
-#     once), and
-#   - persisted the session id to /tmp/.hud_scenario_session.
+#     once),
+#   - persisted the session id to /tmp/.hud_scenario_session, and
+#   - spawned a background keepalive that pings the session so it
+#     survives the agent's run.
 #
 # So all we need is ``hud scenario grade`` — which loads the saved
 # session id, calls ``_hud_submit``, reads the grader resource, and
@@ -16,14 +18,31 @@
 #
 # Per-task config from environment variables:
 #   HUD_TASK_SCENARIO  — full scenario name (env:scenario)
-set -euo pipefail
+#   ANSWER             — optional override; if unset we extract the
+#                        agent's final response from
+#                        /logs/agent/claude-code.txt (Harbor's
+#                        claude-code wrapper writes the stream-json
+#                        there). Filesystem-graded scenarios ignore
+#                        the answer; text-answer scenarios (rubric,
+#                        regex, web-research) need it.
+set -uo pipefail
 
 REWARD_DIR=${REWARD_DIR:-/logs/verifier}
 mkdir -p "$REWARD_DIR"
 
+# Always-write helper. Harbor raises ``RewardFileNotFoundError`` if
+# reward.txt is missing, which loses every diagnostic we'd otherwise
+# have surfaced (env grader errors, dead sessions, etc.). With this
+# trap, every exit path produces a parseable ``reward = 0`` and the
+# real error message reaches stderr.
+write_reward() {
+    echo "$1" > "$REWARD_DIR/reward.txt"
+}
+trap '[ -f "$REWARD_DIR/reward.txt" ] || write_reward 0' EXIT
+
 if [[ -z "${HUD_TASK_SCENARIO:-}" ]]; then
     echo "HUD_TASK_SCENARIO is not set" >&2
-    echo 0 > "$REWARD_DIR/reward.txt"
+    write_reward 0
     exit 1
 fi
 
@@ -36,26 +55,109 @@ HUD_MCP_URL=${HUD_MCP_URL:-http://localhost:$HUD_MCP_PORT/mcp}
 if ! (echo > "/dev/tcp/127.0.0.1/$HUD_MCP_PORT") 2>/dev/null; then
     echo "hud dev is not running on :$HUD_MCP_PORT — entrypoint may have failed" >&2
     cat /tmp/hud-dev.log >&2 2>/dev/null || true
-    echo 0 > "$REWARD_DIR/reward.txt"
+    write_reward 0
     exit 1
 fi
 
 # Confirm the entrypoint registered a session.
 if [[ ! -s /tmp/.hud_scenario_session ]]; then
     echo "/tmp/.hud_scenario_session is missing — entrypoint scenario setup failed" >&2
-    echo 0 > "$REWARD_DIR/reward.txt"
+    write_reward 0
     exit 1
 fi
 
-RESULT=$(hud scenario grade "$HUD_TASK_SCENARIO" --answer "${ANSWER:-}" --url "$HUD_MCP_URL")
+# Pull the agent's final response from Harbor's claude-code stream-json
+# log if no explicit ANSWER was passed in. Harbor's claude-code wrapper
+# tees ``--output-format=stream-json`` to /logs/agent/claude-code.txt
+# and the final event is ``{"type":"result","subtype":"success",
+# "result":"..."}``. For other Harbor agents (codex, oracle, nemo, ...)
+# the file isn't there or has a different shape and we fall through to
+# whatever the caller set ANSWER to (default: empty).
+#
+# Filesystem-graded scenarios (verilog-shaped) ignore the answer
+# entirely — their grader inspects file state via MCP. Empty answer
+# is fine. Text-answer scenarios (rubric/regex/web-research) need
+# this bridge: claude-code is HUD-unaware and never calls
+# ``_hud_submit`` itself, so without this extraction the env's grader
+# would run against ``""``.
+if [[ -z "${ANSWER:-}" && -f /logs/agent/claude-code.txt ]]; then
+    ANSWER=$(python3 - <<'PY' 2>/dev/null
+import json, sys
+result = ""
+last_assistant_text = ""
+try:
+    with open("/logs/agent/claude-code.txt", encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # Authoritative final answer: claude-code emits one of these
+            # at end-of-turn. ``subtype == "success"`` carries the full
+            # response in ``result``; on error there's no ``result`` so
+            # we fall through to the assistant-text fallback below.
+            if obj.get("type") == "result" and obj.get("subtype") == "success":
+                value = obj.get("result")
+                if isinstance(value, str) and value:
+                    result = value
+                break
+            # Fallback: track the last assistant text block. Used when
+            # the run errored before emitting a "result" event.
+            if obj.get("type") == "assistant":
+                msg = obj.get("message") or {}
+                for item in msg.get("content") or []:
+                    if item.get("type") == "text":
+                        text = item.get("text")
+                        if isinstance(text, str) and text:
+                            last_assistant_text = text
+except FileNotFoundError:
+    pass
+sys.stdout.write(result or last_assistant_text)
+PY
+)
+fi
+ANSWER=${ANSWER:-}
+
+# Capture stdout AND stderr together so an env-side grader error
+# actually surfaces in Harbor's logs instead of being swallowed by
+# command substitution. We dropped ``set -e`` above so the failure
+# path here is explicit; otherwise Harbor would just see a missing
+# reward.txt and raise ``RewardFileNotFoundError``.
+GRADE_OUTPUT=$(hud scenario grade "$HUD_TASK_SCENARIO" --answer "$ANSWER" --url "$HUD_MCP_URL" 2>&1)
+GRADE_RC=$?
+if [ "$GRADE_RC" -ne 0 ]; then
+    echo "hud scenario grade failed (rc=$GRADE_RC):" >&2
+    echo "$GRADE_OUTPUT" >&2
+    # Dump the side-band logs so a session-termination diagnosis isn't
+    # lost when the container exits. ``/logs/agent/keepalive.log`` is
+    # the entrypoint's keepalive subprocess output (Harbor only mounts
+    # /logs/{agent,verifier,artifacts}, NOT /logs itself, so writes
+    # outside those subdirs disappear at container teardown).
+    # ``/tmp/hud-dev.log`` is the env's ``hud dev`` server output
+    # (visible from test.sh because Harbor runs the agent + verifier
+    # as ``docker exec`` against the same container).
+    for log in /logs/agent/keepalive.log /tmp/hud-keepalive.log /tmp/hud-dev.log; do
+        if [ -f "$log" ]; then
+            echo "" >&2
+            echo "=== tail $log ===" >&2
+            tail -50 "$log" >&2
+        fi
+    done
+    write_reward 0
+    exit 1
+fi
+
 # Parse with the Python that ships with `hud` — avoids depending on jq.
-REWARD=$(printf '%s' "$RESULT" | python3 -c \
+REWARD=$(printf '%s' "$GRADE_OUTPUT" | python3 -c \
     'import json,sys
 try:
     print(float(json.loads(sys.stdin.read()).get("reward", 0)))
 except Exception:
     print(0)')
 
-echo "$REWARD" > "$REWARD_DIR/reward.txt"
+write_reward "$REWARD"
 
 awk -v r="$REWARD" 'BEGIN { exit (r+0 > 0) ? 0 : 1 }'

--- a/hud/cli/export/templates/test.sh
+++ b/hud/cli/export/templates/test.sh
@@ -151,12 +151,27 @@ if [ "$GRADE_RC" -ne 0 ]; then
 fi
 
 # Parse with the Python that ships with `hud` — avoids depending on jq.
+# ``GRADE_OUTPUT`` mixes stderr noise (deprecation warnings from
+# fastmcp/authlib, etc.) with the grader's stdout JSON because we
+# captured ``2>&1`` to surface errors. Skim for the LAST line that
+# parses as a dict with a ``reward`` key — that's authoritative.
 REWARD=$(printf '%s' "$GRADE_OUTPUT" | python3 -c \
     'import json,sys
-try:
-    print(float(json.loads(sys.stdin.read()).get("reward", 0)))
-except Exception:
-    print(0)')
+reward = 0
+for line in sys.stdin.read().splitlines():
+    line = line.strip()
+    if not line.startswith("{"):
+        continue
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if isinstance(obj, dict) and "reward" in obj:
+        try:
+            reward = float(obj["reward"])
+        except (TypeError, ValueError):
+            pass
+print(reward)')
 
 write_reward "$REWARD"
 

--- a/hud/cli/export/templates/test.sh
+++ b/hud/cli/export/templates/test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Generic Harbor verifier for HUD-exported tasks.
+# Boots the HUD MCP server inside the running container, registers a fresh
+# scenario session against the (pre-baked) filesystem state, then calls
+# `hud scenario grade` and writes the reward to /logs/verifier/reward.txt.
+#
+# Per-task config comes from environment variables baked into the image:
+#   HUD_TASK_SCENARIO  — full scenario name (env:scenario)
+#   HUD_TASK_ARGS      — JSON args (may be "{}")
+set -euo pipefail
+
+REWARD_DIR=${REWARD_DIR:-/logs/verifier}
+mkdir -p "$REWARD_DIR"
+
+if [[ -z "${HUD_TASK_SCENARIO:-}" ]]; then
+    echo "HUD_TASK_SCENARIO is not set" >&2
+    echo 0 > "$REWARD_DIR/reward.txt"
+    exit 1
+fi
+
+HUD_MCP_PORT=${HUD_MCP_PORT:-8765}
+HUD_MCP_URL=${HUD_MCP_URL:-http://localhost:$HUD_MCP_PORT/mcp}
+HUD_DEV_ARGS=${HUD_DEV_ARGS:-env:env}
+
+# Bash parameter expansion stops at the first '}', so '${X:-{}}' doesn't
+# default to '{}'. Use an explicit fallback instead.
+ARGS=${HUD_TASK_ARGS-}
+[[ -z "$ARGS" ]] && ARGS='{}'
+
+hud dev $HUD_DEV_ARGS --port "$HUD_MCP_PORT" &
+SERVER_PID=$!
+trap 'kill "$SERVER_PID" 2>/dev/null || true' EXIT
+
+for _ in $(seq 1 30); do
+    if (echo > "/dev/tcp/127.0.0.1/$HUD_MCP_PORT") 2>/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+# Re-register session against the baked filesystem state.
+# Setup must be idempotent on already-set-up state.
+hud scenario setup "$HUD_TASK_SCENARIO" --args "$ARGS" --url "$HUD_MCP_URL" >/dev/null
+
+RESULT=$(hud scenario grade "$HUD_TASK_SCENARIO" --answer "${ANSWER:-}" --url "$HUD_MCP_URL")
+# Parse with the Python that ships with `hud` — avoids depending on jq.
+REWARD=$(printf '%s' "$RESULT" | python3 -c \
+    'import json,sys
+try:
+    print(float(json.loads(sys.stdin.read()).get("reward", 0)))
+except Exception:
+    print(0)')
+
+echo "$REWARD" > "$REWARD_DIR/reward.txt"
+
+awk -v r="$REWARD" 'BEGIN { exit (r+0 > 0) ? 0 : 1 }'

--- a/hud/cli/export/tests/test_harbor.py
+++ b/hud/cli/export/tests/test_harbor.py
@@ -17,8 +17,10 @@ from hud.cli.export import (
 )
 from hud.cli.export.base import ExportInput
 from hud.cli.export.harbor import (
+    _HARBOR_MCP_PORT,
     _full_scenario_name,
     _render_keywords,
+    _rewrite_stdio_to_port,
     _slugify,
     _toml_escape,
 )
@@ -111,6 +113,29 @@ class TestTomlEscape:
 
     def test_newline(self) -> None:
         assert _toml_escape("a\nb") == "a\\nb"
+
+
+class TestRewriteStdioToPort:
+    def test_standalone_token(self) -> None:
+        assert _rewrite_stdio_to_port(["hud", "dev", "env:env", "--stdio"], 8765) == [
+            "hud",
+            "dev",
+            "env:env",
+            "--port",
+            "8765",
+        ]
+
+    def test_embedded_in_shell_string(self) -> None:
+        assert _rewrite_stdio_to_port(
+            ["sh", "-c", "uvicorn app & exec hud dev env:env --stdio"], 8765
+        ) == ["sh", "-c", "uvicorn app & exec hud dev env:env --port 8765"]
+
+    def test_passthrough_without_stdio(self) -> None:
+        assert _rewrite_stdio_to_port(["hud", "dev", "env:env"], 8765) == [
+            "hud",
+            "dev",
+            "env:env",
+        ]
 
 
 # --------------------------------------------------------------------------- #
@@ -212,6 +237,30 @@ class TestHarborExport:
         dockerfile = result.files["tasks/wrongflag/environment/Dockerfile"]
         assert isinstance(dockerfile, str)
         assert "GITHUB_TOKEN" in dockerfile
+
+    def test_dockerfile_rewrites_runtime_command_stdio_to_port(self) -> None:
+        result = HarborExporter().export(
+            _make_input(
+                env_runtime_command=[
+                    "sh",
+                    "-c",
+                    "uvicorn app:app & exec hud dev env:env --stdio",
+                ]
+            )
+        )
+        dockerfile = result.files["tasks/wrongflag/environment/Dockerfile"]
+        assert isinstance(dockerfile, str)
+        assert "HUD_LAUNCH_COMMAND=" in dockerfile
+        # ``--stdio`` must not survive into the stamped value — the
+        # runtime scripts consume it verbatim and don't rewrite.
+        assert "--stdio" not in dockerfile
+        assert f"--port {_HARBOR_MCP_PORT}" in dockerfile
+
+    def test_dockerfile_omits_launch_command_when_no_runtime_command(self) -> None:
+        result = HarborExporter().export(_make_input())
+        dockerfile = result.files["tasks/wrongflag/environment/Dockerfile"]
+        assert isinstance(dockerfile, str)
+        assert "HUD_LAUNCH_COMMAND" not in dockerfile
 
     def test_test_sh_calls_hud_scenario_grade(self) -> None:
         result = HarborExporter().export(_make_input())

--- a/hud/cli/export/tests/test_harbor.py
+++ b/hud/cli/export/tests/test_harbor.py
@@ -1,0 +1,308 @@
+"""Tests for the HUD → Harbor exporter."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from hud.cli.export import (
+    HarborExporter,
+    export,
+    get_exporter,
+    list_formats,
+    write_result,
+)
+from hud.cli.export.base import ExportInput
+from hud.cli.export.harbor import (
+    _full_scenario_name,
+    _render_keywords,
+    _slugify,
+    _toml_escape,
+)
+from hud.eval.task import Task
+
+
+def _task(
+    *,
+    slug: str | None = None,
+    scenario: str = "solve",
+    env_name: str | None = "outline",
+    args: dict | None = None,
+    metadata: dict | None = None,
+    system_prompt: str | None = None,
+) -> Task:
+    """Build a minimal Task without booting an Environment."""
+    env_dict = {"name": env_name} if env_name else None
+    return Task.model_construct(
+        env=env_dict,
+        scenario=scenario,
+        slug=slug,
+        args=args,
+        metadata=metadata or {},
+        agent_config={"system_prompt": system_prompt} if system_prompt else None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+class TestSlugify:
+    def test_lowercases(self) -> None:
+        assert _slugify("WrongFlag") == "wrongflag"
+
+    def test_replaces_non_alnum(self) -> None:
+        assert _slugify("fix bug #42") == "fix-bug-42"
+
+    def test_collapses_runs(self) -> None:
+        assert _slugify("a___b---c") == "a-b-c"
+
+    def test_strips_edges(self) -> None:
+        assert _slugify("--hello--") == "hello"
+
+    def test_empty_falls_back(self) -> None:
+        assert _slugify("###") == "task"
+
+
+class TestFullScenarioName:
+    def test_passthrough_if_qualified(self) -> None:
+        t = _task(scenario="env:foo")
+        assert _full_scenario_name(t, "anything") == "env:foo"
+
+    def test_uses_env_dict_name(self) -> None:
+        t = _task(scenario="checkout", env_name="browser")
+        assert _full_scenario_name(t, "ts") == "browser:checkout"
+
+    def test_falls_back_to_taskset(self) -> None:
+        t = _task(scenario="solve", env_name=None)
+        assert _full_scenario_name(t, "My Set") == "my-set:solve"
+
+    def test_missing_scenario_raises(self) -> None:
+        t = _task(scenario="", env_name="e")
+        t.scenario = None  # type: ignore[assignment]
+        with pytest.raises(ValueError):
+            _full_scenario_name(t, "ts")
+
+
+class TestRenderKeywords:
+    def test_empty(self) -> None:
+        assert _render_keywords([]) == "[]"
+
+    def test_quotes_each(self) -> None:
+        assert _render_keywords(["a", "b"]) == '["a", "b"]'
+
+    def test_escapes(self) -> None:
+        assert _render_keywords(['has"quote']) == '["has\\"quote"]'
+
+
+class TestTomlEscape:
+    def test_quote(self) -> None:
+        assert _toml_escape('a"b') == 'a\\"b'
+
+    def test_backslash(self) -> None:
+        assert _toml_escape("a\\b") == "a\\\\b"
+
+    def test_newline(self) -> None:
+        assert _toml_escape("a\nb") == "a\\nb"
+
+
+# --------------------------------------------------------------------------- #
+# HarborExporter.export
+# --------------------------------------------------------------------------- #
+
+
+def _make_input(**overrides) -> ExportInput:
+    base = {
+        "tasks": [
+            _task(
+                slug="wrongflag",
+                scenario="solve",
+                env_name="outline",
+                args={"problem_id": "wrongflag"},
+                metadata={"difficulty": "easy", "keywords": ["typescript"]},
+                system_prompt="You are an expert TS engineer.",
+            ),
+            _task(
+                slug="redis-bug",
+                scenario="solve",
+                env_name="outline",
+                args={"problem_id": "redis"},
+                metadata={"difficulty": "hard"},
+            ),
+        ],
+        "env_image": "ghcr.io/hud-evals/outline@sha256:deadbeef",
+        "env_required_env": ["GITHUB_TOKEN"],
+        "rendered_prompts": {
+            "wrongflag": "Fix the emoji picker.",
+            "redis-bug": "Fix the redis connection.",
+        },
+        "taskset_name": "outline-coding",
+    }
+    base.update(overrides)
+    return ExportInput(**base)
+
+
+class TestHarborExport:
+    def test_emits_top_level_files(self) -> None:
+        result = HarborExporter().export(_make_input())
+        assert "README.md" in result.files
+        assert "sample-run.sh" in result.files
+        assert "manifest.json" in result.files
+
+    def test_emits_per_task_files(self) -> None:
+        result = HarborExporter().export(_make_input())
+        for slug in ("wrongflag", "redis-bug"):
+            for sub in (
+                "instruction.md",
+                "task.toml",
+                "environment/Dockerfile",
+                "environment/bake-setup.sh",
+                "tests/test.sh",
+            ):
+                assert f"tasks/{slug}/{sub}" in result.files, f"missing tasks/{slug}/{sub}"
+
+    def test_instruction_combines_system_and_user(self) -> None:
+        result = HarborExporter().export(_make_input())
+        instr = result.files["tasks/wrongflag/instruction.md"]
+        assert isinstance(instr, str)
+        assert "You are an expert TS engineer." in instr
+        assert "---" in instr
+        assert "Fix the emoji picker." in instr
+
+    def test_instruction_user_only_when_no_system_prompt(self) -> None:
+        result = HarborExporter().export(_make_input())
+        instr = result.files["tasks/redis-bug/instruction.md"]
+        assert isinstance(instr, str)
+        assert "---" not in instr
+        assert "Fix the redis connection." in instr
+
+    def test_dockerfile_uses_base_image_and_bakes_setup(self) -> None:
+        result = HarborExporter().export(_make_input())
+        dockerfile = result.files["tasks/wrongflag/environment/Dockerfile"]
+        assert isinstance(dockerfile, str)
+        assert "FROM ghcr.io/hud-evals/outline@sha256:deadbeef" in dockerfile
+        assert "ENV HUD_TASK_SCENARIO=outline:solve" in dockerfile
+        assert '"problem_id": "wrongflag"' in dockerfile
+        assert "/opt/hud/bake-setup.sh" in dockerfile
+
+    def test_dockerfile_emits_platform_when_provided(self) -> None:
+        result = HarborExporter().export(_make_input(env_platform="linux/amd64"))
+        dockerfile = result.files["tasks/wrongflag/environment/Dockerfile"]
+        assert isinstance(dockerfile, str)
+        assert dockerfile.startswith(
+            "FROM --platform=linux/amd64 ghcr.io/hud-evals/outline@sha256:deadbeef"
+        )
+
+    def test_dockerfile_omits_platform_when_unset(self) -> None:
+        result = HarborExporter().export(_make_input())
+        dockerfile = result.files["tasks/wrongflag/environment/Dockerfile"]
+        assert isinstance(dockerfile, str)
+        assert dockerfile.startswith("FROM ghcr.io/hud-evals/outline@sha256:deadbeef")
+        assert "--platform" not in dockerfile
+
+    def test_dockerfile_records_required_env(self) -> None:
+        result = HarborExporter().export(_make_input())
+        dockerfile = result.files["tasks/wrongflag/environment/Dockerfile"]
+        assert isinstance(dockerfile, str)
+        assert "GITHUB_TOKEN" in dockerfile
+
+    def test_test_sh_calls_hud_scenario_grade(self) -> None:
+        result = HarborExporter().export(_make_input())
+        test_sh = result.files["tasks/wrongflag/tests/test.sh"]
+        assert isinstance(test_sh, str)
+        assert "hud scenario grade" in test_sh
+        assert "reward.txt" in test_sh
+
+    def test_task_toml_contains_metadata(self) -> None:
+        result = HarborExporter().export(_make_input())
+        task_toml = result.files["tasks/wrongflag/task.toml"]
+        assert isinstance(task_toml, str)
+        assert 'name = "outline-coding/wrongflag"' in task_toml
+        assert 'difficulty = "easy"' in task_toml
+        assert '"typescript"' in task_toml
+
+    def test_manifest_lists_tasks(self) -> None:
+        result = HarborExporter().export(_make_input())
+        manifest = json.loads(result.files["manifest.json"])
+        assert manifest["format"] == "harbor"
+        assert manifest["task_count"] == 2
+        assert manifest["task_slugs"] == ["wrongflag", "redis-bug"]
+        assert manifest["base_image"] == "ghcr.io/hud-evals/outline@sha256:deadbeef"
+
+    def test_subset_filter(self) -> None:
+        result = HarborExporter().export(_make_input(task_subset=["wrongflag"]))
+        assert "tasks/wrongflag/task.toml" in result.files
+        assert "tasks/redis-bug/task.toml" not in result.files
+
+    def test_no_tasks_raises(self) -> None:
+        inp = _make_input(task_subset=["does-not-exist"])
+        with pytest.raises(ValueError, match="No tasks selected"):
+            HarborExporter().export(inp)
+
+    def test_dedupes_collisions(self) -> None:
+        inp = _make_input(
+            tasks=[
+                _task(slug="dup", scenario="a"),
+                _task(slug="dup", scenario="b"),
+            ],
+            rendered_prompts={},
+        )
+        result = HarborExporter().export(inp)
+        assert "tasks/dup/task.toml" in result.files
+        assert "tasks/dup-2/task.toml" in result.files
+
+    def test_placeholder_when_prompt_missing(self) -> None:
+        inp = _make_input(rendered_prompts={})
+        result = HarborExporter().export(inp)
+        instr = result.files["tasks/wrongflag/instruction.md"]
+        assert isinstance(instr, str)
+        assert "not rendered" in instr
+
+    def test_sample_run_targets_first_task(self) -> None:
+        result = HarborExporter().export(_make_input())
+        assert "wrongflag" in result.sample_run_script
+        assert "__FIRST_TASK__" not in result.sample_run_script
+
+
+# --------------------------------------------------------------------------- #
+# write_result + registry
+# --------------------------------------------------------------------------- #
+
+
+class TestWriteResult:
+    def test_materializes_files(self, tmp_path: Path) -> None:
+        result = HarborExporter().export(_make_input())
+        out = write_result(result, tmp_path / "out")
+        assert (out / "tasks" / "wrongflag" / "task.toml").exists()
+        assert (out / "tasks" / "redis-bug" / "tests" / "test.sh").exists()
+        assert (out / "manifest.json").exists()
+
+    def test_marks_shell_scripts_executable(self, tmp_path: Path) -> None:
+        result = HarborExporter().export(_make_input())
+        out = write_result(result, tmp_path / "out")
+        sample = out / "sample-run.sh"
+        assert sample.stat().st_mode & stat.S_IXUSR
+        test_sh = out / "tasks" / "wrongflag" / "tests" / "test.sh"
+        assert test_sh.stat().st_mode & stat.S_IXUSR
+
+
+class TestRegistry:
+    def test_lists_formats(self) -> None:
+        names = {n for n, _ in list_formats()}
+        assert "harbor" in names
+
+    def test_get_exporter(self) -> None:
+        assert isinstance(get_exporter("harbor"), HarborExporter)
+        assert get_exporter("nope") is None
+
+    def test_export_dispatches_by_name(self) -> None:
+        result = export("harbor", _make_input())
+        assert "manifest.json" in result.files
+
+    def test_export_unknown_format_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown export format"):
+            export("nope", _make_input())

--- a/hud/cli/export/tests/test_harbor.py
+++ b/hud/cli/export/tests/test_harbor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import stat
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -23,6 +23,9 @@ from hud.cli.export.harbor import (
     _toml_escape,
 )
 from hud.eval.task import Task
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _task(

--- a/hud/cli/tests/test_build.py
+++ b/hud/cli/tests/test_build.py
@@ -710,9 +710,9 @@ ENV API_KEY
         mock_get_id.return_value = "sha256:abc123"
 
         # Mock final rebuild. ``stdout="[]"`` keeps the global subprocess
-        # mock JSON-parseable for the ``docker inspect`` calls that
-        # ``get_docker_cmd`` / ``get_docker_entrypoint`` make during
-        # build (they ``json.loads`` the stdout).
+        # mock JSON-parseable for the ``docker inspect`` call that
+        # ``_inspect_config`` makes during build (it ``json.loads`` the
+        # stdout to read Entrypoint + Cmd off ``Config``).
         mock_result = mock.Mock()
         mock_result.returncode = 0
         mock_result.stdout = "[]"

--- a/hud/cli/tests/test_build.py
+++ b/hud/cli/tests/test_build.py
@@ -709,9 +709,13 @@ ENV API_KEY
         }
         mock_get_id.return_value = "sha256:abc123"
 
-        # Mock final rebuild
+        # Mock final rebuild. ``stdout="[]"`` keeps the global subprocess
+        # mock JSON-parseable for the ``docker inspect`` calls that
+        # ``get_docker_cmd`` / ``get_docker_entrypoint`` make during
+        # build (they ``json.loads`` the stdout).
         mock_result = mock.Mock()
         mock_result.returncode = 0
+        mock_result.stdout = "[]"
         mock_run.return_value = mock_result
 
         # Run build
@@ -780,6 +784,7 @@ FROM python:3.11
 
         mock_result = mock.Mock()
         mock_result.returncode = 0
+        mock_result.stdout = "[]"
         mock_run.return_value = mock_result
 
         build_environment(str(env_dir), "env-int:latest")

--- a/hud/cli/utils/docker.py
+++ b/hud/cli/utils/docker.py
@@ -71,6 +71,23 @@ def get_docker_cmd(image: str) -> list[str] | None:
         return None
 
 
+def get_docker_entrypoint(image: str) -> list[str] | None:
+    """Extract the ENTRYPOINT from a Docker image. ``None`` if unset."""
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", image],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        inspect_data = json.loads(result.stdout)
+        if inspect_data and isinstance(inspect_data[0], dict):
+            entrypoint = inspect_data[0].get("Config", {}).get("Entrypoint") or []
+            return list(entrypoint) or None
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, FileNotFoundError):
+        return None
+
+
 DEFAULT_HTTP_PORT = 8765
 
 

--- a/hud/cli/utils/docker.py
+++ b/hud/cli/utils/docker.py
@@ -43,36 +43,14 @@ def extract_name_and_tag(image_ref: str) -> tuple[str, str]:
     return name, tag
 
 
-def get_docker_cmd(image: str) -> list[str] | None:
+def _inspect_config(image: str) -> dict | None:
+    """Return ``Config`` block from ``docker inspect`` for ``image``.
+
+    Callers that need a single field can read it directly off the
+    returned dict (e.g. ``Entrypoint``, ``WorkingDir``); ``get_docker_cmd``
+    is a thin wrapper around ``Config.Cmd``. Returns ``None`` on any
+    inspect/parse error.
     """
-    Extract the CMD from a Docker image.
-
-    Args:
-        image: Docker image name
-
-    Returns:
-        List of command parts or None if not found
-    """
-    try:
-        result = subprocess.run(
-            ["docker", "inspect", image],  # noqa: S607
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-        inspect_data = json.loads(result.stdout)
-        if inspect_data and len(inspect_data) > 0 and isinstance(inspect_data[0], dict):
-            config = inspect_data[0].get("Config", {})
-            cmd = config.get("Cmd", [])
-            return cmd if cmd else None
-
-    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, FileNotFoundError):
-        return None
-
-
-def get_docker_entrypoint(image: str) -> list[str] | None:
-    """Extract the ENTRYPOINT from a Docker image. ``None`` if unset."""
     try:
         result = subprocess.run(
             ["docker", "inspect", image],  # noqa: S607
@@ -82,10 +60,19 @@ def get_docker_entrypoint(image: str) -> list[str] | None:
         )
         inspect_data = json.loads(result.stdout)
         if inspect_data and isinstance(inspect_data[0], dict):
-            entrypoint = inspect_data[0].get("Config", {}).get("Entrypoint") or []
-            return list(entrypoint) or None
+            return inspect_data[0].get("Config") or {}
     except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, FileNotFoundError):
         return None
+    return None
+
+
+def get_docker_cmd(image: str) -> list[str] | None:
+    """Extract the CMD from a Docker image. ``None`` if unset."""
+    config = _inspect_config(image)
+    if config is None:
+        return None
+    cmd = config.get("Cmd") or []
+    return list(cmd) or None
 
 
 DEFAULT_HTTP_PORT = 8765

--- a/hud/cli/utils/lockfile.py
+++ b/hud/cli/utils/lockfile.py
@@ -132,7 +132,21 @@ def build_lock_data(
 
     required_from_extra = set(additional_required_env_vars or [])
     provided_env_vars = set((env_vars or {}).keys())
-    all_required = (set(required_env) | required_from_extra | provided_env_vars) - set(optional_env)
+    scenario_required: set[str] = set()
+    for source_key in ("prompts", "scenarios"):
+        items = analysis.get(source_key) or []
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            meta = item.get("meta") or {}
+            declared = meta.get("required_env_vars") or []
+            if isinstance(declared, list):
+                scenario_required.update(v for v in declared if isinstance(v, str))
+    all_required = (
+        set(required_env) | required_from_extra | provided_env_vars | scenario_required
+    ) - set(optional_env)
     if all_required or optional_env:
         variables: dict[str, Any] = {
             "_note": (

--- a/hud/cli/utils/lockfile.py
+++ b/hud/cli/utils/lockfile.py
@@ -65,6 +65,8 @@ def build_lock_data(
     build_method: str | None = None,
     directory_name: str | None = None,
     local_image_ref: str | None = None,
+    runtime_command: list[str] | None = None,
+    runtime_workdir: str | None = None,
 ) -> dict[str, Any]:
     """Build a `hud.lock.yaml`-compatible dict from shared analysis data."""
     from hud.cli.build import extract_env_vars_from_dockerfile, parse_base_image
@@ -105,6 +107,10 @@ def build_lock_data(
             "internalToolCount": int(analysis.get("internalToolCount", 0) or 0),
         },
     }
+    if runtime_command:
+        lock_content["environment"]["command"] = list(runtime_command)
+    if runtime_workdir:
+        lock_content["environment"]["workdir"] = runtime_workdir
     if build_id is not None:
         lock_content["build"]["buildId"] = build_id
     if build_method is not None:

--- a/hud/cli/utils/tests/test_docker.py
+++ b/hud/cli/utils/tests/test_docker.py
@@ -8,6 +8,7 @@ from hud.cli.utils.docker import (
     build_run_command,
     generate_container_name,
     get_docker_cmd,
+    get_docker_entrypoint,
     image_exists,
     remove_container,
     require_docker_running,
@@ -56,6 +57,24 @@ def test_get_docker_cmd_success(mock_run):
 def test_get_docker_cmd_none(mock_run):
     mock_run.return_value = MagicMock(stdout="[]", returncode=0)
     assert get_docker_cmd("img") is None
+
+
+@patch("subprocess.run")
+def test_get_docker_entrypoint_present(mock_run):
+    mock_run.return_value = MagicMock(
+        stdout='[{"Config": {"Entrypoint": ["/start.sh"], "Cmd": null}}]',
+        returncode=0,
+    )
+    assert get_docker_entrypoint("img") == ["/start.sh"]
+
+
+@patch("subprocess.run")
+def test_get_docker_entrypoint_none_when_unset(mock_run):
+    mock_run.return_value = MagicMock(
+        stdout='[{"Config": {"Entrypoint": null, "Cmd": ["x"]}}]',
+        returncode=0,
+    )
+    assert get_docker_entrypoint("img") is None
 
 
 @patch("subprocess.run")

--- a/hud/cli/utils/tests/test_docker.py
+++ b/hud/cli/utils/tests/test_docker.py
@@ -8,7 +8,6 @@ from hud.cli.utils.docker import (
     build_run_command,
     generate_container_name,
     get_docker_cmd,
-    get_docker_entrypoint,
     image_exists,
     remove_container,
     require_docker_running,
@@ -57,24 +56,6 @@ def test_get_docker_cmd_success(mock_run):
 def test_get_docker_cmd_none(mock_run):
     mock_run.return_value = MagicMock(stdout="[]", returncode=0)
     assert get_docker_cmd("img") is None
-
-
-@patch("subprocess.run")
-def test_get_docker_entrypoint_present(mock_run):
-    mock_run.return_value = MagicMock(
-        stdout='[{"Config": {"Entrypoint": ["/start.sh"], "Cmd": null}}]',
-        returncode=0,
-    )
-    assert get_docker_entrypoint("img") == ["/start.sh"]
-
-
-@patch("subprocess.run")
-def test_get_docker_entrypoint_none_when_unset(mock_run):
-    mock_run.return_value = MagicMock(
-        stdout='[{"Config": {"Entrypoint": null, "Cmd": ["x"]}}]',
-        returncode=0,
-    )
-    assert get_docker_entrypoint("img") is None
 
 
 @patch("subprocess.run")

--- a/hud/environment/environment.py
+++ b/hud/environment/environment.py
@@ -802,29 +802,29 @@ class Environment(
 
         if conn_name is None:
             # Local resource -- read via local provider
-            try:
-                resource = await self._local_provider.get_resource(uri)
-                if resource is None:
-                    raise ValueError(f"Resource not found: {uri}")
-                result = await resource.read()
-                resource_uri = AnyUrl(uri)
+            resource = await self._local_provider.get_resource(uri)
+            if resource is None:
+                raise ValueError(f"Resource not found: {uri}")
+            # Intentionally do *not* wrap ``resource.read()`` exceptions
+            # in a ``Resource not found`` ValueError — that masks
+            # actually-actionable failures from inside the resource
+            # handler (missing API keys, scenario-evaluator bugs, etc.).
+            result = await resource.read()
+            resource_uri = AnyUrl(uri)
 
-                content = getattr(result, "content", result)
-                if isinstance(content, str):
-                    return [mcp_types.TextResourceContents(uri=resource_uri, text=content)]
-                if hasattr(content, "text"):
-                    return [mcp_types.TextResourceContents(uri=resource_uri, text=content.text)]  # type: ignore[union-attr]
-                import base64
+            content = getattr(result, "content", result)
+            if isinstance(content, str):
+                return [mcp_types.TextResourceContents(uri=resource_uri, text=content)]
+            if hasattr(content, "text"):
+                return [mcp_types.TextResourceContents(uri=resource_uri, text=content.text)]  # type: ignore[union-attr]
+            import base64
 
-                raw = content if isinstance(content, bytes) else str(content).encode()
-                return [
-                    mcp_types.BlobResourceContents(
-                        uri=resource_uri, blob=base64.b64encode(raw).decode()
-                    )
-                ]
-            except Exception as e:
-                logger.debug("Local resource read failed for %s: %s", uri, e)
-                raise ValueError(f"Resource not found: {uri}") from e
+            raw = content if isinstance(content, bytes) else str(content).encode()
+            return [
+                mcp_types.BlobResourceContents(
+                    uri=resource_uri, blob=base64.b64encode(raw).decode()
+                )
+            ]
         else:
             # Remote resource
             conn = self._connections.get(conn_name)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new export pipeline (local + remote) that shells out to Docker and calls the HUD platform API, plus extends lockfile generation/consumption; these affect build artifacts and external integrations. Also changes local resource reads to surface underlying errors, which could alter runtime error behavior for environments relying on those exceptions.
> 
> **Overview**
> Adds a new `hud export` command group with a pluggable exporter registry and an initial `harbor` exporter that generates a Harbor-compatible bundle (per-task Dockerfiles, instructions, tests, manifest, and runnable scripts), with optional live prompt rendering by booting the env image and querying MCP.
> 
> Introduces a `--remote` mode that delegates export to the HUD platform (queue job, poll status, download/extract tarball) and rejects local-only flags when used.
> 
> Extends `hud build`/`hud.lock.yaml` to record the image runtime launch command (from `docker inspect` entrypoint+cmd) and to treat scenario-declared `required_env_vars` as required envs; updates Docker inspection helpers and tests accordingly. Separately, local `read_resource` no longer masks underlying `resource.read()` failures as "not found", improving diagnosability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f875a74a6660976058cc6d5d6e484196add0b34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->