### PR TITLE
fixed for attribute errors

### DIFF
--- a/hud/agents/base.py
+++ b/hud/agents/base.py
@@ -968,4 +968,9 @@ def find_content(result: MCPToolResult) -> str | None:
                             return value
                 except json.JSONDecodeError:
                     pass
+                if not isinstance(json_content,dict):
+                    continue
+                for key, value in json_content.items():
+                    if key in accept_keys:
+                        return value
     return ""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, localized change to content extraction logic; main risk is slight behavior change when text parses as non-object JSON (now skipped rather than raising).
> 
> **Overview**
> Prevents `find_content` in `hud/agents/base.py` from throwing when `types.TextContent` parses as non-object JSON by skipping values that aren’t dicts before searching for accepted keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de66bdbcbfeb040306ae90f3d6f78a696adef0ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->