### PR TITLE
Fix: narrow JSON parse try-blocks and added guards

### DIFF
--- a/hud/agents/base.py
+++ b/hud/agents/base.py
@@ -937,11 +937,13 @@ def find_reward(result: MCPToolResult) -> float:
             if isinstance(content, types.TextContent):
                 try:
                     json_content = json.loads(content.text)
-                    for key, value in json_content.items():
-                        if key in accept_keys:
-                            return value
                 except json.JSONDecodeError:
-                    pass
+                    continue
+                if not isinstance(json_content, dict):
+                    continue
+                for key, value in json_content.items():
+                    if key in accept_keys:
+                        return value
 
     logger.error("Couldn't parse reward from result: %s", str(result.structuredContent))
     return 0.0
@@ -963,12 +965,9 @@ def find_content(result: MCPToolResult) -> str | None:
             if isinstance(content, types.TextContent):
                 try:
                     json_content = json.loads(content.text)
-                    for key, value in json_content.items():
-                        if key in accept_keys:
-                            return value
                 except json.JSONDecodeError:
-                    pass
-                if not isinstance(json_content,dict):
+                    continue
+                if not isinstance(json_content, dict):
                     continue
                 for key, value in json_content.items():
                     if key in accept_keys:

--- a/hud/agents/base.py
+++ b/hud/agents/base.py
@@ -968,4 +968,9 @@ def find_content(result: MCPToolResult) -> str | None:
                             return value
                 except json.JSONDecodeError:
                     pass
+                if not isinstance(json_content,dict):
+                    continue
+                for key, value in json_content.items():
+                    if key in accept_keys:
+                        return value
     return ""

--- a/hud/shared/exceptions.py
+++ b/hud/shared/exceptions.py
@@ -266,19 +266,19 @@ class HudRequestError(HudException):
 
         # Try to get detailed error info from JSON if available
         response_json = None
+        message = f"Request failed with status {status_code}"
         try:
-            response_json = response.json()
+            parsed = response.json()
+        except Exception:
+            parsed = None
+        if isinstance(parsed, dict):
+            response_json = parsed
             detail = response_json.get("detail")
             if detail:
                 message = f"Request failed: {detail}"
-            else:
-                # If no detail field but we have JSON, include a summary
-                message = f"Request failed with status {status_code}"
-                if len(response_json) <= 5:  # If it's a small object, include it in the message
-                    message += f" - JSON response: {response_json}"
-        except Exception:
-            # Fallback to simple message if JSON parsing fails
-            message = f"Request failed with status {status_code}"
+            elif len(response_json) <= 5:
+                # Small object — include it in the message
+                message += f" - JSON response: {response_json}"
 
         # Add context if provided
         if context:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only harden JSON parsing/error-message construction and should reduce false positives/crashes, with minimal behavior change aside from skipping non-dict JSON payloads.
> 
> **Overview**
> Tightens JSON parsing in `find_reward` and `find_content` to only wrap `json.loads` in the `try`, then *skips* invalid JSON or non-dict payloads before scanning for accepted keys.
> 
> Refactors `HudRequestError.from_httpx_error` to parse `response.json()` into a temporary value, only treat dict JSON as structured error data, and consistently build the fallback message while optionally appending small JSON responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84213217c19270c8228c64f96f5f88656b7375d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->