### PR TITLE
Yang/gemini tool fix drag and drop

### DIFF
--- a/hud/tools/computer/gemini.py
+++ b/hud/tools/computer/gemini.py
@@ -171,7 +171,7 @@ class GeminiComputerTool(HudComputerTool):
             **kwargs,
         )
 
-    def _inset_drag_coordinate(self, value: float) -> float:
+    def _inset_drag_coordinate(self, value: int) -> int:
         """Keep Gemini normalized drag endpoints away from display edges."""
         if (
             self.coordinate_space is None

--- a/hud/tools/computer/gemini.py
+++ b/hud/tools/computer/gemini.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+GEMINI_DRAG_INSET = 25
+DISPLAY_DRAG_INSET_PIXELS = 20
+
 SUPPORTED_GEMINI_COMPUTER_USE_MODELS = (
     "gemini-2.5-computer-use-preview-10-2025",
     "gemini-3-flash-preview",
@@ -167,6 +170,30 @@ class GeminiComputerTool(HudComputerTool):
             description=description or "Control computer with mouse, keyboard, and screenshots",
             **kwargs,
         )
+
+    def _inset_drag_coordinate(self, value: float) -> float:
+        """Keep Gemini normalized drag endpoints away from display edges."""
+        if (
+            self.coordinate_space is None
+            or not isinstance(value, int | float)
+            or not 0 <= value <= self.coordinate_space
+        ):
+            return value
+
+        max_value = max(self.coordinate_space - GEMINI_DRAG_INSET, GEMINI_DRAG_INSET)
+        return min(max(value, GEMINI_DRAG_INSET), max_value)
+
+    def _inset_scaled_drag_path(self, path: list[tuple[int, int]]) -> list[tuple[int, int]]:
+        """Keep scaled drag points inside the display so they do not hit OS/window edges."""
+        max_x = max(self.environment_width - 1 - DISPLAY_DRAG_INSET_PIXELS, 0)
+        max_y = max(self.environment_height - 1 - DISPLAY_DRAG_INSET_PIXELS, 0)
+        return [
+            (
+                min(max(int(x), DISPLAY_DRAG_INSET_PIXELS), max_x),
+                min(max(int(y), DISPLAY_DRAG_INSET_PIXELS), max_y),
+            )
+            for x, y in path
+        ]
 
     async def __call__(
         self,
@@ -381,7 +408,16 @@ class GeminiComputerTool(HudComputerTool):
                         message="x, y, destination_x, and destination_y are required",
                     )
                 )
-            path = self._scale_path([(x, y), (destination_x, destination_y)])
+            path = self._scale_path(
+                [
+                    (self._inset_drag_coordinate(x), self._inset_drag_coordinate(y)),
+                    (
+                        self._inset_drag_coordinate(destination_x),
+                        self._inset_drag_coordinate(destination_y),
+                    ),
+                ]
+            )
+            path = self._inset_scaled_drag_path(path)
             result = await self.executor.drag(path=path)
             return await _finalize(result)
 

--- a/hud/tools/computer/tests/test_computer.py
+++ b/hud/tools/computer/tests/test_computer.py
@@ -12,7 +12,18 @@ from hud.tools.computer.hud import HudComputerTool
 from hud.tools.computer.openai import OpenAIComputerTool
 from hud.tools.computer.qwen import QwenComputerTool
 from hud.tools.executors.base import BaseExecutor
+from hud.tools.executors.xdo import XDOExecutor
 from hud.tools.types import Coordinate
+
+
+class RecordingExecutor(BaseExecutor):
+    def __init__(self):
+        super().__init__()
+        self.drag_paths: list[list[tuple[int, int]]] = []
+
+    async def drag(self, path, pattern=None, hold_keys=None, take_screenshot=True):
+        self.drag_paths.append(path)
+        return await super().drag(path, pattern, hold_keys, take_screenshot=False)
 
 
 @pytest.mark.asyncio
@@ -149,6 +160,58 @@ def test_normalized_coordinate_max_stays_in_display_bounds():
     assert y is not None
     assert int(x) <= comp.environment_width - 1
     assert int(y) <= comp.environment_height - 1
+
+
+def test_drag_path_interpolation_adds_intermediate_points():
+    executor = BaseExecutor()
+
+    path = executor._interpolate_drag_path([(0, 0), (120, 0)])
+
+    assert path[0] == (0, 0)
+    assert path[-1] == (120, 0)
+    assert len(path) == 11
+
+
+@pytest.mark.asyncio
+async def test_gemini_drag_clamps_edges_and_interpolates_executor_path():
+    executor = RecordingExecutor()
+    comp = GeminiComputerTool(executor=executor, width=1400, height=850)
+
+    blocks = await comp(
+        action="drag_and_drop",
+        x=0,
+        y=500,
+        destination_x=1000,
+        destination_y=500,
+    )
+
+    assert blocks
+    path = executor.drag_paths[0]
+    assert path[0][0] >= 20
+    assert path[-1][0] <= comp.environment_width - 1 - 20
+
+    interpolated = executor._interpolate_drag_path(path)
+    assert len(interpolated) > 2
+
+
+@pytest.mark.asyncio
+async def test_xdo_drag_executes_interpolated_mouse_moves():
+    executor = XDOExecutor()
+    commands: list[str] = []
+
+    async def record_execute(command, take_screenshot=True):
+        commands.append(command)
+        return None
+
+    executor.execute = record_execute
+
+    result = await executor.drag([(0, 0), (120, 0)], take_screenshot=False)
+
+    mouse_moves = [command for command in commands if command.startswith("mousemove ")]
+    assert result.output == "Dragged along 11 points"
+    assert len(mouse_moves) == 11
+    assert mouse_moves[0] == "mousemove 0 0"
+    assert mouse_moves[-1] == "mousemove 120 0"
 
 
 class TestHudComputerToolExtended:

--- a/hud/tools/computer/tests/test_computer.py
+++ b/hud/tools/computer/tests/test_computer.py
@@ -13,7 +13,17 @@ from hud.tools.computer.openai import OpenAIComputerTool
 from hud.tools.computer.qwen import QwenComputerTool
 from hud.tools.executors.base import BaseExecutor
 from hud.tools.executors.xdo import XDOExecutor
-from hud.tools.types import Coordinate
+from hud.tools.types import ContentResult, Coordinate
+
+
+class RecordingXDOExecutor(XDOExecutor):
+    def __init__(self):
+        super().__init__()
+        self.commands: list[str] = []
+
+    async def execute(self, command: str, take_screenshot: bool = True):
+        self.commands.append(command)
+        return ContentResult(output=command)
 
 
 class RecordingExecutor(BaseExecutor):
@@ -196,18 +206,11 @@ async def test_gemini_drag_clamps_edges_and_interpolates_executor_path():
 
 @pytest.mark.asyncio
 async def test_xdo_drag_executes_interpolated_mouse_moves():
-    executor = XDOExecutor()
-    commands: list[str] = []
-
-    async def record_execute(command, take_screenshot=True):
-        commands.append(command)
-        return None
-
-    executor.execute = record_execute
+    executor = RecordingXDOExecutor()
 
     result = await executor.drag([(0, 0), (120, 0)], take_screenshot=False)
 
-    mouse_moves = [command for command in commands if command.startswith("mousemove ")]
+    mouse_moves = [command for command in executor.commands if command.startswith("mousemove ")]
     assert result.output == "Dragged along 11 points"
     assert len(mouse_moves) == 11
     assert mouse_moves[0] == "mousemove 0 0"

--- a/hud/tools/executors/base.py
+++ b/hud/tools/executors/base.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import math
 from io import BytesIO
+from itertools import pairwise
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from hud.tools.types import ContentResult
@@ -12,6 +14,8 @@ if TYPE_CHECKING:
     from PIL import Image
 
 logger = logging.getLogger(__name__)
+
+DRAG_STEP_PIXELS = 12
 
 
 class BaseExecutor:
@@ -41,6 +45,31 @@ class BaseExecutor:
             self.display_num = display_num
         self._screenshot_delay = 0.5
         logger.info("BaseExecutor initialized")
+
+    def _interpolate_drag_path(
+        self, path: list[tuple[int, int]], step_pixels: int = DRAG_STEP_PIXELS
+    ) -> list[tuple[int, int]]:
+        """Fill long drag segments with intermediate points for pointer-delta UIs."""
+        if len(path) < 2:
+            return path
+
+        interpolated: list[tuple[int, int]] = [path[0]]
+        for start, end in pairwise(path):
+            start_x, start_y = start
+            end_x, end_y = end
+            distance = math.hypot(end_x - start_x, end_y - start_y)
+            steps = max(1, math.ceil(distance / max(step_pixels, 1)))
+
+            for step in range(1, steps + 1):
+                t = step / steps
+                point = (
+                    round(start_x + (end_x - start_x) * t),
+                    round(start_y + (end_y - start_y) * t),
+                )
+                if point != interpolated[-1]:
+                    interpolated.append(point)
+
+        return interpolated
 
     # ===== Core CLA Actions =====
 

--- a/hud/tools/executors/pyautogui.py
+++ b/hud/tools/executors/pyautogui.py
@@ -478,33 +478,26 @@ class PyAutoGUIExecutor(BaseExecutor):
             return ContentResult(error="Drag path must have at least 2 points")
 
         try:
+            drag_path = self._interpolate_drag_path(path)
+
             # Hold keys if specified
             self._hold_keys_context(hold_keys)
 
             try:
                 # Move to start
-                start_x, start_y = path[0]
+                start_x, start_y = drag_path[0]
                 self.pyautogui.moveTo(start_x, start_y)
 
-                # Handle multi-point drag
-                if len(path) == 2:
-                    # Simple drag
-                    end_x, end_y = path[1]
-                    self.pyautogui.dragTo(end_x, end_y, duration=0.5, button="left")
-                    result = ContentResult(
-                        output=f"Dragged from ({start_x}, {start_y}) to ({end_x}, {end_y})"
-                    )
-                else:
-                    # Multi-point drag
-                    self.pyautogui.mouseDown(button="left")
-                    for i, (x, y) in enumerate(path[1:], 1):
-                        duration = 0.1
-                        if pattern and i - 1 < len(pattern):
-                            duration = pattern[i - 1] / 1000.0  # Convert ms to seconds
-                        self.pyautogui.moveTo(x, y, duration=duration)
-                    self.pyautogui.mouseUp(button="left")
+                # Move through enough points for pointer-delta-sensitive UIs.
+                self.pyautogui.mouseDown(button="left")
+                for i, (x, y) in enumerate(drag_path[1:], 1):
+                    duration = 0.01
+                    if pattern and i - 1 < len(pattern):
+                        duration = pattern[i - 1] / 1000.0  # Convert ms to seconds
+                    self.pyautogui.moveTo(x, y, duration=duration)
+                self.pyautogui.mouseUp(button="left")
 
-                    result = ContentResult(output=f"Dragged along {len(path)} points")
+                result = ContentResult(output=f"Dragged along {len(drag_path)} points")
 
                 if hold_keys:
                     result = ContentResult(output=f"{result.output} while holding {hold_keys}")

--- a/hud/tools/executors/tests/test_pyautogui_executor.py
+++ b/hud/tools/executors/tests/test_pyautogui_executor.py
@@ -116,15 +116,22 @@ class TestPyAutoGUIExecutor:
         """Test drag when pyautogui is available."""
         executor = PyAutoGUIExecutor()
 
-        with patch("pyautogui.dragTo") as mock_drag:
+        with (
+            patch("pyautogui.moveTo") as mock_move,
+            patch("pyautogui.mouseDown") as mock_down,
+            patch("pyautogui.mouseUp") as mock_up,
+        ):
             # drag expects a path (list of coordinate tuples)
             path = [(100, 100), (300, 400)]
             result = await executor.drag(path)
 
             assert isinstance(result, ContentResult)
             assert result.output and "Dragged" in result.output
-            # Implementation uses dragTo to move to each point
-            mock_drag.assert_called()
+            # Implementation holds the button and moves through interpolated points.
+            mock_move.assert_any_call(100, 100)
+            assert mock_move.call_count > len(path)
+            mock_down.assert_called_once_with(button="left")
+            mock_up.assert_called_once_with(button="left")
 
     @pytest.mark.asyncio
     async def test_wait(self):

--- a/hud/tools/executors/xdo.py
+++ b/hud/tools/executors/xdo.py
@@ -425,20 +425,24 @@ class XDOExecutor(BaseExecutor):
         if len(path) < 2:
             return ContentResult(error="Drag path must have at least 2 points")
 
+        drag_path = self._interpolate_drag_path(path)
+
         # Hold keys if specified
         await self._hold_keys_context(hold_keys)
 
         try:
             # Start drag
-            start_x, start_y = path[0]
+            start_x, start_y = drag_path[0]
             await self.execute(f"mousemove {start_x} {start_y}", take_screenshot=False)
             await self.execute("mousedown 1", take_screenshot=False)
 
             # Move through intermediate points
-            for i, (x, y) in enumerate(path[1:], 1):
+            for i, (x, y) in enumerate(drag_path[1:], 1):
                 # Apply delay if pattern is specified
                 if pattern and i - 1 < len(pattern):
                     await asyncio.sleep(pattern[i - 1] / 1000.0)  # Convert ms to seconds
+                else:
+                    await asyncio.sleep(0.008)
 
                 await self.execute(f"mousemove {x} {y}", take_screenshot=False)
 
@@ -449,10 +453,10 @@ class XDOExecutor(BaseExecutor):
             if take_screenshot:
                 screenshot = await self.screenshot()
                 result = ContentResult(
-                    output=f"Dragged along {len(path)} points", base64_image=screenshot
+                    output=f"Dragged along {len(drag_path)} points", base64_image=screenshot
                 )
             else:
-                result = ContentResult(output=f"Dragged along {len(path)} points")
+                result = ContentResult(output=f"Dragged along {len(drag_path)} points")
 
         finally:
             # Release held keys


### PR DESCRIPTION
- Interpolate drag paths in shared computer executors so long drags are executed as smooth pointer movements instead of a single start/end jump.
- Clamp Gemini drag endpoints away from screen edges to avoid OS/window-boundary misses.
- Add regression coverage for Gemini edge drags and XDO drag interpolation.
- Tested with Local Claude/Gemini drag and drop all works now interpolated drags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes low-level input simulation (drag timing/path) in `XDOExecutor` and `PyAutoGUIExecutor`, which can subtly affect automation behavior across platforms.
> 
> **Overview**
> Improves drag-and-drop reliability for Gemini computer-use by **insetting drag endpoints** away from normalized and pixel-level screen edges before executing the drag.
> 
> Adds shared `BaseExecutor._interpolate_drag_path` and updates `XDOExecutor` and `PyAutoGUIExecutor` drags to **move through interpolated points** (with small default delays) instead of a single start/end jump, improving compatibility with pointer-delta-sensitive UIs.
> 
> Extends tests to cover drag-path interpolation, Gemini edge clamping, and that XDO drags issue the expected sequence of `mousemove` commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06faab72ca0ce01713e23c028deead75aa433779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->