### PR TITLE
Fix public docs SDK imports

### DIFF
--- a/docs/platform/subagent.mdx
+++ b/docs/platform/subagent.mdx
@@ -25,23 +25,21 @@ The workflow is:
 Scenarios define what your agent does. In your environment code:
 
 ```python
-from hud import Env
+from hud import Environment
 
-env = Env("my-assistant")
+env = Environment("my-assistant")
 
 @env.scenario()
 async def answer_question(query: str):
     """Answer a user question using available tools."""
     
-    yield env.setup(f"Answer this question: {query}")
+    result = yield f"Answer this question: {query}"
     
-    result = yield  # Agent runs here
-    
-    # Evaluate the result
+    # Evaluate the result.
     if "helpful" in result.lower():
-        yield env.reward(1.0)
+        yield 1.0
     else:
-        yield env.reward(0.0)
+        yield 0.0
 ```
 
 Deploy your environment through the platform:
@@ -74,7 +72,7 @@ Once your scenario exists, call it via the REST API:
 ### cURL
 
 ```bash
-curl -X POST https://api.hud.so/v1/agent/run \
+curl -X POST https://api.hud.ai/agent/run \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $HUD_API_KEY" \
   -d '{
@@ -161,7 +159,7 @@ Trigger agent runs from external events:
 @app.post("/webhook")
 async def handle_webhook(event: dict):
     response = requests.post(
-        "https://api.hud.so/v1/agent/run",
+        "https://api.hud.ai/agent/run",
         headers={"Authorization": f"Bearer {HUD_API_KEY}"},
         json={
             "env_name": "support-agent",
@@ -179,7 +177,7 @@ Run agents on a schedule with cron or similar:
 
 ```bash
 # Run daily cleanup agent
-0 0 * * * curl -X POST https://api.hud.so/v1/agent/run \
+0 0 * * * curl -X POST https://api.hud.ai/agent/run \
   -H "Authorization: Bearer $HUD_API_KEY" \
   -d '{"env_name": "ops", "scenario_name": "daily_cleanup", "scenario_args": {}, "model": "claude-sonnet-4-5"}'
 ```
@@ -190,7 +188,7 @@ Power a chat UI with agent capabilities:
 
 ```javascript
 async function sendMessage(message) {
-  const response = await fetch("https://api.hud.so/v1/agent/run", {
+  const response = await fetch("https://api.hud.ai/agent/run", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/docs/reference/agents.mdx
+++ b/docs/reference/agents.mdx
@@ -11,7 +11,7 @@ The HUD SDK provides a base `MCPAgent` class and several pre-built agent impleme
 Use the `create()` factory method to instantiate agents with typed parameters:
 
 ```python
-from hud.agents import ClaudeAgent
+from hud.agents.claude import ClaudeAgent
 
 agent = ClaudeAgent.create(
     model="claude-sonnet-4-5",
@@ -78,7 +78,7 @@ def get_available_tools() -> list[types.Tool]
 ### ClaudeAgent
 
 ```python
-from hud.agents import ClaudeAgent
+from hud.agents.claude import ClaudeAgent
 ```
 
 Claude-specific implementation using Anthropic's API.
@@ -97,7 +97,7 @@ Claude-specific implementation using Anthropic's API.
 
 ```python
 from hud import Environment
-from hud.agents import ClaudeAgent
+from hud.agents.claude import ClaudeAgent
 
 env = Environment("browser").connect_hub("hud-evals/browser")
 
@@ -162,7 +162,7 @@ Inherits all `OpenAIAgent` parameters.
 ### GeminiAgent
 
 ```python
-from hud.agents import GeminiAgent
+from hud.agents.gemini import GeminiAgent
 ```
 
 Google Gemini agent for standard tool-calling tasks.
@@ -192,7 +192,7 @@ agent = GeminiAgent.create(
 ### GeminiCUAAgent
 
 ```python
-from hud.agents import GeminiCUAAgent
+from hud.agents.gemini_cua import GeminiCUAAgent
 ```
 
 Google Gemini Computer Use Agent with native computer-use capabilities. Extends `GeminiAgent` with support for Gemini's predefined computer actions (click, type, scroll, etc.).
@@ -229,7 +229,7 @@ GeminiCUAAgent supports these native Gemini computer actions:
 
 ```python
 from hud import Environment
-from hud.agents import GeminiCUAAgent
+from hud.agents.gemini_cua import GeminiCUAAgent
 
 env = Environment("browser").connect_hub("hud-evals/browser")
 
@@ -288,7 +288,7 @@ agent = OpenAIChatAgent.create(
 
 ```python
 from hud import Environment
-from hud.agents import ClaudeAgent
+from hud.agents.claude import ClaudeAgent
 
 # Define environment with scenario
 env = Environment("browser").connect_hub("hud-evals/browser")

--- a/docs/reference/mcpserver.mdx
+++ b/docs/reference/mcpserver.mdx
@@ -492,15 +492,15 @@ hud analyze my-env:latest
 
 # Python testing
 async def test():
-    from hud.clients import MCPClient
+    from hud import Environment
     
-    client = MCPClient({
+    env = Environment("test").connect_mcp_config({
         "env": {"command": "docker", "args": ["run", "-i", "my-env"]}
     })
     
-    async with client:
-        tools = await client.list_tools()
-        result = await client.call_tool("setup", {"value": 0})
+    async with env:
+        tools = await env.list_tools()
+        result = await env.call_tool("setup", value=0)
 ```
 
 ## See Also


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only changes with no runtime impact; primary risk is incorrect examples if the documented SDK/API signatures diverge.
> 
> **Overview**
> Documentation examples are updated to reflect the current SDK API: `Env` is replaced with `Environment`, scenario examples now `yield` the prompt and numeric reward directly, and MCP testing switches from `MCPClient` to `Environment.connect_mcp_config()` with updated `call_tool` usage.
> 
> All Subagent API examples update the REST endpoint from `https://api.hud.so/v1/agent/run` to `https://api.hud.ai/agent/run`, and agent docs fix imports to use module-specific paths like `from hud.agents.claude import ClaudeAgent`/`hud.agents.gemini*` instead of `hud.agents` re-exports; minor formatting/link cleanup is included in `mcpserver` docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2831b89020ab96e817171731beeef3728fe0db9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->