### PR TITLE
Update Harbor converter runtime isolation

### DIFF
--- a/hud/cli/convert/__init__.py
+++ b/hud/cli/convert/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 from pathlib import Path
 
@@ -36,6 +37,17 @@ LOGGER = logging.getLogger(__name__)
 
 # Shell script extensions that need CRLF -> LF normalization
 _SHELL_EXTENSIONS = frozenset({".sh", ".bash", ".zsh", ".ksh"})
+_SOURCE_CONTEXT_MARKDOWN_RE = re.compile(r"^[a-z]{2,8}-\d+(?:-\d+)*\.md$", re.IGNORECASE)
+
+
+def _should_skip_task_data_item(path: Path) -> bool:
+    """Return True for source task files that should not be exposed to agents."""
+    lower_name = path.name.lower()
+    return (
+        path.name in ("environment", "solution")
+        or lower_name in (".dockerignore", "scoring.md")
+        or bool(_SOURCE_CONTEXT_MARKDOWN_RE.match(path.name))
+    )
 
 
 def _normalize_line_endings(directory: Path) -> None:
@@ -154,8 +166,8 @@ def write_result(result: ConvertResult, output_dir: Path) -> Path:
             dest.mkdir(parents=True, exist_ok=True)
 
             for item in source_dir.iterdir():
-                # Skip dirs that are handled by the Dockerfile or ignored
-                if item.name in ("environment", "solution"):
+                # Skip dirs handled elsewhere and files that leak scoring/source context.
+                if _should_skip_task_data_item(item):
                     continue
                 if item.is_dir():
                     shutil.copytree(item, dest / item.name)

--- a/hud/cli/convert/harbor.py
+++ b/hud/cli/convert/harbor.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
+import shlex
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003 - used at runtime
@@ -76,6 +77,56 @@ def _normalize_name(name: str) -> str:
     return normalized.strip("-") or "converted"
 
 
+def _docker_instruction_name(line: str) -> str | None:
+    """Return the Dockerfile instruction name for *line*, if it has one."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    return stripped.split(maxsplit=1)[0].upper()
+
+
+def _docker_instruction_value(line: str) -> str:
+    """Return the remainder of a Dockerfile instruction line."""
+    parts = line.strip().split(maxsplit=1)
+    return parts[1] if len(parts) > 1 else ""
+
+
+def _extract_workdir(content: str) -> str:
+    """Return the last Dockerfile WORKDIR, defaulting to /app."""
+    workdir = "/app"
+    for line in content.splitlines():
+        if _docker_instruction_name(line) != "WORKDIR":
+            continue
+        value = _docker_instruction_value(line)
+        if value:
+            workdir = value
+    return workdir
+
+
+def _make_task_slug(task_id: str, used_slugs: set[str]) -> str:
+    """Create a stable, unique HUD task slug from a Harbor task id."""
+    base = _normalize_name(task_id)
+    digest = hashlib.sha256(task_id.encode()).hexdigest()[:8]
+
+    def with_suffix(suffix: str) -> str:
+        prefix_limit = 99 - len(suffix)
+        return f"{base[:prefix_limit].rstrip('-')}-{suffix}"
+
+    slug = with_suffix(digest) if len(base) > 100 else base
+
+    if slug in used_slugs:
+        slug = with_suffix(f"{digest}-1" if len(base) > 100 else digest)
+
+    counter = 2
+    while slug in used_slugs:
+        suffix = f"{digest}-{counter}"
+        slug = with_suffix(suffix)
+        counter += 1
+
+    used_slugs.add(slug)
+    return slug
+
+
 def _find_dockerfile(env_dir: Path) -> str | None:
     """Read the Dockerfile from a Harbor environment directory."""
     for name in ("Dockerfile", "dockerfile"):
@@ -92,8 +143,20 @@ def _adapt_harbor_dockerfile(content: str) -> str:
     """
     lines = content.splitlines()
     adapted: list[str] = []
+    in_healthcheck_continuation = False
     for line in lines:
         stripped = line.strip().upper()
+
+        if stripped.startswith("HEALTHCHECK "):
+            adapted.append(line)
+            in_healthcheck_continuation = line.rstrip().endswith("\\")
+            continue
+
+        if in_healthcheck_continuation:
+            adapted.append(line)
+            in_healthcheck_continuation = line.rstrip().endswith("\\")
+            continue
+
         if stripped.startswith(("CMD ", "CMD[", "ENTRYPOINT ", "ENTRYPOINT[")):
             adapted.append(f"# [harbor original] {line}")
         else:
@@ -167,26 +230,64 @@ then executes the test script and parses the reward.
 
 import json
 import logging
+import os
 import subprocess
 from pathlib import Path
 {extra_imports}
 from hud import Environment
 from hud.tools import BashTool, EditTool
 from hud.tools.filesystem import GlobTool, GrepTool, ListTool, ReadTool
+from hud.tools.types import ToolError
 
 LOGGER = logging.getLogger(__name__)
 
-TASKS_DIR = Path("/harbor/tasks")
+TASKS_DIR = Path("/root/.hud_harbor/tasks")
+AGENT_WORKDIR = os.path.expandvars({agent_workdir!r})
+
+
+def _set_agent_workdir() -> None:
+    """Put agent shell sessions in the original Harbor challenge workdir."""
+    try:
+        os.chdir(AGENT_WORKDIR)
+    except FileNotFoundError:
+        if TASKS_DIR.exists():
+            LOGGER.warning("Agent workdir does not exist: %s", AGENT_WORKDIR)
+        else:
+            LOGGER.debug("Skipping container workdir on host import: %s", AGENT_WORKDIR)
+
+
+_set_agent_workdir()
+
+
+def _resolve_within_base(file_path: Path, base_path: Path) -> Path:
+    resolved = file_path.resolve() if file_path.is_absolute() else (base_path / file_path).resolve()
+    try:
+        resolved.relative_to(base_path)
+    except ValueError:
+        raise ToolError(f"Path escapes base directory: {{file_path}}") from None
+    return resolved
+
+
+class ScopedEditTool(EditTool):
+    """EditTool variant constrained to the task workdir."""
+
+    def __init__(self, base_path: str | Path) -> None:
+        super().__init__()
+        self._base_path = Path(base_path).resolve()
+
+    def validate_path(self, command: str, path: Path) -> None:
+        resolved = _resolve_within_base(path, self._base_path)
+        super().validate_path(command, resolved)
 
 env = Environment("{env_name}")
 
 # Standard coding tools - agents interact via bash (matching Harbor's model)
-env.add_tool(BashTool())
-env.add_tool(EditTool())
-env.add_tool(ReadTool())
-env.add_tool(GrepTool())
-env.add_tool(GlobTool())
-env.add_tool(ListTool())
+env.add_tool(BashTool(timeout=600.0))
+env.add_tool(ScopedEditTool(base_path=AGENT_WORKDIR))
+env.add_tool(ReadTool(base_path=AGENT_WORKDIR))
+env.add_tool(GrepTool(base_path=AGENT_WORKDIR))
+env.add_tool(GlobTool(base_path=AGENT_WORKDIR))
+env.add_tool(ListTool(base_path=AGENT_WORKDIR))
 
 '''
 
@@ -208,7 +309,7 @@ async def run_task(task_id: TaskId):
 _SCENARIO_BODY = '''\
     """Run a Harbor task by ID.
 
-    Reads /harbor/tasks/<task_id>/instruction.md as the prompt.
+    Reads the root-only task bundle's instruction.md as the prompt.
     After the agent works, runs tests/test.sh and parses
     /logs/verifier/reward.txt or reward.json for the reward.
     """
@@ -228,6 +329,11 @@ _SCENARIO_BODY = '''\
     # Ensure log output directory exists
     logs_dir = Path("/logs/verifier")
     logs_dir.mkdir(parents=True, exist_ok=True)
+    for reward_file in (Path("/logs/verifier/reward.txt"), Path("/logs/verifier/reward.json")):
+        try:
+            reward_file.unlink(missing_ok=True)
+        except OSError as exc:
+            LOGGER.warning("Failed to clear stale reward file %s: %s", reward_file, exc)
 
     # Harbor mounts the task's tests/ directory at /tests/ — replicate that
     tests_link = Path("/tests")
@@ -243,7 +349,7 @@ _SCENARIO_BODY = '''\
         try:
             result = subprocess.run(
                 ["bash", str(test_script)],
-                cwd="/app",
+                cwd=AGENT_WORKDIR if Path(AGENT_WORKDIR).is_dir() else "/app",
                 capture_output=True,
                 text=True,
                 timeout={verifier_timeout},
@@ -303,6 +409,7 @@ def _build_env_py(
     source_path: str,
     task_ids: list[str],
     verifier_timeout: int,
+    agent_workdir: str,
 ) -> str:
     """Build the env.py content, adapting the scenario signature to task count."""
     if len(task_ids) == 1:
@@ -318,6 +425,7 @@ def _build_env_py(
         source_path=source_path,
         task_count=len(task_ids),
         extra_imports=extra_imports,
+        agent_workdir=agent_workdir,
     )
     body = _SCENARIO_BODY.format(verifier_timeout=verifier_timeout)
     return header + scenario + body
@@ -327,6 +435,14 @@ def _build_env_py(
 # Shared snippet: install uv standalone (works on any base image with curl or
 # apt), then use uv to bootstrap Python and sync dependencies.
 _HUD_LAYER = """\
+USER root
+# HUD coding subprocesses run as uid/gid 1000, so let them edit the original
+# challenge tree while keeping scenario-only task data outside that tree.
+RUN agent_workdir={agent_workdir_shell} \\
+    && eval "agent_workdir=\\"$agent_workdir\\"" \\
+    && mkdir -p /workspace /app \\
+    && if [ -d "$agent_workdir" ]; then chmod -R a+rwX "$agent_workdir"; fi
+
 # ============================================================
 # HUD MCP server layer
 # ============================================================
@@ -341,11 +457,14 @@ RUN command -v curl >/dev/null 2>&1 || \\
 ENV PATH="/root/.local/bin:$PATH"
 
 COPY pyproject.toml uv.lock* ./
-RUN uv sync --frozen --no-dev --no-install-project 2>/dev/null || \\
-    uv sync --no-dev --no-install-project
+RUN uv sync --frozen --no-dev --no-install-project --python 3.12 2>/dev/null || \\
+    uv sync --no-dev --no-install-project --python 3.12
+ENV PATH="/hud/.venv/bin:$PATH"
 
-# Harbor task data (instructions + test scripts baked into image)
-COPY tasks/ /harbor/tasks/
+# The scenario reads task data directly from a root-only bundle. The agent only
+# receives the yielded prompt and task workdir files.
+COPY tasks/ /root/.hud_harbor/tasks/
+RUN chown -R root:root /root/.hud_harbor && chmod -R go-rwx /root/.hud_harbor
 
 # Ensure standard directories exist and are writable at runtime
 # (MCP server may run as non-root; Harbor tasks expect /app writable)
@@ -353,7 +472,7 @@ RUN mkdir -p /logs/verifier /workspace /app && chmod 777 /logs/verifier /workspa
 
 COPY env.py ./
 
-CMD ["uv", "run", "--no-project", "python", "-m", "hud", "dev", "env:env", "--stdio"]
+CMD ["hud", "dev", "env:env", "--stdio"]
 """
 
 DOCKERFILE_WITH_BASE_TEMPLATE = (
@@ -457,6 +576,7 @@ class HarborConverter(BaseConverter):
         # Generate environments and taskset
         environments: list[GeneratedEnvironment] = []
         taskset: list[dict[str, Any]] = []
+        used_slugs: set[str] = set()
         base_name = f"hud-harbor-{_normalize_name(dataset_name)}"
 
         # Sort groups by size (largest first) for consistent naming
@@ -470,6 +590,13 @@ class HarborConverter(BaseConverter):
             rep_task = group_tasks[0]
             env_dir = rep_task.directory / "environment"
             dockerfile_content = _find_dockerfile(env_dir) if env_dir.exists() else None
+            agent_workdir = _extract_workdir(dockerfile_content or "")
+            env_cfg = rep_task.config.get("environment", {})
+            if isinstance(env_cfg, dict):
+                configured_workdir = env_cfg.get("workdir")
+                if isinstance(configured_workdir, str) and configured_workdir:
+                    agent_workdir = configured_workdir
+            agent_workdir_shell = shlex.quote(agent_workdir)
 
             # Extract verifier timeout from config
             verifier_timeout = 600
@@ -487,6 +614,7 @@ class HarborConverter(BaseConverter):
                 source_path=path.as_posix(),
                 task_ids=task_ids,
                 verifier_timeout=verifier_timeout,
+                agent_workdir=agent_workdir,
             )
 
             # --- Generate Dockerfile.hud ---
@@ -495,9 +623,12 @@ class HarborConverter(BaseConverter):
                 dockerfile = DOCKERFILE_WITH_BASE_TEMPLATE.format(
                     source=env_dir.as_posix(),
                     base_dockerfile=adapted,
+                    agent_workdir_shell=agent_workdir_shell,
                 )
             else:
-                dockerfile = DOCKERFILE_FALLBACK_TEMPLATE
+                dockerfile = DOCKERFILE_FALLBACK_TEMPLATE.format(
+                    agent_workdir_shell=agent_workdir_shell,
+                )
 
             # --- Generate pyproject.toml ---
             pyproject = PYPROJECT_TEMPLATE.format(name=env_name)
@@ -532,10 +663,13 @@ class HarborConverter(BaseConverter):
 
                 taskset.append(
                     {
+                        "slug": _make_task_slug(task.task_id, used_slugs),
                         "env": {"name": env_name},
                         "scenario": f"{env_name}:run-task",
                         "args": {"task_id": task.task_id},
                         "metadata": metadata,
+                        "agent_config": {"append_setup_output": False},
+                        "validation": None,
                     }
                 )
 

--- a/hud/cli/convert/tests/test_harbor.py
+++ b/hud/cli/convert/tests/test_harbor.py
@@ -7,6 +7,7 @@ defined in conftest.py.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import TYPE_CHECKING
 
@@ -19,9 +20,11 @@ from hud.cli.convert import detect_format, get_converter, list_formats, write_re
 from hud.cli.convert.harbor import (
     HarborConverter,
     _adapt_harbor_dockerfile,
+    _extract_workdir,
     _find_dockerfile,
     _hash_directory,
     _is_harbor_task,
+    _make_task_slug,
     _normalize_name,
     _parse_task,
 )
@@ -59,6 +62,22 @@ class TestNormalizeName:
         assert _normalize_name("a---b") == "a-b"
 
 
+class TestTaskSlug:
+    def test_long_name_collision_uses_first_counter_suffix(self) -> None:
+        task_id = "long-task-name-" + ("segment-" * 20)
+        digest = hashlib.sha256(task_id.encode()).hexdigest()[:8]
+        used_slugs: set[str] = set()
+
+        first = _make_task_slug(task_id, used_slugs)
+        second = _make_task_slug(task_id, used_slugs)
+
+        assert first.endswith(f"-{digest}")
+        assert second.endswith(f"-{digest}-1")
+        assert len(first) <= 100
+        assert len(second) <= 100
+        assert first != second
+
+
 class TestAdaptDockerfile:
     def test_comments_cmd(self) -> None:
         result = _adapt_harbor_dockerfile('CMD ["bash"]')
@@ -84,6 +103,23 @@ class TestAdaptDockerfile:
     def test_no_cmd_or_entrypoint(self) -> None:
         dockerfile = "FROM python:3.11\nRUN apt-get update"
         assert _adapt_harbor_dockerfile(dockerfile) == dockerfile
+
+    def test_preserves_healthcheck_cmd(self) -> None:
+        dockerfile = (
+            "FROM python:3.11\n"
+            "HEALTHCHECK --interval=10s \\\n"
+            "    CMD pg_isready -q || exit 1\n"
+            'ENTRYPOINT ["/entrypoint.sh"]'
+        )
+        result = _adapt_harbor_dockerfile(dockerfile)
+        assert "    CMD pg_isready -q || exit 1" in result
+        assert '# [harbor original] ENTRYPOINT ["/entrypoint.sh"]' in result
+
+
+class TestDockerfileExtraction:
+    def test_extracts_last_workdir(self) -> None:
+        dockerfile = "FROM python:3.11\nWORKDIR /tmp\nWORKDIR /app/src\n"
+        assert _extract_workdir(dockerfile) == "/app/src"
 
 
 class TestHashDirectory:
@@ -247,6 +283,7 @@ class TestHarborConverterConvertSingleTask:
         result = self.converter.convert(single_task)
         entry = result.taskset[0]
         env_name = result.environments[0].name
+        assert entry["slug"] == "cancel-async-tasks"
         assert entry["scenario"] == f"{env_name}:run-task"
         assert entry["args"]["task_id"] == "cancel-async-tasks"
 
@@ -277,6 +314,11 @@ class TestHarborConverterConvertDataset:
         result = self.converter.convert(dataset_same_env)
         task_ids = {e["args"]["task_id"] for e in result.taskset}
         assert task_ids == {"cancel-async-tasks", "build-pmars", "chess-best-move"}
+
+    def test_all_task_slugs_present(self, dataset_same_env: Path) -> None:
+        result = self.converter.convert(dataset_same_env)
+        slugs = {e["slug"] for e in result.taskset}
+        assert slugs == {"cancel-async-tasks", "build-pmars", "chess-best-move"}
 
     def test_env_name_from_dataset(self, dataset_same_env: Path) -> None:
         result = self.converter.convert(dataset_same_env)
@@ -481,6 +523,12 @@ class TestTasksetMetadata:
         assert meta.get("category") == "systems"
         assert meta.get("difficulty") == "medium"
 
+    def test_taskset_disables_agent_setup_append(self, single_task: Path) -> None:
+        result = self.converter.convert(single_task)
+        entry = result.taskset[0]
+        assert entry["agent_config"] == {"append_setup_output": False}
+        assert entry["validation"] is None
+
 
 # ============================================================================
 # Dockerfile generation
@@ -507,7 +555,18 @@ class TestDockerfileGeneration:
     def test_tasks_copied_into_image(self, single_task: Path) -> None:
         result = self.converter.convert(single_task)
         dockerfile = result.environments[0].dockerfile
-        assert "COPY tasks/ /harbor/tasks/" in dockerfile
+        assert "COPY tasks/ /root/.hud_harbor/tasks/" in dockerfile
+
+    def test_task_data_hidden_from_agent_uid(self, single_task: Path) -> None:
+        result = self.converter.convert(single_task)
+        dockerfile = result.environments[0].dockerfile
+        assert "chmod -R go-rwx /root/.hud_harbor" in dockerfile
+
+    def test_agent_workdir_permissions_added(self, single_task: Path) -> None:
+        result = self.converter.convert(single_task)
+        dockerfile = result.environments[0].dockerfile
+        assert "agent_workdir=/workspace" in dockerfile
+        assert 'chmod -R a+rwX "$agent_workdir"' in dockerfile
 
     def test_logs_dir_created(self, single_task: Path) -> None:
         result = self.converter.convert(single_task)
@@ -529,12 +588,45 @@ class TestEnvPyGeneration:
         env_py = result.environments[0].env_py
         assert "from hud import Environment" in env_py
         assert "from hud.tools import BashTool" in env_py
+        assert "from hud.tools.filesystem import GlobTool, GrepTool, ListTool, ReadTool" in env_py
+        assert "from hud.tools.types import ToolError" in env_py
 
     def test_tools_added(self, single_task: Path) -> None:
         result = self.converter.convert(single_task)
         env_py = result.environments[0].env_py
-        assert "env.add_tool(BashTool())" in env_py
-        assert "env.add_tool(EditTool())" in env_py
+        assert "env.add_tool(BashTool(timeout=600.0))" in env_py
+        assert "env.add_tool(ScopedEditTool(base_path=AGENT_WORKDIR))" in env_py
+        for tool in ("GlobTool", "GrepTool", "ListTool", "ReadTool"):
+            assert f"env.add_tool({tool}(base_path=AGENT_WORKDIR))" in env_py
+        assert "class ScopedEditTool(EditTool)" in env_py
+
+    def test_agent_workdir_set_from_dockerfile(self, single_task: Path) -> None:
+        result = self.converter.convert(single_task)
+        env_py = result.environments[0].env_py
+        assert "AGENT_WORKDIR = os.path.expandvars('/workspace')" in env_py
+        assert "_set_agent_workdir()" in env_py
+        assert 'cwd=AGENT_WORKDIR if Path(AGENT_WORKDIR).is_dir() else "/app"' in env_py
+
+    def test_agent_workdir_prefers_task_config(self, tmp_path: Path) -> None:
+        task_toml = """
+[metadata]
+category = "systems"
+
+[environment]
+workdir = "/build/repo"
+
+[verifier]
+timeout_sec = 120
+"""
+        task = make_harbor_task(
+            tmp_path,
+            "configured-workdir",
+            task_toml=task_toml,
+            dockerfile="FROM python:3.11\nWORKDIR /donotaccess\n",
+        )
+        result = self.converter.convert(task)
+        env_py = result.environments[0].env_py
+        assert "AGENT_WORKDIR = os.path.expandvars('/build/repo')" in env_py
 
     def test_reward_parsing_logic(self, single_task: Path) -> None:
         result = self.converter.convert(single_task)
@@ -662,6 +754,7 @@ class TestWriteResult:
 
         assert isinstance(data, list)
         assert len(data) == 1
+        assert data[0]["slug"] == "cancel-async-tasks"
         assert data[0]["args"]["task_id"] == "cancel-async-tasks"
 
     def test_task_files_copied(self, single_task: Path, tmp_path: Path) -> None:
@@ -675,6 +768,23 @@ class TestWriteResult:
         assert (task_out / "instruction.md").is_file()
         assert (task_out / "task.toml").is_file()
         assert (task_out / "tests" / "test.sh").is_file()
+
+    def test_scoring_and_source_context_not_copied(self, single_task: Path, tmp_path: Path) -> None:
+        hidden_files = ("SCORING.md", "ref-1.md", "note-12-3.md", ".dockerignore")
+        for file_name in hidden_files:
+            (single_task / file_name).write_text("hidden task context", encoding="utf-8")
+        (single_task / "README.md").write_text("public task context", encoding="utf-8")
+
+        result = self.converter.convert(single_task)
+        out = tmp_path / "output"
+        write_result(result, out)
+
+        env = result.environments[0]
+        task_out = out / env.name / "tasks" / "cancel-async-tasks"
+
+        for file_name in hidden_files:
+            assert not (task_out / file_name).exists()
+        assert (task_out / "README.md").is_file()
 
     def test_environment_dir_not_copied(self, single_task: Path, tmp_path: Path) -> None:
         result = self.converter.convert(single_task)


### PR DESCRIPTION
this PR updates the Harbor converter based on issues found while converting Harbor-format tasks.

changes:
- preserve Harbor task workdir behavior, including `[environment].workdir` overrides, and make sure the original challenge workdir is writable for demoted coding tools
- keep multiline `HEALTHCHECK` continuations intact when commenting out the original `CMD`/`ENTRYPOINT`
- emit v5-compatible task fields: `slug`, `agent_config`, and `validation`
- skip scoring/source-context files when baking task data (`SCORING.md`, advisory/reference markdown files, `.dockerignore`)

runtime/deploy fixes (@ryantzr1):
- run the generated HUD server via `hud` on the generated venv `PATH` instead of wrapping startup with `uv run`
- pin the generated controller venv to Python 3.12 for hosted analysis compatibility
- clear stale verifier reward files before each scenario run
- use a longer bash timeout for Harbor coding tasks

isolation fix:
- baked task data now lives under `/root/.hud_harbor/tasks`
- task data is root-only (`chown root:root` + `chmod go-rwx`)
- `EditTool`, `ReadTool`, `GrepTool`, `GlobTool`, and `ListTool` are scoped to `AGENT_WORKDIR`
- keeps the working deploy path: `WORKDIR /hud`, `ENV PATH="/hud/.venv/bin:$PATH"`, `CMD ["hud", "dev", "env:env", "--stdio"]`

validation:
- `uv run pytest hud/cli/convert/tests/test_harbor.py`
- `uv run ruff check hud/cli/convert/harbor.py hud/cli/convert/__init__.py hud/cli/convert/tests/test_harbor.py`

this was also fully tested from converting one Harbor task that had issues, deployed the generated environment, and syncing the generated taskset successfully


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how converted Harbor environments run (workdir handling, tool scoping, Dockerfile/entrypoint, and reward file lifecycle), which could break existing converted tasks or alter agent filesystem access. However the scope is limited to the Harbor converter and associated writer logic with added tests.
> 
> **Overview**
> Improves Harbor conversions to better isolate *source task data* from agents while preserving expected runtime behavior. Converted images now store task bundles under root-only `/root/.hud_harbor/tasks`, scope filesystem/edit tools to the extracted/configured Harbor workdir, and ensure that workdir is writable for the demoted agent user.
> 
> Updates generated runtime artifacts: Dockerfile generation preserves multi-line `HEALTHCHECK` continuations, pins the HUD venv sync to Python 3.12, switches startup to `hud` (via venv `PATH`), and clears stale reward files before each run; the scenario also runs `test.sh` from the Harbor workdir and increases `BashTool` timeout.
> 
> Updates output compatibility and hygiene: taskset entries now include stable `slug`s plus v5 fields `agent_config` and `validation`, and `write_result` skips copying scoring/source-context files (e.g., `SCORING.md`, `.dockerignore`, and reference-style markdown). Tests were expanded to cover slug generation, workdir extraction/override, healthcheck preservation, task-data hiding, and the new skip rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d803253ab28cfd3d6b923965dcf730d4323af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->