### PR TITLE
cli hud tasks

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,10 @@ title: "Changelog"
 description: "Product updates and release notes for HUD SDK and Platform."
 ---
 
+<Update label="May 11, 2026">
+- **`hud tasks` CLI** — list, show, status (set/clear, with `--all`), duplicate, and move tasks across tasksets. See the [`hud tasks` reference](/reference/cli/tasks).
+</Update>
+
 <Update label="May 6, 2026">
 ## Models, Tasksets, Templates & Sharing
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,6 +125,7 @@
               "reference/cli/eval",
               "reference/cli/rl",
               "reference/cli/sync",
+              "reference/cli/tasks",
               "reference/cli/misc"
             ]
           },

--- a/docs/reference/cli/overview.mdx
+++ b/docs/reference/cli/overview.mdx
@@ -59,6 +59,11 @@ hud login
 |---------|-------|-------------|---------|
 | `hud sync tasks` | Taskset + source | Sync local tasks to platform | `hud sync tasks my-taskset` |
 | `hud sync` | (stored config) | Sync using .hud/config.json | `hud sync` |
+| `hud tasks list` | Taskset | List tasks with status & pass rate | `hud tasks list` |
+| `hud tasks show` | Slug | Inspect one task | `hud tasks show my-slug` |
+| `hud tasks status` | Slugs or `--all` | Set or clear task status | `hud tasks status my-slug --set ready` |
+| `hud tasks duplicate` | Slugs | Clone tasks, optionally across tasksets | `hud tasks duplicate my-slug --to <id>` |
+| `hud tasks move` | Slugs + target | Move tasks to another taskset | `hud tasks move my-slug --to <id>` |
 
 ### Local Development
 | Command | Input | Description | Example |

--- a/docs/reference/cli/tasks.mdx
+++ b/docs/reference/cli/tasks.mdx
@@ -1,0 +1,154 @@
+---
+title: "hud tasks"
+description: "List, inspect, and mutate tasks on the HUD platform"
+icon: "list-check"
+---
+
+`hud tasks` is a thin CLI over the platform tasks API.
+
+## Typical workflow
+
+```bash
+hud tasks list
+hud tasks show my-slug
+hud tasks status my-slug --set ready
+hud tasks duplicate my-slug --to <target-taskset-id>
+hud tasks move my-slug --to <target-taskset-id>
+```
+
+## Source taskset
+
+- `hud tasks list` takes the taskset ID as an **optional positional argument**.
+- All other commands take it via `--taskset` / `-t`.
+- When the source taskset is omitted, every command falls back to the taskset ID stored in `.hud/config.json` (set by `hud sync tasks <name>`).
+
+## `hud tasks list`
+
+```bash
+hud tasks list [taskset]
+```
+
+Columns: slug, version, status, `pass>0`, scorable runs.
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `taskset` | From `.hud/config.json` | Taskset ID |
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Emit raw JSON instead of a table |
+
+```bash
+hud tasks list                                          # use stored taskset
+hud tasks list 6f8f8d45-45c7-429c-a255-4dc92fac1f2d     # explicit taskset
+hud tasks list --json                                   # machine-readable
+```
+
+## `hud tasks show`
+
+```bash
+hud tasks show <slug> [--taskset <id>]
+```
+
+Prints the full JSON record for the given slug.
+
+| Argument | Description |
+|----------|-------------|
+| `slug` | Task slug (`external_id`) |
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--taskset` / `-t` | Source taskset ID (falls back to `.hud/config.json`) |
+
+```bash
+hud tasks show my-task
+hud tasks show my-task -t 6f8f8d45-45c7-429c-a255-4dc92fac1f2d
+```
+
+## `hud tasks status`
+
+```bash
+hud tasks status <slug...> --set <value> [--taskset <id>]
+hud tasks status <slug...> --clear [--taskset <id>]
+hud tasks status --all --set <value> [--taskset <id>]
+```
+
+With explicit slugs, the CLI sends one bulk request. With `--all`, it first fetches the taskset to expand slugs, then sends the bulk request.
+
+| Argument | Description |
+|----------|-------------|
+| `slug...` | One or more task slugs (omit when using `--all`) |
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--set <value>` | Status to apply (server validates) |
+| `--clear` | Clear the current status |
+| `--all` | Apply to every task in the taskset (mutually exclusive with explicit slugs) |
+| `--taskset` / `-t` | Source taskset ID |
+| `--json` | Emit raw JSON instead of a summary |
+
+```bash
+hud tasks status my-task --set ready                   # one task
+hud tasks status task-a task-b task-c --set verified   # several in one request
+hud tasks status --all --set ready                     # every task in the taskset
+hud tasks status my-task --clear                       # clear status
+```
+
+Per-task failures are relayed verbatim; partial successes commit.
+
+## `hud tasks duplicate`
+
+```bash
+hud tasks duplicate <slug...> [--to <id>] [--on-conflict <strategy>] [--taskset <id>]
+```
+
+With `--to`, copies into a different taskset; without it, clones within the source taskset.
+
+| Argument | Description |
+|----------|-------------|
+| `slug...` | One or more task slugs |
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--to <id>` | Target taskset ID (omit to copy within the source taskset) |
+| `--on-conflict <strategy>` | Slug conflict strategy (server-validated, default `error`). Only applies with `--to`; ignored when cloning in place. |
+| `--taskset` / `-t` | Source taskset ID |
+| `--json` | Emit raw JSON |
+
+```bash
+hud tasks duplicate my-task                                                       # clone in place
+hud tasks duplicate task-a task-b --to <target-taskset-id>                        # copy into another taskset
+hud tasks duplicate task-a --to <target-taskset-id> --on-conflict rename          # handle slug collisions
+```
+
+## `hud tasks move`
+
+```bash
+hud tasks move <slug...> --to <id> [--on-conflict <strategy>] [--taskset <id>]
+```
+
+| Argument | Description |
+|----------|-------------|
+| `slug...` | One or more task slugs |
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--to <id>` | Target taskset ID (**required**) |
+| `--on-conflict <strategy>` | Slug conflict strategy (server-validated, default `error`) |
+| `--taskset` / `-t` | Source taskset ID |
+| `--json` | Emit raw JSON |
+
+```bash
+hud tasks move my-task --to <target-taskset-id>
+hud tasks move task-a task-b --to <target-taskset-id> --on-conflict skip
+```

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -44,6 +44,7 @@ from .push import push_command  # noqa: E402
 from .rl import rl_run_command, rl_status_command  # noqa: E402
 from .scenario import scenario_app  # noqa: E402
 from .sync import sync_app  # noqa: E402
+from .tasks import tasks_app  # noqa: E402
 
 _EXTRA_ARGS = {"allow_extra_args": True, "ignore_unknown_options": True}
 
@@ -116,6 +117,9 @@ app.add_typer(scenario_app, name="scenario")
 
 # Sync subcommand group
 app.add_typer(sync_app, name="sync")
+
+# Tasks subcommand group
+app.add_typer(tasks_app, name="tasks")
 
 # RL subcommand group
 rl_app = typer.Typer(help="🚀 RL training commands\n\nExample: hud rl run my-taskset -m <model-id>")

--- a/hud/cli/tasks.py
+++ b/hud/cli/tasks.py
@@ -1,9 +1,4 @@
-"""`hud tasks` — CLI for listing, inspecting, and mutating tasks on the HUD platform.
-
-Each command is a thin wrapper: parse args, call the corresponding endpoint,
-render the response. Validation, status semantics, and access control are
-owned by the platform.
-"""
+"""``hud tasks`` command group — list, inspect, and mutate tasks on the platform."""
 
 from __future__ import annotations
 

--- a/hud/cli/tasks.py
+++ b/hud/cli/tasks.py
@@ -76,9 +76,7 @@ def list_command(
         None,
         help="Taskset id (falls back to .hud/config.json if omitted)",
     ),
-    as_json: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of a table"
-    ),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw JSON instead of a table"),
 ) -> None:
     """List tasks in a taskset with status + pass-rate."""
     require_api_key("list tasks")
@@ -91,7 +89,7 @@ def list_command(
     payload = resp.json()
     tasks: list[dict[str, Any]] = payload.get("tasks") or []
     stats_by_version: dict[str, dict[str, Any]] = {
-        s["task_version_id"]: s for s in (payload.get("task_stats") or [])
+        str(s["task_version_id"]): s for s in (payload.get("task_stats") or [])
     }
 
     if as_json:
@@ -103,9 +101,7 @@ def list_command(
         return
 
     evalset_name = payload.get("evalset_name")
-    title = (
-        f'Tasks in "{evalset_name}" ({ts[:7]})' if evalset_name else f"Tasks in {ts[:12]}"
-    )
+    title = f'Tasks in "{evalset_name}" ({ts[:7]})' if evalset_name else f"Tasks in {ts[:12]}"
     table = Table(title=title, show_lines=False)
     table.add_column("slug", style="cyan", no_wrap=True)
     table.add_column("ver", justify="right")
@@ -152,7 +148,7 @@ def show_command(
     payload = resp.json()
     tasks: list[dict[str, Any]] = payload.get("tasks") or []
     stats_by_version: dict[str, dict[str, Any]] = {
-        s["task_version_id"]: s for s in (payload.get("task_stats") or [])
+        str(s["task_version_id"]): s for s in (payload.get("task_stats") or [])
     }
     for entry in tasks:
         task = entry.get("task") or {}
@@ -177,21 +173,13 @@ def status_command(
     slugs: list[str] | None = typer.Argument(  # noqa: B008
         None, help="One or more task slugs (omit when using --all)"
     ),
-    set_value: str | None = typer.Option(
-        None, "--set", help="Status to apply"
-    ),
-    clear: bool = typer.Option(
-        False, "--clear", help="Clear the current status"
-    ),
-    all_tasks: bool = typer.Option(
-        False, "--all", help="Apply to every task in the taskset"
-    ),
+    set_value: str | None = typer.Option(None, "--set", help="Status to apply"),
+    clear: bool = typer.Option(False, "--clear", help="Clear the current status"),
+    all_tasks: bool = typer.Option(False, "--all", help="Apply to every task in the taskset"),
     taskset: str | None = typer.Option(
         None, "--taskset", "-t", help="Taskset id (falls back to .hud/config.json)"
     ),
-    as_json: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of summary"
-    ),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw JSON instead of summary"),
 ) -> None:
     """Set or clear status for one, many, or all tasks in a taskset."""
     require_api_key("set task status")
@@ -261,15 +249,11 @@ def duplicate_command(
     target: str | None = typer.Option(
         None, "--to", help="Target taskset id (omit to copy within the source taskset)"
     ),
-    on_conflict: str = typer.Option(
-        "error", "--on-conflict", help="Slug conflict strategy"
-    ),
+    on_conflict: str = typer.Option("error", "--on-conflict", help="Slug conflict strategy"),
     taskset: str | None = typer.Option(
         None, "--taskset", "-t", help="Source taskset id (falls back to .hud/config.json)"
     ),
-    as_json: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of summary"
-    ),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw JSON instead of summary"),
 ) -> None:
     """Duplicate tasks within their source taskset or into another."""
     require_api_key("duplicate tasks")
@@ -325,18 +309,12 @@ def move_command(
     slugs: list[str] = typer.Argument(  # noqa: B008
         ..., help="One or more task slugs"
     ),
-    target: str = typer.Option(
-        ..., "--to", help="Target taskset id (required)"
-    ),
-    on_conflict: str = typer.Option(
-        "error", "--on-conflict", help="Slug conflict strategy"
-    ),
+    target: str = typer.Option(..., "--to", help="Target taskset id (required)"),
+    on_conflict: str = typer.Option("error", "--on-conflict", help="Slug conflict strategy"),
     taskset: str | None = typer.Option(
         None, "--taskset", "-t", help="Source taskset id (falls back to .hud/config.json)"
     ),
-    as_json: bool = typer.Option(
-        False, "--json", help="Emit raw JSON instead of summary"
-    ),
+    as_json: bool = typer.Option(False, "--json", help="Emit raw JSON instead of summary"),
 ) -> None:
     """Move tasks to another taskset."""
     require_api_key("move tasks")
@@ -358,9 +336,7 @@ def move_command(
         Console().print_json(data=payload)
         return
 
-    hud_console.success(
-        f"Moved {payload.get('tasks_moved', 0)} task(s) into {target[:12]}"
-    )
+    hud_console.success(f"Moved {payload.get('tasks_moved', 0)} task(s) into {target[:12]}")
     if payload.get("renamed_count"):
         hud_console.info(f"  renamed: {payload['renamed_count']}")
     if payload.get("skipped_count"):

--- a/hud/cli/tasks.py
+++ b/hud/cli/tasks.py
@@ -1,0 +1,377 @@
+"""`hud tasks` — CLI for listing, inspecting, and mutating tasks on the HUD platform.
+
+Each command is a thin wrapper: parse args, call the corresponding endpoint,
+render the response. Validation, status semantics, and access control are
+owned by the platform.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from hud.cli.utils.api import hud_headers, require_api_key
+from hud.cli.utils.project_config import get_taskset_id
+from hud.settings import settings
+from hud.utils.hud_console import HUDConsole
+
+tasks_app = typer.Typer(
+    name="tasks",
+    help="Inspect and mutate tasks on the HUD platform",
+    no_args_is_help=True,
+)
+
+
+def _resolve_taskset(taskset_flag: str | None, positional: str | None = None) -> str:
+    """Resolve taskset id: positional arg → flag → .hud/config.json → error."""
+    resolved = positional or taskset_flag or get_taskset_id()
+    if not resolved:
+        hud_console = HUDConsole()
+        hud_console.error(
+            "No taskset specified. Pass one as a positional or --taskset, "
+            "or set one via `hud sync tasks <name>`."
+        )
+        raise typer.Exit(1)
+    return resolved
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    json: dict[str, Any] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = 30.0,
+) -> httpx.Response:
+    """Issue a single platform request with API key auth."""
+    url = f"{settings.hud_api_url}{path}"
+    return httpx.request(
+        method,
+        url,
+        headers=hud_headers(),
+        json=json,
+        params=params,
+        timeout=timeout,
+    )
+
+
+def _handle_error(resp: httpx.Response) -> None:
+    """Render a platform error and exit. Server's `detail` is relayed verbatim."""
+    hud_console = HUDConsole()
+    try:
+        detail = resp.json().get("detail", resp.text)
+    except Exception:
+        detail = resp.text
+    hud_console.error(f"{resp.status_code}: {detail}")
+    raise typer.Exit(1)
+
+
+# ---------------------------------------------------------------------------
+# List tasks in a taskset
+# ---------------------------------------------------------------------------
+
+
+@tasks_app.command("list")
+def list_command(
+    taskset: str | None = typer.Argument(
+        None,
+        help="Taskset id (falls back to .hud/config.json if omitted)",
+    ),
+    as_json: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of a table"
+    ),
+) -> None:
+    """List tasks in a taskset with status + pass-rate."""
+    require_api_key("list tasks")
+    ts = _resolve_taskset(None, positional=taskset)
+
+    resp = _request("GET", f"/tasks/evalsets/{ts}/tasks-with-stats")
+    if resp.status_code != 200:
+        _handle_error(resp)
+
+    payload = resp.json()
+    tasks: list[dict[str, Any]] = payload.get("tasks") or []
+    stats_by_version: dict[str, dict[str, Any]] = {
+        s["task_version_id"]: s for s in (payload.get("task_stats") or [])
+    }
+
+    if as_json:
+        Console().print_json(data=payload)
+        return
+
+    if not tasks:
+        HUDConsole().info(f"No tasks in taskset {ts}.")
+        return
+
+    evalset_name = payload.get("evalset_name")
+    title = (
+        f'Tasks in "{evalset_name}" ({ts[:7]})' if evalset_name else f"Tasks in {ts[:12]}"
+    )
+    table = Table(title=title, show_lines=False)
+    table.add_column("slug", style="cyan", no_wrap=True)
+    table.add_column("ver", justify="right")
+    table.add_column("status")
+    table.add_column("pass>0", justify="right")
+    table.add_column("n", justify="right")
+    for entry in tasks:
+        task = entry.get("task") or {}
+        version = entry.get("version") or {}
+        stats = stats_by_version.get(str(version.get("id") or ""), {})
+        pr = stats.get("pass_rate")
+        sc = stats.get("scorable_count") or 0
+        status = stats.get("progress_status") or "pending"
+        table.add_row(
+            str(task.get("external_id") or ""),
+            str(version.get("version") or ""),
+            status,
+            f"{pr:.0%}" if isinstance(pr, (int, float)) else "—",
+            str(sc),
+        )
+    Console().print(table)
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+@tasks_app.command("show")
+def show_command(
+    slug: str = typer.Argument(..., help="Task slug (external_id)"),
+    taskset: str | None = typer.Option(
+        None, "--taskset", "-t", help="Taskset id (falls back to .hud/config.json)"
+    ),
+) -> None:
+    """Print one task's full JSON record."""
+    require_api_key("show task")
+    ts = _resolve_taskset(taskset)
+
+    resp = _request("GET", f"/tasks/evalsets/{ts}/tasks-with-stats")
+    if resp.status_code != 200:
+        _handle_error(resp)
+
+    payload = resp.json()
+    tasks: list[dict[str, Any]] = payload.get("tasks") or []
+    stats_by_version: dict[str, dict[str, Any]] = {
+        s["task_version_id"]: s for s in (payload.get("task_stats") or [])
+    }
+    for entry in tasks:
+        task = entry.get("task") or {}
+        if task.get("external_id") == slug:
+            version = entry.get("version") or {}
+            stats = stats_by_version.get(str(version.get("id") or ""), {})
+            output = {"task": task, "version": version, "stats": stats}
+            Console().print_json(data=output)
+            return
+
+    HUDConsole().error(f"No task with slug '{slug}' in taskset {ts}.")
+    raise typer.Exit(1)
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+@tasks_app.command("status")
+def status_command(
+    slugs: list[str] | None = typer.Argument(  # noqa: B008
+        None, help="One or more task slugs (omit when using --all)"
+    ),
+    set_value: str | None = typer.Option(
+        None, "--set", help="Status to apply"
+    ),
+    clear: bool = typer.Option(
+        False, "--clear", help="Clear the current status"
+    ),
+    all_tasks: bool = typer.Option(
+        False, "--all", help="Apply to every task in the taskset"
+    ),
+    taskset: str | None = typer.Option(
+        None, "--taskset", "-t", help="Taskset id (falls back to .hud/config.json)"
+    ),
+    as_json: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of summary"
+    ),
+) -> None:
+    """Set or clear status for one, many, or all tasks in a taskset."""
+    require_api_key("set task status")
+    hud_console = HUDConsole()
+
+    if (set_value is None) == (not clear):
+        hud_console.error("Provide exactly one of `--set <value>` or `--clear`.")
+        raise typer.Exit(1)
+    if bool(slugs) == bool(all_tasks):
+        hud_console.error("Provide either task slugs or `--all`, not both.")
+        raise typer.Exit(1)
+
+    ts = _resolve_taskset(taskset)
+
+    if all_tasks:
+        list_resp = _request("GET", f"/tasks/evalsets/{ts}/tasks-with-stats")
+        if list_resp.status_code != 200:
+            _handle_error(list_resp)
+        slugs = [
+            entry["task"]["external_id"]
+            for entry in (list_resp.json().get("tasks") or [])
+            if entry.get("task", {}).get("external_id")
+        ]
+        if not slugs:
+            hud_console.info(f"No tasks in taskset {ts}.")
+            return
+
+    body: dict[str, Any] = {"slugs": slugs, "evalset_id": ts}
+    if set_value is not None:
+        body["status"] = set_value
+    else:
+        body["clear"] = True
+
+    resp = _request("PATCH", "/tasks/status", json=body)
+    if resp.status_code >= 400:
+        _handle_error(resp)
+
+    payload = resp.json()
+    if as_json:
+        Console().print_json(data=payload)
+        return
+
+    succeeded = payload.get("succeeded") or []
+    unchanged = payload.get("unchanged") or []
+    failures = payload.get("failures") or []
+
+    if succeeded:
+        hud_console.success(f"{len(succeeded)} updated")
+    if unchanged:
+        hud_console.info(f"{len(unchanged)} unchanged (already in target state)")
+    for f in failures:
+        hud_console.error(f"  {f.get('input')}: {f.get('reason')} [{f.get('code')}]")
+    if failures and not (succeeded or unchanged):
+        raise typer.Exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate/copy tasks to another taskset
+# ---------------------------------------------------------------------------
+
+
+@tasks_app.command("duplicate")
+def duplicate_command(
+    slugs: list[str] = typer.Argument(  # noqa: B008
+        ..., help="One or more task slugs"
+    ),
+    target: str | None = typer.Option(
+        None, "--to", help="Target taskset id (omit to copy within the source taskset)"
+    ),
+    on_conflict: str = typer.Option(
+        "error", "--on-conflict", help="Slug conflict strategy"
+    ),
+    taskset: str | None = typer.Option(
+        None, "--taskset", "-t", help="Source taskset id (falls back to .hud/config.json)"
+    ),
+    as_json: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of summary"
+    ),
+) -> None:
+    """Duplicate tasks within their source taskset or into another."""
+    require_api_key("duplicate tasks")
+    hud_console = HUDConsole()
+
+    ts = _resolve_taskset(taskset)
+
+    if target:
+        body = {
+            "slugs": slugs,
+            "evalset_id": ts,
+            "target_taskset_id": target,
+            "conflict_strategy": on_conflict,
+        }
+        resp = _request("POST", "/tasks/duplicate-to-taskset", json=body)
+    else:
+        body = {"slugs": slugs, "evalset_id": ts}
+        resp = _request("POST", "/tasks/duplicate", json=body)
+
+    if resp.status_code >= 400:
+        _handle_error(resp)
+
+    payload = resp.json()
+    if as_json:
+        Console().print_json(data=payload)
+        return
+
+    if target:
+        hud_console.success(
+            f"Duplicated {payload.get('tasks_copied', 0)} task(s) into {target[:12]}"
+        )
+        if payload.get("renamed_count"):
+            hud_console.info(f"  renamed: {payload['renamed_count']}")
+        if payload.get("skipped_count"):
+            hud_console.info(f"  skipped: {payload['skipped_count']}")
+        if payload.get("linked_count"):
+            hud_console.info(f"  linked: {payload['linked_count']}")
+    else:
+        duplicated = payload.get("tasks") or []
+        failed = payload.get("failed_ids") or []
+        hud_console.success(f"Duplicated {len(duplicated)} task(s)")
+        for fid in failed:
+            hud_console.error(f"  failed: {fid}")
+
+
+# ---------------------------------------------------------------------------
+# Move tasks to another taskset
+# ---------------------------------------------------------------------------
+
+
+@tasks_app.command("move")
+def move_command(
+    slugs: list[str] = typer.Argument(  # noqa: B008
+        ..., help="One or more task slugs"
+    ),
+    target: str = typer.Option(
+        ..., "--to", help="Target taskset id (required)"
+    ),
+    on_conflict: str = typer.Option(
+        "error", "--on-conflict", help="Slug conflict strategy"
+    ),
+    taskset: str | None = typer.Option(
+        None, "--taskset", "-t", help="Source taskset id (falls back to .hud/config.json)"
+    ),
+    as_json: bool = typer.Option(
+        False, "--json", help="Emit raw JSON instead of summary"
+    ),
+) -> None:
+    """Move tasks to another taskset."""
+    require_api_key("move tasks")
+    hud_console = HUDConsole()
+
+    ts = _resolve_taskset(taskset)
+    body = {
+        "slugs": slugs,
+        "evalset_id": ts,
+        "target_taskset_id": target,
+        "conflict_strategy": on_conflict,
+    }
+    resp = _request("POST", "/tasks/move-to-taskset", json=body)
+    if resp.status_code >= 400:
+        _handle_error(resp)
+
+    payload = resp.json()
+    if as_json:
+        Console().print_json(data=payload)
+        return
+
+    hud_console.success(
+        f"Moved {payload.get('tasks_moved', 0)} task(s) into {target[:12]}"
+    )
+    if payload.get("renamed_count"):
+        hud_console.info(f"  renamed: {payload['renamed_count']}")
+    if payload.get("skipped_count"):
+        hud_console.info(f"  skipped: {payload['skipped_count']}")
+    if payload.get("linked_count"):
+        hud_console.info(f"  linked: {payload['linked_count']}")
+
+
+__all__ = ["tasks_app"]

--- a/hud/cli/tests/test_tasks.py
+++ b/hud/cli/tests/test_tasks.py
@@ -1,0 +1,318 @@
+"""Tests for `hud tasks` CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from hud.cli.tasks import tasks_app
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _set_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every CLI command checks for an API key — provide a fake one."""
+    from hud.settings import settings
+
+    monkeypatch.setattr(settings, "api_key", "test-api-key")
+    monkeypatch.setattr(settings, "hud_api_url", "https://test.example.com")
+
+
+def _mock_response(status_code: int = 200, json_data: dict[str, Any] | None = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = str(json_data or "")
+    return resp
+
+
+def test_list_falls_back_to_config_taskset(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("hud.cli.tasks.get_taskset_id", lambda: "stored-evalset")
+    captured: dict[str, str] = {}
+
+    def fake_request(method: str, path: str, **_: Any) -> MagicMock:
+        captured["method"] = method
+        captured["path"] = path
+        return _mock_response(200, {"tasks": [], "task_stats": []})
+
+    with patch("hud.cli.tasks._request", side_effect=fake_request):
+        result = runner.invoke(tasks_app, ["list"])
+    assert result.exit_code == 0
+    assert captured["path"] == "/tasks/evalsets/stored-evalset/tasks-with-stats"
+
+
+def test_list_errors_when_no_taskset_anywhere(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("hud.cli.tasks.get_taskset_id", lambda: None)
+    result = runner.invoke(tasks_app, ["list"])
+    assert result.exit_code == 1
+    assert "No taskset" in result.output
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+def test_show_filters_to_matching_slug(runner: CliRunner) -> None:
+    payload = {
+        "tasks": [
+            {"task": {"external_id": "alpha"}, "version": {"id": "v-1"}},
+            {"task": {"external_id": "beta"}, "version": {"id": "v-2"}},
+        ],
+        "task_stats": [
+            {"task_version_id": "v-1", "pass_rate": 1.0},
+            {"task_version_id": "v-2", "pass_rate": 0.5},
+        ],
+    }
+    with patch("hud.cli.tasks._request", return_value=_mock_response(200, payload)):
+        result = runner.invoke(tasks_app, ["show", "beta", "--taskset", "e-1"])
+    assert result.exit_code == 0
+    assert "beta" in result.output
+    assert "alpha" not in result.output
+    assert '"pass_rate": 0.5' in result.output
+
+
+def test_show_404s_when_slug_absent(runner: CliRunner) -> None:
+    payload = {"tasks": [{"task": {"external_id": "alpha"}, "version": {}}]}
+    with patch("hud.cli.tasks._request", return_value=_mock_response(200, payload)):
+        result = runner.invoke(tasks_app, ["show", "ghost", "-t", "e-1"])
+    assert result.exit_code == 1
+    assert "No task with slug 'ghost'" in result.output
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def test_status_sends_bulk_request_with_set(runner: CliRunner) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, path: str, **kwargs: Any) -> MagicMock:
+        captured["method"] = method
+        captured["path"] = path
+        captured["json"] = kwargs.get("json")
+        return _mock_response(200, {"succeeded": ["t-1", "t-2"], "unchanged": [], "failures": []})
+
+    with patch("hud.cli.tasks._request", side_effect=fake_request):
+        result = runner.invoke(
+            tasks_app,
+            ["status", "alpha", "beta", "--set", "ready", "-t", "e-1"],
+        )
+    assert result.exit_code == 0
+    assert captured["method"] == "PATCH"
+    assert captured["path"] == "/tasks/status"
+    assert captured["json"] == {
+        "slugs": ["alpha", "beta"],
+        "evalset_id": "e-1",
+        "status": "ready",
+    }
+    assert "2 updated" in result.output
+
+
+def test_status_sends_clear_when_clear_flag(runner: CliRunner) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, path: str, **kwargs: Any) -> MagicMock:
+        captured["json"] = kwargs.get("json")
+        return _mock_response(200, {"succeeded": [], "unchanged": ["t-1"], "failures": []})
+
+    with patch("hud.cli.tasks._request", side_effect=fake_request):
+        result = runner.invoke(tasks_app, ["status", "alpha", "--clear", "-t", "e-1"])
+    assert result.exit_code == 0
+    assert captured["json"]["clear"] is True
+    assert "status" not in captured["json"]
+    assert "unchanged" in result.output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["status", "alpha", "--set", "ready", "--clear", "-t", "e-1"],
+        ["status", "alpha", "-t", "e-1"],
+    ],
+)
+def test_status_requires_exactly_one_mutation(args: list[str], runner: CliRunner) -> None:
+    result = runner.invoke(tasks_app, args)
+    assert result.exit_code == 1
+    assert "exactly one" in result.output
+
+
+def test_status_all_fetches_slugs_then_mutates(runner: CliRunner) -> None:
+    """--all → GET tasks-with-stats, then PATCH /tasks/status with all slugs."""
+    calls: list[dict[str, Any]] = []
+
+    def fake_request(method: str, path: str, **kwargs: Any) -> MagicMock:
+        calls.append({"method": method, "path": path, "json": kwargs.get("json")})
+        if method == "GET":
+            return _mock_response(
+                200,
+                {
+                    "tasks": [
+                        {"task": {"external_id": "alpha"}, "version": {"id": "v-1"}},
+                        {"task": {"external_id": "beta"}, "version": {"id": "v-2"}},
+                    ]
+                },
+            )
+        return _mock_response(200, {"succeeded": ["t-1", "t-2"], "unchanged": [], "failures": []})
+
+    with patch("hud.cli.tasks._request", side_effect=fake_request):
+        result = runner.invoke(tasks_app, ["status", "--set", "ready", "--all", "-t", "e-1"])
+    assert result.exit_code == 0, result.output
+    assert calls[0]["method"] == "GET"
+    assert calls[1]["method"] == "PATCH"
+    assert calls[1]["json"]["slugs"] == ["alpha", "beta"]
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["status", "alpha", "--set", "ready", "--all", "-t", "e-1"],
+        ["status", "--set", "ready", "-t", "e-1"],
+    ],
+)
+def test_status_requires_slugs_or_all(args: list[str], runner: CliRunner) -> None:
+    result = runner.invoke(tasks_app, args)
+    assert result.exit_code == 1
+    assert "either task slugs or `--all`" in result.output
+
+
+def test_status_renders_failures(runner: CliRunner) -> None:
+    payload = {
+        "succeeded": ["t-1"],
+        "unchanged": [],
+        "failures": [
+            {
+                "input": "ghost",
+                "resolved_id": None,
+                "reason": "Task not found",
+                "code": "not_found",
+            }
+        ],
+    }
+    with patch("hud.cli.tasks._request", return_value=_mock_response(200, payload)):
+        result = runner.invoke(
+            tasks_app, ["status", "alpha", "ghost", "--set", "ready", "-t", "e-1"]
+        )
+    # Mixed outcome: some succeeded → exit 0, but failures rendered
+    assert result.exit_code == 0
+    assert "1 updated" in result.output
+    assert "ghost" in result.output
+    assert "Task not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# duplicate
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_in_place_hits_duplicate_endpoint(runner: CliRunner) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, path: str, **kwargs: Any) -> MagicMock:
+        captured["path"] = path
+        captured["json"] = kwargs.get("json")
+        return _mock_response(200, {"tasks": [{"id": "t-1-copy"}], "failed_ids": []})
+
+    with patch("hud.cli.tasks._request", side_effect=fake_request):
+        result = runner.invoke(tasks_app, ["duplicate", "alpha", "-t", "e-1"])
+    assert result.exit_code == 0
+    assert captured["path"] == "/tasks/duplicate"
+    assert captured["json"] == {"slugs": ["alpha"], "evalset_id": "e-1"}
+
+
+def test_duplicate_to_target_hits_duplicate_to_taskset(runner: CliRunner) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, path: str, **kwargs: Any) -> MagicMock:
+        captured["path"] = path
+        captured["json"] = kwargs.get("json")
+        return _mock_response(
+            200,
+            {"tasks_copied": 2, "versions_copied": 2, "traces_copied": 0},
+        )
+
+    with patch("hud.cli.tasks._request", side_effect=fake_request):
+        result = runner.invoke(
+            tasks_app,
+            [
+                "duplicate",
+                "alpha",
+                "beta",
+                "--to",
+                "e-2",
+                "-t",
+                "e-1",
+                "--on-conflict",
+                "lolwat",
+            ],
+        )
+    assert result.exit_code == 0
+    assert captured["path"] == "/tasks/duplicate-to-taskset"
+    assert captured["json"]["target_taskset_id"] == "e-2"
+    assert captured["json"]["slugs"] == ["alpha", "beta"]
+    assert captured["json"]["conflict_strategy"] == "lolwat"
+
+
+# ---------------------------------------------------------------------------
+# move
+# ---------------------------------------------------------------------------
+
+
+def test_move_hits_move_to_taskset(runner: CliRunner) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_request(method: str, path: str, **kwargs: Any) -> MagicMock:
+        captured["path"] = path
+        captured["json"] = kwargs.get("json")
+        return _mock_response(200, {"tasks_moved": 1})
+
+    with patch("hud.cli.tasks._request", side_effect=fake_request):
+        result = runner.invoke(
+            tasks_app,
+            [
+                "move",
+                "alpha",
+                "--to",
+                "e-2",
+                "-t",
+                "e-1",
+                "--on-conflict",
+                "lolwat",
+            ],
+        )
+    assert result.exit_code == 0
+    assert captured["path"] == "/tasks/move-to-taskset"
+    assert captured["json"]["target_taskset_id"] == "e-2"
+    assert captured["json"]["conflict_strategy"] == "lolwat"
+
+
+def test_move_requires_to_flag(runner: CliRunner) -> None:
+    result = runner.invoke(tasks_app, ["move", "alpha", "-t", "e-1"])
+    assert result.exit_code != 0  # typer enforces required option
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_4xx_relays_server_detail_verbatim(runner: CliRunner) -> None:
+    err_resp = _mock_response(403, {"detail": "Access denied to this task"})
+    with patch("hud.cli.tasks._request", return_value=err_resp):
+        result = runner.invoke(tasks_app, ["status", "alpha", "--set", "verified", "-t", "e-1"])
+    assert result.exit_code == 1
+    assert "Access denied to this task" in result.output
+    assert "403" in result.output


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new CLI commands that can mutate task state and move/copy tasks across tasksets via platform API calls; incorrect usage or API contract mismatches could impact task organization/status.
> 
> **Overview**
> Introduces a new `hud tasks` CLI command group with `list`, `show`, `status` (set/clear, including `--all`), `duplicate`, and `move`, backed by HTTP calls to the platform tasks API and shared error handling.
> 
> Updates CLI registration to expose the new subcommands, adds comprehensive unit tests for request shapes and validation/error cases, and extends docs/navigation/changelog with a new `hud tasks` reference page and overview entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2501b8e7ecd70a3e2b5e00bffdc48d87411c3253. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->