### PR TITLE
Rename Robot Capability + Add MainThreadSimRunner

### DIFF
--- a/docs/v6/faq.mdx
+++ b/docs/v6/faq.mdx
@@ -101,7 +101,7 @@ Yes. The Harbor integration loads Harbor-format tasks straight into a `Taskset` 
 </Accordion>
 
 <Accordion title="Does HUD support robotics / VLA policies?">
-Yes, in **beta**: the `robot/0.1` capability is a schema-driven observation/action loop over WebSocket for simulator and robot environments, with a LeRobot-ready agent harness and trace playback with action-chunk markers. See the [Robots reference](/v6/reference/robots) and the [robot benchmark cookbook](/v6/cookbooks/robot-benchmark).
+Yes, in **beta**: the `openpi/0` capability is a schema-driven observation/action loop over WebSocket for simulator and robot environments, with a LeRobot-ready agent harness and trace playback with action-chunk markers. See the [Robots reference](/v6/reference/robots) and the [robot benchmark cookbook](/v6/cookbooks/robot-benchmark).
 </Accordion>
 
 <Accordion title="I'm upgrading from v5 — what changed?">

--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -86,7 +86,7 @@ class MyAgent(Agent):
 
 `BrowserUseAgent` (in `hud.agents.browser_use`, config `BrowserUseConfig`) is this pattern wrapping `browser-use` on the `cdp` capability.
 
-`RobotAgent` (in `hud.agents.robot`, beta — the `robot` extra) is the non-LLM version of the same pattern: it opens the `robot/0.1` capability and runs an observe → infer → act loop, with your policy plugged in through `Model`/`Adapter` seams. See [Robots](/v6/reference/robots).
+`RobotAgent` (in `hud.agents.robot`, beta — the `robot` extra) is the non-LLM version of the same pattern: it opens the `openpi/0` capability and runs an observe → infer → act loop, with your policy plugged in through `Model`/`Adapter` seams. See [Robots](/v6/reference/robots).
 
 ## See also
 

--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -12,7 +12,7 @@ A **capability** is a connection the environment exposes; a harness attaches its
 | `mcp`  | `mcp/2025-11-25` | Your own tools over the Model Context Protocol | `fastmcp` |
 | `cdp`  | `cdp/1.3` | Browser control over the Chrome DevTools Protocol | Chromium (`playwright`) |
 | `rfb`  | `rfb/3.8` | Full computer-use over VNC: screen + keyboard/mouse | `Xvfb` + `x11vnc` |
-| `robot` | `robot/0.1` | Schema-driven robot observation/action loop over WebSocket *(beta)* | robot bridge |
+| `robot` | `openpi/0` | Schema-driven robot observation/action loop over WebSocket *(beta)* | robot bridge |
 
 ```python
 from hud.capabilities import Capability
@@ -221,7 +221,7 @@ async def _down():
 Capability.robot(*, name="robot", url, contract)
 ```
 
-The `robot/0.1` control loop *(beta)*. `contract` is the environment's full self-describing schema — `robot_type`, `control_rate`, and every observation/action feature — carried in the manifest params so the agent wires itself with no shared config. The serving bridge binds an ephemeral loopback port, so publish this from an `@env.initialize` hook after `await bridge.start()`:
+The `openpi/0` control loop *(beta)*. This is an **openpi-like** protocol: it reuses openpi's wire format (msgpack with transparent, recursive numpy serialization) and its flat observation/action naming schema (`observation/...` keys, `actions`), so an openpi policy server and a HUD env speak the same bytes. It differs fundamentally in **role assignment** — in openpi a policy *server* answers inference requests; here the **environment is the server** (it owns the world and pushes observations) and the **agent is the client** (it acts in the world, replying with actions). `contract` is the environment's full self-describing schema — `robot_type`, `control_rate`, and every observation/action feature — carried in the manifest params so the agent wires itself with no shared config. The serving bridge binds an ephemeral loopback port, so publish this from an `@env.initialize` hook after `await bridge.start()`:
 
 ```python
 @env.initialize
@@ -274,7 +274,7 @@ A harness opens a capability to get a live client. The capability clients live i
 | `MCPClient` | `mcp/2025-11-25` |
 | `CDPClient` | `cdp/1.3` |
 | `RFBClient` | `rfb/3.8` |
-| `RobotClient` | `robot/0.1` — joins the registry on first open (the `robot` extra: numpy/msgpack) |
+| `RobotClient` | `openpi/0` — joins the registry on first open (the `robot` extra: numpy/openpi-client) |
 
 The bundled provider agents open these automatically based on which capabilities the manifest advertises (see [Agents](/v6/reference/agents)). To write your own harness, attach to the capability you need and define your tool spec.
 

--- a/docs/v6/reference/robots.mdx
+++ b/docs/v6/reference/robots.mdx
@@ -6,12 +6,12 @@ tag: "Beta"
 ---
 
 <Note>
-The `robot` capability is in **beta**. The wire protocol is versioned `robot/0.1`; the contract schema is v0. Expect additive changes while the design settles.
+The `robot` capability is in **beta**. The wire protocol is versioned `openpi/0`; the contract schema is v0. Expect additive changes while the design settles.
 </Note>
 
-HUD runs robot environments the same way it runs everything else — an environment declares tasks and capabilities, an agent drives a live `Run` — but a policy at 10 Hz can't ride discrete tool calls. The `robot` capability is a **schema-driven observation/action loop over WebSocket** (msgpack + raw arrays): the environment owns the simulator and serves frames; the agent runs the policy and streams actions back.
+HUD runs robot environments the same way it runs everything else — an environment declares tasks and capabilities, an agent drives a live `Run` — but a policy at 10 Hz can't ride discrete tool calls. The `robot` capability is a **schema-driven observation/action loop over WebSocket**. It is **openpi-like** — it reuses openpi's wire format (msgpack with transparent, recursive numpy serialization) and flat observation/action naming (`observation/...` keys, `actions`) — but flips the roles: the **environment is the server** (owns the simulator, serves frames) and the **agent is the client** (runs the policy, streams actions back). On connect the env sends a metadata frame, then pushes observations; failures surface as a string traceback frame rather than a silent close.
 
-Everything below ships behind the `robot` extra (`pip install hud-python[robot]` — numpy + msgpack).
+Everything below ships behind the `robot` extra (`pip install hud-python[robot]` — numpy + openpi-client).
 
 ## Overview
 
@@ -152,7 +152,7 @@ Zero-config: with HUD telemetry configured, `RobotAgent` streams one span per st
 
 | Symbol | Where | Role |
 |--------|-------|------|
-| `RobotEndpoint.capability(contract=...)` | `hud.environment.robot` | Build the `robot/0.1` capability after `start()` |
+| `RobotEndpoint.capability(contract=...)` | `hud.environment.robot` | Build the `openpi/0` capability after `start()` |
 | `Capability.robot(name, url, contract)` | `hud.capabilities` | Lower-level constructor (usually via `endpoint.capability`) |
 | `RobotClient` | `hud.capabilities.robot` | Agent-side wire client (`spaces`, `get_observation`, `send_action`, `send_chunk`) |
 | `RobotBridge` | `hud.environment.robot` | Env-side serve loop; subclass with your sim |

--- a/hud/agents/robot/agent.py
+++ b/hud/agents/robot/agent.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from .adapter import Adapter
     from .model import Model
 
-ROBOT_PROTOCOL = "robot/0.1"
+ROBOT_PROTOCOL = "openpi/0"
 
 
 class RobotAgent(Agent):
@@ -46,7 +46,7 @@ class RobotAgent(Agent):
 
     **Override if needed:**
 
-    - :attr:`robot_protocol` — class attr if not ``robot/0.1``
+    - :attr:`robot_protocol` — class attr if not ``openpi/0``
     - :meth:`on_episode_start` — mostly internal; override (with ``super()``) to
       add per-episode setup (e.g. reading the env contract).
     - :meth:`should_stop` — custom early-exit condition beyond ``obs["terminated"]``

--- a/hud/capabilities/base.py
+++ b/hud/capabilities/base.py
@@ -173,18 +173,20 @@ class Capability:
         url: str,
         contract: dict[str, Any],
     ) -> Capability:
-        """``robot/0.1`` — schema-driven action/observation loop over WebSocket.
+        """``openpi/0`` — schema-driven action/observation loop over WebSocket.
 
-        ``contract`` is the env's full self-describing config: ``robot_type``,
-        ``control_rate``, and a ``features`` map where each feature declares its
-        ``role`` (``"action"`` / ``"observation"``), layout (``dtype`` / ``shape``
-        / ``names``) and normalization ``stats``. It round-trips verbatim through
-        the manifest, so the agent gets everything it needs to wire a policy
-        without a shared config file. ``RobotClient.spaces()`` splits the
+        openpi-like: reuses openpi's msgpack-numpy wire format and flat obs/action
+        naming, but the env is the server and the agent is the client (see
+        :mod:`hud.capabilities.robot`). ``contract`` is the env's full self-describing
+        config: ``robot_type``, ``control_rate``, and a ``features`` map where each
+        feature declares its ``role`` (``"action"`` / ``"observation"``), layout
+        (``dtype`` / ``shape`` / ``names``) and normalization ``stats``. It round-trips
+        verbatim through the manifest, so the agent gets everything it needs to wire a
+        policy without a shared config file. ``RobotClient.spaces()`` splits the
         contract's features into action/observation spaces by ``role``.
         """
         normalized = normalize_url(url, default_scheme="ws", default_port=9091)
-        return cls(name=name, protocol="robot/0.1", url=normalized, params={"contract": contract})
+        return cls(name=name, protocol="openpi/0", url=normalized, params={"contract": contract})
 
 
 class CapabilityClient(ABC):

--- a/hud/capabilities/robot.py
+++ b/hud/capabilities/robot.py
@@ -1,8 +1,10 @@
-"""The ``robot`` protocol: wire codec + the agent-side client.
+"""The ``openpi/0`` protocol: wire codec + the agent-side client.
 
-This module defines the ``robot`` wire format (msgpack + raw numpy array buffers) and
-:class:`RobotClient`, the agent-side capability client that dials a robot env and exchanges
-observations/actions over it.
+``openpi/0`` is openpi-like — it reuses openpi's msgpack-numpy wire format and flat
+observation/action naming — but flips the roles: here the *env* is the WebSocket
+server (it owns the world) and the *agent* is the client (it acts in the world).
+:class:`RobotClient` is that agent-side client; it dials a robot env and exchanges
+observations/actions over the socket.
 
 The *env-side* counterpart — the server bridge that owns the simulator
 (:class:`~hud.environment.robot.bridge.RobotBridge`) — lives in
@@ -18,43 +20,31 @@ from typing import Any, ClassVar, Self
 import numpy as np
 import websockets
 import websockets.exceptions
+from openpi_client import msgpack_numpy
 
 from .base import Capability, CapabilityClient
 
-# ─── wire codec (msgpack + raw array buffers, no base64) ─────────────────────
-
-
-def _encode_array(arr: Any) -> dict[str, Any]:
-    a = np.ascontiguousarray(arr)
-    return {"shape": list(a.shape), "dtype": str(a.dtype), "data": a.tobytes()}
-
-
-def _decode_array(d: dict[str, Any]) -> np.ndarray:
-    return np.frombuffer(d["data"], dtype=np.dtype(d["dtype"])).reshape(d["shape"]).copy()
-
-
-def _packb(obj: Any) -> bytes:
-    import msgpack
-
-    return msgpack.packb(obj, use_bin_type=True)
-
-
-def _unpackb(data: bytes) -> Any:
-    import msgpack
-
-    return msgpack.unpackb(data, raw=False)
+# ─── wire codec ──────────────────────────────────────────────────────────────
+# openpi's msgpack-numpy codec: numpy arrays nested anywhere in a message serialize
+# transparently and recursively, so neither end wraps obs/action fields by hand.
+_packb = msgpack_numpy.packb
+_unpackb = msgpack_numpy.unpackb
 
 
 # ─── agent-side client ───────────────────────────────────────────────────────
 
 
 class RobotClient(CapabilityClient):
-    """Live ``robot`` connection: send actions, receive observations."""
+    """Live ``openpi/0`` connection: send actions, receive observations."""
 
-    protocol: ClassVar[str] = "robot"
+    protocol: ClassVar[str] = "openpi"
 
-    def __init__(self, capability: Capability, ws: Any) -> None:
+    def __init__(
+        self, capability: Capability, ws: Any, metadata: dict[str, Any] | None = None
+    ) -> None:
         self.capability = capability
+        #: The env's connect-time metadata frame (first frame on the socket).
+        self.server_metadata: dict[str, Any] = dict(metadata or {})
         self._ws = ws
         self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=1)
         self._mailman = asyncio.create_task(self._recv_loop())
@@ -80,41 +70,37 @@ class RobotClient(CapabilityClient):
     @classmethod
     async def connect(cls, cap: Capability) -> Self:
         ws = await websockets.connect(cap.url, max_size=None)
-        return cls(cap, ws)
+        metadata = _unpackb(await ws.recv())  # env sends a metadata frame on connect
+        return cls(cap, ws, metadata)
 
     async def get_observation(self) -> dict[str, Any]:
         """Await the latest observation: ``{"data": {name: ndarray}, "terminated": bool}``.
 
-        Realtime (free-running) bridges also attach a ``"meta"`` block carrying the
-        realtime control state used for async/RTC inference::
+        On the wire the env sends an openpi-style *flat* dict (``{name: ndarray, ...}``)
+        with ``terminated`` (and, for realtime bridges, ``meta``) as sibling keys; we
+        regroup the array fields under ``"data"`` for the agent harness. Arrays — nested
+        anywhere, including inside ``meta`` (e.g. ``unexecuted_chunk``) — are already
+        decoded by the codec.
 
-            {
-                "obs_index": int,  # episode control-tick counter at emit time
-                "queue_remaining": int,  # actions still buffered env-side
-                "delay": int,  # env's conservative inference-delay estimate (ticks)
-                "unexecuted_chunk": ndarray | None,
-            }  # [T, A] not-yet-executed tail (executable space); RTC prefix source
+        Realtime (free-running) bridges attach a ``"meta"`` block carrying the realtime
+        control state used for async/RTC inference (``obs_index``, ``queue_remaining``,
+        ``delay``, ``unexecuted_chunk``); sync bridges omit it.
 
-        Legacy sync bridges omit ``"meta"`` entirely, so it is only present when the
-        env is realtime.
+        Raises if the env reported an error (a string traceback frame).
         """
         msg = await self._queue.get()
-        data = {name: _decode_array(d) for name, d in msg["data"].items()}
-        out: dict[str, Any] = {"data": data, "terminated": bool(msg.get("terminated", False))}
-        meta = msg.get("meta")
+        if "error" in msg:
+            raise RuntimeError(f"robot env error:\n{msg['error']}")
+        terminated = bool(msg.pop("terminated", False))
+        meta = msg.pop("meta", None)
+        out: dict[str, Any] = {"data": msg, "terminated": terminated}
         if meta is not None:
-            decoded = dict(meta)
-            unexecuted_chunk = meta.get("unexecuted_chunk")
-            decoded["unexecuted_chunk"] = (
-                _decode_array(unexecuted_chunk) if unexecuted_chunk is not None else None
-            )
-            out["meta"] = decoded
+            out["meta"] = meta
         return out
 
     async def send_action(self, action: Any) -> None:
-        """Encode the action and send it (legacy single-action sync path)."""
-        arr = np.asarray(action, dtype=np.float32)
-        await self._ws.send(_packb({"data": _encode_array(arr)}))
+        """Send a single action under the openpi ``"actions"`` key (sync path)."""
+        await self._ws.send(_packb({"actions": np.asarray(action, dtype=np.float32)}))
 
     async def send_chunk(
         self, chunk: Any, *, obs_index: int | None = None, delay_used: int | None = None
@@ -125,8 +111,7 @@ class RobotClient(CapabilityClient):
         can measure the real inference delay (ticks consumed in flight); ``delay_used``
         is the delay the agent conditioned on (informational).
         """
-        arr = np.asarray(chunk, dtype=np.float32)
-        msg: dict[str, Any] = {"chunk": _encode_array(arr)}
+        msg: dict[str, Any] = {"actions": np.asarray(chunk, dtype=np.float32)}
         if obs_index is not None:
             msg["obs_index"] = int(obs_index)
         if delay_used is not None:
@@ -143,9 +128,11 @@ class RobotClient(CapabilityClient):
     async def _recv_loop(self) -> None:
         try:
             async for raw in self._ws:
+                # A string frame is the env's error convention (a traceback), not an obs.
+                msg = {"error": raw} if isinstance(raw, str) else _unpackb(raw)
                 if self._queue.full():
                     self._queue.get_nowait()
-                await self._queue.put(_unpackb(raw))
+                await self._queue.put(msg)
         except websockets.exceptions.ConnectionClosed:
             pass
         except asyncio.CancelledError:

--- a/hud/capabilities/robot.py
+++ b/hud/capabilities/robot.py
@@ -39,12 +39,8 @@ class RobotClient(CapabilityClient):
 
     protocol: ClassVar[str] = "openpi"
 
-    def __init__(
-        self, capability: Capability, ws: Any, metadata: dict[str, Any] | None = None
-    ) -> None:
+    def __init__(self, capability: Capability, ws: Any) -> None:
         self.capability = capability
-        #: The env's connect-time metadata frame (first frame on the socket).
-        self.server_metadata: dict[str, Any] = dict(metadata or {})
         self._ws = ws
         self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=1)
         self._mailman = asyncio.create_task(self._recv_loop())
@@ -70,8 +66,11 @@ class RobotClient(CapabilityClient):
     @classmethod
     async def connect(cls, cap: Capability) -> Self:
         ws = await websockets.connect(cap.url, max_size=None)
-        metadata = _unpackb(await ws.recv())  # env sends a metadata frame on connect
-        return cls(cap, ws, metadata)
+        # Consume the connect-time metadata frame (always first); a string frame is the env's error convention.
+        raw = await ws.recv()
+        if isinstance(raw, str):
+            raise RuntimeError(f"robot env error on connect:\n{raw}")
+        return cls(cap, ws)
 
     async def get_observation(self) -> dict[str, Any]:
         """Await the latest observation: ``{"data": {name: ndarray}, "terminated": bool}``.

--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -244,8 +244,8 @@ class HudClient:
         cap_client = self._opened.get(cap.name)
         if cap_client is None:
             client_cls = _CLIENT_REGISTRY.get(cap.protocol)
-            if client_cls is None and cap.protocol.split("/", 1)[0] == "robot":
-                # RobotClient pulls optional deps (numpy/msgpack — the ``robot``
+            if client_cls is None and cap.protocol.split("/", 1)[0] == "openpi":
+                # RobotClient pulls optional deps (numpy/openpi-client — the ``robot``
                 # extra), so it joins the registry on first open, not at import.
                 from hud.capabilities.robot import RobotClient
 

--- a/hud/environment/robot/__init__.py
+++ b/hud/environment/robot/__init__.py
@@ -5,8 +5,8 @@ an agent over the ``robot`` WebSocket protocol:
 
 - :class:`~hud.environment.robot.bridge.RobotBridge` — the server-side (synchronous)
   bridge: one sim step per received action.
-- :class:`~hud.environment.robot.sim_runner.SimRunner` (``Inline`` / ``Thread``) — the
-  strategy for *which thread* runs the thread-affine simulator.
+- :class:`~hud.environment.robot.sim_runner.SimRunner` (``Inline`` / ``Thread`` /
+  ``MainThread``) — the strategy for *which thread* runs the thread-affine simulator.
 
 The agent-side counterpart, :class:`~hud.capabilities.robot.RobotClient`, lives under
 :mod:`hud.capabilities` (it is a capability *client*, dialed by the agent); these two ends
@@ -17,10 +17,11 @@ from __future__ import annotations
 
 from .bridge import RobotBridge
 from .endpoint import RobotEndpoint
-from .sim_runner import InlineSimRunner, SimRunner, ThreadSimRunner
+from .sim_runner import InlineSimRunner, MainThreadSimRunner, SimRunner, ThreadSimRunner
 
 __all__ = [
     "InlineSimRunner",
+    "MainThreadSimRunner",
     "RobotBridge",
     "RobotEndpoint",
     "SimRunner",

--- a/hud/environment/robot/bridge.py
+++ b/hud/environment/robot/bridge.py
@@ -18,9 +18,9 @@ from typing import TYPE_CHECKING, Any
 import websockets
 import websockets.exceptions
 
-# The robot wire codec is defined alongside the agent-side client; reuse it so both
+# The openpi/0 wire codec is defined alongside the agent-side client; reuse it so both
 # ends of the protocol stay in lockstep (env -> capabilities is the correct direction).
-from hud.capabilities.robot import _decode_array, _encode_array, _packb, _unpackb
+from hud.capabilities.robot import _packb, _unpackb
 
 from .sim_runner import InlineSimRunner, SimRunner
 
@@ -59,6 +59,8 @@ class RobotBridge(ABC):
         self._port = port
         self._client: Any = None  # robot serves a single agent at a time
         self._server: Any = None
+        # Connect-time metadata frame (sent first on each connection); subclasses may set it.
+        self.metadata: dict[str, Any] = {}
         # Which thread runs the (thread-affine) sim. Default InlineSimRunner (loop
         # thread); inject a ThreadSimRunner (or custom) when render-heavy or thread-bound.
         self._sim_runner: SimRunner = sim_runner or InlineSimRunner()
@@ -138,13 +140,21 @@ class RobotBridge(ABC):
         # A later connection replaces the previous one (only one agent at a time).
         self._client = ws
         try:
+            await ws.send(_packb(self.metadata))  # connect-time metadata frame
             await self._send_observation()  # current obs on connect (if ready)
             async for raw in ws:
-                action = _decode_array(_unpackb(raw)["data"])
+                action = _unpackb(raw)["actions"]  # codec already returns an ndarray
                 await self._sim_runner.call(self.step, action)  # on the sim thread
                 await self._send_observation()
         except websockets.exceptions.ConnectionClosed:
             pass
+        except Exception:
+            # Surface failures as a string frame (a traceback) instead of a silent close.
+            import traceback
+
+            with contextlib.suppress(Exception):
+                await ws.send(traceback.format_exc())
+            raise
         finally:
             if self._client is ws:
                 self._client = None
@@ -157,10 +167,8 @@ class RobotBridge(ABC):
         if out is None:
             return
         data, terminated = out
-        msg = {
-            "terminated": bool(terminated),
-            "data": {name: _encode_array(arr) for name, arr in data.items()},
-        }
+        # openpi-style flat obs dict: array fields at the top level, terminated alongside.
+        msg = {**data, "terminated": bool(terminated)}
         with contextlib.suppress(websockets.exceptions.ConnectionClosed):
             await self._client.send(_packb(msg))
 

--- a/hud/environment/robot/sim_runner.py
+++ b/hud/environment/robot/sim_runner.py
@@ -1,21 +1,28 @@
 """Sim execution strategies: *which thread* runs the (thread-affine) simulator.
 
-A sim (MuJoCo/EGL, a hardware SDK) is usually thread-affine — every touch must run
-on the thread that created it — but the bridge's asyncio loop can't be stalled by a
+A sim (MuJoCo/EGL, Isaac, a hardware SDK) is usually thread-affine — every touch must
+run on the thread that created it — but the bridge's asyncio loop can't be stalled by a
 blocking step. A :class:`SimRunner` hides that choice behind one :meth:`~SimRunner.call`
 verb:
 
 - :class:`InlineSimRunner` — runs on the loop thread. Default; for cheap/CPU sims + tests.
 - :class:`ThreadSimRunner` — sim on a dedicated worker thread, loop kept free. For
   heavy/blocking sims; used by the realtime bridges.
+- :class:`MainThreadSimRunner` — sim on the main thread, for runtimes that own *both* the
+  main thread and the asyncio loop themselves (Isaac/Omniverse: ``omni.kit.async_engine``
+  drives one main-thread loop, and ``env.reset()`` internally calls ``run_until_complete``
+  for USD loading — which must not nest inside a running task). HUD's servers run on that
+  same loop; the owner's pump loop calls :meth:`~MainThreadSimRunner.drain` to run queued
+  sim touches on the main thread *outside* any task.
 """
 
 from __future__ import annotations
 
 import asyncio
+import queue
 import threading
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -67,4 +74,38 @@ class ThreadSimRunner(SimRunner):
         self._executor.shutdown(wait=False)
 
 
-__all__ = ["InlineSimRunner", "SimRunner", "ThreadSimRunner"]
+class MainThreadSimRunner(SimRunner):
+    """Sim on the main thread, for runtimes that own both it and the loop (Isaac/Omniverse:
+    Kit drives one main-thread loop and ``env.reset()`` nests ``run_until_complete``, which
+    can't run inside a task). A handler's :meth:`call` queues each sim touch; the owner's
+    pump loop :meth:`drain`\\ s it between ticks so it runs on main, *outside* any task."""
+
+    def __init__(self) -> None:
+        self._q: queue.Queue[tuple[Callable[[], Any], Future]] = queue.Queue()
+        # loop/tasks/drain share one thread, so thread id can't tell "in a task" from "in
+        # drain" — this flag can: a task queues, a sim touch re-entering call() runs inline.
+        self._draining = False
+
+    async def call(self, fn: Callable[..., Any], *args: Any) -> Any:
+        if self._draining:
+            return fn(*args)  # re-entrant from a sim touch — already task-free
+        fut: Future = Future()
+        self._q.put((lambda: fn(*args), fut))
+        return await asyncio.wrap_future(fut)
+
+    def drain(self) -> None:
+        """Run all queued sim touches on main, task-free. Call between the owner's loop ticks."""
+        self._draining = True
+        try:
+            while not self._q.empty():
+                fn, fut = self._q.get_nowait()
+                if fut.set_running_or_notify_cancel():
+                    try:
+                        fut.set_result(fn())
+                    except BaseException as exc:  # propagate to the awaiting caller
+                        fut.set_exception(exc)
+        finally:
+            self._draining = False
+
+
+__all__ = ["InlineSimRunner", "MainThreadSimRunner", "SimRunner", "ThreadSimRunner"]

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hud.utils.platform import PlatformClient
+from hud.telemetry import flush
 
 from .job import Job, job_enter
 from .run import rollout
@@ -268,6 +269,7 @@ class Taskset:
             f", max_concurrent={max_concurrent}" if max_concurrent else "",
         )
         job.runs.extend(await asyncio.gather(*(_one(t, gid) for t, gid in expanded)))
+        await asyncio.to_thread(flush, timeout=90.0)
         return job
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,10 +138,10 @@ browseruse = [
     "browser-use>=0.11.13",
 ]
 
-# Robot capability (robot protocol wire codec + bridges + agent harness)
+# Robot capability (openpi/0 protocol wire codec + bridges + agent harness)
 robot = [
     "numpy>=1.24",
-    "msgpack>=1.0",
+    "openpi-client>=0.1.2",  # openpi msgpack-numpy wire codec (the openpi/0 format)
 ]
 
 


### PR DESCRIPTION
Re-bases the robot capability onto an **openpi-compatible** wire protocol and adds
a sim runner for main-thread-owning runtimes.
- **Protocol `robot/0.1` → `openpi/0`.** Replaces the bespoke msgpack + raw-array
  codec with openpi's `msgpack_numpy` (transparent, recursive numpy serialization),
  and adopts openpi's flat naming — observations as a flat `{name: ndarray}` dict,
  actions under `"actions"`. So an openpi policy server and a HUD env now speak the
  same bytes; the difference is role assignment (here the **env is the server**, the
  **agent is the client**).
- **Connect-time metadata frame.** The bridge sends `self.metadata` as the first
  frame; `RobotClient` exposes it as `server_metadata`.
- **Error convention.** The env surfaces failures as a string traceback frame
  instead of a silent close; the client raises `RuntimeError`.
- **`MainThreadSimRunner`.** New `SimRunner` for runtimes that own both the main
  thread and the asyncio loop (Isaac/Omniverse), draining queued sim touches between
  ticks via `drain()`.
- Dependency: `robot` extra now pulls `openpi-client>=0.1.2` instead of `msgpack`.
- Docs (`faq`, `agents`, `capabilities`, `robots`) updated to the new protocol name
  and openpi-like framing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking wire and manifest protocol change (`robot/0.1` → `openpi/0`) affects all robot env/agent pairings and optional deps; bridge/client behavior changes can break existing integrations until both sides upgrade.
> 
> **Overview**
> Replaces **`robot/0.1`** with **`openpi/0`** for the robot capability: wire encoding now uses **`openpi-client`’s `msgpack_numpy`** instead of custom msgpack + raw array buffers, observations are a **flat** dict on the wire (with `terminated` / optional `meta` as siblings), and actions use the **`"actions"`** key for both single steps and chunks. **`Capability.robot`**, **`RobotAgent`**, and lazy client registration now key off the **`openpi`** protocol family; the **`robot`** extra depends on **`openpi-client>=0.1.2`** instead of **`msgpack`**.
> 
> **`RobotBridge`** sends a **connect-time metadata** frame (`self.metadata`), emits flat observations, reads **`actions`** from inbound messages, and reports failures as **string traceback** frames; **`RobotClient`** consumes metadata on connect, maps string frames to **`RuntimeError`**, and keeps the harness-facing **`{"data": ...}`** shape internally.
> 
> Adds **`MainThreadSimRunner`** (queue + **`drain()`**) for simulators that must run on the main thread (e.g. Isaac/Omniverse). **`Taskset.run`** now **`flush`**es telemetry (90s timeout) after a batch completes. v6 docs are updated to describe the openpi-like protocol and role flip (env server, agent client).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57aceb510501dac90e9fbce59ae0cac071d9e6ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->