### PR TITLE
Resolve registry name from the served Environment, not a source scan

### DIFF
--- a/hud/cli/deploy.py
+++ b/hud/cli/deploy.py
@@ -126,6 +126,46 @@ def _validate_before_deploy(env_source: EnvironmentSource, console: HUDConsole) 
         console.success("Validation passed")
 
 
+def _resolve_declared_name(env_source: EnvironmentSource, console: HUDConsole) -> str | None:
+    """The environment name declared in code, or None for legacy MCP projects.
+
+    Prefers the Environment served by the Dockerfile entrypoint
+    (``hud serve module:attr``), so a project may define auxiliary in-process
+    Environments — e.g. a verification sub-agent — without making the
+    deployable identity ambiguous. Otherwise a lone declared name wins, and the
+    choice is only an error when nothing disambiguates between several names.
+    """
+    served = env_source.served_environment_name()
+    if served is not None:
+        return served
+
+    references = env_source.environment_name_references()
+    if not references:
+        return None
+
+    named = sorted({ref.name for ref in references if ref.name is not None})
+
+    if len(named) > 1:
+        console.error("Multiple Environment names declared in source:")
+        for ref in references:
+            if ref.name is not None:
+                console.error(f"  {ref.file.relative_to(env_source.root)}:{ref.line}: {ref.text}")
+        console.info(
+            "Name the served Environment via the Dockerfile entrypoint "
+            "(e.g. `hud serve env:env`), or declare exactly one name."
+        )
+        raise typer.Exit(1)
+
+    if not named:
+        console.error("Environment(...) is constructed without an explicit name:")
+        for ref in references:
+            console.error(f"  {ref.file.relative_to(env_source.root)}:{ref.line}: {ref.text}")
+        console.info('Give your environment a literal name, e.g. Environment("my-env").')
+        raise typer.Exit(1)
+
+    return named[0]
+
+
 def _resolve_environment_name(
     env_source: EnvironmentSource,
     registry_id: str | None,
@@ -139,37 +179,20 @@ def _resolve_environment_name(
     Projects without an ``Environment(...)`` call (legacy MCP environments)
     fall back to the directory name.
     """
-    references = env_source.environment_name_references()
-    named = sorted({ref.name for ref in references if ref.name is not None})
-
-    if len(named) > 1:
-        console.error("Multiple Environment names declared in source:")
-        for ref in references:
-            if ref.name is not None:
-                console.error(f"  {ref.file.relative_to(env_source.root)}:{ref.line}: {ref.text}")
-        console.info("A deployable environment must declare exactly one name.")
-        raise typer.Exit(1)
-
-    if references and not named:
-        console.error("Environment(...) is constructed without an explicit name:")
-        for ref in references:
-            console.error(f"  {ref.file.relative_to(env_source.root)}:{ref.line}: {ref.text}")
-        console.info('Give your environment a literal name, e.g. Environment("my-env").')
-        raise typer.Exit(1)
-
-    name = named[0] if named else env_source.environment_name()
+    declared = _resolve_declared_name(env_source, console)
+    name = declared if declared is not None else env_source.environment_name()
 
     if registry_id:
         registry_env = get_registry_environment(platform, registry_id)
         if registry_env is not None:
-            if named and normalize_environment_name(name) != registry_env.name:
+            if declared is not None and normalize_environment_name(name) != registry_env.name:
                 console.error(
                     f"Code declares Environment('{name}') but --registry-id targets "
                     f"'{registry_env.name}'. Rename the environment in code or drop "
                     "--registry-id to deploy by name."
                 )
                 raise typer.Exit(1)
-            if not named:
+            if declared is None:
                 name = registry_env.name
 
     console.info(f"Environment name: {name}")

--- a/hud/cli/tests/test_deploy.py
+++ b/hud/cli/tests/test_deploy.py
@@ -46,6 +46,17 @@ class TestResolveEnvironmentName:
         with pytest.raises(typer.Exit):
             self._resolve(tmp_path)
 
+    def test_entrypoint_disambiguates_subagent(self, tmp_path: Path) -> None:
+        (tmp_path / "Dockerfile").write_text(
+            'CMD ["hud", "dev", "env:env", "--port", "8765"]\n', encoding="utf-8"
+        )
+        (tmp_path / "env.py").write_text('env = Environment("trace-explorer")\n', encoding="utf-8")
+        (tmp_path / "verify.py").write_text(
+            'verify_env = Environment("qa-verifier")\n', encoding="utf-8"
+        )
+
+        assert self._resolve(tmp_path) == "trace-explorer"
+
     def test_unnamed_environment_exit(self, tmp_path: Path) -> None:
         (tmp_path / "env.py").write_text("env = Environment()\n", encoding="utf-8")
 

--- a/hud/cli/utils/source.py
+++ b/hud/cli/utils/source.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -148,6 +149,34 @@ class EnvironmentSource:
                     )
                 )
         return references
+
+    def served_environment_module(self) -> str | None:
+        dockerfile = self.dockerfile
+        if dockerfile is None:
+            return None
+        try:
+            content = dockerfile.read_text(encoding="utf-8")
+        except OSError:
+            return None
+
+        for tokens in _dockerfile_command_tokens(content):
+            spec = _hud_serve_spec(tokens)
+            if spec is not None:
+                return spec.partition(":")[0]
+        return None
+
+    def served_environment_name(self) -> str | None:
+        module = self.served_environment_module()
+        if module is None:
+            return None
+
+        served_file = (self.root / module).with_suffix(".py").resolve()
+        names = {
+            ref.name
+            for ref in self.environment_name_references()
+            if ref.file.resolve() == served_file and ref.name is not None
+        }
+        return next(iter(names)) if len(names) == 1 else None
 
     def environment_name(self) -> str:
         """Directory-derived fallback name for projects without ``Environment(...)``."""
@@ -431,6 +460,72 @@ class EnvironmentSource:
             LOGGER.info("Migrated .hud/deploy.json to .hud/config.json")
         except OSError as exc:
             LOGGER.warning("Failed to migrate deploy.json to config.json: %s", exc)
+
+
+def _dockerfile_instructions(content: str) -> list[str]:
+    """Logical Dockerfile instructions, joining ``\\`` line continuations."""
+    instructions: list[str] = []
+    buffer = ""
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.endswith("\\"):
+            buffer += line[:-1].strip() + " "
+            continue
+        buffer += line
+        instructions.append(buffer.strip())
+        buffer = ""
+    if buffer.strip():
+        instructions.append(buffer.strip())
+    return instructions
+
+
+def _command_tokens(remainder: str) -> list[str]:
+    """Tokens of a CMD/ENTRYPOINT body in either exec (JSON) or shell form."""
+    if remainder.startswith("["):
+        try:
+            parsed = json.loads(remainder)
+        except json.JSONDecodeError:
+            return []
+        return [str(token) for token in parsed] if isinstance(parsed, list) else []
+    try:
+        return shlex.split(remainder)
+    except ValueError:
+        return remainder.split()
+
+
+def _dockerfile_command_tokens(content: str) -> list[list[str]]:
+    """Token lists for each CMD/ENTRYPOINT instruction in a Dockerfile."""
+    commands: list[list[str]] = []
+    for instruction in _dockerfile_instructions(content):
+        keyword, _, remainder = instruction.partition(" ")
+        if keyword.upper() not in {"CMD", "ENTRYPOINT"}:
+            continue
+        tokens = _command_tokens(remainder.strip())
+        if tokens:
+            commands.append(tokens)
+    return commands
+
+
+def _hud_serve_spec(tokens: list[str]) -> str | None:
+    """The serve target from a ``hud serve|dev <spec>`` token list.
+
+    Returns the explicit ``module[:attr]`` spec, ``"env"`` when ``hud serve`` is
+    invoked with no target (the runtime default), or ``None`` when the tokens
+    contain no ``hud serve``/``hud dev`` invocation.
+    """
+    for index, token in enumerate(tokens):
+        if Path(token).name != "hud":
+            continue
+        rest = tokens[index + 1 :]
+        if not rest or rest[0] not in {"serve", "dev"}:
+            continue
+        target = rest[1] if len(rest) > 1 else None
+        if target is None or target.startswith("-"):
+            return "env"
+        return target
+    return None
 
 
 def _environment_call_name(node: ast.Call) -> str | None:

--- a/hud/cli/utils/tests/test_source.py
+++ b/hud/cli/utils/tests/test_source.py
@@ -184,6 +184,47 @@ def test_no_references_is_a_pass(tmp_path: Path) -> None:
     assert EnvironmentSource.open(tmp_path).environment_name_references() == []
 
 
+# ─── served environment (Dockerfile entrypoint) ──────────────────────────
+
+
+def test_served_module_parses_exec_form(tmp_path: Path) -> None:
+    _write(tmp_path / "Dockerfile", 'CMD ["hud", "dev", "env:env", "--port", "8765"]\n')
+
+    assert EnvironmentSource.open(tmp_path).served_environment_module() == "env"
+
+
+def test_served_module_parses_shell_form(tmp_path: Path) -> None:
+    _write(tmp_path / "Dockerfile", "CMD hud serve app:app\n")
+
+    assert EnvironmentSource.open(tmp_path).served_environment_module() == "app"
+
+
+def test_served_module_defaults_when_target_omitted(tmp_path: Path) -> None:
+    _write(tmp_path / "Dockerfile", 'CMD ["hud", "serve", "--port", "8765"]\n')
+
+    assert EnvironmentSource.open(tmp_path).served_environment_module() == "env"
+
+
+def test_served_module_none_without_entrypoint(tmp_path: Path) -> None:
+    _write(tmp_path / "Dockerfile", 'CMD ["python", "main.py"]\n')
+
+    assert EnvironmentSource.open(tmp_path).served_environment_module() is None
+
+
+def test_served_name_ignores_in_process_subagent(tmp_path: Path) -> None:
+    _write(tmp_path / "Dockerfile", 'CMD ["hud", "dev", "env:env", "--port", "8765"]\n')
+    _write(tmp_path / "env.py", 'env = Environment(name="trace-explorer")\n')
+    _write(tmp_path / "verify.py", 'verify_env = Environment(name="qa-verifier")\n')
+
+    assert EnvironmentSource.open(tmp_path).served_environment_name() == "trace-explorer"
+
+
+def test_served_name_none_without_dockerfile(tmp_path: Path) -> None:
+    _write(tmp_path / "env.py", 'env = Environment(name="solo")\n')
+
+    assert EnvironmentSource.open(tmp_path).served_environment_name() is None
+
+
 # ─── validation ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Problem

`hud deploy` figured out an environment's name by scanning all `*.py` files for `Environment(...)` calls and erroring if it found more than one. Environments that legitimately define a second in-process `Environment` — e.g. a verification sub-agent run via `run_eval` — could not deploy:

```
✖ Multiple Environment names declared in source:
✖   qa_verification.py: Environment(name="qa-verifier")
✖   env.py: Environment(name="trace-explorer")
A deployable environment must declare exactly one name.
```

The deployable one was never actually ambiguous — the Dockerfile entrypoint (`hud serve env:env`) already says which Environment is served.

## Solution

Resolve the name from the **served** Environment: parse the Dockerfile `hud serve`/`hud dev` entrypoint for its entry module and take that module's sole literal-named `Environment`. Auxiliary in-process Environments are ignored.

Falls back to the previous behavior when there's no such entrypoint (a lone declared name wins; multiple-and-undisambiguated is still an error; none → directory name), so single-Environment projects are unchanged.

## Changes

- `hud/cli/utils/source.py`: `served_environment_module()` / `served_environment_name()`
- `hud/cli/deploy.py`: `_resolve_environment_name()` prefers the served name
- tests for both

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy name resolution changes how multi-Environment projects register on the platform; CI no longer installs Playwright, so browser-dependent tests may not run in CI.
> 
> **Overview**
> **`hud deploy`** no longer treats every `Environment(...)` in the repo as competing registry identities. It first parses the Dockerfile `CMD` for `hud serve` / `hud dev`, takes that entry module, and uses the **single literal name** declared there—so auxiliary in-process environments (e.g. a QA verifier next to the main `env.py`) no longer block deploy. If there is no serve entrypoint, behavior is unchanged: one declared name still wins; several names with no disambiguation still error.
> 
> New helpers live on `EnvironmentSource` (`served_environment_module`, `served_environment_name`); `_resolve_declared_name` in deploy prefers the served name, with tests in `hud/cli/utils/tests/test_source.py` and `hud/cli/tests/test_deploy.py`.
> 
> The same branch also **reshapes docs and examples toward v6**: Mintlify nav splits **v6** (default) vs **v5 (Legacy)** with redirects, adds `migrate-v6.mdx`, `AGENTS.md` / `docs/skill.md`, rewrites the root **README** around the protocol, and moves runnable cookbooks under `cookbooks/` (A2A chat, Codex-style coding). **CI** drops Playwright/Xvfb setup and runs `pytest` without `--rootdir=hud`; the repo **pre-push hook file is removed** (CONTRIBUTING still documents optional `.githooks`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a78c769b94aa3a1e507a81b0144b8e499e87e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->