### PR TITLE
feat(filetracking): workspace file-tracking capability + telemetry

### DIFF
--- a/hud/capabilities/__init__.py
+++ b/hud/capabilities/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from .base import Capability, CapabilityClient
 from .cdp import CDPClient
+from .filetracking import FileTrackingClient
 from .mcp import MCPClient
 from .rfb import RFBClient
 from .ssh import SSHClient
@@ -28,6 +29,7 @@ __all__ = [
     "CDPClient",
     "Capability",
     "CapabilityClient",
+    "FileTrackingClient",
     "MCPClient",
     "RFBClient",
     "RobotClient",

--- a/hud/capabilities/base.py
+++ b/hud/capabilities/base.py
@@ -166,6 +166,23 @@ class Capability:
         return cls(name=name, protocol="mcp/2025-11-25", url=normalized, params=params)
 
     @classmethod
+    def filetracking(
+        cls,
+        *,
+        name: str = "filetracking",
+        url: str,
+    ) -> Capability:
+        """``filetracking/1`` — observation-only workspace diff/snapshot stream.
+
+        A dedicated protocol (not MCP): the env serves diff/snapshot/advance over
+        a small framed-JSON wire, the client pulls and re-emits the results as
+        ``hud.filetracking.v1`` telemetry. Because the protocol is not in any
+        agent's client catalog, ``ToolAgent`` never opens it as a tool.
+        """
+        normalized = normalize_url(url, default_scheme="tcp", default_port=None)
+        return cls(name=name, protocol="filetracking/1", url=normalized, params={})
+
+    @classmethod
     def robot(
         cls,
         *,

--- a/hud/capabilities/filetracking.py
+++ b/hud/capabilities/filetracking.py
@@ -1,0 +1,85 @@
+"""FileTrackingClient — pulls workspace diffs over the ``filetracking/1`` wire.
+
+A tiny framed-JSON request/response client (newline-delimited JSON, one request
+in flight at a time). The matching server lives in
+:mod:`hud.environment.file_tracking`. Kept dependency-free of the environment
+package so importing capabilities never pulls the environment stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+from typing import Any, ClassVar, Self
+from urllib.parse import urlsplit
+
+from .base import Capability, CapabilityClient
+
+
+class FileTrackingClient(CapabilityClient):
+    """Live ``filetracking/1`` connection: ``diff`` / ``snapshot`` / ``advance``."""
+
+    protocol: ClassVar[str] = "filetracking/1"
+
+    def __init__(
+        self,
+        capability: Capability,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        self.capability = capability
+        self._reader = reader
+        self._writer = writer
+        self._id = 0
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    async def connect(cls, cap: Capability) -> Self:
+        parts = urlsplit(cap.url)
+        if parts.hostname is None or parts.port is None:
+            raise ValueError(f"filetracking capability missing host or port: {cap.url!r}")
+        reader, writer = await asyncio.open_connection(parts.hostname, parts.port)
+        return cls(cap, reader, writer)
+
+    async def diff(self) -> dict[str, Any]:
+        """Changes since the previous call (advances the server's baseline)."""
+        return await self._call("diff")
+
+    async def snapshot(self) -> dict[str, Any]:
+        """The current full manifest: ``{files: [{path, size, content_hash}], ...}``."""
+        return await self._call("snapshot")
+
+    async def advance(self) -> None:
+        """Re-baseline without producing a diff (skip setup / post-burst churn)."""
+        await self._call("advance")
+
+    async def close(self) -> None:
+        self._writer.close()
+        with contextlib.suppress(OSError):
+            await self._writer.wait_closed()
+
+    async def _call(self, method: str) -> dict[str, Any]:
+        async with self._lock:
+            self._id += 1
+            msg_id = self._id
+            payload = json.dumps(
+                {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": {}},
+                separators=(",", ":"),
+            )
+            self._writer.write(payload.encode("utf-8") + b"\n")
+            await self._writer.drain()
+            line = await self._reader.readline()
+            if not line:
+                raise ConnectionError(f"filetracking: connection closed during {method!r}")
+            reply: dict[str, Any] = json.loads(line)
+            if "error" in reply:
+                err = reply["error"]
+                raise RuntimeError(f"filetracking {method!r} error: {err.get('message')}")
+            result = reply.get("result")
+            if not isinstance(result, dict):
+                raise RuntimeError(f"filetracking {method!r}: result was not an object")
+            return result
+
+
+__all__ = ["FileTrackingClient"]

--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -21,6 +21,7 @@ from hud.capabilities import (
     Capability,
     CapabilityClient,
     CDPClient,
+    FileTrackingClient,
     MCPClient,
     RFBClient,
     SSHClient,
@@ -36,7 +37,7 @@ LOGGER = logging.getLogger("hud.clients")
 
 #: protocol -> CapabilityClient subclass, for ``HudClient.open``.
 _CLIENT_REGISTRY: dict[str, type[CapabilityClient]] = {
-    cls.protocol: cls for cls in (SSHClient, RFBClient, MCPClient, CDPClient)
+    cls.protocol: cls for cls in (SSHClient, RFBClient, MCPClient, CDPClient, FileTrackingClient)
 }
 
 

--- a/hud/environment/env.py
+++ b/hud/environment/env.py
@@ -279,6 +279,7 @@ class Environment(LegacyEnvMixin):
         root: Path | str,
         *,
         name: str = "shell",
+        track_files: bool | None = None,
         **kwargs: Any,
     ) -> Workspace:
         """Attach a :class:`Workspace` serving ``name`` over ``ssh/2``.
@@ -286,13 +287,23 @@ class Environment(LegacyEnvMixin):
         Registers the start → publish → stop lifecycle on this env's hooks;
         nothing touches the filesystem until the env actually serves. Extra
         kwargs go to :class:`Workspace` (``network=``, ``env=``, ...).
+
+        When ``track_files`` is set (defaulting to ``HUD_FILE_TRACKING_ENABLED``)
+        the workspace also publishes an observation-only ``filetracking/1``
+        capability the rollout streams diffs from.
         """
-        ws = Workspace(root, **kwargs)
+        if track_files is None:
+            from hud.settings import settings
+
+            track_files = settings.file_tracking_enabled
+        ws = Workspace(root, track_files=track_files, **kwargs)
 
         @self.initialize
         async def _up() -> None:
             await ws.start()
             self.add_capability(ws.capability(name))
+            if ws.tracks_files:
+                self.add_capability(ws.file_tracking_capability())
 
         @self.shutdown
         async def _down() -> None:

--- a/hud/environment/file_tracker.py
+++ b/hud/environment/file_tracker.py
@@ -188,7 +188,6 @@ class FileTracker:
 
         self._previous_snapshot: Snapshot | None = None
         self._baseline_snapshot: Snapshot | None = None
-        self._all_diffs: list[dict[str, Any]] = []
 
         self._gitignore_patterns: list[str] = []
         self._gitignore_loaded = False
@@ -247,7 +246,6 @@ class FileTracker:
         self._previous_snapshot = current
 
         if diff.files_changed > 0:
-            self._all_diffs.append(diff.to_dict())
             LOGGER.info(
                 "Snapshot diff: %d files changed (%d scanned) in %.1fms",
                 diff.files_changed,
@@ -267,10 +265,6 @@ class FileTracker:
                 files_changed=0,
             )
         return self._diff(self._baseline_snapshot, self._scan())
-
-    def get_all_diffs(self) -> list[dict[str, Any]]:
-        """All recorded per-snapshot diffs (each in ``DiffResult.to_dict()`` shape)."""
-        return list(self._all_diffs)
 
     def current_manifest(self) -> list[dict[str, Any]]:
         """The latest file manifest: ``[{path, size, content_hash}, ...]``.

--- a/hud/environment/file_tracker.py
+++ b/hud/environment/file_tracker.py
@@ -1,0 +1,574 @@
+"""Filesystem change tracker for a workspace directory.
+
+Snapshots a directory tree and produces unified diffs (patches) between
+snapshots, so a rollout can record exactly what changed on disk over time. The
+tracker is pure computation over a local ``root`` — it does no networking and
+holds no credentials; a serving layer (:mod:`hud.environment.file_tracking`)
+exposes it as a capability and the client side decides what to record.
+
+Ported from the orchestrator sidecar's ``/proc``-scanning tracker, with the
+Kubernetes coupling removed (it scans an injected ``root`` instead of
+``/proc/{pid}/root``) and a non-overridable secrets deny-list added: paths that
+look like credentials are tracked at the metadata tier only — their content is
+never read, hashed-for-fingerprint only, and never emitted as a diff.
+"""
+
+from __future__ import annotations
+
+import difflib
+import fnmatch
+import hashlib
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+LOGGER = logging.getLogger("hud.environment.file_tracker")
+
+#: Noise paths excluded from tracking entirely (build output, caches, VCS internals).
+DEFAULT_EXCLUDE_PATTERNS: tuple[str, ...] = (
+    "node_modules/",
+    ".venv/",
+    "__pycache__/",
+    "*.pyc",
+    ".cache/",
+    ".npm/",
+    ".git/objects/",
+    ".git/logs/",
+    # The Workspace's own SSH credential dir, materialized under root at serve time.
+    ".hud/",
+    "*.so",
+    "*.o",
+    "*.a",
+)
+
+#: Credential-shaped paths tracked at the metadata tier only — content is never
+#: read or emitted, regardless of any capture policy. Not overridable.
+SECRET_DENY_PATTERNS: tuple[str, ...] = (
+    ".env",
+    ".env.*",
+    "*.pem",
+    "id_*",
+    "*_key",
+    "*_key.*",
+    "credentials",
+    "credentials.*",
+    ".netrc",
+    ".git-credentials",
+    ".ssh/",
+    ".aws/",
+)
+
+#: Skip files larger than this during scanning (default 10 MB).
+DEFAULT_MAX_FILE_SIZE: int = 10 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """Snapshot of a single file's state."""
+
+    rel_path: str
+    size: int
+    mtime_ns: int
+    content_hash: str
+    # Cached text content for diffing. None = binary, unreadable, over-budget, or
+    # a redacted secret. Stored as a tuple so unchanged files share it across
+    # snapshots without re-reading.
+    lines: tuple[str, ...] | None = None
+    # A credential-shaped path: tracked for change detection, never for content.
+    redacted: bool = False
+
+
+@dataclass
+class ScanBudget:
+    """Per-scan counter of new file-content bytes read into memory.
+
+    Threaded through the recursive walk so each ``_scan()`` has its own counter
+    (thread-safe when scans run concurrently via ``run_in_executor``).
+    """
+
+    bytes_loaded: int = 0
+
+
+@dataclass
+class Snapshot:
+    """A point-in-time snapshot of the tracked filesystem."""
+
+    timestamp: float
+    files: dict[str, FileEntry] = field(default_factory=dict)
+    scan_duration_ms: float = 0.0
+
+
+@dataclass
+class PatchEntry:
+    """A single file's diff between two snapshots."""
+
+    rel_path: str
+    status: str  # "added", "modified", "deleted"
+    patch: str  # unified diff text (placeholder for binary/redacted/over-limit)
+    size_before: int = 0
+    size_after: int = 0
+
+
+@dataclass
+class DiffResult:
+    """Result of diffing two snapshots."""
+
+    patches: list[PatchEntry]
+    snapshot_timestamp: float
+    scan_duration_ms: float
+    files_scanned: int
+    files_changed: int
+    truncated: bool = False  # True if the diff payload was capped by _MAX_DIFF_BYTES
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSON transport (the filetracking/1 wire shape)."""
+        result: dict[str, Any] = {
+            "snapshot_timestamp": self.snapshot_timestamp,
+            "scan_duration_ms": round(self.scan_duration_ms, 2),
+            "files_scanned": self.files_scanned,
+            "files_changed": self.files_changed,
+            "patches": [
+                {
+                    "path": p.rel_path,
+                    "status": p.status,
+                    "patch": p.patch,
+                    "size_before": p.size_before,
+                    "size_after": p.size_after,
+                }
+                for p in self.patches
+            ],
+        }
+        if self.truncated:
+            result["truncated"] = True
+        return result
+
+
+class FileTracker:
+    """Tracks file changes under a directory ``root`` via snapshot diffing.
+
+    Usage::
+
+        tracker = FileTracker("/workspace")
+        tracker.take_baseline()  # at session start
+        diff = tracker.take_snapshot()  # later — diff since the last snapshot
+    """
+
+    # Maximum bytes of NEW file content to read into memory per scan. Unchanged
+    # files reuse the previous snapshot's cached lines (zero cost). Once
+    # exhausted, new/modified files are still recorded (hash + metadata) with
+    # ``lines=None`` so they show as changed with a placeholder rather than a
+    # full diff. 50 MB raw is ~100 MB in Python text objects.
+    _MAX_SCAN_CONTENT_BYTES: int = 50 * 1024 * 1024
+
+    # Hard cap on total serialized diff payload. Patches that would push the
+    # cumulative total past this are skipped (smaller ones still pack in).
+    _MAX_DIFF_BYTES: int = 50 * 1024 * 1024
+
+    # Per-file size cap for diff generation. Larger files get a placeholder
+    # instead of a full unified diff, so ``difflib`` never allocates unbounded.
+    _MAX_DIFF_FILE_BYTES: int = 1 * 1024 * 1024
+
+    def __init__(
+        self,
+        root: Path | str,
+        *,
+        exclude_patterns: tuple[str, ...] = DEFAULT_EXCLUDE_PATTERNS,
+        honor_gitignore: bool = True,
+        max_file_size: int = DEFAULT_MAX_FILE_SIZE,
+        secret_deny_patterns: tuple[str, ...] = SECRET_DENY_PATTERNS,
+    ) -> None:
+        self._root = Path(root).resolve()
+        self._exclude_patterns = exclude_patterns
+        self._secret_deny_patterns = secret_deny_patterns
+        self._honor_gitignore = honor_gitignore
+        self._max_file_size = max_file_size
+
+        self._previous_snapshot: Snapshot | None = None
+        self._baseline_snapshot: Snapshot | None = None
+        self._all_diffs: list[dict[str, Any]] = []
+
+        self._gitignore_patterns: list[str] = []
+        self._gitignore_loaded = False
+
+        LOGGER.info(
+            "FileTracker initialized: root=%s, excludes=%d, max_size=%dMB",
+            self._root,
+            len(self._exclude_patterns),
+            self._max_file_size // (1024 * 1024),
+        )
+
+    # ─── public API ───────────────────────────────────────────────────
+
+    def take_baseline(self) -> Snapshot:
+        """Take the initial baseline snapshot. Call once at session start."""
+        snapshot = self._scan()
+        self._baseline_snapshot = snapshot
+        self._previous_snapshot = snapshot
+        LOGGER.info(
+            "Baseline snapshot: %d files in %.1fms",
+            len(snapshot.files),
+            snapshot.scan_duration_ms,
+        )
+        return snapshot
+
+    def advance_baseline(self) -> None:
+        """Re-scan and update the previous snapshot WITHOUT producing a diff.
+
+        Used after scenario setup (which writes many files that are not agent
+        edits) and after a truncated diff (a ``git checkout`` / ``npm install``
+        burst) so the next snapshot starts clean.
+        """
+        prev_count = len(self._previous_snapshot.files) if self._previous_snapshot else 0
+        snapshot = self._scan()
+        self._previous_snapshot = snapshot
+        if len(snapshot.files) != prev_count:
+            LOGGER.info(
+                "file diff baseline advanced: %d files (was %d)", len(snapshot.files), prev_count
+            )
+
+    def take_snapshot(self) -> DiffResult:
+        """Scan and diff against the previous snapshot, then advance the baseline."""
+        if self._previous_snapshot is None:
+            LOGGER.warning("No baseline snapshot; taking one now")
+            baseline = self.take_baseline()
+            return DiffResult(
+                patches=[],
+                snapshot_timestamp=baseline.timestamp,
+                scan_duration_ms=baseline.scan_duration_ms,
+                files_scanned=len(baseline.files),
+                files_changed=0,
+            )
+
+        current = self._scan()
+        diff = self._diff(self._previous_snapshot, current)
+        self._previous_snapshot = current
+
+        if diff.files_changed > 0:
+            self._all_diffs.append(diff.to_dict())
+            LOGGER.info(
+                "Snapshot diff: %d files changed (%d scanned) in %.1fms",
+                diff.files_changed,
+                diff.files_scanned,
+                diff.scan_duration_ms,
+            )
+        return diff
+
+    def get_cumulative_diff(self) -> DiffResult:
+        """Diff from the baseline to the current state (a final summary)."""
+        if self._baseline_snapshot is None:
+            return DiffResult(
+                patches=[],
+                snapshot_timestamp=time.time(),
+                scan_duration_ms=0.0,
+                files_scanned=0,
+                files_changed=0,
+            )
+        return self._diff(self._baseline_snapshot, self._scan())
+
+    def get_all_diffs(self) -> list[dict[str, Any]]:
+        """All recorded per-snapshot diffs (each in ``DiffResult.to_dict()`` shape)."""
+        return list(self._all_diffs)
+
+    def current_manifest(self) -> list[dict[str, Any]]:
+        """The latest file manifest: ``[{path, size, content_hash}, ...]``.
+
+        The full-state anchor a ``snapshot`` request returns — paths + hashes,
+        never content (so it is safe regardless of capture policy).
+        """
+        snapshot = self._previous_snapshot or self._baseline_snapshot
+        if snapshot is None:
+            return []
+        return [
+            {"path": e.rel_path, "size": e.size, "content_hash": e.content_hash}
+            for e in sorted(snapshot.files.values(), key=lambda e: e.rel_path)
+        ]
+
+    # ─── scanning ─────────────────────────────────────────────────────
+
+    def _scan(self) -> Snapshot:
+        start = time.monotonic()
+        files: dict[str, FileEntry] = {}
+        budget = ScanBudget()
+
+        if self._honor_gitignore and not self._gitignore_loaded:
+            self._gitignore_patterns = self._collect_gitignore_patterns()
+            self._gitignore_loaded = True
+
+        if self._root.is_dir():
+            self._walk_directory(str(self._root), files, budget)
+
+        return Snapshot(
+            timestamp=time.time(),
+            files=files,
+            scan_duration_ms=(time.monotonic() - start) * 1000,
+        )
+
+    def _walk_directory(
+        self, abs_dir: str, files: dict[str, FileEntry], budget: ScanBudget
+    ) -> None:
+        try:
+            scanner = os.scandir(abs_dir)
+        except (PermissionError, OSError) as exc:
+            LOGGER.debug("Cannot scan %s: %s", abs_dir, exc)
+            return
+
+        root_str = str(self._root)
+        with scanner:
+            for entry in scanner:
+                try:
+                    # Path relative to root, posix-style, no leading slash.
+                    rel = os.path.relpath(entry.path, root_str).replace(os.sep, "/")
+                    is_dir = entry.is_dir(follow_symlinks=False)
+
+                    if self._should_exclude(rel, is_dir):
+                        continue
+
+                    if is_dir:
+                        self._walk_directory(entry.path, files, budget)
+                        continue
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+
+                    try:
+                        stat = entry.stat(follow_symlinks=False)
+                    except (PermissionError, OSError):
+                        continue
+                    if stat.st_size > self._max_file_size:
+                        continue
+
+                    files[rel] = self._build_entry(entry.path, rel, stat, budget)
+                except (PermissionError, OSError, ValueError):
+                    continue
+
+    def _build_entry(
+        self, abs_path: str, rel: str, stat: os.stat_result, budget: ScanBudget
+    ) -> FileEntry:
+        """Build a ``FileEntry``, reusing cached content when unchanged."""
+        prev = self._previous_snapshot.files.get(rel) if self._previous_snapshot else None
+        if prev is not None and prev.mtime_ns == stat.st_mtime_ns and prev.size == stat.st_size:
+            # Unchanged — reuse cached hash + lines (no allocation).
+            return FileEntry(
+                rel_path=rel,
+                size=stat.st_size,
+                mtime_ns=stat.st_mtime_ns,
+                content_hash=prev.content_hash,
+                lines=prev.lines,
+                redacted=prev.redacted,
+            )
+
+        if self._is_secret(rel):
+            # Credential-shaped: detect change via fingerprint, never read content.
+            return FileEntry(
+                rel_path=rel,
+                size=stat.st_size,
+                mtime_ns=stat.st_mtime_ns,
+                content_hash=f"redacted:{stat.st_size}:{stat.st_mtime_ns}",
+                lines=None,
+                redacted=True,
+            )
+        if stat.st_size > self._MAX_DIFF_FILE_BYTES:
+            content_hash = f"overlimit:{stat.st_size}:{stat.st_mtime_ns}"
+            lines = None
+        elif budget.bytes_loaded + stat.st_size > self._MAX_SCAN_CONTENT_BYTES:
+            content_hash = f"budget_exceeded:{stat.st_size}:{stat.st_mtime_ns}"
+            lines = None
+        else:
+            content_hash = self._hash_file(abs_path, stat.st_size)
+            lines = self._read_lines(abs_path)
+            budget.bytes_loaded += stat.st_size
+
+        return FileEntry(
+            rel_path=rel,
+            size=stat.st_size,
+            mtime_ns=stat.st_mtime_ns,
+            content_hash=content_hash,
+            lines=lines,
+        )
+
+    def _should_exclude(self, rel: str, is_dir: bool) -> bool:
+        return self._matches(rel, is_dir, self._exclude_patterns + tuple(self._gitignore_patterns))
+
+    def _is_secret(self, rel: str) -> bool:
+        return self._matches(rel, False, self._secret_deny_patterns)
+
+    @staticmethod
+    def _matches(rel: str, is_dir: bool, patterns: tuple[str, ...]) -> bool:
+        path = f"/{rel}"
+        name = PurePosixPath(path).name
+        for pattern in patterns:
+            if pattern.endswith("/"):
+                dir_name = pattern.rstrip("/")
+                if (is_dir and name == dir_name) or f"/{dir_name}/" in path:
+                    return True
+            elif fnmatch.fnmatch(name, pattern):
+                return True
+        return False
+
+    def _collect_gitignore_patterns(self) -> list[str]:
+        """Read ``.gitignore`` from the root and one level of subdirectories."""
+        patterns: list[str] = []
+        root_gitignore = self._root / ".gitignore"
+        if root_gitignore.is_file():
+            patterns.extend(self._parse_gitignore(root_gitignore))
+        else:
+            try:
+                with os.scandir(self._root) as scanner:
+                    for entry in scanner:
+                        if entry.is_dir(follow_symlinks=False):
+                            sub = Path(entry.path) / ".gitignore"
+                            if sub.is_file():
+                                patterns.extend(self._parse_gitignore(sub))
+            except (PermissionError, OSError):
+                pass
+        if patterns:
+            LOGGER.info("Loaded %d gitignore patterns", len(patterns))
+        return patterns
+
+    @staticmethod
+    def _parse_gitignore(path: Path) -> list[str]:
+        patterns: list[str] = []
+        try:
+            with path.open("r", encoding="utf-8", errors="replace") as f:
+                for raw in f:
+                    line = raw.strip()
+                    # Skip comments, blanks, and negations (unsupported).
+                    if not line or line.startswith(("#", "!")):
+                        continue
+                    patterns.append(line.lstrip("/"))
+        except (PermissionError, OSError) as exc:
+            LOGGER.debug("Cannot read gitignore %s: %s", path, exc)
+        return patterns
+
+    @staticmethod
+    def _read_lines(path: str) -> tuple[str, ...] | None:
+        """Read a file as text lines; None if binary/unreadable."""
+        try:
+            with open(path, encoding="utf-8", errors="strict") as f:
+                return tuple(f.read().splitlines())
+        except UnicodeDecodeError:
+            return None
+        except (PermissionError, OSError, FileNotFoundError):
+            return None
+
+    @staticmethod
+    def _hash_file(path: str, size: int) -> str:
+        """SHA-256 of a file's content (a content-address; the diff dedup key)."""
+        h = hashlib.sha256()
+        try:
+            with open(path, "rb") as f:
+                while chunk := f.read(65536):
+                    h.update(chunk)
+        except (PermissionError, OSError):
+            return f"unreadable:{size}"
+        return h.hexdigest()
+
+    # ─── diffing ──────────────────────────────────────────────────────
+
+    def _diff(self, old: Snapshot, new: Snapshot) -> DiffResult:
+        """Unified diffs between two snapshots, smallest-first within a byte cap."""
+        changed: list[tuple[str, FileEntry | None, FileEntry | None, str]] = []
+        for path in set(old.files) | set(new.files):
+            old_entry = old.files.get(path)
+            new_entry = new.files.get(path)
+            if old_entry is None and new_entry is not None:
+                changed.append((path, old_entry, new_entry, "added"))
+            elif old_entry is not None and new_entry is None:
+                changed.append((path, old_entry, new_entry, "deleted"))
+            elif (
+                old_entry is not None
+                and new_entry is not None
+                and old_entry.content_hash != new_entry.content_hash
+            ):
+                changed.append((path, old_entry, new_entry, "modified"))
+
+        # Smallest first so many small agent edits pack in before the budget is
+        # eaten by a few large files.
+        changed.sort(key=lambda c: max(c[1].size if c[1] else 0, c[2].size if c[2] else 0))
+
+        patches: list[PatchEntry] = []
+        total_bytes = 0
+        skipped = 0
+        for path, old_entry, new_entry, status in changed:
+            size_before = old_entry.size if old_entry else 0
+            size_after = new_entry.size if new_entry else 0
+            patch_text = self._patch_text(path, old_entry, new_entry, size_before, size_after)
+
+            patch_bytes = len(patch_text.encode("utf-8", errors="replace"))
+            if total_bytes + patch_bytes > self._MAX_DIFF_BYTES:
+                skipped += 1
+                continue
+            total_bytes += patch_bytes
+            patches.append(
+                PatchEntry(
+                    rel_path=path,
+                    status=status,
+                    patch=patch_text,
+                    size_before=size_before,
+                    size_after=size_after,
+                )
+            )
+
+        total_changed = len(patches) + skipped
+        if skipped:
+            LOGGER.warning(
+                "Diff size cap (%d MB): %d/%d changed files included, %d skipped",
+                self._MAX_DIFF_BYTES // (1024 * 1024),
+                len(patches),
+                total_changed,
+                skipped,
+            )
+        return DiffResult(
+            patches=patches,
+            snapshot_timestamp=new.timestamp,
+            scan_duration_ms=new.scan_duration_ms,
+            files_scanned=len(new.files),
+            files_changed=total_changed,
+            truncated=skipped > 0,
+        )
+
+    def _patch_text(
+        self,
+        path: str,
+        old_entry: FileEntry | None,
+        new_entry: FileEntry | None,
+        size_before: int,
+        size_after: int,
+    ) -> str:
+        if (old_entry and old_entry.redacted) or (new_entry and new_entry.redacted):
+            return f"Secret file changed (content redacted): {path}\n"
+        if size_before > self._MAX_DIFF_FILE_BYTES or size_after > self._MAX_DIFF_FILE_BYTES:
+            return f"File too large to diff ({size_before} -> {size_after} bytes): {path}\n"
+        old_lines = old_entry.lines if old_entry else ()
+        new_lines = new_entry.lines if new_entry else ()
+        return self._unified_diff(path, old_lines, new_lines)
+
+    @staticmethod
+    def _unified_diff(
+        path: str, old_lines: tuple[str, ...] | None, new_lines: tuple[str, ...] | None
+    ) -> str:
+        if old_lines is None or new_lines is None:
+            return f"Binary file changed: {path}\n"
+        return "\n".join(
+            difflib.unified_diff(
+                list(old_lines),
+                list(new_lines),
+                fromfile=f"a/{path}",
+                tofile=f"b/{path}",
+                lineterm="",
+            )
+        )
+
+
+__all__ = [
+    "DEFAULT_EXCLUDE_PATTERNS",
+    "DEFAULT_MAX_FILE_SIZE",
+    "SECRET_DENY_PATTERNS",
+    "DiffResult",
+    "FileEntry",
+    "FileTracker",
+    "PatchEntry",
+    "Snapshot",
+]

--- a/hud/environment/file_tracker.py
+++ b/hud/environment/file_tracker.py
@@ -122,6 +122,10 @@ class DiffResult:
     files_scanned: int
     files_changed: int
     truncated: bool = False  # True if the diff payload was capped by _MAX_DIFF_BYTES
+    # Paths dropped by the byte cap. Internal-only (never serialized): the
+    # tracker uses it to keep those files pending so they re-diff on a later
+    # poll instead of being silently baselined away.
+    skipped_paths: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize for JSON transport (the filetracking/1 wire shape)."""
@@ -243,6 +247,15 @@ class FileTracker:
 
         current = self._scan()
         diff = self._diff(self._previous_snapshot, current)
+        # Keep budget-skipped files pending: revert each to its previous state in
+        # the new baseline (drop added-but-skipped files) so the next scan still
+        # sees them as changed and re-diffs them, rather than dropping the change.
+        for path in diff.skipped_paths:
+            old_entry = self._previous_snapshot.files.get(path)
+            if old_entry is None:
+                current.files.pop(path, None)
+            else:
+                current.files[path] = old_entry
         self._previous_snapshot = current
 
         if diff.files_changed > 0:
@@ -402,21 +415,21 @@ class FileTracker:
         return False
 
     def _collect_gitignore_patterns(self) -> list[str]:
-        """Read ``.gitignore`` from the root and one level of subdirectories."""
-        patterns: list[str] = []
+        """Read the root ``.gitignore`` only.
+
+        Patterns are matched tree-wide (see :meth:`_matches`), which is only
+        sound for ignore rules that are themselves root-scoped. Nested
+        per-directory ``.gitignore`` files are intentionally not loaded: applying
+        a subdirectory's rules globally would wrongly exclude (or fail to
+        exclude) paths elsewhere in the tree. The built-in
+        ``DEFAULT_EXCLUDE_PATTERNS`` already drop the dominant noise
+        (``node_modules/``, ``.venv/``, ``__pycache__/``, build artifacts), so a
+        root-only honor is enough for a telemetry noise filter.
+        """
         root_gitignore = self._root / ".gitignore"
-        if root_gitignore.is_file():
-            patterns.extend(self._parse_gitignore(root_gitignore))
-        else:
-            try:
-                with os.scandir(self._root) as scanner:
-                    for entry in scanner:
-                        if entry.is_dir(follow_symlinks=False):
-                            sub = Path(entry.path) / ".gitignore"
-                            if sub.is_file():
-                                patterns.extend(self._parse_gitignore(sub))
-            except (PermissionError, OSError):
-                pass
+        if not root_gitignore.is_file():
+            return []
+        patterns = self._parse_gitignore(root_gitignore)
         if patterns:
             LOGGER.info("Loaded %d gitignore patterns", len(patterns))
         return patterns
@@ -484,7 +497,7 @@ class FileTracker:
 
         patches: list[PatchEntry] = []
         total_bytes = 0
-        skipped = 0
+        skipped_paths: list[str] = []
         for path, old_entry, new_entry, status in changed:
             size_before = old_entry.size if old_entry else 0
             size_after = new_entry.size if new_entry else 0
@@ -492,7 +505,7 @@ class FileTracker:
 
             patch_bytes = len(patch_text.encode("utf-8", errors="replace"))
             if total_bytes + patch_bytes > self._MAX_DIFF_BYTES:
-                skipped += 1
+                skipped_paths.append(path)
                 continue
             total_bytes += patch_bytes
             patches.append(
@@ -505,14 +518,14 @@ class FileTracker:
                 )
             )
 
-        total_changed = len(patches) + skipped
-        if skipped:
+        total_changed = len(patches) + len(skipped_paths)
+        if skipped_paths:
             LOGGER.warning(
                 "Diff size cap (%d MB): %d/%d changed files included, %d skipped",
                 self._MAX_DIFF_BYTES // (1024 * 1024),
                 len(patches),
                 total_changed,
-                skipped,
+                len(skipped_paths),
             )
         return DiffResult(
             patches=patches,
@@ -520,7 +533,8 @@ class FileTracker:
             scan_duration_ms=new.scan_duration_ms,
             files_scanned=len(new.files),
             files_changed=total_changed,
-            truncated=skipped > 0,
+            truncated=len(skipped_paths) > 0,
+            skipped_paths=skipped_paths,
         )
 
     def _patch_text(

--- a/hud/environment/file_tracking.py
+++ b/hud/environment/file_tracking.py
@@ -1,0 +1,75 @@
+"""Serving layer for :class:`~hud.environment.file_tracker.FileTracker`.
+
+Exposes one tracker over the ``filetracking/1`` wire: a framed-JSON request
+loop handling ``diff`` / ``snapshot`` / ``advance``. Scans run in a thread
+executor (CPU-bound directory walks must not block the event loop) and are
+serialized by a lock, since the tracker's baseline is mutable state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .utils import error, read_frame, reply, send_frame
+
+if TYPE_CHECKING:
+    from .file_tracker import FileTracker
+
+LOGGER = logging.getLogger("hud.environment.file_tracking")
+
+
+class _FileTrackingHandler:
+    """Per-server dispatcher; one tracker shared across connections under a lock."""
+
+    def __init__(self, tracker: FileTracker) -> None:
+        self._tracker = tracker
+        self._lock = asyncio.Lock()
+
+    async def handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while (msg := await read_frame(reader)) is not None:
+                msg_id = msg.get("id")
+                method = msg.get("method", "")
+                try:
+                    result = await self._dispatch(method)
+                except Exception as exc:  # never tear the connection down on one bad call
+                    LOGGER.debug("filetracking %s failed: %s", method, exc)
+                    if isinstance(msg_id, int):
+                        await send_frame(writer, error(msg_id, -32000, str(exc)))
+                    continue
+                if isinstance(msg_id, int):
+                    await send_frame(writer, reply(msg_id, result))
+        except (ConnectionError, OSError):
+            pass
+        finally:
+            writer.close()
+
+    async def _dispatch(self, method: str) -> dict[str, Any]:
+        loop = asyncio.get_running_loop()
+        async with self._lock:
+            if method == "diff":
+                diff = await loop.run_in_executor(None, self._tracker.take_snapshot)
+                return diff.to_dict()
+            if method == "snapshot":
+                manifest = self._tracker.current_manifest()
+                return {"files": manifest, "files_scanned": len(manifest)}
+            if method == "advance":
+                await loop.run_in_executor(None, self._tracker.advance_baseline)
+                return {"advanced": True}
+            raise ValueError(f"unknown filetracking method: {method!r}")
+
+
+async def serve_file_tracking(
+    tracker: FileTracker, host: str = "127.0.0.1", port: int = 0
+) -> asyncio.Server:
+    """Bind a ``filetracking/1`` server for ``tracker``. Caller drives the port."""
+    handler = _FileTrackingHandler(tracker)
+    server = await asyncio.start_server(handler.handle, host, port)
+    sock = server.sockets[0].getsockname()
+    LOGGER.info("filetracking bound on %s:%s", sock[0], sock[1])
+    return server
+
+
+__all__ = ["serve_file_tracking"]

--- a/hud/environment/tests/test_file_tracker.py
+++ b/hud/environment/tests/test_file_tracker.py
@@ -1,0 +1,142 @@
+"""FileTracker: snapshot diffing, excludes, gitignore, and the secrets deny-list."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from hud.environment.file_tracker import FileTracker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_modified_file_produces_a_unified_diff(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("line1\nline2\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    (tmp_path / "a.txt").write_text("line1\nCHANGED\n")
+    diff = tracker.take_snapshot()
+
+    assert diff.files_changed == 1
+    patch = diff.patches[0]
+    assert patch.rel_path == "a.txt"
+    assert patch.status == "modified"
+    assert "CHANGED" in patch.patch
+
+
+def test_added_and_deleted_files(tmp_path: Path) -> None:
+    (tmp_path / "keep.txt").write_text("x\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    (tmp_path / "new.txt").write_text("hello\n")
+    (tmp_path / "keep.txt").unlink()
+    diff = tracker.take_snapshot()
+
+    by_path = {p.rel_path: p for p in diff.patches}
+    assert by_path["new.txt"].status == "added"
+    assert by_path["new.txt"].size_before == 0
+    assert by_path["keep.txt"].status == "deleted"
+
+
+def test_no_changes_yields_empty_diff(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("x\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    diff = tracker.take_snapshot()
+
+    assert diff.files_changed == 0
+    assert diff.patches == []
+
+
+def test_exclude_patterns_skip_build_output(tmp_path: Path) -> None:
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "dep.js").write_text("module.exports = 1;\n")
+    (tmp_path / "src.py").write_text("x = 1\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    manifest_paths = {entry["path"] for entry in tracker.current_manifest()}
+    assert "src.py" in manifest_paths
+    assert not any(p.startswith("node_modules/") for p in manifest_paths)
+
+
+def test_gitignore_is_honored(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("ignored.txt\n")
+    (tmp_path / "ignored.txt").write_text("secret-ish\n")
+    (tmp_path / "tracked.txt").write_text("x\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    manifest_paths = {entry["path"] for entry in tracker.current_manifest()}
+    assert "tracked.txt" in manifest_paths
+    assert "ignored.txt" not in manifest_paths
+
+
+def test_secret_files_are_tracked_but_content_is_never_emitted(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text("API_KEY=supersecretvalue\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    (tmp_path / ".env").write_text("API_KEY=supersecretvalue\nDB_PASSWORD=hunter2\n")
+    diff = tracker.take_snapshot()
+
+    assert diff.files_changed == 1
+    patch = diff.patches[0]
+    assert patch.rel_path == ".env"
+    assert patch.status == "modified"
+    # The change is detected, but the content is redacted — never in the patch.
+    assert "redacted" in patch.patch.lower()
+    assert "supersecretvalue" not in patch.patch
+    assert "hunter2" not in patch.patch
+
+
+def test_per_file_diff_cap_emits_a_placeholder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(FileTracker, "_MAX_DIFF_FILE_BYTES", 4)
+    (tmp_path / "big.txt").write_text("aaaaaaaa\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    (tmp_path / "big.txt").write_text("bbbbbbbb\n")
+    diff = tracker.take_snapshot()
+
+    assert diff.files_changed == 1
+    assert "too large to diff" in diff.patches[0].patch
+
+
+def test_manifest_carries_paths_and_hashes(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("x\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    manifest = tracker.current_manifest()
+
+    assert len(manifest) == 1
+    entry = manifest[0]
+    assert entry["path"] == "a.txt"
+    assert entry["size"] == (tmp_path / "a.txt").stat().st_size
+    assert len(entry["content_hash"]) == 64  # sha256 hex
+
+
+def test_to_dict_shape_matches_wire_contract(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("1\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+    (tmp_path / "a.txt").write_text("2\n")
+
+    payload = tracker.take_snapshot().to_dict()
+
+    assert set(payload) >= {
+        "snapshot_timestamp",
+        "scan_duration_ms",
+        "files_scanned",
+        "files_changed",
+        "patches",
+    }
+    assert set(payload["patches"][0]) == {"path", "status", "patch", "size_before", "size_after"}

--- a/hud/environment/tests/test_file_tracker.py
+++ b/hud/environment/tests/test_file_tracker.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pytest
-
 from hud.environment.file_tracker import FileTracker
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 
 
 def test_modified_file_produces_a_unified_diff(tmp_path: Path) -> None:

--- a/hud/environment/tests/test_file_tracker.py
+++ b/hud/environment/tests/test_file_tracker.py
@@ -110,6 +110,50 @@ def test_per_file_diff_cap_emits_a_placeholder(
     assert "too large to diff" in diff.patches[0].patch
 
 
+def test_budget_skipped_files_stay_pending_until_emitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "a.txt").write_text("a1\n")
+    (tmp_path / "b.txt").write_text("b1\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    (tmp_path / "a.txt").write_text("a2\n")
+    (tmp_path / "b.txt").write_text("b2\n")
+
+    # Cap so small no patch fits: both changes are skipped this poll.
+    monkeypatch.setattr(FileTracker, "_MAX_DIFF_BYTES", 1)
+    first = tracker.take_snapshot()
+    assert first.truncated
+    assert first.patches == []
+    assert set(first.skipped_paths) == {"a.txt", "b.txt"}
+
+    # Next poll with headroom: the skipped changes must not be lost — the
+    # baseline kept them pending, so they re-diff now.
+    monkeypatch.setattr(FileTracker, "_MAX_DIFF_BYTES", 50 * 1024 * 1024)
+    second = tracker.take_snapshot()
+    by_path = {p.rel_path: p for p in second.patches}
+    assert set(by_path) == {"a.txt", "b.txt"}
+    assert "a2" in by_path["a.txt"].patch
+
+
+def test_nested_gitignore_is_not_honored_or_leaked(tmp_path: Path) -> None:
+    # Root has no .gitignore; a nested package does. With root-only honoring the
+    # nested rule must neither take effect locally nor leak tree-wide (the old
+    # basename match would have excluded "data.txt" everywhere).
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / ".gitignore").write_text("data.txt\n")
+    (pkg / "data.txt").write_text("local\n")
+    (tmp_path / "data.txt").write_text("root\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    manifest_paths = {entry["path"] for entry in tracker.current_manifest()}
+    assert "data.txt" in manifest_paths
+    assert "pkg/data.txt" in manifest_paths
+
+
 def test_manifest_carries_paths_and_hashes(tmp_path: Path) -> None:
     (tmp_path / "a.txt").write_text("x\n")
     tracker = FileTracker(tmp_path)

--- a/hud/environment/tests/test_file_tracking.py
+++ b/hud/environment/tests/test_file_tracking.py
@@ -1,0 +1,47 @@
+"""filetracking/1 wire roundtrip: serve a FileTracker, drive it via the client."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from hud.capabilities import Capability, FileTrackingClient
+from hud.environment.file_tracker import FileTracker
+from hud.environment.file_tracking import serve_file_tracking
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+async def test_diff_snapshot_advance_roundtrip(tmp_path: Path) -> None:
+    (tmp_path / "a.txt").write_text("x\n")
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+
+    server = await serve_file_tracking(tracker)
+    host, port = server.sockets[0].getsockname()[:2]
+    client = await FileTrackingClient.connect(Capability.filetracking(url=f"tcp://{host}:{port}"))
+    try:
+        # Nothing changed yet.
+        assert (await client.diff())["files_changed"] == 0
+
+        # An edit shows up as a diff on the next pull.
+        (tmp_path / "a.txt").write_text("x\ny\n")
+        diff = await client.diff()
+        assert diff["files_changed"] == 1
+        assert diff["patches"][0]["path"] == "a.txt"
+
+        # diff() advanced the baseline, so a re-pull is empty.
+        assert (await client.diff())["files_changed"] == 0
+
+        # snapshot() returns the full manifest.
+        snapshot = await client.snapshot()
+        assert any(entry["path"] == "a.txt" for entry in snapshot["files"])
+
+        # advance() re-baselines without erroring.
+        (tmp_path / "b.txt").write_text("z\n")
+        await client.advance()
+        assert (await client.diff())["files_changed"] == 0
+    finally:
+        await client.close()
+        server.close()
+        await server.wait_closed()

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 
     from hud.capabilities import Capability
 
+    from .file_tracker import FileTracker
+
 LOGGER = logging.getLogger("hud.environment.workspace")
 
 # Set once the first Workspace logs the missing-bwrap notice (avoid per-instance spam).
@@ -130,6 +132,7 @@ class Workspace:
         user: str = _DEFAULT_USER,
         host_key_path: Path | None = None,
         authorized_client_keys: list[Path] | None = None,
+        track_files: bool = False,
     ) -> None:
         self.root: Path = Path(root).resolve()
         # Unique id for this instance's credential subdirectory so parallel
@@ -170,6 +173,13 @@ class Workspace:
         self._sock: socket.socket | None = None
         self._bound_host: str | None = None
         self._bound_port: int | None = None
+        # File tracking: an observation-only filetracking/1 server over the same
+        # root. Materialized at start() when enabled.
+        self._track_files = track_files
+        self._file_tracker: FileTracker | None = None
+        self._ft_server: asyncio.Server | None = None
+        self._ft_host: str | None = None
+        self._ft_port: int | None = None
 
     def _prepare_runtime(self) -> None:
         """Materialize filesystem credentials and bind the SSH socket."""
@@ -232,6 +242,20 @@ class Workspace:
             self._serve_task = asyncio.get_event_loop().create_task(self._serve())
         # Yield so the acceptor binds before first use.
         await asyncio.sleep(0)
+        if self._track_files and self._ft_server is None:
+            await self._start_file_tracking()
+
+    async def _start_file_tracking(self) -> None:
+        """Take the baseline snapshot and bind the filetracking/1 server."""
+        from .file_tracker import FileTracker
+        from .file_tracking import serve_file_tracking
+
+        tracker = FileTracker(self.root)
+        # The baseline walk is CPU-bound; keep it off the event loop.
+        await asyncio.get_running_loop().run_in_executor(None, tracker.take_baseline)
+        self._file_tracker = tracker
+        self._ft_server = await serve_file_tracking(tracker, host=self._ssh_host)
+        self._ft_host, self._ft_port = self._ft_server.sockets[0].getsockname()[:2]
 
     async def stop(self) -> None:
         """Stop accepting SSH sessions and release the socket.
@@ -239,6 +263,13 @@ class Workspace:
         Credentials stay on disk; a later :meth:`start` re-binds (fresh port
         unless one was pinned) and reuses them.
         """
+        if self._ft_server is not None:
+            self._ft_server.close()
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(self._ft_server.wait_closed(), 5.0)
+            self._ft_server = None
+            self._ft_host = self._ft_port = None
+            self._file_tracker = None
         if self._serve_task is not None:
             self._serve_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -304,6 +335,19 @@ class Workspace:
             client_key=key_path.read_text() if key_path else None,
             client_key_path=key_path,
         )
+
+    @property
+    def tracks_files(self) -> bool:
+        """Whether this workspace serves a ``filetracking/1`` capability."""
+        return self._track_files
+
+    def file_tracking_capability(self, name: str = "filetracking") -> Capability:
+        """The concrete ``filetracking/1`` capability (requires ``track_files=True``)."""
+        from hud.capabilities import Capability
+
+        if self._ft_port is None:
+            raise RuntimeError("file tracking not started; call start() with track_files=True")
+        return Capability.filetracking(name=name, url=f"tcp://{self._ft_host}:{self._ft_port}")
 
     # ─── argv builders (public — useful if you want your own subprocess) ──
 

--- a/hud/eval/file_tracking.py
+++ b/hud/eval/file_tracking.py
@@ -52,15 +52,14 @@ async def file_tracking_observer(client: HudClient) -> AsyncIterator[None]:
         yield
         return
 
-    ft = cast("FileTrackingClient", await client.open("filetracking"))
-    # Re-baseline past scenario setup (so the first emitted diff is the agent's,
-    # not setup churn) and emit the post-setup manifest as the reconstruction
-    # anchor (paths + hashes, no content). Both are preconditions for correct
-    # telemetry: a failed re-baseline misattributes scenario-setup edits to the
-    # agent, and a missing anchor leaves the streamed diffs with no baseline to
-    # reconstruct against. If either fails, skip tracking this rollout rather
-    # than stream misleading data.
+    # Open the capability, re-baseline past scenario setup (so the first emitted
+    # diff is the agent's, not setup churn), and emit the post-setup manifest as
+    # the reconstruction anchor (paths + hashes, no content). Tracking is
+    # observation-only, so any setup failure — a refused tunnel, a failed
+    # re-baseline (which would misattribute setup edits to the agent), or a
+    # missing anchor — skips tracking rather than breaking the agent loop.
     try:
+        ft = cast("FileTrackingClient", await client.open("filetracking"))
         await ft.advance()
         emit_file_snapshot(await ft.snapshot(), started_at=now_iso())
     except Exception as exc:

--- a/hud/eval/file_tracking.py
+++ b/hud/eval/file_tracking.py
@@ -53,12 +53,20 @@ async def file_tracking_observer(client: HudClient) -> AsyncIterator[None]:
         return
 
     ft = cast("FileTrackingClient", await client.open("filetracking"))
-    # Re-baseline past scenario setup so the first emitted diff is the agent's,
-    # then emit the post-setup manifest as the reconstruction anchor (paths +
-    # hashes, no content).
-    with contextlib.suppress(Exception):
+    # Re-baseline past scenario setup (so the first emitted diff is the agent's,
+    # not setup churn) and emit the post-setup manifest as the reconstruction
+    # anchor (paths + hashes, no content). Both are preconditions for correct
+    # telemetry: a failed re-baseline misattributes scenario-setup edits to the
+    # agent, and a missing anchor leaves the streamed diffs with no baseline to
+    # reconstruct against. If either fails, skip tracking this rollout rather
+    # than stream misleading data.
+    try:
         await ft.advance()
         emit_file_snapshot(await ft.snapshot(), started_at=now_iso())
+    except Exception as exc:
+        logger.warning("file tracking setup failed; not tracking this rollout: %s", exc)
+        yield
+        return
 
     stop = asyncio.Event()
     task = asyncio.create_task(_poll(ft, settings.file_tracking_interval, stop))

--- a/hud/eval/file_tracking.py
+++ b/hud/eval/file_tracking.py
@@ -33,13 +33,17 @@ _DRAIN_TIMEOUT = 10.0
 async def file_tracking_observer(client: HudClient) -> AsyncIterator[None]:
     """Stream workspace diffs to telemetry for the duration of the ``with`` block.
 
-    A no-op unless file tracking + telemetry are enabled and the manifest has a
-    ``filetracking`` binding. The opened client is owned by ``client`` and
-    closed on its teardown, so this never closes it directly.
+    A no-op unless telemetry is enabled and the manifest has a ``filetracking``
+    binding. The binding's presence is the authoritative opt-in: it is published
+    iff the workspace was served with ``track_files=True`` (which itself defaults
+    to ``HUD_FILE_TRACKING_ENABLED``), so honoring it here means an explicit
+    ``track_files=True`` streams even when the global setting is off. The opened
+    client is owned by ``client`` and closed on its teardown, so this never
+    closes it directly.
     """
     from hud.settings import settings
 
-    if not (settings.file_tracking_enabled and settings.telemetry_enabled):
+    if not settings.telemetry_enabled:
         yield
         return
     try:
@@ -70,8 +74,12 @@ async def file_tracking_observer(client: HudClient) -> AsyncIterator[None]:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
-        else:
-            await _emit_once(ft)  # trailing diff: edits since the last sample
+        # Trailing diff: edits since the last successful sample. Attempt it in
+        # both paths (clean drain or forced cancel); bound it so a connection
+        # desynced by the cancel above can't wedge teardown. ``_emit_once`` logs
+        # and swallows its own failures.
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(_emit_once(ft), _DRAIN_TIMEOUT)
 
 
 async def _poll(ft: FileTrackingClient, interval: float, stop: asyncio.Event) -> None:

--- a/hud/eval/file_tracking.py
+++ b/hud/eval/file_tracking.py
@@ -1,0 +1,97 @@
+"""Rollout-level file-tracking observer.
+
+Wraps the agent loop: if the env published a ``filetracking/1`` capability and
+file tracking is on, open it, skip the scenario-setup churn, then sample diffs
+on a fixed interval and emit each as a ``hud.filetracking.v1`` span. Decoupled
+from the tool loop — spans are self-timestamped and the viewer correlates them
+to steps by time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, cast
+
+from hud.telemetry.filetracking import emit_file_diff, emit_file_snapshot
+from hud.utils.time import now_iso
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from hud.capabilities import FileTrackingClient
+    from hud.clients.client import HudClient
+
+logger = logging.getLogger("hud.eval.file_tracking")
+
+_DRAIN_TIMEOUT = 10.0
+
+
+@asynccontextmanager
+async def file_tracking_observer(client: HudClient) -> AsyncIterator[None]:
+    """Stream workspace diffs to telemetry for the duration of the ``with`` block.
+
+    A no-op unless file tracking + telemetry are enabled and the manifest has a
+    ``filetracking`` binding. The opened client is owned by ``client`` and
+    closed on its teardown, so this never closes it directly.
+    """
+    from hud.settings import settings
+
+    if not (settings.file_tracking_enabled and settings.telemetry_enabled):
+        yield
+        return
+    try:
+        client.binding("filetracking")
+    except (KeyError, RuntimeError):
+        yield
+        return
+
+    ft = cast("FileTrackingClient", await client.open("filetracking"))
+    # Re-baseline past scenario setup so the first emitted diff is the agent's,
+    # then emit the post-setup manifest as the reconstruction anchor (paths +
+    # hashes, no content).
+    with contextlib.suppress(Exception):
+        await ft.advance()
+        emit_file_snapshot(await ft.snapshot(), started_at=now_iso())
+
+    stop = asyncio.Event()
+    task = asyncio.create_task(_poll(ft, settings.file_tracking_interval, stop))
+    try:
+        yield
+    finally:
+        stop.set()
+        # Let the current iteration finish cleanly (never cancel mid-request, which
+        # would desync the connection); fall back to cancel only if it wedges.
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), _DRAIN_TIMEOUT)
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        else:
+            await _emit_once(ft)  # trailing diff: edits since the last sample
+
+
+async def _poll(ft: FileTrackingClient, interval: float, stop: asyncio.Event) -> None:
+    while not stop.is_set():
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(stop.wait(), timeout=interval)
+        if stop.is_set():
+            return
+        await _emit_once(ft)
+
+
+async def _emit_once(ft: FileTrackingClient) -> None:
+    started_at = now_iso()
+    try:
+        result = await ft.diff()
+    except Exception as exc:
+        logger.debug("file tracking diff failed: %s", exc)
+        return
+    if result.get("files_changed"):
+        emit_file_diff(result, started_at=started_at)
+
+
+__all__ = ["file_tracking_observer"]

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -34,6 +34,7 @@ from hud.telemetry.context import set_trace_context
 from hud.types import Step, TaskCall, Trace
 from hud.utils.time import now_iso
 
+from .file_tracking import file_tracking_observer
 from .job import job_enter, trace_enter, trace_exit
 
 if TYPE_CHECKING:
@@ -304,7 +305,11 @@ async def rollout(
                 async with live:  # start on enter; grade on exit
                     run = live  # bound only once live: an earlier failure synthesizes
                     _phase = "agent loop"
-                    await agent(run)
+                    # File tracking (when enabled) streams workspace diffs to
+                    # telemetry for the duration of the agent loop; setup churn is
+                    # skipped because the run is already started here.
+                    async with file_tracking_observer(client):
+                        await agent(run)
                     _phase = "grading"
         except TimeoutError:
             raise

--- a/hud/eval/tests/test_file_tracking_observer.py
+++ b/hud/eval/tests/test_file_tracking_observer.py
@@ -49,6 +49,16 @@ class _FakeClient:
         return self._ft
 
 
+class _OpenFailsClient:
+    """A bound capability whose open() fails (e.g. a refused tunnel)."""
+
+    def binding(self, name: str) -> object:
+        return object()
+
+    async def open(self, name: str) -> object:
+        raise ConnectionError("tunnel refused")
+
+
 def _record_emitters(monkeypatch: pytest.MonkeyPatch) -> tuple[list[Any], list[Any]]:
     diffs: list[Any] = []
     snapshots: list[Any] = []
@@ -100,3 +110,19 @@ async def test_successful_setup_anchors_and_polls(monkeypatch: pytest.MonkeyPatc
     assert len(snapshots) == 1  # manifest anchor emitted once
     assert ft.diff_calls >= 1
     assert diffs  # at least one diff streamed
+
+
+async def test_open_failure_does_not_break_the_rollout(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hud.settings import settings
+
+    monkeypatch.setattr(settings, "telemetry_enabled", True)
+    diffs, snapshots = _record_emitters(monkeypatch)
+
+    # A failed open must degrade to a no-op, not raise into the agent loop.
+    ran = False
+    async with observer.file_tracking_observer(_OpenFailsClient()):  # type: ignore[arg-type]
+        ran = True
+
+    assert ran
+    assert diffs == []
+    assert snapshots == []

--- a/hud/eval/tests/test_file_tracking_observer.py
+++ b/hud/eval/tests/test_file_tracking_observer.py
@@ -1,0 +1,102 @@
+"""file_tracking_observer: setup must gate polling.
+
+The observer re-baselines past scenario setup and emits the manifest anchor
+before it starts streaming diffs. If that setup fails, it must not poll — a
+stale baseline would misattribute scenario-setup edits to the agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from hud.eval import file_tracking as observer
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class _FakeFt:
+    def __init__(self, *, advance_raises: bool = False) -> None:
+        self.advance_raises = advance_raises
+        self.advance_calls = 0
+        self.snapshot_calls = 0
+        self.diff_calls = 0
+
+    async def advance(self) -> dict[str, Any]:
+        self.advance_calls += 1
+        if self.advance_raises:
+            raise RuntimeError("advance boom")
+        return {"advanced": True}
+
+    async def snapshot(self) -> dict[str, Any]:
+        self.snapshot_calls += 1
+        return {"files": [], "files_scanned": 0}
+
+    async def diff(self) -> dict[str, Any]:
+        self.diff_calls += 1
+        return {"files_changed": 1, "patches": [{"path": "a.txt"}]}
+
+
+class _FakeClient:
+    def __init__(self, ft: _FakeFt) -> None:
+        self._ft = ft
+
+    def binding(self, name: str) -> object:
+        return object()
+
+    async def open(self, name: str) -> _FakeFt:
+        return self._ft
+
+
+def _record_emitters(monkeypatch: pytest.MonkeyPatch) -> tuple[list[Any], list[Any]]:
+    diffs: list[Any] = []
+    snapshots: list[Any] = []
+
+    def _diff(payload: Any, *, started_at: str, ended_at: str | None = None) -> bool:
+        diffs.append(payload)
+        return True
+
+    def _snapshot(payload: Any, *, started_at: str, ended_at: str | None = None) -> bool:
+        snapshots.append(payload)
+        return True
+
+    monkeypatch.setattr(observer, "emit_file_diff", _diff)
+    monkeypatch.setattr(observer, "emit_file_snapshot", _snapshot)
+    return diffs, snapshots
+
+
+async def test_setup_failure_skips_polling(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hud.settings import settings
+
+    monkeypatch.setattr(settings, "telemetry_enabled", True)
+    monkeypatch.setattr(settings, "file_tracking_interval", 0.01)
+    diffs, snapshots = _record_emitters(monkeypatch)
+    ft = _FakeFt(advance_raises=True)
+
+    async with observer.file_tracking_observer(_FakeClient(ft)):  # type: ignore[arg-type]
+        await asyncio.sleep(0.05)
+
+    assert ft.advance_calls == 1
+    # advance() raised, so the anchor snapshot and all diff polling are skipped.
+    assert ft.snapshot_calls == 0
+    assert ft.diff_calls == 0
+    assert diffs == []
+    assert snapshots == []
+
+
+async def test_successful_setup_anchors_and_polls(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hud.settings import settings
+
+    monkeypatch.setattr(settings, "telemetry_enabled", True)
+    monkeypatch.setattr(settings, "file_tracking_interval", 0.01)
+    diffs, snapshots = _record_emitters(monkeypatch)
+    ft = _FakeFt()
+
+    async with observer.file_tracking_observer(_FakeClient(ft)):  # type: ignore[arg-type]
+        await asyncio.sleep(0.05)
+
+    assert ft.advance_calls == 1
+    assert len(snapshots) == 1  # manifest anchor emitted once
+    assert ft.diff_calls >= 1
+    assert diffs  # at least one diff streamed

--- a/hud/settings.py
+++ b/hud/settings.py
@@ -147,6 +147,21 @@ class Settings(BaseSettings):
         validation_alias="HUD_TELEMETRY_LOCAL_DIR",
     )
 
+    file_tracking_enabled: bool = Field(
+        default=False,
+        description="Publish a workspace's filetracking/1 capability and stream file-change "
+        "diffs to telemetry during a rollout. Opt-in; off by default.",
+        validation_alias="HUD_FILE_TRACKING_ENABLED",
+    )
+
+    file_tracking_interval: float = Field(
+        default=2.0,
+        gt=0,
+        description="Seconds between rollout-level file-tracking snapshots. Each snapshot "
+        "diffs the workspace against the previous one and emits a hud.filetracking.v1 span.",
+        validation_alias="HUD_FILE_TRACKING_INTERVAL",
+    )
+
     hud_logging: bool = Field(
         default=True,
         description="Enable fancy logging for the HUD SDK",

--- a/hud/telemetry/filetracking.py
+++ b/hud/telemetry/filetracking.py
@@ -1,0 +1,76 @@
+"""Emit file-tracking observations as ``hud.filetracking.v1`` telemetry spans.
+
+A standalone span schema — *not* attached to tool-call results. The rollout
+observer pulls a diff from the workspace's ``filetracking/1`` capability and
+calls :func:`emit_file_diff`, which builds an OTel-shaped span under the active
+trace context and hands it to the exporter. Each span is self-timestamped so
+the viewer correlates file changes to the step timeline by time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hud.telemetry.context import get_current_trace_id
+from hud.telemetry.exporter import queue_span
+from hud.telemetry.span import (
+    PAYLOAD_ATTRIBUTE,
+    SCHEMA_ATTRIBUTE,
+    TASK_RUN_ID_ATTRIBUTE,
+    Span,
+    new_span_id,
+    normalize_trace_id,
+)
+from hud.utils.time import now_iso
+
+#: Schema tag the platform projector dispatches on to build ``file_change`` /
+#: ``file_snapshot`` events.
+FILETRACKING_SCHEMA = "hud.filetracking.v1"
+
+DIFF_SPAN_NAME = "filetracking.diff"
+SNAPSHOT_SPAN_NAME = "filetracking.snapshot"
+
+
+def _emit(payload: dict[str, Any], name: str, started_at: str, ended_at: str | None) -> bool:
+    """Build and queue one file-tracking span. No-ops outside a rollout."""
+    task_run_id = get_current_trace_id()
+    if task_run_id is None:
+        return False
+    span = Span(
+        name=name,
+        trace_id=normalize_trace_id(task_run_id),
+        span_id=new_span_id(),
+        start_time=started_at,
+        end_time=ended_at or now_iso(),
+        status_code="OK",
+        attributes={
+            SCHEMA_ATTRIBUTE: FILETRACKING_SCHEMA,
+            TASK_RUN_ID_ATTRIBUTE: task_run_id,
+            PAYLOAD_ATTRIBUTE: payload,
+        },
+    )
+    queue_span(span.model_dump(mode="json"))
+    return True
+
+
+def emit_file_diff(
+    payload: dict[str, Any], *, started_at: str, ended_at: str | None = None
+) -> bool:
+    """Emit a per-scan diff (``DiffResult.to_dict()`` shape); ``False`` outside a rollout."""
+    return _emit(payload, DIFF_SPAN_NAME, started_at, ended_at)
+
+
+def emit_file_snapshot(
+    payload: dict[str, Any], *, started_at: str, ended_at: str | None = None
+) -> bool:
+    """Emit the baseline manifest (``{files, files_scanned}``). The reconstruction anchor."""
+    return _emit(payload, SNAPSHOT_SPAN_NAME, started_at, ended_at)
+
+
+__all__ = [
+    "DIFF_SPAN_NAME",
+    "FILETRACKING_SCHEMA",
+    "SNAPSHOT_SPAN_NAME",
+    "emit_file_diff",
+    "emit_file_snapshot",
+]

--- a/hud/telemetry/tests/test_filetracking.py
+++ b/hud/telemetry/tests/test_filetracking.py
@@ -1,0 +1,60 @@
+"""The hud.filetracking.v1 span emitter."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from hud.telemetry.context import set_trace_context
+from hud.telemetry.filetracking import (
+    DIFF_SPAN_NAME,
+    FILETRACKING_SCHEMA,
+    SNAPSHOT_SPAN_NAME,
+    emit_file_diff,
+    emit_file_snapshot,
+)
+
+_PAYLOAD = {"files_changed": 1, "patches": [{"path": "a.txt", "status": "modified"}]}
+
+
+def test_emit_noops_without_a_trace_context() -> None:
+    with patch("hud.telemetry.filetracking.queue_span") as queue_span:
+        emitted = emit_file_diff(_PAYLOAD, started_at="2026-06-18T22:00:00Z")
+    assert emitted is False
+    queue_span.assert_not_called()
+
+
+def test_emit_builds_a_schema_tagged_span() -> None:
+    captured: list[dict[str, Any]] = []
+    with (
+        patch("hud.telemetry.filetracking.queue_span", side_effect=captured.append),
+        set_trace_context("run-abc-123"),
+    ):
+        emitted = emit_file_diff(_PAYLOAD, started_at="2026-06-18T22:00:00Z")
+
+    assert emitted is True
+    assert len(captured) == 1
+    span = captured[0]
+    assert span["name"] == DIFF_SPAN_NAME
+    attributes = span["attributes"]
+    assert attributes["hud.schema"] == FILETRACKING_SCHEMA
+    assert attributes["hud.task_run_id"] == "run-abc-123"
+    assert attributes["hud.payload"]["files_changed"] == 1
+    # trace_id is the normalized 32-hex telemetry id, not the raw run id.
+    assert len(span["trace_id"]) == 32
+
+
+def test_emit_snapshot_uses_the_snapshot_span_name() -> None:
+    captured: list[dict[str, Any]] = []
+    manifest = {"files_scanned": 2, "files": [{"path": "a", "size": 1, "content_hash": "h"}]}
+    with (
+        patch("hud.telemetry.filetracking.queue_span", side_effect=captured.append),
+        set_trace_context("run-abc-123"),
+    ):
+        emitted = emit_file_snapshot(manifest, started_at="2026-06-18T22:00:00Z")
+
+    assert emitted is True
+    span = captured[0]
+    assert span["name"] == SNAPSHOT_SPAN_NAME
+    assert span["attributes"]["hud.schema"] == FILETRACKING_SCHEMA
+    assert span["attributes"]["hud.payload"]["files_scanned"] == 2


### PR DESCRIPTION
## Summary
Workspace file-tracking capability + telemetry for v6.

- `capabilities/filetracking` — `FileTrackingClient` (`filetracking/1` protocol)
- `environment/file_tracker` — workspace scanner + unified-diff engine (gitignore-aware, size/secret/binary caps)
- `environment/file_tracking` — `filetracking/1` server + client transport
- `environment/workspace` — serves `filetracking/1` alongside ssh (`track_files`)
- `eval/file_tracking` — rollout observer: baseline snapshot + interval diffs, drained on exit
- `telemetry/filetracking` — emits `hud.filetracking.v1` spans (`filetracking.snapshot` / `.diff`)
- `settings` — `HUD_FILE_TRACKING_ENABLED` / `HUD_FILE_TRACKING_INTERVAL`
- tests for the tracker, the server, and the span emitter

## Validation
- `ruff` clean. (`pytest` / `pyright` were not run in the extraction worktree — worth a pass before merge.)

## Notes
- Based on `v6`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New filesystem scanning and diff emission could increase CPU/memory and telemetry payload size; secret redaction and fail-open observer mitigate credential leakage and rollout breakage, but mis-tuned caps or large workspaces still warrant review.
> 
> **Overview**
> Adds **opt-in workspace file tracking** so rollouts can record how the agent changed files on disk, without exposing it as an agent tool.
> 
> **Environment side:** Workspaces can enable `track_files` (defaulting to `HUD_FILE_TRACKING_ENABLED`). When on, a `FileTracker` scans the workspace root, produces snapshot diffs (unified patches with excludes, root `.gitignore`, size/budget caps, and a fixed **secret-path deny list** that never reads or emits credential content), and serves **`filetracking/1`** (`diff` / `snapshot` / `advance`) alongside SSH. `Capability.filetracking()` and `FileTrackingClient` are registered on `HudClient`.
> 
> **Rollout side:** `rollout` wraps the agent loop with `file_tracking_observer`, which (when telemetry is on and the binding exists) re-baselines after task start, emits a manifest anchor span, polls diffs on `HUD_FILE_TRACKING_INTERVAL`, and drains a final diff on exit—**failing setup degrades to a no-op** so the agent loop is unaffected. Spans use schema **`hud.filetracking.v1`** (`filetracking.snapshot` / `filetracking.diff`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e48355b723445bc48dd1e9e5bdc9b3044348b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->