### PR TITLE
[codex] add modal runtime provider wiring

### DIFF
--- a/hud/cli/deploy.py
+++ b/hud/cli/deploy.py
@@ -24,12 +24,14 @@ from hud.utils.hud_console import HUDConsole
 from hud.utils.platform import PlatformClient
 
 LOGGER = logging.getLogger(__name__)
+_VALID_RUNTIMES = {"modal"}
 
 
 @dataclass(frozen=True)
 class _DeployPlan:
     name: str
     registry_id: str | None
+    runtime: str | None
     env_vars: dict[str, str]
     build_args: dict[str, str]
     build_secrets: dict[str, str]
@@ -59,6 +61,18 @@ def _parse_key_value_flags(
             continue
         values[parsed[0]] = parsed[1]
     return values
+
+
+def _normalize_runtime(runtime: str | None, console: HUDConsole) -> str | None:
+    if runtime is None:
+        return None
+    normalized = runtime.strip().lower()
+    if normalized in _VALID_RUNTIMES:
+        return normalized
+    console.error(
+        f"Invalid runtime {runtime!r}; expected one of: {', '.join(sorted(_VALID_RUNTIMES))}"
+    )
+    raise typer.Exit(1)
 
 
 def _load_env_vars(path: Path, console: HUDConsole, *, warn_missing: bool) -> dict[str, str]:
@@ -307,6 +321,7 @@ def _prepare_deploy_plan(
     registry_id: str | None,
     build_args: list[str] | None,
     build_secrets: list[str] | None,
+    runtime: str | None,
     verbose: bool,
     platform: PlatformClient,
     console: HUDConsole,
@@ -346,6 +361,7 @@ def _prepare_deploy_plan(
     return _DeployPlan(
         name=resolved_name,
         registry_id=registry_id,
+        runtime=_normalize_runtime(runtime, console),
         env_vars=env_vars,
         build_args=build_args_dict,
         build_secrets=_collect_build_secrets(build_secrets, env_dir=env_dir, console=console),
@@ -362,6 +378,7 @@ def deploy_environment(
     registry_id: str | None = None,
     build_args: list[str] | None = None,
     build_secrets: list[str] | None = None,
+    runtime: str | None = None,
 ) -> None:
     """Deploy one HUD environment to the platform."""
     hud_console = HUDConsole()
@@ -393,6 +410,7 @@ def deploy_environment(
         registry_id=registry_id,
         build_args=build_args,
         build_secrets=build_secrets,
+        runtime=runtime,
         verbose=verbose,
         platform=platform,
         console=hud_console,
@@ -437,10 +455,11 @@ async def _create_build_upload(platform: PlatformClient) -> _BuildUpload:
 
 async def _upload_build_context(upload_url: str, tarball_path: Path) -> None:
     """PUT the tarball to the presigned S3 URL (not a platform API call)."""
+    content = await asyncio.to_thread(tarball_path.read_bytes)
     async with httpx.AsyncClient(timeout=300.0) as s3_client:
         response = await s3_client.put(
             upload_url,
-            content=tarball_path.read_bytes(),
+            content=content,
             headers={"Content-Type": "application/gzip"},
         )
         response.raise_for_status()
@@ -464,6 +483,8 @@ async def _trigger_build(
     }
     if plan.registry_id:
         payload["registry_id"] = plan.registry_id
+    if plan.runtime:
+        payload["runtime_provider"] = plan.runtime
     if plan.env_vars:
         payload["environment_variables"] = plan.env_vars
     if plan.build_args:
@@ -622,6 +643,7 @@ def deploy_all(
     verbose: bool = False,
     build_args: list[str] | None = None,
     build_secrets: list[str] | None = None,
+    runtime: str | None = None,
 ) -> None:
     """Deploy each HUD environment under a parent directory."""
     hud_console = HUDConsole()
@@ -660,6 +682,7 @@ def deploy_all(
                 registry_id=None,
                 build_args=build_args,
                 build_secrets=build_secrets,
+                runtime=runtime,
             )
             succeeded.append(env_dir.name)
         except (typer.Exit, SystemExit):
@@ -734,6 +757,11 @@ def deploy_command(
         help="Existing registry ID for rebuilds (advanced)",
         hidden=True,
     ),
+    runtime: str | None = typer.Option(
+        None,
+        "--runtime",
+        help="Persist Modal as the hosted runtime for this registry",
+    ),
 ) -> None:
     """Deploy HUD environment to the platform.
 
@@ -752,6 +780,7 @@ def deploy_command(
             verbose=verbose,
             build_args=build_args,
             build_secrets=secrets,
+            runtime=runtime,
         )
         return
 
@@ -765,4 +794,5 @@ def deploy_command(
         registry_id=registry_id,
         build_args=build_args,
         build_secrets=secrets,
+        runtime=runtime,
     )

--- a/hud/cli/tests/test_deploy.py
+++ b/hud/cli/tests/test_deploy.py
@@ -261,6 +261,7 @@ class TestDeployAsync:
                 plan=_DeployPlan(
                     name="test-env",
                     registry_id=None,
+                    runtime=None,
                     env_vars={},
                     build_args={},
                     build_secrets={},
@@ -290,6 +291,7 @@ class TestDeployAsync:
                 plan=_DeployPlan(
                     name="test-env",
                     registry_id=None,
+                    runtime=None,
                     env_vars={},
                     build_args={},
                     build_secrets={},
@@ -299,6 +301,47 @@ class TestDeployAsync:
             )
 
         assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_build_sends_runtime_provider(self) -> None:
+        """Test deploy runtime flag maps to the platform runtime_provider field."""
+        from hud.cli.deploy import _DeployPlan, _trigger_build
+        from hud.utils.hud_console import HUDConsole
+        from hud.utils.platform import PlatformClient
+
+        class FakePlatform(PlatformClient):
+            payload: dict[str, object] | None = None
+
+            async def apost(
+                self,
+                path: str,
+                *,
+                json: object | None = None,
+            ) -> dict[str, object]:
+                assert path == "/builds/trigger"
+                assert isinstance(json, dict)
+                object.__setattr__(self, "payload", json)
+                return {"id": "build-1", "registry_id": "registry-1"}
+
+        platform = FakePlatform("https://api.example", "key")
+        result = await _trigger_build(
+            platform,
+            build_id="build-1",
+            plan=_DeployPlan(
+                name="test-env",
+                registry_id=None,
+                runtime="modal",
+                env_vars={},
+                build_args={},
+                build_secrets={},
+            ),
+            no_cache=False,
+            console=HUDConsole(),
+        )
+
+        assert result == {"id": "build-1", "registry_id": "registry-1"}
+        assert platform.payload is not None
+        assert platform.payload["runtime_provider"] == "modal"
 
 
 class TestSaveDeployLink:

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -48,7 +48,7 @@ from hud.utils.platform import PlatformClient
 from .run import Grade, Run, rollout
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Sequence
+    from collections.abc import AsyncIterator, Mapping, Sequence
 
     from hud.agents.base import Agent
     from hud.environment.env import Environment
@@ -140,6 +140,13 @@ class Runtime:
 
     def __call__(self, task: Task) -> AbstractAsyncContextManager[Runtime]:
         return nullcontext(self)
+
+
+def _modal_image_from_uri(modal: Any, image_uri: str) -> Any:
+    modal_uri_prefix = "modal://"
+    if image_uri.startswith(modal_uri_prefix):
+        return modal.Image.from_id(image_uri.removeprefix(modal_uri_prefix))
+    return modal.Image.from_registry(image_uri)
 
 
 class LocalRuntime:
@@ -299,13 +306,17 @@ class ModalRuntime:
         image: Any = None,
         command: Sequence[str] | None = None,
         app_name: str = "hud-envs",
+        workdir: str | None = None,
         port: int = 8765,
         runtime_config: RuntimeConfig | dict[str, Any] | None = None,
+        env_vars: Mapping[str, str] | None = None,
     ) -> None:
         self.image_name = image_name
         self.port = port
-        # Default CMD mirrors the scaffolded Dockerfile.hud entrypoint; the image's
-        # WORKDIR selects which env.py is served. Override for a non-default layout.
+        self.env_vars = dict(env_vars or {})
+        self.workdir = workdir
+        # Default CMD mirrors the scaffolded Dockerfile.hud entrypoint. Leave
+        # workdir unset by default so Modal preserves the image WORKDIR.
         self.command = (
             tuple(command)
             if command is not None
@@ -337,7 +348,7 @@ class ModalRuntime:
 
         app = None
         if config.image is not None:
-            image = modal.Image.from_registry(config.image)
+            image = _modal_image_from_uri(modal, config.image)
         elif self.image_name is not None:
             image = modal.Image.from_name(self.image_name)
         elif self._image is None:
@@ -353,11 +364,13 @@ class ModalRuntime:
                         await self._image.build.aio(app=app)
                         self._resolved = self._image
             image = self._resolved
+        if self.env_vars:
+            image = image.env(self.env_vars)
 
         if app is None:
             app = await modal.App.lookup.aio(self.app_name, create_if_missing=True)
 
-        sandbox_kwargs: dict[str, float | int | str] = {}
+        sandbox_kwargs: dict[str, Any] = {}
         resources = config.resources
         if resources is not None and resources.cpu is not None:
             sandbox_kwargs["cpu"] = resources.cpu
@@ -378,6 +391,7 @@ class ModalRuntime:
             *self.command,
             app=app,
             image=image,
+            workdir=self.workdir,
             unencrypted_ports=[self.port],
             readiness_probe=modal.Probe.with_tcp(self.port),
             # Modal types both timeouts as int seconds; floats raise at proto encode.
@@ -846,8 +860,6 @@ class HostedRuntime:
         group_id: str | None,
         trace_id: str,
     ) -> dict[str, Any]:
-        if task.runtime_config is not None:
-            raise ValueError("HostedRuntime does not support task runtime_config yet")
         spec_of = getattr(agent, "hosted_spec", None)
         if not callable(spec_of):
             raise ValueError(
@@ -869,6 +881,10 @@ class HostedRuntime:
         }
         if group_id is not None:
             payload["group_id"] = group_id
+        if task.runtime_config is not None:
+            runtime_config = task.runtime_config.model_dump(mode="json", exclude_none=True)
+            if runtime_config:
+                payload["runtime_config"] = runtime_config
         await platform.apost("/rollouts/submit", json=payload)
         try:
             return await self._await_terminal(platform, payload["trace_id"])

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -116,10 +116,18 @@ def _row() -> Task:
     return Task(env="any-env", id="t")
 
 
+async def _docker_calls(docker_log: Path) -> list[str]:
+    return (await asyncio.to_thread(docker_log.read_text)).splitlines()
+
+
 @dataclass(frozen=True)
 class _ModalImageRef:
     kind: str
     name: str
+    env_vars: dict[str, str] | None = None
+
+    def env(self, vars: dict[str, str]) -> _ModalImageRef:
+        return _ModalImageRef(self.kind, self.name, dict(vars))
 
 
 class _FakeModalSandbox:
@@ -156,6 +164,11 @@ def _install_fake_modal(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
         def from_registry(name: str) -> _ModalImageRef:
             calls["registry_image"] = name
             return _ModalImageRef("registry", name)
+
+        @staticmethod
+        def from_id(image_id: str) -> _ModalImageRef:
+            calls["modal_image_id"] = image_id
+            return _ModalImageRef("id", image_id)
 
     async def lookup(app_name: str, *, create_if_missing: bool) -> str:
         calls["app_lookup"] = (app_name, create_if_missing)
@@ -330,11 +343,11 @@ async def test_acquisition_publishes_ephemeral_port_and_removes_container(
     provider = DockerRuntime("img:tag", run_args=("-e", "X=1"))
     async with provider(_row()) as runtime:
         assert runtime.url == "tcp://127.0.0.1:43210"
-        calls = docker_log.read_text().splitlines()
+        calls = await _docker_calls(docker_log)
         assert calls[0] == "run --detach -e X=1 --publish 127.0.0.1::8765 img:tag"
         assert calls[1] == "port cid-42 8765"
 
-    assert docker_log.read_text().splitlines()[-1] == "rm --force cid-42"
+    assert (await _docker_calls(docker_log))[-1] == "rm --force cid-42"
 
 
 async def test_runtime_config_supplies_image_and_resources(
@@ -355,7 +368,7 @@ async def test_runtime_config_supplies_image_and_resources(
         assert runtime.url == "tcp://127.0.0.1:43210"
         assert runtime.config == task.runtime_config
 
-    calls = docker_log.read_text().splitlines()
+    calls = await _docker_calls(docker_log)
     assert calls[0] == (
         "run --detach --cpus 2 --memory 4096m --gpus 1 --publish 127.0.0.1::8765 img:firefox"
     )
@@ -379,7 +392,7 @@ async def test_task_runtime_config_overrides_default_image(
             resources=RuntimeResources(cpu=2, memory_mb=4096),
         )
 
-    assert docker_log.read_text().splitlines()[0] == (
+    assert (await _docker_calls(docker_log))[0] == (
         "run --detach --cpus 2 --memory 4096m --publish 127.0.0.1::8765 img:task"
     )
 
@@ -492,6 +505,7 @@ async def test_modal_runtime_config_flows_into_modal_sdk(
     assert calls["sandbox_kwargs"] == {
         "app": "app",
         "image": _ModalImageRef("registry", "img:tag"),
+        "workdir": None,
         "unencrypted_ports": [8765],
         "readiness_probe": ("tcp", 8765),
         "timeout": 120,
@@ -501,6 +515,26 @@ async def test_modal_runtime_config_flows_into_modal_sdk(
     }
     assert calls["ready_timeout"] == 30
     assert calls["terminated"] is True
+
+
+async def test_modal_runtime_accepts_modal_image_uri(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    config = RuntimeConfig(image="modal://im-built")
+
+    async with ModalRuntime(runtime_config=config)(_row()) as runtime:
+        assert runtime.config == config
+
+    assert calls["modal_image_id"] == "im-built"
+    assert calls["sandbox_kwargs"] == {
+        "app": "app",
+        "image": _ModalImageRef("id", "im-built"),
+        "workdir": None,
+        "unencrypted_ports": [8765],
+        "readiness_probe": ("tcp", 8765),
+        "timeout": 3600,
+    }
 
 
 async def test_modal_task_runtime_config_overlays_provider_defaults(
@@ -527,6 +561,7 @@ async def test_modal_task_runtime_config_overlays_provider_defaults(
     assert calls["sandbox_kwargs"] == {
         "app": "app",
         "image": _ModalImageRef("registry", "img:task"),
+        "workdir": None,
         "unencrypted_ports": [8765],
         "readiness_probe": ("tcp", 8765),
         "timeout": 120,
@@ -544,6 +579,40 @@ async def test_modal_runtime_config_image_overrides_image_name(
         assert runtime.config == config
 
     assert calls["registry_image"] == "img:tag"
+
+
+async def test_modal_runtime_can_override_workdir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    config = RuntimeConfig(image="img:tag")
+    provider = ModalRuntime(runtime_config=config, workdir="/app")
+
+    async with provider(_row()) as runtime:
+        assert runtime.config == config
+
+    sandbox_kwargs = calls["sandbox_kwargs"]
+    assert isinstance(sandbox_kwargs, dict)
+    assert sandbox_kwargs["workdir"] == "/app"
+
+
+async def test_modal_runtime_applies_env_vars_to_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    config = RuntimeConfig(image="img:tag")
+    provider = ModalRuntime(runtime_config=config, env_vars={"TOKEN": "secret"})
+
+    async with provider(_row()) as runtime:
+        assert runtime.config == config
+
+    sandbox_kwargs = calls["sandbox_kwargs"]
+    assert isinstance(sandbox_kwargs, dict)
+    assert sandbox_kwargs["image"] == _ModalImageRef(
+        "registry",
+        "img:tag",
+        {"TOKEN": "secret"},
+    )
 
 
 async def test_daytona_runtime_config_flows_into_daytona_sdk(
@@ -668,6 +737,6 @@ async def test_container_that_dies_before_serving_fails_with_its_logs(
             pass
 
     assert "ImportError: boom" in str(err.value)
-    calls = docker_log.read_text().splitlines()
+    calls = await _docker_calls(docker_log)
     assert "logs --tail 40 cid-42" in calls
     assert calls[-1] == "rm --force cid-42"  # cleanup still runs on failure

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -20,7 +20,16 @@ import pytest
 from hud.agents.openai_compatible import OpenAIChatAgent
 from hud.agents.types import OpenAIChatConfig
 from hud.eval.run import Run
-from hud.eval.runtime import HostedRuntime, HUDRuntime, Runtime, _splice_websocket
+from hud.eval.runtime import (
+    HostedRuntime,
+    HUDRuntime,
+    Runtime,
+    RuntimeConfig,
+    RuntimeGPU,
+    RuntimeLimits,
+    RuntimeResources,
+    _splice_websocket,
+)
 from hud.eval.task import Task
 from hud.settings import settings
 
@@ -117,7 +126,16 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     hosted = HostedRuntime(poll_interval=0.0)
     trace_id = uuid.uuid4().hex
     job_id = uuid.uuid4().hex
-    task = Task(env="sums", id="add", args={"a": 1, "b": 2})
+    task = Task(
+        env="sums",
+        id="add",
+        args={"a": 1, "b": 2},
+        runtime_config=RuntimeConfig(
+            image="registry.example/sums:latest",
+            resources=RuntimeResources(cpu=2, gpu=RuntimeGPU(type="L4", count=1)),
+            limits=RuntimeLimits(startup_timeout_s=120, run_timeout_s=900),
+        ),
+    )
 
     run = await hosted.run(task, _agent(), job_id=job_id, group_id="g1", trace_id=trace_id)
 
@@ -135,6 +153,11 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert payload["env"] == "sums"
     assert payload["task"] == "add"
     assert payload["args"] == {"a": 1, "b": 2}
+    assert payload["runtime_config"] == {
+        "image": "registry.example/sums:latest",
+        "resources": {"cpu": 2.0, "gpu": {"type": "L4", "count": 1}},
+        "limits": {"startup_timeout_s": 120, "run_timeout_s": 900},
+    }
     assert payload["group_id"] == "g1"
     assert payload["agent"]["type"] == "openai_compatible"
     assert payload["agent"]["config"]["model"] == "test-model"


### PR DESCRIPTION
## Summary

Adds the SDK-side contract needed for Modal-native hosted rollouts:

- `hud deploy --runtime modal` persists `runtime_provider=modal` on build trigger payloads
- `HostedRuntime` forwards `Task.runtime_config` to `/rollouts/submit`
- `ModalRuntime` accepts `modal://` image ids, applies env vars to images, and exposes an optional `workdir` override while preserving the image `WORKDIR` by default

This keeps build behavior consistent with the existing platform contract: the submitted Docker context controls which `hud-python` version is installed, while `--runtime modal` opts the registry into Modal for hosted execution.

## Validation

- `uv run --no-sync ruff check hud/cli/deploy.py hud/cli/tests/test_deploy.py hud/eval/runtime.py hud/eval/tests/test_docker_provider.py hud/eval/tests/test_hosted.py`
- `uv run --no-sync pytest packages/hud-python/hud/eval/tests/test_docker_provider.py -q`
- `uv run --no-sync pytest packages/hud-python/hud/eval/tests/test_hosted.py packages/hud-python/hud/cli/tests/test_deploy.py -q`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted rollout submit payloads and deploy build triggers (platform contract); Modal sandbox image/workdir/env behavior affects how remote envs boot.
> 
> **Overview**
> Wires the SDK to **Modal-native hosted execution** end-to-end: deploy can opt a registry into Modal, hosted rollouts can carry per-task runtime requirements, and local Modal sandboxes understand platform-built images.
> 
> **Deploy CLI** adds `--runtime` (currently only `modal`), validates it, and includes `runtime_provider` on `/builds/trigger` when set; the same flag flows through single-env and `--all` deploys. Build context upload reads the tarball via `asyncio.to_thread` instead of blocking the event loop.
> 
> **Hosted rollouts** stop rejecting `Task.runtime_config` and now attach a JSON `runtime_config` blob to `/rollouts/submit` when the task defines one (image, resources, limits).
> 
> **ModalRuntime** resolves `modal://…` image IDs via `Image.from_id`, can apply `env_vars` on the image before sandbox create, passes an optional `workdir` into `Sandbox.create` (default `None` so the image WORKDIR is preserved), and tests cover the new behavior plus async docker log reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d5d196988dc2d3b069806dba4851563a537a5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->