### PR TITLE
Standardize default job names

### DIFF
--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -38,11 +38,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger("hud.eval.taskset")
 
 
-def _job_name(tasks: list[Task], group: int) -> str:
+def _job_name(taskset_name: str, tasks: list[Task], group: int) -> str:
     suffix = f" ({group} times)" if group > 1 else ""
     if len(tasks) == 1:
-        return f"Task Run: {tasks[0].id}{suffix}"
-    return f"Batch Run: {len(tasks)} tasks{suffix}"
+        return f"{tasks[0].id}{suffix}"
+    return f"{taskset_name} ({len(tasks)} tasks){suffix}"
 
 
 class Taskset:
@@ -242,7 +242,7 @@ class Taskset:
             expanded.extend((task, group_id) for _ in range(group))
 
         if job is None:
-            job = Job(id=uuid.uuid4().hex, name=_job_name(task_list, group), group=group)
+            job = Job(id=uuid.uuid4().hex, name=_job_name(self.name, task_list, group), group=group)
             await job_enter(job.id, name=job.name, group=group)
         job_id = job.id
 


### PR DESCRIPTION
## Summary

Standardizes the default name assigned to a new job (`hud/eval/taskset.py`).

- Drops the divergent `Task Run:` / `Batch Run:` prefixes.
- Default job names now use the bare subject:
  - single task → the task id (matching the lone-rollout path in `run.py` and the chat path in `chat.py`),
  - batch → `{taskset name} ({N} tasks)`.
- This aligns with the platform's `{subject} on {model}` job-naming convention (the platform-side PR adds the `on {model} (Job N)` portion for UI-launched jobs).

The group suffix (` ({group} times)`) is preserved.

## Test plan

- [ ] Run a single-task taskset → job name is the task id.
- [ ] Run a multi-task taskset → job name is `{taskset} (N tasks)`.
- [ ] Confirm names render sensibly on the platform Jobs list.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change to default job labels sent via `job_enter`; no rollout, auth, or persistence logic is modified.
> 
> **Overview**
> **Default job names** from `Taskset.run` no longer use `Task Run:` / `Batch Run:` prefixes. They now match other eval entry points and the platform’s `{subject} on {model}` style.
> 
> For a **single-task** run, the job name is the task id (optionally with ` ({group} times)` when `group > 1`). For **multi-task** runs, it is `{taskset name} ({N} tasks)` with the same group suffix. `_job_name` takes `taskset_name` and `Taskset.run` passes `self.name` when auto-creating a `Job`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db5250694ac23729f3898771e5c4b79803f903e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->