### PR TITLE
L/v6 template updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ __pycache__
 .pytest_cache
 dist/
 build/
+# The broad build/ rule above also matches docs/v6/build/, which is real docs
+# content (linked from docs.json). Keep tracking it so docs.hud.ai/v6/build/*
+# does not 404.
+!docs/v6/build/
 *.egg-info/
 uv.lock
 

--- a/cookbooks/rl-training/README.md
+++ b/cookbooks/rl-training/README.md
@@ -18,22 +18,29 @@ each `optim_step` closes the on-policy loop.
 
 ## Run
 
-Needs `HUD_API_KEY` and `HUD_MODEL` (a trainable gateway model).
-
-**Train on a deployed taskset (the real flow).** You've built a taskset and
-pushed it (`hud deploy` + `hud sync`); now train on it. Point `HUD_TASKSET` at it
-and rollouts run on **remote HUD boxes** — nothing local:
+Needs `HUD_API_KEY` (from your environment or `.env`). List the trainable
+gateway models on your account, pick one, and set it as the `MODEL` constant at
+the top of `simple_train.py` / `ppo_custom_loss.py`:
 
 ```bash
-HUD_MODEL=<trainable-model> HUD_TASKSET=<taskset-name-or-id> uv run simple_train.py --steps 10
-HUD_MODEL=<trainable-model> HUD_TASKSET=<taskset-name-or-id> uv run ppo_custom_loss.py --steps 10
+hud models
 ```
 
-**Quickstart (self-contained).** Leave `HUD_TASKSET` unset and a tiny local
+**Train on a deployed taskset (the real flow).** You've built a taskset and
+pushed it (`hud deploy` + `hud sync`); now train on it. Set the `TASKSET`
+constant in `common.py` to its name/id and rollouts run on **remote HUD
+boxes** — nothing local:
+
+```bash
+uv run simple_train.py --steps 10
+uv run ppo_custom_loss.py --steps 10
+```
+
+**Quickstart (self-contained).** Leave `TASKSET` empty and a tiny local
 arithmetic taskset runs against the bundled `env.py`:
 
 ```bash
-HUD_MODEL=<trainable-model> uv run simple_train.py --steps 10
+uv run simple_train.py --steps 10
 ```
 
 The swap is `common.py`'s `load_taskset_and_runtime()` — `Taskset.from_api(name)`

--- a/cookbooks/rl-training/common.py
+++ b/cookbooks/rl-training/common.py
@@ -5,31 +5,33 @@ The training loop is agnostic to where rollouts come from — it only consumes
 local quickstart differ only in *which taskset* and *which runtime* you hand to
 ``Taskset.run``; the training code never changes.
 
-``load_taskset_and_runtime()`` picks between them from the environment:
+``load_taskset_and_runtime()`` picks between them from the ``TASKSET`` constant:
 
-- ``HUD_TASKSET`` set — the real flow: load a taskset you already built and
+- ``TASKSET`` set — the real flow: load a taskset you already built and
   pushed (``hud deploy`` + ``hud sync``) from the platform with
   ``Taskset.from_api``, and run every rollout on a leased HUD box with
   ``HUDRuntime`` (the agent runs remotely, next to the env). Nothing local.
-- unset — a self-contained quickstart: a tiny arithmetic taskset driven against
+- empty — a self-contained quickstart: a tiny arithmetic taskset driven against
   the bundled ``env.py`` locally.
 """
 
 from __future__ import annotations
 
-import os
 import random
 
 from hud.eval import HUDRuntime, LocalRuntime, Provider, Taskset
 
 from env import multiply
 
+# Deployed taskset to train on (its name or id, from `hud deploy` + `hud sync`).
+# Leave empty for the self-contained local quickstart against env.py.
+TASKSET = ""
+
 
 def load_taskset_and_runtime() -> tuple[Taskset, Provider | HUDRuntime]:
-    """Resolve the rollout source from ``HUD_TASKSET`` (see module docstring)."""
-    taskset_name = os.environ.get("HUD_TASKSET")
-    if taskset_name:
-        return Taskset.from_api(taskset_name), HUDRuntime()
+    """Resolve the rollout source from the ``TASKSET`` constant (see module docstring)."""
+    if TASKSET:
+        return Taskset.from_api(TASKSET), HUDRuntime()
 
     # Three-digit x two-digit multiplication *with* reasoning: hard enough that a
     # 4B reasoner is right only sometimes (a sub-1.0 baseline with within-group

--- a/cookbooks/rl-training/ppo_custom_loss.py
+++ b/cookbooks/rl-training/ppo_custom_loss.py
@@ -13,7 +13,7 @@ reuse the rollout logprobs as the behavior proxy, form the token ratio
 trust region (zero gradient, not clipped), and normalize at the token level so
 long and short trajectories contribute evenly.
 
-    HUD_MODEL=<trainable-gateway-model> uv run ppo_custom_loss.py --steps 10
+    uv run ppo_custom_loss.py --steps 10   # set MODEL below (pick one with `hud models`)
 
 Requires torch (declared in this cookbook's pyproject; in the SDK it is the
 ``hud-python[train]`` extra).
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import os
 
 import torch
 from dotenv import load_dotenv
@@ -33,6 +32,10 @@ from hud import TrainingClient
 from hud.agents import create_agent
 from hud.eval import Job
 from hud.train import DatumTensors
+
+# The trainable gateway model to sample from and train, in place.
+# Pick one with `hud models` and paste its id here.
+MODEL = "<trainable-model>"
 
 
 def glm_double_sided_is(
@@ -92,7 +95,7 @@ def glm_double_sided_is(
 
 
 async def main(*, steps: int, group: int, learning_rate: float, max_concurrent: int) -> None:
-    model = os.environ["HUD_MODEL"]  # a trainable gateway model string
+    model = MODEL  # the trainable gateway model (set at the top of this file)
 
     # Training rollout: capture token ids + logprobs onto each turn's Sample;
     # room for chain-of-thought (the task needs scratch work).

--- a/cookbooks/rl-training/simple_train.py
+++ b/cookbooks/rl-training/simple_train.py
@@ -10,14 +10,13 @@ Runs are passed directly: ``TrainingClient`` reads each ``Run``'s trajectory and
 reward. (Pass ``run.trace_id`` strings instead to train on trajectories the
 platform already holds.)
 
-    HUD_MODEL=<trainable-gateway-model> uv run simple_train.py --steps 10
+    uv run simple_train.py --steps 10   # set MODEL below (pick one with `hud models`)
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
-import os
 import time
 
 from dotenv import load_dotenv
@@ -27,6 +26,10 @@ from hud import TrainingClient
 from hud.agents import create_agent
 from hud.agents.types import AgentStep
 from hud.eval import Job
+
+# The trainable gateway model to sample from and train, in place.
+# Pick one with `hud models` and paste its id here.
+MODEL = "Qwen3 4B Instruct 2507 (Tinker)"
 
 
 def _output_tokens(runs: list) -> int:
@@ -41,7 +44,7 @@ def _output_tokens(runs: list) -> int:
 
 
 async def main(*, steps: int, group: int, learning_rate: float, max_concurrent: int) -> None:
-    model = os.environ["HUD_MODEL"]  # a trainable gateway model string
+    model = MODEL  # the trainable gateway model (set at the top of this file)
 
     # return_token_ids tells the gateway/agent this is a training rollout: the
     # response carries token ids + per-token logprobs, which the agent records on

--- a/docs/v6/build/environments.mdx
+++ b/docs/v6/build/environments.mdx
@@ -1,0 +1,96 @@
+---
+title: "Environments"
+description: "Define where the agent acts and the connections it can drive."
+icon: "cube"
+---
+
+An **environment** is where the agent acts. Everything an agent needs from one is *access* — a way to act on the system — so that's all an environment exposes: a **capability**, a connection the system already speaks.
+
+| Capability | What it exposes |
+|------------|-----------------|
+| **`ssh`**  | Shell + files (bash, SFTP) in a sandboxed workspace |
+| **`mcp`**  | Tools over the Model Context Protocol |
+| **`cdp`**  | Browser control over the Chrome DevTools Protocol |
+| **`rfb`**  | Full computer-use over VNC: screen + keyboard/mouse |
+| **`robot`** | Schema-driven robot observation/action loop over WebSocket *(beta)* |
+
+A machine has a shell, so it speaks `ssh`; a web app has a browser, so it speaks `cdp`. You expose the connection the system already has — no action schema to invent — and the agent drives it natively with its own tools. Two things fall out for free: **wrapping any system is trivial**, and **nothing about the agent is baked in**, so the same environment keeps working with any model or harness, today's or next year's.
+
+## A shell environment
+
+The most common capability is a shell. A `Workspace` is a sandboxed directory the agent works in over `ssh`; `env.workspace(root)` brings it up, publishes its `ssh` capability, and tears it down with the env — one line, no hook:
+
+```python env.py
+from hud.environment import Environment
+
+env = Environment(name="coder")
+env.workspace("workspace")
+```
+
+That's a complete environment. Any harness that speaks `ssh` — Claude Code, a coding agent, your own — can now open a shell and edit files in the workspace.
+
+## Other capabilities
+
+Every other protocol — `mcp` (your own tools), `cdp` (browser), `rfb` (computer-use), `robot` (robot policies) — is a daemon you run and publish. The Capabilities reference has a working, copy-pasteable spin-up for each, with the library that backs it.
+
+<Card title="Spin up any capability" icon="plug" href="/v6/reference/capabilities#spinning-up-a-capability">
+  Tested examples for `ssh`, `mcp`, `cdp`, `rfb`, and `robot` — each with the library it needs and the lifecycle wired up.
+</Card>
+
+## Lifecycle hooks
+
+A daemon the env runs itself publishes its address when the env starts. Bring it up in `@env.initialize` and publish it with `env.add_capability(...)`; tear it down in `@env.shutdown`:
+
+```python env.py
+from hud.capabilities import Capability
+
+browser = None
+
+@env.initialize
+async def _up():
+    global browser
+    browser = await launch_chromium()        # bring up whatever your tasks need
+    env.add_capability(Capability.cdp(name="browser", url=f"ws://127.0.0.1:{browser.port}"))
+
+@env.shutdown
+async def _down():
+    if browser is not None:
+        await browser.close()
+```
+
+`@env.initialize` runs once before the env accepts connections; `@env.shutdown` runs on stop. `env.add_capability` replaces any same-named entry, so re-serving overwrites a stale address rather than duplicating it. For the full pattern — starting a server task and blocking until it binds — see [Capabilities](/v6/reference/capabilities#spinning-up-a-capability).
+
+## Serving the environment
+
+An environment serves a tcp control channel. Three ways to bring it up:
+
+<CardGroup cols={3}>
+<Card title="hud serve" icon="wrench">
+  `hud serve env.py` serves locally on `tcp://127.0.0.1:8765` while you iterate.
+</Card>
+<Card title="hud deploy" icon="rocket">
+  Builds and publishes the environment to HUD infra in one step.
+</Card>
+<Card title="env.serve()" icon="code">
+  `await env.serve("127.0.0.1", 8765)` is the in-code equivalent.
+</Card>
+</CardGroup>
+
+You rarely call `serve` yourself — `hud eval` and `task.run()` bring the environment up for you (see [Tasks](/v6/build/tasks)).
+
+## Next steps
+
+<CardGroup cols={2}>
+<Card title="Tasks, tasksets & grading" icon="list-check" href="/v6/build/tasks">
+  Add tasks that prompt and grade against this environment.
+</Card>
+<Card title="Capabilities reference" icon="plug" href="/v6/reference/capabilities">
+  Every protocol factory and its params.
+</Card>
+<Card title="Run on any model" icon="robot" href="/v6/run/models">
+  Point a harness at the capabilities you declared.
+</Card>
+<Card title="Deploy & scale" icon="layer-group" href="/v6/run/deploy">
+  Package once, run anywhere.
+</Card>
+</CardGroup>

--- a/docs/v6/build/tasks.mdx
+++ b/docs/v6/build/tasks.mdx
@@ -1,0 +1,183 @@
+---
+title: "Tasks & grading"
+description: "Write a task template that prompts and grades, and turn one definition into a whole dataset of tasks."
+icon: "list-check"
+---
+
+A **task template** is the measurement instrument: one async generator that prompts and grades. Calling it with different arguments mints different **tasks** — one function becomes a whole dataset, no duplication.
+
+The template ships **inside the environment image** — one image mints every task in your dataset on demand, with no separate artifact per task.
+
+## The two-yield generator
+
+Register a template with `@env.template()`. The first `yield` is the prompt; the value it returns is the agent's answer; the second `yield` is the reward (a float, usually `0.0`–`1.0`).
+
+```python tasks.py
+from hud import Environment
+
+env = Environment(name="letter-count")
+
+@env.template()
+async def count_letter(word: str = "strawberry", letter: str = "r"):
+    answer = yield f"How many '{letter}'s are in '{word}'? Reply with just the number."
+    yield 1.0 if answer and str(word.count(letter)) in answer else 0.0
+```
+
+The template id defaults to the function name; override it with `@env.template(id="...")`.
+
+## Tasks: one definition, many data points
+
+Calling the template **mints a task** — one runnable, parameterized row bound to the environment by name:
+
+```python tasks.py
+tasks = [count_letter(word=w) for w in ("strawberry", "raspberry", "blueberry")]
+```
+
+`count_letter(word="raspberry")` doesn't run anything; it returns a `Task` (a plain row: env name, template id, args). A list of tasks is a dataset, and `hud eval tasks.py claude` runs each one. This is the core move: parameterize the generator, and a single definition spans a whole spread of difficulties or inputs.
+
+## Grading
+
+The second yield is the reward. You have three options, in increasing power.
+
+### 1. Plain Python
+
+For simple checks, just compute a float. HUD ships normalized comparison helpers in `hud.graders`:
+
+```python tasks.py
+from hud.graders import numeric_match
+
+@env.template()
+async def count_letter(word: str = "strawberry", letter: str = "r"):
+    answer = yield f"How many '{letter}'s are in '{word}'?"
+    yield numeric_match(answer, word.count(letter))
+```
+
+Available helpers (each returns a `float`): `exact_match`, `contains`, `contains_any`, `contains_all`, `numeric_match`, `f1_score`, and `normalize` (a text-normalization building block). See the [Graders reference](/v6/reference/graders).
+
+### 2. Async graders
+
+`BashGrader` runs a shell command and scores by exit code (`1.0` if it exits `0`); `LLMJudgeGrader` scores an answer against rubric criteria with an LLM. Both are async and return a `SubScore`:
+
+```python tasks.py
+from hud.graders import BashGrader
+
+@env.template()
+async def fix_tests(target: str = "tests/"):
+    answer = yield f"Make the tests in {target} pass."
+    result = await BashGrader.grade(weight=1.0, command=f"pytest {target} -q")
+    yield result.value
+```
+
+### 3. Composed graders
+
+`combine` runs several graders in parallel and combines them into a weighted `EvaluationResult` you can yield directly. Positive weights are normalized to sum to `1.0`:
+
+```python tasks.py
+from hud.graders import BashGrader, LLMJudgeGrader, SubScore, combine, exact_match
+
+@env.template()
+async def implement_feature(spec: str = "add a /health endpoint"):
+    answer = yield f"Implement this and summarize what you changed: {spec}"
+    yield await combine(
+        BashGrader.grade(weight=0.5, command="pytest -q"),
+        LLMJudgeGrader.grade(weight=0.3, answer=answer, criteria=["Matches the spec"]),
+        SubScore(name="mentions_endpoint", value=exact_match(answer, "/health"), weight=0.2),
+    )
+```
+
+Subscores show up in the trace, so a partial reward is legible: you can see which component earned it. (`LLMJudgeGrader` needs the `rubric` package: `pip install rubric`.)
+
+<Warning>
+A grader that returns a constant, or echoes the answer back as a pass, teaches a model nothing and invites reward hacking. Design graders that actually separate good work from bad — see [Designing tasks for signal](/v6/run/signal).
+</Warning>
+
+## Grade the outcome, not just the answer
+
+A grader doesn't have to read the agent's words. Because the agent acts on a real system through its capabilities, the most reliable thing to score is often the **state it left behind** — tests passing, a file written, a row in a database, a service responding. The task simply skips the `answer =` and grades the world:
+
+```python tasks.py
+from hud import Environment
+from hud.graders import BashGrader
+
+env = Environment(name="api")
+ws = env.workspace("workspace")
+
+@env.template()
+async def add_endpoint():
+    yield "Add a /health endpoint to the app in your workspace and make it return 200."
+    result = await BashGrader.grade(weight=1.0, command="pytest tests/test_health.py -q", cwd=str(ws.root))
+    yield result.value
+```
+
+This is **outcome verification**: you score what the agent *did*, not how it described it — the same rigor as a test suite, with no fixed step-by-step protocol for the agent to conform to. The agent works however it likes through the capability; the grader checks the result.
+
+## Structured answers
+
+By default the answer is the agent's raw text. To receive a typed, parsed answer, declare `returns=` with a type; the answer arrives as an `Answer[T]` (parsed `content`, original `raw`):
+
+```python tasks.py
+from pydantic import BaseModel
+
+class Summary(BaseModel):
+    title: str
+    bullets: list[str]
+
+@env.template(returns=Summary)
+async def summarize(doc: str = "..."):
+    answer = yield f"Summarize:\n\n{doc}"
+    yield 1.0 if len(answer.content.bullets) >= 3 else 0.0
+```
+
+Use `input=` and `returns=` to surface JSON schemas in the environment's manifest. See the [Types reference](/v6/reference/types).
+
+## Sync metadata: `slug` and `columns`
+
+When you publish a [taskset](/v6/run/deploy#publish-your-tasks-as-a-taskset) to the platform (`hud sync tasks`), each task carries optional metadata. `slug` is its stable id (defaults to the template id plus an args hash); `columns` are arbitrary fields surfaced as filterable columns and leaderboard facets on the platform:
+
+```python tasks.py
+easy = count_letter(word="strawberry")
+easy.slug = "count-strawberry"
+easy.columns = {"difficulty": "easy", "length": 10}
+```
+
+## Run them
+
+While authoring, one command runs your tasks — it loads the env from your source and grades each one:
+
+```bash
+hud eval tasks.py claude --group 3          # one task, 3 rollouts
+hud eval tasks.py claude --full --group 3   # the whole dataset, 3 rollouts each
+```
+
+That's the loop you'll live in. In code, calling a template mints a `Task`; `run` it for a [`Job`](/v6/reference/tasks#job) of graded runs. With no `runtime=`, it serves the source the task was defined in, so it just works locally:
+
+```python run.py
+from hud.agents import create_agent
+from tasks import count_letter
+
+agent = create_agent("claude-sonnet-4-5")
+job = await count_letter(word="strawberry").run(agent)
+print(job.reward)
+```
+
+From here the path forks — and that's where `runtime=` comes in:
+
+- **Scale** — package the environment and run it on your own infra or HUD-hosted. See [Run tasks anywhere](/v6/run/deploy).
+- **Train** — drive a `Taskset` in a loop and turn rewards into GRPO advantages. See [Train on your tasks](/v6/run/training).
+
+## Next steps
+
+<CardGroup cols={2}>
+<Card title="Designing tasks for signal" icon="signal" href="/v6/run/signal">
+  Make tasks that actually teach: difficulty, spread, and anti-reward-hacking.
+</Card>
+<Card title="Graders reference" icon="check-double" href="/v6/reference/graders">
+  Every grader, comparison helper, and the `combine` combiner.
+</Card>
+<Card title="Run on any model" icon="robot" href="/v6/run/models">
+  Evaluate with Claude, OpenAI, Gemini, or your own endpoint.
+</Card>
+<Card title="Train on your tasks" icon="dumbbell" href="/v6/run/training">
+  Turn a group of rewards into GRPO advantages.
+</Card>
+</CardGroup>

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.5.41"
+    assert hud.__version__ == "0.6.0"

--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.5.41"
+__version__ = "0.6.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation, ignore-rule fix, cookbook ergonomics, and a version bump with no production SDK logic changes in the diff.
> 
> **Overview**
> Bumps the SDK to **0.6.0** and fixes **`.gitignore`** so the broad `build/` ignore no longer drops tracked **`docs/v6/build/`** pages (avoids 404s on published docs).
> 
> Adds v6 **Environments** and **Tasks & grading** MDX guides covering capabilities, lifecycle hooks, two-yield templates, graders, and how to run/eval tasks.
> 
> The **RL training cookbook** stops requiring **`HUD_MODEL`** / **`HUD_TASKSET`** env vars: trainable model is a **`MODEL`** constant in the train scripts, deployed taskset is **`TASKSET`** in **`common.py`**, and the README shows simpler `uv run` commands plus **`hud models`** for picking a model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cd60a08a7e0d877a6e0fa8e2fdfa947e91d967f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->