### PR TITLE
feat(models): surface is_trainable + model id in hud models (v0.6.2)

### DIFF
--- a/cookbooks/rl-training/README.md
+++ b/cookbooks/rl-training/README.md
@@ -18,12 +18,13 @@ each `optim_step` closes the on-policy loop.
 
 ## Run
 
-Needs `HUD_API_KEY` (from your environment or `.env`). List the trainable
-gateway models on your account, pick one, and set it as the `MODEL` constant at
-the top of `simple_train.py` / `ppo_custom_loss.py`:
+Needs `HUD_API_KEY` (from your environment or `.env`). List the gateway models
+on your account, pick a trainable one (the **Trainable** column marks them), and
+set it as the `MODEL` constant at the top of `simple_train.py` /
+`ppo_custom_loss.py`:
 
 ```bash
-hud models
+hud models list          # Name | Model (API) | ID | Provider | Agent | Trainable
 ```
 
 **Train on a deployed taskset (the real flow).** You've built a taskset and

--- a/docs/v6/run/training.mdx
+++ b/docs/v6/run/training.mdx
@@ -12,6 +12,17 @@ The rewards are the signal: the tasks you evaluate are already training data —
 - A task with **spread** in its rewards — a group that all scores `0.0` (or all `1.0`) produces zero advantage and teaches nothing. See [Designing tasks for signal](/v6/run/signal).
 - For the managed trainer: a **trainable model** (created below).
 
+## Find a trainable base
+
+`hud models list` is the source of truth for what the gateway serves — it prints each model's name, API slug, **id**, provider, agent type, and a **Trainable** column. Only models marked trainable can be forked and trained:
+
+```bash
+hud models list                 # the Trainable column (✓) marks forkable bases
+hud models list --json          # same data, scriptable
+```
+
+Use the **slug** ("Model (API)") or **id** from that table wherever a model string is expected (`HUD_MODEL`, `create_agent`, `TrainingClient`).
+
 ## Create a trainable model
 
 A trainable model is a private, team-owned model whose weights you advance. Fork one from any trainable base — the fork starts from the base's active checkpoint, so you continue where it left off:
@@ -20,7 +31,7 @@ A trainable model is a private, team-owned model whose weights you advance. Fork
 hud models fork Qwen/Qwen3.5-4B --name arith-rl
 ```
 
-The new model's slug (`arith-rl`) is both what you **sample** (through the gateway, like any other model) and what you **train**. Inspect a model's catalog entry any time with `hud models list`.
+The new model's slug (`arith-rl`) is both what you **sample** (through the gateway, like any other model) and what you **train**.
 
 ## Train it
 

--- a/hud/cli/models.py
+++ b/hud/cli/models.py
@@ -56,14 +56,18 @@ def list_models(
     table = Table()
     table.add_column("Name", style="cyan")
     table.add_column("Model (API)", style="green")
+    table.add_column("ID", style="blue", no_wrap=True)
     table.add_column("Provider", style="yellow")
     table.add_column("Agent", style="magenta")
+    table.add_column("Trainable", style="green", justify="center")
     for model in models_list:
         table.add_row(
             model.name or model.id or "-",
             model.model_name or model.id or "-",
+            model.id or "-",
             model.provider.name or "-",
             model.sdk_agent_type or "-",
+            "✓" if model.is_trainable else "",
         )
     console.print(table)
     console.print(f"\n[dim]Gateway: {settings.hud_gateway_url}[/dim]")

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.1"
+    assert hud.__version__ == "0.6.2"

--- a/hud/utils/gateway.py
+++ b/hud/utils/gateway.py
@@ -35,6 +35,7 @@ class GatewayModelInfo(BaseModel):
     name: str | None = None
     model_name: str | None = None
     sdk_agent_type: str | None = None
+    is_trainable: bool = False
     provider: GatewayProviderInfo = Field(default_factory=GatewayProviderInfo)
 
 

--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hud-python"
-version = "0.6.1"
+version = "0.6.2"
 description = "SDK for the HUD platform."
 readme = "README.md"
 requires-python = ">=3.11, <3.13"


### PR DESCRIPTION
## Summary

- **`is_trainable` now flows through the SDK**: `GatewayModelInfo` carries it, so `list_gateway_models()` (and anything reading the gateway catalog) can tell which models are forkable/trainable.
- **`hud models list` is now accurate for prod**: added an **ID** column (the model UUID) and a **Trainable** column alongside name/slug/provider/agent.
- **Docs point at `hud models list` as the discovery mechanism**: the training guide gains a "Find a trainable base" step, and the rl-training cookbook README uses `hud models list` (the bare `hud models` only prints help).
- **Version bump to `0.6.2`** (`pyproject.toml`, `hud/version.py`, `hud/tests/test_version.py`).

## Context

Pairs with the platform-side catalog refresh (22 verified-serving Tinker base models, all `is_trainable`). With this, `hud models list` shows the Trainable column so users can pick a base to fork via `hud models fork`.

## Test plan

- [ ] `hud models list` renders the ID + Trainable columns; trainable bases show the check.
- [ ] `list_gateway_models()[i].is_trainable` is populated.
- [ ] `uv run pytest hud/tests/test_version.py` passes (asserts 0.6.2).
- [ ] `hud models list --json` includes `is_trainable`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive catalog field and CLI columns plus doc/version bumps; no auth or training-path behavior changes.
> 
> **Overview**
> Gateway catalog entries now include **`is_trainable`** on `GatewayModelInfo`, so `list_gateway_models()` and `hud models list --json` expose which bases can be forked for training.
> 
> **`hud models list`** adds an **ID** column (model UUID) and a **Trainable** column (✓ when forkable), alongside the existing name, API slug, provider, and agent type.
> 
> Training docs and the **rl-training** cookbook now point users at `hud models list` (not bare `hud models`) to pick a trainable base before `hud models fork` / `TrainingClient`.
> 
> Release **0.6.2** (`pyproject.toml`, `hud/version.py`, version test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26ee4e775bef01f2e7ec802b6374f53b6f0f3de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->