### PR TITLE
feat(gateway): enhance model alias handling and update default models

### DIFF
--- a/hud/agents/__init__.py
+++ b/hud/agents/__init__.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from hud.types import AgentType
-from hud.utils.gateway import build_gateway_client, list_gateway_models
+from hud.utils.gateway import (
+    build_gateway_client,
+    gateway_model_aliases,
+    list_gateway_models,
+    normalize_gateway_model_id,
+)
 
 if TYPE_CHECKING:
     from typing import TypeAlias
@@ -27,6 +32,8 @@ def create_agent(model: str, **kwargs: Any) -> GatewayAgent:
 
     For direct API access with provider API keys, instantiate the agent classes directly.
     """
+    requested_model = model
+    model = normalize_gateway_model_id(model)
     agent_type = next((candidate for candidate in AgentType if candidate.value == model), None)
     if agent_type is not None:
         model_id = model
@@ -73,7 +80,8 @@ def create_agent(model: str, **kwargs: Any) -> GatewayAgent:
                 for n in (gm.id, gm.name, gm.model_name)
                 if isinstance(n, str)
             ]
-            near = difflib.get_close_matches(model, known, n=3, cutoff=0.5)
+            known.extend(gateway_model_aliases())
+            near = difflib.get_close_matches(requested_model, known, n=3, cutoff=0.5)
             hint = (
                 f" Did you mean: {', '.join(near)}?"
                 if near
@@ -84,7 +92,7 @@ def create_agent(model: str, **kwargs: Any) -> GatewayAgent:
                 if gateway_models
                 else "the HUD gateway registry (empty — is HUD_API_KEY set?)"
             )
-            raise ValueError(f"Model {model!r} not found in {source}.{hint}")
+            raise ValueError(f"Model {requested_model!r} not found in {source}.{hint}")
 
     kwargs.setdefault("model", model_id)
     kwargs.setdefault("model_client", build_gateway_client(provider_name))

--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -108,7 +108,7 @@ def test_create_agent_resolves_gateway_model_metadata(
 
     model = GatewayModelInfo(
         id="ft:custom-123",
-        model_name="gpt-5.4",
+        model_name="gpt-5.5",
         sdk_agent_type="openai_compatible",
         provider=GatewayProviderInfo(name="openai"),
     )
@@ -122,4 +122,40 @@ def test_create_agent_resolves_gateway_model_metadata(
     agent = create_agent("ft:custom-123")
 
     assert isinstance(agent, OpenAIChatAgent)
-    assert agent.config.model == "gpt-5.4"  # resolved to the model's real name
+    assert agent.config.model == "gpt-5.5"  # resolved to the model's real name
+
+
+@pytest.mark.parametrize(
+    ("alias", "canonical"),
+    [
+        ("deepseek-v4", "deepseek/deepseek-v4-pro"),
+        ("deepseek-v4-flash", "deepseek/deepseek-v4-flash"),
+        ("glm-5.2", "z-ai/glm-5.2"),
+        ("kimi-k2.6", "moonshotai/kimi-k2.6"),
+        ("minimax-m3", "MiniMax-M3"),
+    ],
+)
+def test_create_agent_accepts_gateway_model_aliases(
+    alias: str,
+    canonical: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.utils.gateway import GatewayModelInfo, GatewayProviderInfo
+
+    model = GatewayModelInfo(
+        id=canonical,
+        model_name=canonical,
+        sdk_agent_type="openai_compatible",
+        provider=GatewayProviderInfo(name="openai"),
+    )
+    monkeypatch.setattr("hud.agents.list_gateway_models", lambda: [model])
+
+    def _build_client(_provider: str) -> object:
+        return object()
+
+    monkeypatch.setattr("hud.agents.build_gateway_client", _build_client)
+
+    agent = create_agent(alias)
+
+    assert isinstance(agent, OpenAIChatAgent)
+    assert agent.config.model == canonical

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -102,7 +102,7 @@ def _commands(tool: Any) -> list[str]:
 
 
 async def test_openai_shell_wraps_command_with_timeout() -> None:
-    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.4"), client=_ssh())
+    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
 
     result = await tool.execute({"commands": ["pwd"], "timeout_ms": 2500})
 
@@ -114,7 +114,7 @@ async def test_openai_shell_wraps_command_with_timeout() -> None:
 
 
 async def test_openai_shell_runs_each_command_without_timeout() -> None:
-    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.4"), client=_ssh())
+    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
 
     await tool.execute({"commands": ["echo a", "echo b"]})
 
@@ -122,7 +122,7 @@ async def test_openai_shell_runs_each_command_without_timeout() -> None:
 
 
 async def test_openai_shell_rejects_non_list_commands_without_running() -> None:
-    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.4"), client=_ssh())
+    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
 
     result = await tool.execute({"commands": 123})
 
@@ -131,7 +131,7 @@ async def test_openai_shell_rejects_non_list_commands_without_running() -> None:
 
 
 def test_openai_shell_to_params_is_shell_type() -> None:
-    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.4"), client=_ssh())
+    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
     assert tool.to_params()["type"] == "shell"
 
 

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -99,7 +99,7 @@ class OpenAIConfig(AgentConfig):
     """Configuration for OpenAIAgent."""
 
     model_name: str = "OpenAI"
-    model: str = Field(default="gpt-5.4", validation_alias=_model_alias)
+    model: str = Field(default="gpt-5.5", validation_alias=_model_alias)
     max_output_tokens: int | None = None
     temperature: float | None = None
     reasoning: Any = None  # openai Reasoning
@@ -113,7 +113,7 @@ class OpenAIChatConfig(AgentConfig):
     """Configuration for OpenAIChatAgent."""
 
     model_name: str = "OpenAI Chat"
-    model: str = Field(default="gpt-5-mini", validation_alias=_model_alias)
+    model: str = Field(default="gpt-5.4-mini", validation_alias=_model_alias)
     checkpoint: str | None = Field(
         default=None,
         description="Specific checkpoint name for inference routing. "
@@ -139,7 +139,7 @@ class ClaudeSDKConfig(AgentConfig):
     """
 
     model_name: str = "Claude Code"
-    model: str = Field(default="claude-sonnet-4-5", validation_alias=_model_alias)
+    model: str = Field(default="claude-sonnet-4-6", validation_alias=_model_alias)
     permission_mode: str = "bypassPermissions"
     max_steps: int = -1
     allowed_tools: list[str] = Field(

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -414,9 +414,12 @@ class EvalConfig(BaseModel):
             kwargs.update(agent_cfg)
 
         if self.model:
+            kwargs["model"] = self.model
+
+        if isinstance(kwargs.get("model"), str):
             from hud.utils.gateway import normalize_gateway_model_id
 
-            kwargs["model"] = normalize_gateway_model_id(self.model)
+            kwargs["model"] = normalize_gateway_model_id(kwargs["model"])
 
         if self.agent_type == AgentType.OPENAI_COMPATIBLE and "api_key" not in kwargs:
             base_url = kwargs.get("base_url", "")

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -43,8 +43,9 @@ def _resolve_model_from_catalog(model_id: str) -> tuple[AgentType, str] | None:
     Returns None if the model isn't found or the catalog is unreachable.
     """
     try:
-        from hud.utils.gateway import list_gateway_models
+        from hud.utils.gateway import list_gateway_models, normalize_gateway_model_id
 
+        model_id = normalize_gateway_model_id(model_id)
         models = list_gateway_models()
     except Exception:
         return None
@@ -117,8 +118,9 @@ class AgentPreset:
 
 _AGENT_PRESETS: list[AgentPreset] = [
     AgentPreset("Claude Sonnet 4.6", AgentType.CLAUDE, "claude-sonnet-4-6"),
-    AgentPreset("GPT-5.4", AgentType.OPENAI, "gpt-5.4"),
-    AgentPreset("Gemini 3.1 Pro (Preview)", AgentType.GEMINI, "gemini-3-1-pro"),
+    AgentPreset("Claude Opus 4.8", AgentType.CLAUDE, "claude-opus-4-8"),
+    AgentPreset("GPT-5.5", AgentType.OPENAI, "gpt-5.5"),
+    AgentPreset("Gemini 3.1 Pro (Preview)", AgentType.GEMINI, "gemini-3.1-pro-preview"),
     AgentPreset(
         "Grok 4-1 Fast (xAI)",
         AgentType.OPENAI_COMPATIBLE,
@@ -131,10 +133,22 @@ _AGENT_PRESETS: list[AgentPreset] = [
         },
     ),
     AgentPreset(
-        "GLM-4.6V (Z-AI)",
+        "GLM 5.2 (Z.ai)",
         AgentType.OPENAI_COMPATIBLE,
-        "z-ai/glm-4.6v",
-        {"openai_compatible": {"base_url": settings.hud_gateway_url, "model_name": "GLM-4.6V"}},
+        "z-ai/glm-5.2",
+        {"openai_compatible": {"base_url": settings.hud_gateway_url, "model_name": "GLM 5.2"}},
+    ),
+    AgentPreset(
+        "Kimi K2.6 (Moonshot)",
+        AgentType.OPENAI_COMPATIBLE,
+        "moonshotai/kimi-k2.6",
+        {"openai_compatible": {"base_url": settings.hud_gateway_url, "model_name": "Kimi K2.6"}},
+    ),
+    AgentPreset(
+        "MiniMax M3",
+        AgentType.OPENAI_COMPATIBLE,
+        "MiniMax-M3",
+        {"openai_compatible": {"base_url": settings.hud_gateway_url, "model_name": "MiniMax M3"}},
     ),
 ]
 
@@ -162,7 +176,7 @@ _DEFAULT_CONFIG_TEMPLATE = """# HUD Eval Configuration
 # use_computer_beta = true
 
 [openai]
-# model = "gpt-4o"
+# model = "gpt-5.5"
 # temperature = 0.7
 # max_output_tokens = 4096
 
@@ -400,7 +414,9 @@ class EvalConfig(BaseModel):
             kwargs.update(agent_cfg)
 
         if self.model:
-            kwargs["model"] = self.model
+            from hud.utils.gateway import normalize_gateway_model_id
+
+            kwargs["model"] = normalize_gateway_model_id(self.model)
 
         if self.agent_type == AgentType.OPENAI_COMPATIBLE and "api_key" not in kwargs:
             base_url = kwargs.get("base_url", "")

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -50,6 +50,12 @@ def test_get_agent_kwargs_model_precedence_and_flags() -> None:
     assert kwargs["verbose"] is True
 
 
+def test_get_agent_kwargs_normalizes_gateway_model_alias() -> None:
+    cfg = EvalConfig(agent_type="openai_compatible", model="glm-5.2")
+
+    assert cfg.get_agent_kwargs()["model"] == "z-ai/glm-5.2"
+
+
 def test_get_agent_kwargs_requires_agent_type() -> None:
     with pytest.raises(ValueError, match="agent_type must be set"):
         EvalConfig().get_agent_kwargs()
@@ -184,6 +190,23 @@ def test_merge_cli_overrides_fields() -> None:
     assert merged.agent_type is not None and merged.agent_type.value == "openai"
     assert merged.task_ids == ["a", "b"]
     assert merged.max_steps == 7
+
+
+def test_merge_cli_resolves_gateway_model_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hud.utils.gateway import GatewayModelInfo, GatewayProviderInfo
+
+    model = GatewayModelInfo(
+        id="z-ai/glm-5.2",
+        model_name="z-ai/glm-5.2",
+        sdk_agent_type="openai_compatible",
+        provider=GatewayProviderInfo(name="openai"),
+    )
+    monkeypatch.setattr("hud.utils.gateway.list_gateway_models", lambda: [model])
+
+    merged = EvalConfig().merge_cli(agent="glm-5.2")
+
+    assert merged.agent_type is not None and merged.agent_type.value == "openai_compatible"
+    assert merged.model == "z-ai/glm-5.2"
 
 
 def test_merge_cli_namespaced_config() -> None:

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -56,6 +56,15 @@ def test_get_agent_kwargs_normalizes_gateway_model_alias() -> None:
     assert cfg.get_agent_kwargs()["model"] == "z-ai/glm-5.2"
 
 
+def test_get_agent_kwargs_normalizes_config_model_alias() -> None:
+    cfg = EvalConfig(
+        agent_type="openai_compatible",
+        agent_config={"openai_compatible": {"model": "glm-5.2"}},
+    )
+
+    assert cfg.get_agent_kwargs()["model"] == "z-ai/glm-5.2"
+
+
 def test_get_agent_kwargs_requires_agent_type() -> None:
     with pytest.raises(ValueError, match="agent_type must be set"):
         EvalConfig().get_agent_kwargs()
@@ -207,6 +216,14 @@ def test_merge_cli_resolves_gateway_model_alias(monkeypatch: pytest.MonkeyPatch)
 
     assert merged.agent_type is not None and merged.agent_type.value == "openai_compatible"
     assert merged.model == "z-ai/glm-5.2"
+
+
+def test_merge_cli_config_model_alias_is_normalized() -> None:
+    merged = EvalConfig(agent_type="openai_compatible").merge_cli(
+        config=["openai_compatible.model=glm-5.2"]
+    )
+
+    assert merged.get_agent_kwargs()["model"] == "z-ai/glm-5.2"
 
 
 def test_merge_cli_namespaced_config() -> None:

--- a/hud/utils/gateway.py
+++ b/hud/utils/gateway.py
@@ -45,6 +45,29 @@ class GatewayModelsResponse(BaseModel):
     items: list[GatewayModelInfo]
 
 
+_MODEL_ALIASES: dict[str, str] = {
+    "deepseek-v4": "deepseek/deepseek-v4-pro",
+    "deepseek-v4-pro": "deepseek/deepseek-v4-pro",
+    "deepseek-v4-flash": "deepseek/deepseek-v4-flash",
+    "glm-5.2": "z-ai/glm-5.2",
+    "kimi-2.6": "moonshotai/kimi-k2.6",
+    "kimi-k2.6": "moonshotai/kimi-k2.6",
+    "minimax-m3": "MiniMax-M3",
+    "minimax-m2.7": "MiniMax-M2.7",
+    "minimax-m2.5": "MiniMax-M2.5",
+}
+
+
+def normalize_gateway_model_id(model: str) -> str:
+    """Return the canonical HUD gateway model slug for known short aliases."""
+    return _MODEL_ALIASES.get(model.lower(), model)
+
+
+def gateway_model_aliases() -> tuple[str, ...]:
+    """Return accepted short aliases for HUD gateway model slugs."""
+    return tuple(_MODEL_ALIASES)
+
+
 def build_gateway_client(provider: str) -> GatewayClient:
     """Build a client configured for HUD gateway routing.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly alias mapping and default/preset strings; wrong alias tables could route evals to unexpected models but impact is limited to model selection UX.
> 
> **Overview**
> Adds **short gateway model aliases** (e.g. `glm-5.2` → `z-ai/glm-5.2`) via `normalize_gateway_model_id` and `gateway_model_aliases` in `hud.utils.gateway`, and wires normalization through **`create_agent`**, **`hud eval`** catalog lookup, and **`EvalConfig.get_agent_kwargs`**. Unknown-model hints now match against aliases while errors still show the **user’s original** model string.
> 
> **Default models and eval presets** are refreshed (e.g. OpenAI `gpt-5.5`, chat `gpt-5.4-mini`, Claude SDK `claude-sonnet-4-6`), with new interactive presets for Claude Opus 4.8, GLM 5.2, Kimi K2.6, and MiniMax M3. Tests cover alias resolution for agents and eval config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24cf04858779c7a5640bf86c8473e19557bc8ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->