### PR TITLE
fix: best effort evaluate call on error

### DIFF
--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -226,37 +226,22 @@ class Run:
             await self.client.cancel()
             return False
 
-        # A mid-run error still grades best-effort (the env is usually alive);
-        # the failure is kept (status=error) and the exception still propagates.
-        if exc_type is not None:
-            self.trace.status = "error"
-
         answer: dict[str, Any] = {"answer": self.trace.content}
         started_at = now_iso()
-        # grade() blocks on a JSON-RPC read with no timeout and isn't bounded by
-        # rollout_timeout — a wedged env can hang here until the connection drops
-        # (same as the cancel() this replaced). Bound by the deadline if needed.
-        try:
+
+        # A mid-run error grades best-effort (capture a salvageable reward, keep
+        # status=error), but a grade failure must not mask the original error. A
+        # clean run grades normally — a grader fault propagates. grade() also
+        # blocks on an unbounded JSON-RPC read (not bound by rollout_timeout).
+        if exc_type is not None:
+            self.trace.status = "error"
+            try:
+                evaluation = await self.client.grade(answer)
+            except Exception as grade_exc:
+                logger.warning("grade failed after mid-run error: %s", grade_exc)
+                return False
+        else:
             evaluation = await self.client.grade(answer)
-        except Exception as grade_exc:
-            # env unreachable: record the grade failure, don't mask the original.
-            logger.warning("grade failed during teardown: %s", grade_exc)
-            self.record(
-                Step(
-                    source="task",
-                    task_call=TaskCall(
-                        phase="evaluate",
-                        name=self._task_id,
-                        arguments=answer,
-                        result={},
-                    ),
-                    started_at=started_at,
-                    error=f"grade failed: {grade_exc}",
-                ),
-            )
-            if self.trace.status is None:
-                self.trace.status = "error"
-            return False
 
         self.grade = Grade.from_dict(evaluation)
         self.record(

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -218,14 +218,46 @@ class Run:
         exc: BaseException | None,
         tb: TracebackType | None,
     ) -> bool:
-        if exc_type is not None:
-            cancelled = issubclass(exc_type, asyncio.CancelledError | KeyboardInterrupt)
-            self.trace.status = "cancelled" if cancelled else "error"
+        # Ctrl-C isn't a gradable outcome: tear down without grading.
+        if exc_type is not None and issubclass(
+            exc_type, asyncio.CancelledError | KeyboardInterrupt
+        ):
+            self.trace.status = "cancelled"
             await self.client.cancel()
             return False
+
+        # A mid-run error still grades best-effort (the env is usually alive);
+        # the failure is kept (status=error) and the exception still propagates.
+        if exc_type is not None:
+            self.trace.status = "error"
+
         answer: dict[str, Any] = {"answer": self.trace.content}
         started_at = now_iso()
-        evaluation = await self.client.grade(answer)
+        # grade() blocks on a JSON-RPC read with no timeout and isn't bounded by
+        # rollout_timeout — a wedged env can hang here until the connection drops
+        # (same as the cancel() this replaced). Bound by the deadline if needed.
+        try:
+            evaluation = await self.client.grade(answer)
+        except Exception as grade_exc:
+            # env unreachable: record the grade failure, don't mask the original.
+            logger.warning("grade failed during teardown: %s", grade_exc)
+            self.record(
+                Step(
+                    source="task",
+                    task_call=TaskCall(
+                        phase="evaluate",
+                        name=self._task_id,
+                        arguments=answer,
+                        result={},
+                    ),
+                    started_at=started_at,
+                    error=f"grade failed: {grade_exc}",
+                ),
+            )
+            if self.trace.status is None:
+                self.trace.status = "error"
+            return False
+
         self.grade = Grade.from_dict(evaluation)
         self.record(
             Step(
@@ -287,7 +319,8 @@ async def rollout(
     erasing evidence: a failure *before* the run is live (provision, connect,
     start) yields a synthesized :meth:`Run.failed`; a failure *mid-run* keeps
     the real run — prompt, placement record, and the partial trace the agent
-    built — marked as errored. Either way the logged warning names the lifecycle
+    built — marked as errored, and still graded best-effort so a salvageable
+    reward is captured. Either way the logged warning names the lifecycle
     phase (``provisioning``, ``starting task``, ``agent loop``, ``grading``) so
     callers can tell where the failure landed without reading the trace.
     """

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -99,7 +99,32 @@ async def test_mid_run_failure_keeps_the_real_run_and_its_evidence(env_file: Pat
     # agent saw and the runtime the rollout executed against.
     assert run.prompt == "add:2:3"
     assert run.runtime is not None
-    assert run.reward == 0.0  # never graded
+    assert run.reward == 0.0  # graded best-effort, but the agent never answered → 0.0
+
+
+class _AnswerThenBoomAgent(Agent):
+    """Records a correct answer, then raises — a mid-run failure after the env
+    already has a gradable answer in hand."""
+
+    def __init__(self, fn: Any) -> None:
+        self._fn = fn
+
+    async def __call__(self, run: Any) -> None:
+        run.trace.content = self._fn(run.prompt)
+        raise RuntimeError("agent exploded after answering")
+
+
+async def test_mid_run_failure_still_grades_best_effort(env_file: Path) -> None:
+    # The agent answers correctly, then fails. The env is still alive, so the
+    # run is graded best-effort: the reward is captured even though it errored.
+    run = await rollout(
+        _add_task(2, 3), _AnswerThenBoomAgent(_solve_add), runtime=LocalRuntime(env_file)
+    )
+
+    assert run.trace.is_error
+    assert "agent exploded after answering" in (run.trace.error or "")
+    assert run.reward == 1.0  # graded despite the failure
+    assert run.trace.status == "error"  # the failure is preserved, not masked
 
 
 class _SlowAgent(Agent):


### PR DESCRIPTION
This pull request improves how mid-run failures are handled and graded during evaluation runs. Specifically, it ensures that if an agent fails after producing an answer (i.e., a mid-run error), the system still attempts to grade the best-effort output, preserving the reward if possible. Additionally, the changes clarify the distinction between cancellation (e.g., Ctrl-C) and error states, and add tests to verify this behavior.

Error handling and grading improvements:

* Updated `__aexit__` in `hud/eval/run.py` to distinguish between cancellation (like Ctrl-C) and other errors: cancellations now set the status to "cancelled" and skip grading, while other errors set the status to "error" but still attempt to grade the agent's output for best-effort reward. If grading itself fails, this is logged and the original error is preserved.
* Clarified docstring in `rollout` to specify that mid-run failures are graded best-effort, allowing salvageable rewards to be captured even if the run errors.

Testing enhancements:

* Added a new test, `test_mid_run_failure_still_grades_best_effort`, and supporting agent class to verify that when an agent answers and then fails, the run is still graded and the reward is captured. Also clarified comments in an existing test to reflect the new grading behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core eval teardown and reward attribution on failure paths, which affects batch metrics and training signals when agents error after answering.
> 
> **Overview**
> **Mid-run failures** now still call the grader on exit so a partial answer can yield a non-zero reward, while **`trace.status` stays `error`** so the failure is not hidden. **Ctrl-C / cancellation** is treated as non-gradable: status is **`cancelled`**, the client is cancelled, and **grading is skipped** (previously cancellation and other errors were lumped together before grade).
> 
> In `Run.__aexit__`, grading after a mid-run error is wrapped so a **grader failure is logged and does not replace the original agent error**; on a clean run, grader faults still propagate. The `rollout` docstring documents this best-effort grading behavior.
> 
> Tests add **`test_mid_run_failure_still_grades_best_effort`** (answer then explode → reward 1.0, status error) and clarify that a boom-with-no-answer run is graded to 0.0, not skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7468711a48dba2f39402a0e68d7df87ffcba16ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->