### PR TITLE
[codex] send HUDRuntime trace id to sessions

### DIFF
--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -42,6 +42,7 @@ from urllib.parse import urlsplit, urlunsplit
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
+from hud.telemetry.context import get_current_trace_id
 from hud.types import Step
 from hud.utils.platform import PlatformClient
 
@@ -741,6 +742,10 @@ class HUDRuntime:
 
     async def _create_runtime_session(self, runtime_url: str, api_key: str, task: Task) -> str:
         payload: dict[str, Any] = {"environment": task.env}
+        trace_id = get_current_trace_id()
+        if trace_id is not None:
+            with contextlib.suppress(ValueError):
+                payload["trace_id"] = str(uuid.UUID(trace_id))
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 f"{runtime_url}/runtime/sessions",

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -32,6 +32,7 @@ from hud.eval.runtime import (
 )
 from hud.eval.task import Task
 from hud.settings import settings
+from hud.telemetry.context import set_trace_context
 
 
 class _FakePlatform:
@@ -332,6 +333,53 @@ async def test_runtime_session_create_payload_omits_trace_id(
             "path": "https://mcp.hud.ai/runtime/sessions",
             "headers": {"Authorization": "Bearer sk-hud-test"},
             "json": {"environment": "e"},
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_session_create_payload_includes_current_trace_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    posts: list[dict[str, Any]] = []
+    session_id = str(uuid.uuid4())
+    trace_id = uuid.uuid4().hex
+
+    class _RecordingAsyncClient:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> _RecordingAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: Any) -> None:
+            return None
+
+        async def post(
+            self,
+            path: str,
+            *,
+            headers: dict[str, str],
+            json: dict[str, Any],
+        ) -> _FakeResponse:
+            posts.append({"path": path, "headers": headers, "json": json})
+            return _FakeResponse({"id": session_id})
+
+    monkeypatch.setattr("hud.eval.runtime.httpx.AsyncClient", _RecordingAsyncClient)
+
+    with set_trace_context(trace_id):
+        created = await HUDRuntime()._create_runtime_session(
+            "https://mcp.hud.ai",
+            "sk-hud-test",
+            Task(env="e", id="x"),
+        )
+
+    assert created == session_id
+    assert posts == [
+        {
+            "path": "https://mcp.hud.ai/runtime/sessions",
+            "headers": {"Authorization": "Bearer sk-hud-test"},
+            "json": {"environment": "e", "trace_id": str(uuid.UUID(trace_id))},
         }
     ]
 


### PR DESCRIPTION
## Summary
- Include the active trace context in `HUDRuntime` runtime-session creation payloads.
- Keep the payload unchanged when no UUID trace context is active.
- Add payload coverage for the trace id path.

## Validation
- `uv run --project packages/hud-python ruff check packages/hud-python/hud/eval/runtime.py packages/hud-python/hud/eval/tests/test_hosted.py`
- `uv run --project packages/hud-python pytest packages/hud-python/hud/eval/tests/test_hosted.py -k runtime_session`
- 
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive API field on session creation with guarded UUID parsing; behavior unchanged when no trace context is set.
> 
> **Overview**
> **HUDRuntime** now forwards the active telemetry trace into the runtime gateway when opening a session, so hosted env sessions can line up with the same trace as the local rollout.
> 
> On `POST /runtime/sessions`, the JSON body still always includes `environment`; if `get_current_trace_id()` returns a value, the code adds `trace_id` as a canonical UUID string (invalid values are ignored). With no trace context, the payload is unchanged.
> 
> A test asserts the extra field when `set_trace_context` is active, alongside the existing test that omits `trace_id` when context is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6658adf3672576e391586f1d29f92ae997047672. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->