### PR TITLE
docs(v6): refine robots, run & deploy, capabilities, and Advanced TOC

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,7 +69,7 @@
               { "group": "Start here", "pages": ["v6/start/index", "v6/start/quickstart"] },
               { "group": "Overview", "pages": ["v6/build/overview", "v6/core/protocol"] },
               { "group": "Core", "pages": ["v6/core/environment", "v6/core/tasks", "v6/core/capabilities", "v6/core/agents", "v6/core/runtime", "v6/core/graders", "v6/core/advice", "v6/core/training", "v6/core/types", "v6/core/cli"] },
-              { "group": "Advanced", "pages": ["v6/advanced/extending", "v6/core/robots", "v6/advanced/harbor-convert"] },
+              { "group": "Advanced", "pages": ["v6/advanced/extending", "v6/advanced/robots", "v6/advanced/harbor-convert"] },
               { "group": "Cookbooks", "pages": ["v6/cookbooks/coding-agent", "v6/cookbooks/ops-diagnostics", "v6/cookbooks/a2a-chat", "v6/cookbooks/robot-benchmark"] },
               { "group": "More", "pages": ["v6/more/faq", "v6/more/migrate-v6", "v6/more/contributing"] }
             ]
@@ -89,6 +89,7 @@
     { "source": "/v6/protocol", "destination": "/v6/core/protocol" },
     { "source": "/v6/reference/:slug*", "destination": "/v6/core/:slug*" },
     { "source": "/v6/build/protocol", "destination": "/v6/core/protocol" },
+    { "source": "/v6/core/robots", "destination": "/v6/advanced/robots" },
     { "source": "/v6/build/environments", "destination": "/v6/core/environment" },
     { "source": "/v6/build/tasks", "destination": "/v6/core/tasks" },
     { "source": "/v6/build/agents", "destination": "/v6/core/agents" },

--- a/docs/v6/advanced/extending.mdx
+++ b/docs/v6/advanced/extending.mdx
@@ -2,7 +2,6 @@
 title: "Extending HUD"
 description: "Beyond the standard workflow: bring your own harness, compose richer environments, scale tasksets, run subagents as tools, and build multi-turn chats."
 icon: "puzzle-piece"
-mode: "wide"
 ---
 
 The standard workflow - declare an environment, write tasks, run a built-in agent - covers most of
@@ -10,14 +9,14 @@ what you need. This page collects the patterns for going further: plugging in yo
 composing richer environments, scaling tasksets, delegating to subagents, and driving multi-turn
 chats. Each is independent; jump to what you need.
 
-# Bring your own harness
+## Bring your own harness
 
 Because an [environment](/v6/core/environment) only exposes [capabilities](/v6/core/capabilities) and
 never a fixed agent, any loop or framework plugs in as a harness. Wrapping one is a thin adapter, not
 protocol work: you get a [`Run`](/v6/core/types#run), drive the environment off it, and fill
 `run.trace.content`.
 
-## The Agent seam
+### The Agent seam
 
 Subclass `Agent` and implement `__call__`. Open the capabilities you need off `run.client`, do your
 work, and write the answer to `run.trace.content` (graded on exit):
@@ -37,7 +36,7 @@ class MyHarness(Agent):
 That is the whole seam. An agent keeps no per-run state - everything comes from the `run` - so one
 instance drives many concurrent rollouts.
 
-## The Run you drive
+### The Run you drive
 
 The `run` is the one object you work with for the whole task. Three things you do with it:
 
@@ -62,7 +61,7 @@ The `run` is the one object you work with for the whole task. Three things you d
 | `run.record(step)` | Append a step and stream it to the platform live (step types in [Types](/v6/core/types)). |
 | `run.trace.content = ...` | Set the final answer, graded when the run ends. |
 
-## Reusing HUD's loop: `ToolAgent`
+### Reusing HUD's loop: `ToolAgent`
 
 There are two base classes, depending on how much of HUD's loop you want:
 
@@ -77,7 +76,7 @@ Record the step family that matches what happened - `AgentStep` (a model turn), 
 round-trip), or `SubagentStep` (a nested rollout); see [Types](/v6/core/types). `ToolAgent` does all of
 this for you.
 
-## Wrap an existing framework: browser-use on `cdp`
+### Wrap an existing framework: browser-use on `cdp`
 
 The bundled `BrowserUseAgent` is exactly this adapter - `browser-use` driving the `cdp` (browser)
 capability:
@@ -93,7 +92,7 @@ job = await my_browser_task().run(agent)
 Use it as a template for wrapping other frameworks over whichever capability they need (`ssh`, `mcp`,
 `rfb`, `robot`).
 
-## Any OpenAI-compatible endpoint
+### Any OpenAI-compatible endpoint
 
 `OpenAIChatAgent` speaks the OpenAI Chat Completions API, so vLLM servers, local models, and hosted
 checkpoints all work - point `base_url` at the server:
@@ -109,11 +108,11 @@ agent = OpenAIChatAgent(OpenAIChatConfig(
 ))
 ```
 
-# Composing richer environments
+## Composing richer environments
 
 These patterns build on [Environments](/v6/core/environment) once the basics are in place.
 
-## Multiple capabilities at once
+### Multiple capabilities at once
 
 An environment can expose several capabilities; the harness opens whichever it needs. A task that spans
 a shell **and** a browser declares both:
@@ -134,7 +133,7 @@ env.workspace("/workspace")                           # ssh: shell + files, serv
 The same environment serves a shell-only coding task and a browser-driving task - the difference is
 which capabilities the harness opens, not the environment.
 
-## Stateful environments and backing daemons
+### Stateful environments and backing daemons
 
 Use `@env.initialize` / `@env.shutdown` to manage anything the tasks need running - a database, a
 seeded service, a fixture. The hooks run once around serving:
@@ -158,9 +157,9 @@ async def _stop():
 Keep environment state **frozen across rollouts**: every run of a task should see the same starting
 state, so reward differences reflect the agent, not a drifting environment.
 
-# Scaling a taskset
+## Scaling a taskset
 
-## Parameterize for a difficulty spread
+### Parameterize for a difficulty spread
 
 One task definition should span a range. Parameterize the generator and create a concrete task per
 point:
@@ -178,7 +177,7 @@ tasks = [fix_bug(difficulty=d) for d in range(1, 6)]
 A controlled difficulty distribution is what makes a taskset trainable - see
 [Designing tasks](/v6/core/advice).
 
-## Structure a large taskset across files
+### Structure a large taskset across files
 
 Keep tasks in modules and collect them into a `Taskset` at the top:
 
@@ -202,7 +201,7 @@ v = fix_bug(difficulty=3)
 v.slug = "fix-bug-3"
 ```
 
-## Group rollouts for variance
+### Group rollouts for variance
 
 To measure variance (or feed training), run each task several times. `group` repeats share a GRPO
 group:
@@ -213,7 +212,7 @@ job = await taskset.run(agent, group=8, max_concurrent=10)
 rewards = [run.reward for run in job.runs]
 ```
 
-## Route tasks to different substrates
+### Route tasks to different substrates
 
 A [runtime](/v6/core/runtime) is called once per rollout with the task row, so a callable can place
 heavier rows on heavier substrates:
@@ -226,13 +225,13 @@ def placer(task):
 await taskset.run(agent, runtime=placer)
 ```
 
-# Subagents as tools
+## Subagents as tools
 
 An MCP tool is just a function. A **subagent** is just a function that runs an agent over a task and
 returns its answer. Put the two together and an orchestrating agent can call a specialist sub-agent as
 a single tool call - no special class, nothing HUD-specific beyond the rollout you already write.
 
-## Write the subagent as a function
+### Write the subagent as a function
 
 Calling an `@env.template` mints a task; running it drives a fresh rollout whose `Job` carries the
 result. Wrap that in a function and return the agent's answer:
@@ -252,7 +251,7 @@ async def investigate_issue(issue_id: str) -> str:
 The function's signature and docstring are all an MCP server needs to build the tool schema:
 `issue_id: str` becomes the one parameter, the docstring becomes the description.
 
-## Register it as an MCP tool
+### Register it as an MCP tool
 
 Use a baseline [FastMCP](https://github.com/jlowin/fastmcp) server - type hints + docstring become the
 schema, no subclass required:
@@ -264,7 +263,7 @@ tools = FastMCP(name="specialists")
 tools.tool(investigate_issue)        # or write @tools.tool above the function
 ```
 
-## Expose it as an `mcp` capability
+### Expose it as an `mcp` capability
 
 An orchestrating environment declares an `mcp` capability pointing at that server, so any harness that
 opens it sees `investigate_issue` as a callable tool:
@@ -284,7 +283,7 @@ Run the FastMCP server alongside the environment so the URL is live - for local 
 container entrypoint or an
 [`@env.initialize`](/v6/core/environment#lifecycle-hooks-set-up-and-tear-down) hook.
 
-## How it looks to the orchestrator
+### How it looks to the orchestrator
 
 The orchestrating agent opens the `mcp` capability, sees one tool - `investigate_issue(issue_id)` -
 calls it, and gets the specialist's findings back as the tool result. From its side it's a single tool
@@ -293,7 +292,7 @@ can inspect the specialist's work separately from the orchestrator's. Because th
 function, everything composes normally: add retries, fan out to several specialists, or swap the model
 - all in plain Python.
 
-# Chat and multi-turn
+## Chat and multi-turn
 
 Most tasks yield a single text prompt. A **chat-style task** yields a *list of messages* instead, so
 the agent works against a multi-turn conversation. The `Chat` runner drives that conversation turn by
@@ -303,7 +302,7 @@ Reach for chat when the *interaction itself* is the thing - assistants, tool-use
 where the agent needs prior turns. For evals and training, the default single-turn [task](/v6/core/tasks)
 is what you want. Either way the grading model is the same: you still yield a reward.
 
-## A chat-style task
+### A chat-style task
 
 A task's prompt can be plain text **or** a list of `PromptMessage`s. To accept a running conversation,
 take a `messages` parameter and yield it as the prompt:
@@ -323,7 +322,7 @@ async def assistant(messages: list[PromptMessage]):
 `run.prompt` becomes the message list, and agents consume it as normalized turns through
 `run.prompt_messages`.
 
-## Driving it with `Chat`
+### Driving it with `Chat`
 
 `Chat` wraps a concrete **Task** plus an **Agent**. Each `send()` appends the user message, runs the
 agent over a fresh run with the full history, appends the reply, and returns the `Trace`:
@@ -347,7 +346,7 @@ asyncio.run(main())
 replaced with the running conversation on every `send`; pass `runtime=` to place each turn's rollout
 (omit it and the task's source serves locally when minted in-process, else HUD-hosted by env name).
 
-## Managing history
+### Managing history
 
 The conversation history **is** the public `chat.messages` list - persist it, restore it, or reset it
 directly:
@@ -357,7 +356,7 @@ directly:
 | `await chat.send(message)` | Send a user turn; returns the reply `Trace`. |
 | `chat.messages` | The history (`{"role", "content"}` dicts) - `json.dumps` to persist, assign to restore, clear to reset. |
 
-## Serving a chat
+### Serving a chat
 
 `Chat` is protocol-agnostic: any frontend - a web handler, a notebook, a wire protocol - just calls
 `await chat.send(...)`. For example, behind FastAPI:

--- a/docs/v6/advanced/robots.mdx
+++ b/docs/v6/advanced/robots.mdx
@@ -3,7 +3,7 @@ title: "Robots"
 description: "The robot capability: contracts, bridges, and the agent harness."
 icon: "robot"
 tag: "Beta"
-mode: "wide"
+
 ---
 
 <Note>
@@ -32,7 +32,7 @@ pip install 'hud-python[robot]'
 
 ## Overview
 Like with other HUD workflows there's the environment side
-(server - containerized, served on the runtime) and the agent side (cleint - swappable, model with harness)
+(server - containerized, served on the runtime) and the agent side (client - swappable, model with harness).
 For robotics the **environment side** 
 translates incoming actions into changes in the digital or physical environment and serves observations. 
 The **agent side** owns the policy: it reads those observations, runs
@@ -116,7 +116,7 @@ with the agent and  starting/stopping as well as stepping of the simulator at th
 - **`reset`** starts a fresh episode for a task and returns its prompt (the text the agent is given).
 - **`step`** applies one action and advances the sim a tick, setting `success` / `terminated` as the
   episode plays out.
-- **`get_observation`** returns a strctured dict of the current observation 
+- **`get_observation`** returns a structured dict of the current observation
 plus whether the episode is done.
 
 <Note>
@@ -265,7 +265,33 @@ The harness awaits `ainfer`, which runs your (blocking) `infer` in a worker thre
 override `ainfer` only if your policy is natively async. For chunked policies, reduce each `[T, A]`
 chunk to one action per step with an `Ensembler`.
 
-## The contract
+## Batching
+
+Running many rollouts at once, each calling `infer` once per step, wastes the GPU on
+single-observation forwards. `BatchedAgent` fixes that: it wraps a `RobotAgent`, gives each concurrent
+rollout its own episode state, and shares one batched model that coalesces their per-step `infer` calls
+into a single stacked forward.
+
+```python
+from hud.agents.robot.batching import BatchedAgent
+
+agent = BatchedAgent(MyRobotAgent(), batch_size=8)   # set batch_size to your max_concurrent
+
+job = await taskset.run(agent, runtime=DockerRuntime("hud-libero-env"), max_concurrent=8)
+```
+
+Each tick, up to `batch_size` concurrent observations are stacked into one `[N, ...]` batch, run
+through a single forward, and scattered back to each rollout; a short `max_wait_s` (default 50 ms)
+flushes early when fewer rollouts are live, so the tail of a suite never stalls. Set `batch_size` to
+match `max_concurrent` so a full batch can form.
+
+`BatchedAgent` needs an **in-process, stateless** model whose `infer` runs the whole `[N, ...]` batch
+in one forward - `LeRobotModel` qualifies. A remote OpenPI policy server is not supported (its protocol
+has no batched-request shape); run one agent per rollout against it instead. `BatchedAgent` also takes
+ownership of the agent you pass (it swaps in the batched model in place), so give it a dedicated
+instance rather than one you also use for unbatched runs.
+
+## Contract
 
 Embodiments and policies disagree on cameras, state layout, action semantics, and control rate, so
 pairing a model with an env always needs a wiring step. The **contract** makes it explicit: a JSON
@@ -273,37 +299,53 @@ document in the capability manifest that the agent reads back with `RobotClient.
 splits `features` into an observation and an action space by each feature's `role` - so a policy
 wires itself with no shared config.
 
-Here's the smallest contract the bundled adapter accepts - one camera, a state vector, and an action:
+Here's a proper minimal contract - one camera, a state vector, and an action:
 
 ```json
 {
+  "control_rate": 10,
   "features": {
-    "observation/image": { "role": "observation", "type": "rgb" },
-    "observation/state": { "role": "observation" },
-    "action":            { "role": "action" }
+    "observation/image": {
+      "role": "observation",
+      "type": "rgb",
+      "names": ["height", "width", "channel"]
+    },
+    "observation/state": {
+      "role": "observation",
+      "names": ["eef_x", "eef_y", "eef_z", "axis_x", "axis_y", "axis_z", "grip_l", "grip_r"]
+    },
+    "action": {
+      "role": "action",
+      "names": ["dx", "dy", "dz", "drx", "dry", "drz", "gripper"]
+    }
   }
 }
 ```
 
-Only two fields are load-bearing:
+`role` and `type` wire the spaces; `control_rate` and `names` are what make the run legible on the
+platform, so a real contract should always set them:
 
 - **`role`** (`observation` / `action`) - `spaces()` splits the contract by it and the `Adapter` wires
   against that split. Required on every feature.
 - **`type`** on image observations - `rgb`/`bgr`/`gray`/`depth` is how the bundled adapter spots a
   camera; the first observation *without* an image type becomes the state. Omit it and your image is
   mistaken for the state. (On the state and action, `type` is descriptive.)
+- **`control_rate`** (top level, Hz) - the agent reads it as the playback fps for the recorded episode,
+  so the trace viewer plays back at real speed and any saved dataset has the right frame rate. Set it
+  to your real control rate.
+- **`names`** (per feature) - per-element labels the trace viewer shows on each state/action slice;
+  without them the dimensions display unlabeled.
 
 Feature keys are openpi flat slash-paths and must match *verbatim* the keys your bridge returns from
-`get_observation` (`action` is the single action feature). Everything else - `robot_type`,
-`control_rate`, `dtype`, `shape`, `names`, `stats` - is descriptive and never enforced; add `names` if
-you want labeled state/action slices in the trace viewer. Full list in the reference below.
+`get_observation` (`action` is the single action feature). Everything else - `robot_type`, `dtype`,
+`shape`, `stats` - is descriptive and never enforced. Full list in the reference below.
 
 <Accordion title="Full field reference">
 
 | Field | Where | Meaning |
 |-------|-------|---------|
 | `robot_type` | top level | Embodiment id, shown in the trace viewer. Descriptive. |
-| `control_rate` | top level | Control-loop frequency in Hz. Descriptive. |
+| `control_rate` | top level | Control-loop frequency in Hz; the agent reads it as the playback/record fps. Recommended. |
 | `features` | top level | Map of feature name → feature spec (rows below). |
 | `role` | feature | `observation` or `action` - **the only field that splits the spaces**. Load-bearing. |
 | `type` | feature | Representation tag. Observations: `rgb`/`bgr`/`gray`/`depth` mark an image (load-bearing for the bundled adapter); others (`ee_abs`, `ee_del`, `joint_pos`, …) are descriptive control/state modes. |
@@ -334,13 +376,6 @@ that decides *which thread* runs the sim; the bridge routes every sim touch thro
 
 Pass one to the bridge (`RobotBridge(sim_runner=ThreadSimRunner())`), or subclass `SimRunner` for an
 exotic topology.
-
-## Telemetry
-
-Zero-config: with HUD telemetry configured, `RobotAgent` streams one span per step - every camera
-frame the policy saw plus the executed action - and stamps **keyframes** where a fresh action chunk
-was inferred. The platform's trace viewer plays the episode back: scrub through all frames, with
-markers at each chunk-prediction decision point.
 
 ## Recording datasets
 
@@ -447,6 +482,7 @@ downstream (`hud eval`, tasksets, the agent) is unchanged; only *where the bridg
 | `SimRunner` (`Inline`/`Thread`/`MainThread`) | `hud.environment.robot` | Which thread runs the sim |
 | `RobotAgent` | `hud.agents.robot` | The episode-loop harness |
 | `Model` / `LeRobotModel`, `Adapter` / `LeRobotAdapter` | `hud.agents.robot` | Policy + space-translation seams |
+| `BatchedAgent` / `BatchedModel` | `hud.agents.robot.batching` | Many concurrent rollouts against one shared, batched model |
 
 ## See also
 

--- a/docs/v6/build/overview.mdx
+++ b/docs/v6/build/overview.mdx
@@ -2,7 +2,6 @@
 title: "Overview"
 description: "Define any environment, once. Spin it up anywhere. Evaluate and train any AI agent inside it."
 icon: "compass"
-mode: "wide"
 ---
 
 ## HUD

--- a/docs/v6/cookbooks/robot-benchmark.mdx
+++ b/docs/v6/cookbooks/robot-benchmark.mdx
@@ -6,7 +6,7 @@ tag: "Beta"
 ---
 
 <Note>
-The `robot` capability is in **beta** - see the [Robots reference](/v6/core/robots).
+The `robot` capability is in **beta** - see the [Robots reference](/v6/advanced/robots).
 </Note>
 
 This cookbook runs **pi0.5** against **LIBERO** (a Franka Panda manipulation benchmark) packaged as a Docker image: three episodes, each in a fresh container, graded by the sim's own success check. The policy runs in *your* process on your GPU; the container is CPU-only and publishes exactly one port.
@@ -120,7 +120,7 @@ With `HUD_API_KEY` set, every episode streams to the platform automatically: the
 ## See also
 
 <CardGroup cols={2}>
-<Card title="Robots reference" icon="robot" href="/v6/core/robots">
+<Card title="Robots reference" icon="robot" href="/v6/advanced/robots">
   Contracts, bridges, sim threading, and the harness API.
 </Card>
 <Card title="Package & deploy" icon="rocket" href="/v6/core/runtime" />

--- a/docs/v6/core/agents.mdx
+++ b/docs/v6/core/agents.mdx
@@ -119,5 +119,5 @@ the seam, the `Run` object you work with, the step types you record, and worked 
 <Card title="Bring your own harness" icon="screwdriver-wrench" href="/v6/advanced/extending#bring-your-own-harness" />
 <Card title="Capabilities" icon="plug" href="/v6/core/capabilities" />
 <Card title="Types: Run & Trace" icon="code" href="/v6/core/types" />
-<Card title="Robots (beta)" icon="robot" href="/v6/core/robots" />
+<Card title="Robots (beta)" icon="robot" href="/v6/advanced/robots" />
 </CardGroup>

--- a/docs/v6/core/capabilities.mdx
+++ b/docs/v6/core/capabilities.mdx
@@ -13,6 +13,7 @@ A **capability** is a connection the environment exposes; a harness attaches its
 | `cdp`  | `cdp/1.3` | Browser control over the Chrome DevTools Protocol | Chromium (`playwright`) |
 | `rfb`  | `rfb/3.8` | Full computer-use over VNC: screen + keyboard/mouse | `Xvfb` + `x11vnc` |
 | `robot` | `openpi/0` | Schema-driven robot observation/action loop over WebSocket *(beta)* | robot bridge |
+| `filetracking` | `filetracking/1` | Workspace file changes (diffs + snapshots), for telemetry | `Workspace` (`track_files=True`) |
 
 ```python
 from hud.capabilities import Capability
@@ -219,7 +220,7 @@ Capability.robot(*, name="robot", url, contract)
 
 The robot control loop *(beta)*, carried over the `openpi/0` wire protocol. It's an **openpi-like** protocol: it reuses openpi's wire format (msgpack with recursive numpy serialization) and its flat observation/action naming (`observation/...` keys, `actions`), so an openpi policy server and a HUD env speak the same bytes. The one fundamental difference is **role assignment** - in openpi a policy *server* answers inference requests, but here the **environment is the server** (it owns the world and pushes observations) and the **agent is the client** (it acts, replying with actions).
 
-The `contract` is the environment's full self-describing schema - `robot_type`, `control_rate`, and every observation/action feature - carried in the manifest so the agent wires itself with no shared config. The environment drives its simulator through a [`RobotEndpoint`](/v6/core/robots) (not the bridge directly, although possible), and the endpoint builds the capability for you once started:
+The `contract` is the environment's full self-describing schema - `robot_type`, `control_rate`, and every observation/action feature - carried in the manifest so the agent wires itself with no shared config. The environment drives its simulator through a [`RobotEndpoint`](/v6/advanced/robots) (not the bridge directly, although possible), and the endpoint builds the capability for you once started:
 
 ```python
 endpoint = RobotEndpoint(MySimBridge())   # drive the sim only through the endpoint
@@ -230,7 +231,20 @@ async def _up():
     env.add_capability(await endpoint.capability(contract=CONTRACT))
 ```
 
-See [Robots](/v6/core/robots) for the bridge, the endpoint, the harness, and the contract spec.
+See [Robots](/v6/advanced/robots) for the bridge, the endpoint, the harness, and the contract spec.
+
+### `filetracking` - workspace file changes
+
+`filetracking` is observation-only: it reports what changed in a [`Workspace`](#workspace) over a run,
+so HUD can show file diffs in the trace. It's not a tool an agent calls - the rollout opens it for
+telemetry. A `Workspace` serves it when you opt in:
+
+```python env.py
+env.workspace("workspace", track_files=True)   # also publishes the filetracking/1 capability
+```
+
+The client is `FileTrackingClient` (`hud.capabilities`): `diff()` returns the changes since the last
+call, `snapshot()` the full file manifest, and `advance()` re-baselines without producing a diff.
 
 ## Harness clients
 
@@ -243,6 +257,7 @@ Spinning up a capability is the environment side. The harness side is the mirror
 | `CDPClient` | `cdp/1.3` |
 | `RFBClient` | `rfb/3.8` |
 | `RobotClient` | `openpi/0` - joins the registry on first open (the `robot` extra: numpy/openpi-client) |
+| `FileTrackingClient` | `filetracking/1` - observation-only; opened for telemetry, not as a tool |
 
 The bundled provider agents open these automatically based on which capabilities the manifest advertises (see [Agents](/v6/core/agents)). To write your own harness, attach to the capability you need and define your tool spec.
 

--- a/docs/v6/core/cli.mdx
+++ b/docs/v6/core/cli.mdx
@@ -142,8 +142,8 @@ as `Taskset`s - no conversion step. See [Harbor interop](/v6/advanced/harbor-con
 Without an id, lists your most recent jobs. With an id, lists every trace in that job.
 
 ```bash
-hud jobs               # recent jobs — id, name, taskset, status, created
-hud jobs <job-id>      # traces for one job — trace id, status, reward, error
+hud jobs               # recent jobs - id, name, taskset, status, created
+hud jobs <job-id>      # traces for one job - trace id, status, reward, error
 hud jobs --json        # raw JSON
 hud jobs -n 50         # show up to 50 rows (default 20)
 ```

--- a/docs/v6/core/environment.mdx
+++ b/docs/v6/core/environment.mdx
@@ -179,7 +179,7 @@ hud serve env.py     # serve locally on tcp://127.0.0.1:8765 while you iterate
 <Note>
 A dependency that must **own the process main thread** (e.g. Isaac Sim / Omniverse) can't run under
 `hud serve`, which runs the asyncio loop on main. Run `serve(env, host, port)` on a worker thread
-instead and keep the main thread for the dependency - see [Robots](/v6/core/robots#environment-side).
+instead and keep the main thread for the dependency - see [Robots](/v6/advanced/robots#environment-side).
 </Note>
 
 ## Learn from real environments

--- a/docs/v6/core/runtime.mdx
+++ b/docs/v6/core/runtime.mdx
@@ -1,8 +1,14 @@
 ---
 title: "Run & deploy"
-description: "Choose where an environment runs for each rollout - from a local process to the HUD platform - without touching the task."
+description: "Run a task by deploying to the platform or programmatically from your machine."
 icon: "rocket"
 ---
+
+This page covers how you actually run tasks: deploying an environment to the HUD platform, and running
+it programmatically from your own machine. Both go through a **runtime** - the one thing you pass to
+choose where each rollout runs.
+
+## Runtime
 
 A **runtime** decides *where* an environment runs for a rollout. You pass it to `task.run` /
 `taskset.run` at execution time, and the same task and the same `env.py` run anywhere - only the
@@ -65,58 +71,34 @@ image runs unchanged on HUD, on a cloud sandbox, in CI, or on your laptop. After
 `HUDRuntime()` is the natural pair. Pass build config with `--env`, `--build-arg`, and `--secret`. See
 the [CLI reference](/v6/core/cli#hud-deploy) for the full flag set.
 
-## Run on your own infra
+## RuntimeConfig
 
-A **runtime is just a function**: given a task, start a container somewhere and yield its
-control-channel URL. That one function is the whole integration surface for any provider - Modal, E2B,
-Runloop, your own Kubernetes:
+`RuntimeConfig` carries the construction hints a container-based runtime needs: which image, how much
+hardware, and what timeouts. Set it on the runtime (`runtime_config=`) or per row on
+[`Task.runtime_config`](/v6/core/tasks#the-task-row); the runtime merges the two and applies what it
+supports.
 
-```python run.py
-from contextlib import asynccontextmanager
-from hud import Runtime
+```python
+from hud.eval import RuntimeConfig, RuntimeResources, RuntimeGPU, RuntimeLimits
 
-@asynccontextmanager
-async def my_runtime(task):
-    sandbox = await start_my_sandbox(image="my-env")   # your infra brings it up
-    try:
-        yield Runtime(f"tcp://{sandbox.host}:{sandbox.port}")
-    finally:
-        await sandbox.terminate()                       # ...and tears it down
-
-await TASKS.run(agent, runtime=my_runtime)
+RuntimeConfig(
+    image="my-env",
+    resources=RuntimeResources(cpu=4, memory_mb=8192, gpu=RuntimeGPU(type="A100", count=1)),
+    limits=RuntimeLimits(startup_timeout_s=300, run_timeout_s=1800),
+)
 ```
 
-`DockerRuntime` and the rest are just built-in versions of this. Anything that starts your image and
-hands back a URL plugs in with no change to the environment or the task - that's what "run anywhere"
-means concretely. Constructed directly, `Runtime(url)` yields itself with a no-op lifecycle, since
-whoever provisioned the substrate owns teardown.
+| Field | Description |
+|-------|-------------|
+| `image` | Image to run. |
+| `resources` | `RuntimeResources(cpu, memory_mb, gpu=RuntimeGPU(type, count))`. |
+| `limits` | `RuntimeLimits(startup_timeout_s, run_timeout_s)`. |
 
-Placement can also vary per task: a runtime is called once per rollout with the task row being placed,
-so one callable can route heavier rows to heavier substrates.
+Support differs per runtime: `DockerRuntime`, `ModalRuntime`, and `DaytonaRuntime` accept it (Docker
+ignores `limits`; Daytona ignores `run_timeout_s` and resource overrides when booting from a snapshot).
+`LocalRuntime` and `HUDRuntime` reject a per-task `runtime_config`.
 
-## A self-contained image, no HUD account
-
-For a fully local artifact, build straight from the scaffolded `Dockerfile.hud` and drive a task with
-the packaged CLI. `docker exec` runs the commands *inside* the container, so nothing needs to be
-exposed:
-
-```bash
-docker build -f Dockerfile.hud -t my-env .
-
-docker run -d --name run1 my-env
-docker exec run1 hud task start fix_bug                # -> the prompt
-docker exec run1 hud task grade fix_bug --answer "..." # -> the reward
-docker rm -f run1
-```
-
-<Note>
-**Reproducible by construction.** Each rollout gets its own fresh container, so results reproduce
-across runs and machines and one rollout never leaks state into the next. Keep per-task setup in
-[`@env.initialize`](/v6/core/environment#lifecycle-hooks-set-up-and-tear-down) so every run starts from
-the same state.
-</Note>
-
-## Runtime arguments
+## Runtime directory
 
 The constructor for each built-in runtime:
 
@@ -185,46 +167,31 @@ Runtime(url, params=..., config=...)
 - **`url`** - control-channel address of an already-running substrate (e.g. `tcp://host:8765`).
 - **`params`** - connection-time data a transport may need (auth token, sandbox id).
 
-## RuntimeConfig
+## Run on your own infra
 
-`RuntimeConfig` carries the construction hints a container-based runtime needs: which image, how much
-hardware, and what timeouts. Set it on the runtime (`runtime_config=`) or per row on
-[`Task.runtime_config`](/v6/core/tasks#the-task-row); the runtime merges the two and applies what it
-supports.
+A **runtime is just a function**: given a task, start a container somewhere and yield its
+control-channel URL. That one function is the whole integration surface for any provider - Modal, E2B,
+Runloop, your own Kubernetes:
 
-```python
-from hud.eval import RuntimeConfig, RuntimeResources, RuntimeGPU, RuntimeLimits
+```python run.py
+from contextlib import asynccontextmanager
+from hud import Runtime
 
-RuntimeConfig(
-    image="my-env",
-    resources=RuntimeResources(cpu=4, memory_mb=8192, gpu=RuntimeGPU(type="A100", count=1)),
-    limits=RuntimeLimits(startup_timeout_s=300, run_timeout_s=1800),
-)
+@asynccontextmanager
+async def my_runtime(task):
+    sandbox = await start_my_sandbox(image="my-env")   # your infra brings it up
+    try:
+        yield Runtime(f"tcp://{sandbox.host}:{sandbox.port}")
+    finally:
+        await sandbox.terminate()                       # ...and tears it down
+
+await TASKS.run(agent, runtime=my_runtime)
 ```
 
-| Field | Description |
-|-------|-------------|
-| `image` | Image to run. |
-| `resources` | `RuntimeResources(cpu, memory_mb, gpu=RuntimeGPU(type, count))`. |
-| `limits` | `RuntimeLimits(startup_timeout_s, run_timeout_s)`. |
+`DockerRuntime` and the rest are just built-in versions of this. Anything that starts your image and
+hands back a URL plugs in with no change to the environment or the task - that's what "run anywhere"
+means concretely. Constructed directly, `Runtime(url)` yields itself with a no-op lifecycle, since
+whoever provisioned the substrate owns teardown.
 
-Support differs per runtime: `DockerRuntime`, `ModalRuntime`, and `DaytonaRuntime` accept it (Docker
-ignores `limits`; Daytona ignores `run_timeout_s` and resource overrides when booting from a snapshot).
-`LocalRuntime` and `HUDRuntime` reject a per-task `runtime_config`.
-
-## See also
-
-<CardGroup cols={2}>
-<Card title="Agents" icon="robot" href="/v6/core/agents">
-  The agent that connects to the environment and acts.
-</Card>
-<Card title="Train" icon="dumbbell" href="/v6/core/training">
-  Turn the rewards a run collects into a training signal.
-</Card>
-<Card title="CLI reference" icon="terminal" href="/v6/core/cli">
-  `hud deploy`, `hud eval`, `hud task`, and the full flag set.
-</Card>
-<Card title="Tasks & Tasksets" icon="list-check" href="/v6/core/tasks">
-  Per-task placement via `Task.runtime_config`.
-</Card>
-</CardGroup>
+Placement can also vary per task: a runtime is called once per rollout with the task row being placed,
+so one callable can route heavier rows to heavier substrates.

--- a/docs/v6/core/tasks.mdx
+++ b/docs/v6/core/tasks.mdx
@@ -87,7 +87,7 @@ from hud import Task
 task = Task(env="letter-count", id="count_letter", args={"word": "strawberry"}, slug="count-straw")
 ```
 
-## Grading: what the reward measures
+## Grading
 
 The second yield is the reward. The first decision is *what* you score:
 
@@ -150,12 +150,9 @@ async def implement_feature(spec: str = "add a /health endpoint"):
 
 </AccordionGroup>
 
-The full catalog lives in the [Graders reference](/v6/core/graders).
-
-<Warning>
-A grader that returns a constant, or just echoes the answer back as a pass, teaches a model nothing and
-invites reward hacking. A good reward separates good work from bad - see [Advice](/v6/core/advice).
-</Warning>
+The full catalog lives in the [Graders reference](/v6/core/graders). A grader that returns a constant
+or just echoes the answer back teaches a model nothing and invites reward hacking; a good reward
+separates good work from bad - see [Designing tasks](/v6/core/advice).
 
 ## Tasksets
 
@@ -278,7 +275,7 @@ print(plan.summary())
 <Card title="Runtime" icon="server" href="/v6/core/runtime">
   Where each task runs, chosen at execution time.
 </Card>
-<Card title="Advice" icon="lightbulb" href="/v6/core/advice">
+<Card title="Designing tasks" icon="lightbulb" href="/v6/core/advice">
   Design tasks that actually teach: difficulty, spread, and resisting reward hacking.
 </Card>
 </CardGroup>

--- a/docs/v6/core/training.mdx
+++ b/docs/v6/core/training.mdx
@@ -31,7 +31,7 @@ set that loop up.
 - **A task with spread in its rewards.** This is the one prerequisite people miss. If every rollout of
   a task gets the *same* reward, training learns nothing from it (see [Why grouping
   matters](#why-grouping-matters)). Designing tasks that produce spread is its own craft - see
-  [Advice](/v6/core/advice).
+  [Designing tasks](/v6/core/advice).
 - **A trainable model**, which you make by forking one (next).
 
 ## Get a trainable model
@@ -88,7 +88,7 @@ comparison to its siblings on the same task.
 The consequence: if every rollout in a group earns the **same** reward, every advantage is zero and
 **no learning happens** - no matter how high the average looks. That's why you run each task as a group
 (`group=8` above) and why your tasks must produce a **spread** of rewards. Trainability is a property of
-your tasks, not just your loop - the whole point of [Advice](/v6/core/advice).
+your tasks, not just your loop - the whole point of [Designing tasks](/v6/core/advice).
 
 ## Watch it improve
 
@@ -258,7 +258,7 @@ Under the hood `forward` returns a `ForwardResult` (`forward_id` + `data: list[D
 ## See also
 
 <CardGroup cols={2}>
-<Card title="Advice" icon="lightbulb" href="/v6/core/advice">
+<Card title="Designing tasks" icon="lightbulb" href="/v6/core/advice">
   Design tasks that produce reward spread - the prerequisite for training to work.
 </Card>
 <Card title="Tasks & Tasksets" icon="list-check" href="/v6/core/tasks">

--- a/docs/v6/more/faq.mdx
+++ b/docs/v6/more/faq.mdx
@@ -104,7 +104,7 @@ Yes. The Harbor integration loads Harbor-format tasks straight into a `Taskset` 
 </Accordion>
 
 <Accordion title="Does HUD support robotics / VLA policies?">
-Yes, in **beta**: the `openpi/0` capability is a schema-driven observation/action loop over WebSocket for simulator and robot environments, with a LeRobot-ready agent harness and trace playback with action-chunk markers. See the [Robots reference](/v6/core/robots) and the [robot benchmark cookbook](/v6/cookbooks/robot-benchmark).
+Yes, in **beta**: the `openpi/0` capability is a schema-driven observation/action loop over WebSocket for simulator and robot environments, with a LeRobot-ready agent harness and trace playback with action-chunk markers. See the [Robots reference](/v6/advanced/robots) and the [robot benchmark cookbook](/v6/cookbooks/robot-benchmark).
 </Accordion>
 
 <Accordion title="I'm upgrading from v5 - what changed?">


### PR DESCRIPTION
Move robots into the Advanced section and add a Batching section (BatchedAgent/BatchedModel); fix the robot contract example to include control_rate and names, since both drive trace-viewer playback and labeling. Restructure Run & deploy (Runtime heading + overview, RuntimeConfig before the renamed Runtime directory, drop the self-contained-image section, move custom infra to the end). Document the filetracking/1 capability, rename the tasks grading section and drop its warning box, demote Advanced headings so the on-this-page TOC nests, and fix moved links plus a few typos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no runtime or API behavior changes.
> 
> **Overview**
> **Robots** moves from Core to **Advanced** in the nav, with a redirect from `/v6/core/robots`. The robots page adds a **Batching** section (`BatchedAgent` / shared GPU forwards), tightens the **contract** example (`control_rate`, per-feature `names` for trace playback/labels), drops the standalone Telemetry section, and fixes small typos.
> 
> **Run & deploy** is reorganized: short overview plus a **Runtime** section up front, **RuntimeConfig** before the built-in constructor reference (renamed **Runtime directory**), the self-contained Docker image workflow removed, custom runtime integration moved to the end, and the bottom “See also” card group removed.
> 
> **Capabilities** documents **`filetracking/1`** (`Workspace(..., track_files=True)`, `FileTrackingClient` for telemetry diffs). **Extending HUD** drops `mode: wide` and demotes headings (`##` / `###`) so the on-page TOC nests; cross-links now point at **Designing tasks** instead of “Advice,” and robot links use `/v6/advanced/robots`. **Tasks** renames the grading section and folds the old warning into prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96bb359e1beaef15bea340f67beed93ad1c8cb7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->