### PR TITLE
chore: bump version to 0.6.5

### DIFF
--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.4"
+    assert hud.__version__ == "0.6.5"

--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hud-python"
-version = "0.6.4"
+version = "0.6.5"
 description = "SDK for the HUD platform."
 readme = "README.md"
 requires-python = ">=3.11, <3.13"


### PR DESCRIPTION
## Summary
- Bumps version from 0.6.4 → 0.6.5

## Test plan
- [ ] `hud.__version__` returns `"0.6.5"`
- [ ] `test_version` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version string updates only; no runtime or API behavior changes.
> 
> **Overview**
> Bumps the **hud-python** release from **0.6.4** to **0.6.5** in `pyproject.toml`, `hud/version.py` (`__version__`), and the version assertion in `hud/tests/test_version.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e7ef7f4677bf3efafcb1bfc6b55044b4a0e9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->