### PR TITLE
feat(cli): add ARC-AGI-3 preset to hud init

### DIFF
--- a/cookbooks/fireworks-rl-training/train.py
+++ b/cookbooks/fireworks-rl-training/train.py
@@ -92,7 +92,9 @@ def make_tasks(
     ]
 
 
-def format_prompt_tokens(tokenizer: Any, prompt: str, *, enable_thinking: bool = False) -> list[int]:
+def format_prompt_tokens(
+    tokenizer: Any, prompt: str, *, enable_thinking: bool = False
+) -> list[int]:
     messages = [{"role": "user", "content": prompt}]
     # Hybrid reasoning models (e.g. Qwen3) default to a <think> block. For a
     # direct-answer task with a tight token budget that reasoning never reaches

--- a/hud/cli/presets.py
+++ b/hud/cli/presets.py
@@ -138,6 +138,14 @@ ENVIRONMENT_PRESETS: tuple[EnvironmentPreset, ...] = (
         "hud-evals",
         "videogamebench-template",
     ),
+    EnvironmentPreset(
+        "arc-agi-3",
+        "🧩",
+        "ARC-AGI-3",
+        "Interactive reasoning benchmark: agents play ARC-AGI-3 games.",
+        "hud-evals",
+        "ARC-AGI-3",
+    ),
 )
 
 PRESETS_BY_ID: dict[str, EnvironmentPreset] = {p.id: p for p in ENVIRONMENT_PRESETS}

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.5"
+    assert hud.__version__ == "0.6.6"


### PR DESCRIPTION
Add ARC-AGI-3 (hud-evals/ARC-AGI-3) as the final starter preset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Preset list and version bump only; no auth, runtime, or core CLI logic changes beyond registering a new template.
> 
> **Overview**
> Adds **ARC-AGI-3** as a new `hud init` starter preset, pointing at `hud-evals/ARC-AGI-3` for the interactive reasoning benchmark.
> 
> Bumps the package version to **0.6.6** in the version import test. Includes a cosmetic reformat of `format_prompt_tokens` in the Fireworks RL cookbook (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038324e8fc6fd87b0e743e887b1d65540ea26f9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->