### PR TITLE
feat(deploy): add Modal GPU defaults

### DIFF
--- a/hud/cli/deploy.py
+++ b/hud/cli/deploy.py
@@ -32,6 +32,7 @@ class _DeployPlan:
     name: str
     registry_id: str | None
     runtime: str | None
+    runtime_config: dict[str, Any] | None
     env_vars: dict[str, str]
     build_args: dict[str, str]
     build_secrets: dict[str, str]
@@ -73,6 +74,32 @@ def _normalize_runtime(runtime: str | None, console: HUDConsole) -> str | None:
         f"Invalid runtime {runtime!r}; expected one of: {', '.join(sorted(_VALID_RUNTIMES))}"
     )
     raise typer.Exit(1)
+
+
+def _runtime_config_from_flags(
+    *,
+    runtime: str | None,
+    gpu: str | None,
+    gpu_count: int | None,
+    console: HUDConsole,
+) -> dict[str, Any] | None:
+    if gpu is None and gpu_count is None:
+        return None
+    if runtime != "modal":
+        console.error("--gpu and --gpu-count require --runtime modal")
+        raise typer.Exit(1)
+    count = gpu_count or 1
+    if count < 1:
+        console.error("--gpu-count must be at least 1")
+        raise typer.Exit(1)
+    gpu_config: dict[str, Any] = {"count": count}
+    if gpu is not None:
+        gpu_type = gpu.strip()
+        if not gpu_type:
+            console.error("--gpu must be a non-empty Modal GPU type")
+            raise typer.Exit(1)
+        gpu_config["type"] = gpu_type
+    return {"resources": {"gpu": gpu_config}}
 
 
 def _load_env_vars(path: Path, console: HUDConsole, *, warn_missing: bool) -> dict[str, str]:
@@ -322,6 +349,8 @@ def _prepare_deploy_plan(
     build_args: list[str] | None,
     build_secrets: list[str] | None,
     runtime: str | None,
+    gpu: str | None,
+    gpu_count: int | None,
     verbose: bool,
     platform: PlatformClient,
     console: HUDConsole,
@@ -357,11 +386,18 @@ def _prepare_deploy_plan(
     build_args_dict = _parse_key_value_flags(build_args, option="--build-arg", console=console)
     if build_args_dict and verbose:
         console.info(f"Build arguments: {', '.join(build_args_dict.keys())}")
+    normalized_runtime = _normalize_runtime(runtime, console)
 
     return _DeployPlan(
         name=resolved_name,
         registry_id=registry_id,
-        runtime=_normalize_runtime(runtime, console),
+        runtime=normalized_runtime,
+        runtime_config=_runtime_config_from_flags(
+            runtime=normalized_runtime,
+            gpu=gpu,
+            gpu_count=gpu_count,
+            console=console,
+        ),
         env_vars=env_vars,
         build_args=build_args_dict,
         build_secrets=_collect_build_secrets(build_secrets, env_dir=env_dir, console=console),
@@ -379,6 +415,8 @@ def deploy_environment(
     build_args: list[str] | None = None,
     build_secrets: list[str] | None = None,
     runtime: str | None = None,
+    gpu: str | None = None,
+    gpu_count: int | None = None,
 ) -> None:
     """Deploy one HUD environment to the platform."""
     hud_console = HUDConsole()
@@ -411,6 +449,8 @@ def deploy_environment(
         build_args=build_args,
         build_secrets=build_secrets,
         runtime=runtime,
+        gpu=gpu,
+        gpu_count=gpu_count,
         verbose=verbose,
         platform=platform,
         console=hud_console,
@@ -485,6 +525,8 @@ async def _trigger_build(
         payload["registry_id"] = plan.registry_id
     if plan.runtime:
         payload["runtime_provider"] = plan.runtime
+    if plan.runtime_config:
+        payload["runtime_config"] = plan.runtime_config
     if plan.env_vars:
         payload["environment_variables"] = plan.env_vars
     if plan.build_args:
@@ -644,6 +686,8 @@ def deploy_all(
     build_args: list[str] | None = None,
     build_secrets: list[str] | None = None,
     runtime: str | None = None,
+    gpu: str | None = None,
+    gpu_count: int | None = None,
 ) -> None:
     """Deploy each HUD environment under a parent directory."""
     hud_console = HUDConsole()
@@ -683,6 +727,8 @@ def deploy_all(
                 build_args=build_args,
                 build_secrets=build_secrets,
                 runtime=runtime,
+                gpu=gpu,
+                gpu_count=gpu_count,
             )
             succeeded.append(env_dir.name)
         except (typer.Exit, SystemExit):
@@ -762,6 +808,16 @@ def deploy_command(
         "--runtime",
         help="Persist Modal as the hosted runtime for this registry",
     ),
+    gpu: str | None = typer.Option(
+        None,
+        "--gpu",
+        help="Modal GPU type to use for hosted runs, e.g. A10G or H100",
+    ),
+    gpu_count: int | None = typer.Option(
+        None,
+        "--gpu-count",
+        help="Number of Modal GPUs for hosted runs",
+    ),
 ) -> None:
     """Deploy HUD environment to the platform.
 
@@ -781,6 +837,8 @@ def deploy_command(
             build_args=build_args,
             build_secrets=secrets,
             runtime=runtime,
+            gpu=gpu,
+            gpu_count=gpu_count,
         )
         return
 
@@ -795,4 +853,6 @@ def deploy_command(
         build_args=build_args,
         build_secrets=secrets,
         runtime=runtime,
+        gpu=gpu,
+        gpu_count=gpu_count,
     )

--- a/hud/cli/deploy.py
+++ b/hud/cli/deploy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -12,6 +13,7 @@ from typing import Any
 
 import httpx
 import typer
+from pydantic import ValidationError
 
 from hud.cli.utils.build_display import display_build_summary
 from hud.cli.utils.build_logs import poll_build_status, stream_build_logs
@@ -19,6 +21,7 @@ from hud.cli.utils.config import parse_env_file, parse_key_value
 from hud.cli.utils.context import create_build_context_tarball, format_size
 from hud.cli.utils.registry import get_registry_environment
 from hud.cli.utils.source import EnvironmentSource, normalize_environment_name
+from hud.eval.runtime import RuntimeConfig
 from hud.utils.exceptions import HudRequestError
 from hud.utils.hud_console import HUDConsole
 from hud.utils.platform import PlatformClient
@@ -76,30 +79,24 @@ def _normalize_runtime(runtime: str | None, console: HUDConsole) -> str | None:
     raise typer.Exit(1)
 
 
-def _runtime_config_from_flags(
-    *,
-    runtime: str | None,
-    gpu: str | None,
-    gpu_count: int | None,
-    console: HUDConsole,
-) -> dict[str, Any] | None:
-    if gpu is None and gpu_count is None:
+def _load_runtime_config(path: str | None, console: HUDConsole) -> dict[str, Any] | None:
+    if path is None:
         return None
-    if runtime != "modal":
-        console.error("--gpu and --gpu-count require --runtime modal")
-        raise typer.Exit(1)
-    count = gpu_count or 1
-    if count < 1:
-        console.error("--gpu-count must be at least 1")
-        raise typer.Exit(1)
-    gpu_config: dict[str, Any] = {"count": count}
-    if gpu is not None:
-        gpu_type = gpu.strip()
-        if not gpu_type:
-            console.error("--gpu must be a non-empty Modal GPU type")
-            raise typer.Exit(1)
-        gpu_config["type"] = gpu_type
-    return {"resources": {"gpu": gpu_config}}
+    config_path = Path(path).expanduser()
+    try:
+        raw = json.loads(config_path.read_text(encoding="utf-8"))
+        config = RuntimeConfig.model_validate(raw)
+    except FileNotFoundError:
+        console.error(f"Runtime config file not found: {config_path}")
+        raise typer.Exit(1) from None
+    except json.JSONDecodeError as exc:
+        console.error(f"Invalid runtime config JSON in {config_path}: {exc.msg}")
+        raise typer.Exit(1) from exc
+    except ValidationError as exc:
+        console.error(f"Invalid runtime config in {config_path}: {exc}")
+        raise typer.Exit(1) from exc
+    payload = config.model_dump(mode="json", exclude_none=True)
+    return payload or None
 
 
 def _load_env_vars(path: Path, console: HUDConsole, *, warn_missing: bool) -> dict[str, str]:
@@ -349,8 +346,7 @@ def _prepare_deploy_plan(
     build_args: list[str] | None,
     build_secrets: list[str] | None,
     runtime: str | None,
-    gpu: str | None,
-    gpu_count: int | None,
+    runtime_config: str | None,
     verbose: bool,
     platform: PlatformClient,
     console: HUDConsole,
@@ -392,12 +388,7 @@ def _prepare_deploy_plan(
         name=resolved_name,
         registry_id=registry_id,
         runtime=normalized_runtime,
-        runtime_config=_runtime_config_from_flags(
-            runtime=normalized_runtime,
-            gpu=gpu,
-            gpu_count=gpu_count,
-            console=console,
-        ),
+        runtime_config=_load_runtime_config(runtime_config, console),
         env_vars=env_vars,
         build_args=build_args_dict,
         build_secrets=_collect_build_secrets(build_secrets, env_dir=env_dir, console=console),
@@ -415,8 +406,7 @@ def deploy_environment(
     build_args: list[str] | None = None,
     build_secrets: list[str] | None = None,
     runtime: str | None = None,
-    gpu: str | None = None,
-    gpu_count: int | None = None,
+    runtime_config: str | None = None,
 ) -> None:
     """Deploy one HUD environment to the platform."""
     hud_console = HUDConsole()
@@ -449,8 +439,7 @@ def deploy_environment(
         build_args=build_args,
         build_secrets=build_secrets,
         runtime=runtime,
-        gpu=gpu,
-        gpu_count=gpu_count,
+        runtime_config=runtime_config,
         verbose=verbose,
         platform=platform,
         console=hud_console,
@@ -686,8 +675,7 @@ def deploy_all(
     build_args: list[str] | None = None,
     build_secrets: list[str] | None = None,
     runtime: str | None = None,
-    gpu: str | None = None,
-    gpu_count: int | None = None,
+    runtime_config: str | None = None,
 ) -> None:
     """Deploy each HUD environment under a parent directory."""
     hud_console = HUDConsole()
@@ -727,8 +715,7 @@ def deploy_all(
                 build_args=build_args,
                 build_secrets=build_secrets,
                 runtime=runtime,
-                gpu=gpu,
-                gpu_count=gpu_count,
+                runtime_config=runtime_config,
             )
             succeeded.append(env_dir.name)
         except (typer.Exit, SystemExit):
@@ -808,15 +795,10 @@ def deploy_command(
         "--runtime",
         help="Persist Modal as the hosted runtime for this registry",
     ),
-    gpu: str | None = typer.Option(
+    runtime_config: str | None = typer.Option(
         None,
-        "--gpu",
-        help="Modal GPU type to use for hosted runs, e.g. A10G or H100",
-    ),
-    gpu_count: int | None = typer.Option(
-        None,
-        "--gpu-count",
-        help="Number of Modal GPUs for hosted runs",
+        "--runtime-config",
+        help="Path to a JSON RuntimeConfig for hosted runs",
     ),
 ) -> None:
     """Deploy HUD environment to the platform.
@@ -837,8 +819,7 @@ def deploy_command(
             build_args=build_args,
             build_secrets=secrets,
             runtime=runtime,
-            gpu=gpu,
-            gpu_count=gpu_count,
+            runtime_config=runtime_config,
         )
         return
 
@@ -853,6 +834,5 @@ def deploy_command(
         build_args=build_args,
         build_secrets=secrets,
         runtime=runtime,
-        gpu=gpu,
-        gpu_count=gpu_count,
+        runtime_config=runtime_config,
     )

--- a/hud/cli/deploy.py
+++ b/hud/cli/deploy.py
@@ -95,7 +95,7 @@ def _load_runtime_config(path: str | None, console: HUDConsole) -> dict[str, Any
     except ValidationError as exc:
         console.error(f"Invalid runtime config in {config_path}: {exc}")
         raise typer.Exit(1) from exc
-    payload = config.model_dump(mode="json", exclude_none=True)
+    payload = config.request_payload()
     return payload or None
 
 

--- a/hud/cli/tests/test_deploy.py
+++ b/hud/cli/tests/test_deploy.py
@@ -179,6 +179,38 @@ class TestCollectEnvironmentVariables:
         assert "INVALID_FORMAT" not in result
 
 
+class TestRuntimeConfigFile:
+    def test_load_runtime_config_uses_sdk_shape(self, tmp_path: Path) -> None:
+        from hud.cli.deploy import _load_runtime_config
+        from hud.utils.hud_console import HUDConsole
+
+        config_path = tmp_path / "runtime.json"
+        config_path.write_text(
+            json.dumps(
+                {
+                    "resources": {"gpu": {"type": "A10G", "count": 2}},
+                    "limits": {"startup_timeout_s": 300},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert _load_runtime_config(str(config_path), HUDConsole()) == {
+            "resources": {"gpu": {"type": "A10G", "count": 2}},
+            "limits": {"startup_timeout_s": 300},
+        }
+
+    def test_load_runtime_config_rejects_unknown_fields(self, tmp_path: Path) -> None:
+        from hud.cli.deploy import _load_runtime_config
+        from hud.utils.hud_console import HUDConsole
+
+        config_path = tmp_path / "runtime.json"
+        config_path.write_text(json.dumps({"provider_config": {}}), encoding="utf-8")
+
+        with pytest.raises(typer.Exit):
+            _load_runtime_config(str(config_path), HUDConsole())
+
+
 class TestDeployEnvironment:
     """Tests for deploy_environment function."""
 

--- a/hud/cli/tests/test_deploy.py
+++ b/hud/cli/tests/test_deploy.py
@@ -200,6 +200,15 @@ class TestRuntimeConfigFile:
             "limits": {"startup_timeout_s": 300},
         }
 
+    def test_load_runtime_config_preserves_null_override(self, tmp_path: Path) -> None:
+        from hud.cli.deploy import _load_runtime_config
+        from hud.utils.hud_console import HUDConsole
+
+        config_path = tmp_path / "runtime.json"
+        config_path.write_text(json.dumps({"resources": None}), encoding="utf-8")
+
+        assert _load_runtime_config(str(config_path), HUDConsole()) == {"resources": None}
+
     def test_load_runtime_config_rejects_unknown_fields(self, tmp_path: Path) -> None:
         from hud.cli.deploy import _load_runtime_config
         from hud.utils.hud_console import HUDConsole

--- a/hud/cli/tests/test_deploy.py
+++ b/hud/cli/tests/test_deploy.py
@@ -262,6 +262,7 @@ class TestDeployAsync:
                     name="test-env",
                     registry_id=None,
                     runtime=None,
+                    runtime_config=None,
                     env_vars={},
                     build_args={},
                     build_secrets={},
@@ -292,6 +293,7 @@ class TestDeployAsync:
                     name="test-env",
                     registry_id=None,
                     runtime=None,
+                    runtime_config=None,
                     env_vars={},
                     build_args={},
                     build_secrets={},
@@ -331,6 +333,7 @@ class TestDeployAsync:
                 name="test-env",
                 registry_id=None,
                 runtime="modal",
+                runtime_config=None,
                 env_vars={},
                 build_args={},
                 build_secrets={},
@@ -342,6 +345,48 @@ class TestDeployAsync:
         assert result == {"id": "build-1", "registry_id": "registry-1"}
         assert platform.payload is not None
         assert platform.payload["runtime_provider"] == "modal"
+
+    @pytest.mark.asyncio
+    async def test_trigger_build_sends_runtime_config(self) -> None:
+        from hud.cli.deploy import _DeployPlan, _trigger_build
+        from hud.utils.hud_console import HUDConsole
+        from hud.utils.platform import PlatformClient
+
+        class FakePlatform(PlatformClient):
+            payload: dict[str, object] | None = None
+
+            async def apost(
+                self,
+                path: str,
+                *,
+                json: object | None = None,
+            ) -> dict[str, object]:
+                assert path == "/builds/trigger"
+                assert isinstance(json, dict)
+                object.__setattr__(self, "payload", json)
+                return {"id": "build-1", "registry_id": "registry-1"}
+
+        runtime_config = {"resources": {"gpu": {"type": "A10G", "count": 1}}}
+        platform = FakePlatform("https://api.example", "key")
+        result = await _trigger_build(
+            platform,
+            build_id="build-1",
+            plan=_DeployPlan(
+                name="test-env",
+                registry_id=None,
+                runtime="modal",
+                runtime_config=runtime_config,
+                env_vars={},
+                build_args={},
+                build_secrets={},
+            ),
+            no_cache=False,
+            console=HUDConsole(),
+        )
+
+        assert result == {"id": "build-1", "registry_id": "registry-1"}
+        assert platform.payload is not None
+        assert platform.payload["runtime_config"] == runtime_config
 
 
 class TestSaveDeployLink:

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -107,6 +107,9 @@ class RuntimeConfig(BaseModel):
             self.model_dump() | override.model_dump(exclude_unset=True)
         )
 
+    def request_payload(self) -> dict[str, Any]:
+        return self.model_dump(mode="json", exclude_unset=True)
+
 
 class Provider(Protocol):
     """Server placement: called with the task row being placed, acquire one
@@ -887,7 +890,7 @@ class HostedRuntime:
         if group_id is not None:
             payload["group_id"] = group_id
         if task.runtime_config is not None:
-            runtime_config = task.runtime_config.model_dump(mode="json", exclude_none=True)
+            runtime_config = task.runtime_config.request_payload()
             if runtime_config:
                 payload["runtime_config"] = runtime_config
         await platform.apost("/rollouts/submit", json=payload)

--- a/hud/eval/sync.py
+++ b/hud/eval/sync.py
@@ -163,7 +163,7 @@ def task_upload_payload(task: Task) -> dict[str, Any]:
     if task.columns:
         payload["columns"] = task.columns
     if task.runtime_config is not None:
-        payload["runtime_config"] = task.runtime_config.model_dump(exclude_none=True)
+        payload["runtime_config"] = task.runtime_config.request_payload()
     return payload
 
 
@@ -176,7 +176,7 @@ def _task_signature(task: Task) -> str:
     if task.columns:
         sig_data["columns"] = task.columns
     if task.runtime_config is not None:
-        sig_data["runtime_config"] = task.runtime_config.model_dump(exclude_none=True)
+        sig_data["runtime_config"] = task.runtime_config.request_payload()
     return f"{task.id}|" + json.dumps(
         sig_data,
         sort_keys=True,

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -165,6 +165,25 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
 
 
 @pytest.mark.asyncio
+async def test_run_preserves_runtime_config_null_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = _FakePlatform([{"status": "completed", "reward": 0.5}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+
+    await HostedRuntime(poll_interval=0.0).run(
+        Task(env="sums", id="add", runtime_config=RuntimeConfig(resources=None)),
+        _agent(),
+        job_id=uuid.uuid4().hex,
+        trace_id=uuid.uuid4().hex,
+    )
+
+    assert platform.posts[0][1]["runtime_config"] == {"resources": None}
+
+
+@pytest.mark.asyncio
 async def test_run_timeout_requests_platform_cancel(monkeypatch: pytest.MonkeyPatch) -> None:
     platform = _FakePlatform([{"status": "running"}])
     monkeypatch.setattr(

--- a/hud/eval/tests/test_sync.py
+++ b/hud/eval/tests/test_sync.py
@@ -148,3 +148,15 @@ def test_task_upload_payload_includes_runtime_config() -> None:
     payload = task_upload_payload(task)
 
     assert payload["runtime_config"] == {"image": "img:tag"}
+
+
+def test_task_upload_payload_preserves_runtime_config_null_override() -> None:
+    task = Task(
+        env="e",
+        id="solve",
+        runtime_config=RuntimeConfig(resources=None),
+    )
+
+    payload = task_upload_payload(task)
+
+    assert payload["runtime_config"] == {"resources": None}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how runtime_config is serialized for deploy builds and hosted rollouts/task sync; mis-serialization could affect GPU/resource defaults on the platform, but behavior is covered by new tests.
> 
> **Overview**
> Adds **`--runtime-config`** on `hud deploy` (and deploy-all) so you can point at a JSON file that is validated as `RuntimeConfig` and sent on **`/builds/trigger`** as **`runtime_config`** alongside **`--runtime`** (e.g. Modal GPU/limits defaults at registry deploy time).
> 
> Introduces **`RuntimeConfig.request_payload()`** (`model_dump` with **`exclude_unset=True`**) and uses it for deploy, hosted rollout submit, and taskset upload/signatures. That replaces **`exclude_none=True`** dumping so **explicit null overrides** (e.g. `{"resources": null}`) are kept on the wire instead of dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3597932b3e5278c7c7c150d6a04672db45b38b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->