### PR TITLE
feat(docs): fix key docs urls

### DIFF
--- a/docs/v6/more/faq.mdx
+++ b/docs/v6/more/faq.mdx
@@ -65,7 +65,7 @@ For data-handling specifics, see [hud.ai](https://hud.ai) or contact the team.
 </Accordion>
 
 <Accordion title="How much does it cost?">
-Running locally with your own provider key (`hud serve`, `hud eval ... claude`) incurs no HUD charge beyond your provider's usage. The **gateway** uses hosted compute. For current pricing, quotas, and any free tier, see [hud.ai](https://hud.ai/project/api-keys).
+Running locally with your own provider key (`hud serve`, `hud eval ... claude`) incurs no HUD charge beyond your provider's usage. The **gateway** uses hosted compute. For current pricing, quotas, and any free tier, see [hud.ai/project/api-keys](https://hud.ai/project/api-keys).
 </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only link text change with no runtime or behavioral impact.
> 
> **Overview**
> Updates the **How much does it cost?** FAQ entry so the markdown link label matches the destination, using `[hud.ai/project/api-keys](https://hud.ai/project/api-keys)` instead of labeling the link as generic `[hud.ai]` while still pointing at the API keys page.
> 
> This brings that sentence in line with other docs in the same FAQ (e.g. **Do I need an API key?**) and the quickstart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b51ac93401ab5294c9565b813be96588b41c0209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->