### PR TITLE
docs(cookbooks): add cookbooks index + calibrate Fireworks RL cookbook

### DIFF
--- a/cookbooks/fireworks-rl-training/README.md
+++ b/cookbooks/fireworks-rl-training/README.md
@@ -35,38 +35,50 @@ uv sync --pre
 
 ## Calibrate task difficulty first
 
-Calibration defaults to Fireworks' OpenAI-compatible inference API, so it does
-**not** create a trainer, provision a Training API deployment, or call
-`optim_step`. This is the cheap way to tune task difficulty before paying for a
-Training API run.
+What matters for GRPO is **within-group** reward spread: advantages are computed
+within each prompt group, so a group whose rollouts all score the same (all 0 or
+all 1) produces zero advantage and no gradient — even if the *overall* mean looks
+healthy. Calibration reports `within_group_reward_std` for exactly this; treat
+it, not `reward_mean`, as the signal that training has something to learn.
 
-The calibration model is separate from the training base model because the
-`lorenss` key currently exposes only a small serverless inference catalog (no
-Qwen3 8B deployment). Override it with `--inference-model` if you have a closer
-deployed model.
+Two backends:
 
-```bash
-uv run train.py --calibrate-only --groups-per-step 8 --rollouts-per-prompt 8 --parallelism 32
-```
-
-The goal is a reward distribution with variance. If reward is all zero, make the
-task easier:
-
-```bash
-uv run train.py --calibrate-only --min-a 10 --max-a 99 --min-b 2 --max-b 9
-```
-
-If reward is all one, make the task harder:
+- `--calibration-backend inference` (default): Fireworks' OpenAI-compatible API.
+  Cheap, but samples `gpt-oss-120b` (`--inference-model`), not the training base —
+  the small serverless catalog on the `lorenss` key has no Qwen3 8B. Use it only
+  for a rough task sanity check.
+- `--calibration-backend managed`: provisions the same deployment sampler that
+  training uses and samples the **actual base model** (Qwen3 8B). This is the
+  calibration that counts. It still skips the trainer and `optim_step`.
 
 ```bash
-uv run train.py --calibrate-only --min-a 1000 --max-a 9999 --min-b 11 --max-b 99
+uv run train.py --calibrate-only --calibration-backend managed \
+  --groups-per-step 6 --rollouts-per-prompt 6 --parallelism 18 --debug-samples 4
 ```
 
-The current defaults are calibrated for the visible `gpt-oss-120b` inference
-model on the `lorenss` key: 2-digit by 1-digit multiplication with a direct
-"reply only with the integer" prompt. A 32-rollout calibration gave a non-trivial
-baseline (`reward_mean ~= 0.22`, `reward_std ~= 0.42`), while the original
-3-digit by 2-digit range was all-zero.
+`--debug-samples N` prints the first N rollouts (reward, output-token count,
+text) so you can see *why* a group scored the way it did. Tune the multiplication
+range until `within_group_reward_std` is clearly above zero:
+
+- Groups all-correct (`within_group_reward_std ~= 0`) → make it harder
+  (`--min-a/--max-a/--min-b/--max-b`).
+- Groups all-wrong → make it easier, or raise `--max-tokens` so the model can
+  finish its working before the budget cuts it off.
+
+The shipped defaults (3-digit × 3-digit, `--max-tokens 512`, thinking disabled)
+calibrate to `reward_mean ~= 0.47`, `within_group_reward_std ~= 0.20` on Qwen3 8B:
+a regime where the same problem is sometimes solved (when the model shows its
+work) and sometimes slipped (when it answers directly) — so RL has a gradient to
+follow.
+
+### Reasoning models and the token budget
+
+Qwen3 is a hybrid reasoning model: by default it opens a `<think>` block and, on
+a tight `--max-tokens`, spends the whole budget reasoning and never emits the
+answer (reward collapses to zero). This cookbook disables thinking by default
+through the chat template so direct rollouts reach the integer. Pass
+`--enable-thinking` to keep the reasoning block — and raise `--max-tokens`
+accordingly so the answer still fits.
 
 ## Train
 
@@ -80,20 +92,23 @@ This uses the direct Training API managed service path. If you want calibration
 to go through the managed deployment sampler too, pass
 `--calibration-backend managed`; this provisions the same resources as training.
 
-### Current Fireworks preview account blocker
+### Preview account constraints
 
-On the `lorenss` preview account, trainer creation currently fails before the
-first train step with:
+On the `lorenss` preview account today:
 
-```text
-failed to ensure FIREWORKS_API_KEY secret: unkey inference api id is not configured
-```
-
-This happens even with `create_deployment=False`, so it is an account/control
-plane provisioning issue rather than a problem in the rollout or loss code. Once
-Fireworks enables the missing Unkey inference API config for the account, the
-same `uv run train.py ...` command should proceed to trainer startup and the
-first `forward_backward_custom(...)` call.
+- **Trainer creation works** end to end with a provisioned key: rollouts,
+  `forward_backward_custom`, `optim_step`, checkpoint save, and sampler hotload
+  all run, and multi-step training completes. (An earlier `unkey inference api id
+  is not configured` 500 on trainer creation was an account-side provisioning gap,
+  now resolved.)
+- **LoRA is unavailable**: the validated `qwen3-8b-128k` shape only accepts
+  full-parameter training, so `--lora-rank > 0` fails at trainer creation with
+  `no validated training shape exists for ... trainer_mode=LORA_TRAINER`.
+- **Hotloads sync full 8B weights** between steps and occasionally exceed the
+  SDK's 600s hotload budget (`RuntimeError: Hotload failed for sampler snapshot
+  ...`). This is transient preview-infra latency, not a loop bug — re-running the
+  same command generally proceeds. There is no clean knob to extend the timeout
+  on the managed sampler path.
 
 Metrics are written to:
 

--- a/cookbooks/fireworks-rl-training/train.py
+++ b/cookbooks/fireworks-rl-training/train.py
@@ -257,6 +257,27 @@ def reward_stats(records: list[RolloutRecord]) -> dict[str, float]:
     }
 
 
+def within_group_reward_std(records: list[RolloutRecord]) -> float:
+    """Mean per-group reward std — the spread GRPO actually trains on.
+
+    Advantages are computed *within* each prompt group, so between-group spread
+    is irrelevant: if every rollout of a prompt earns the same reward, that
+    group's advantage is zero. This averages each group's std to report whether
+    any learning signal exists at all.
+    """
+    grouped: dict[int, list[float]] = {}
+    for record in records:
+        grouped.setdefault(record.task.group_index, []).append(record.reward)
+    stds: list[float] = []
+    for rewards in grouped.values():
+        if len(rewards) < 2:
+            continue
+        mean = sum(rewards) / len(rewards)
+        variance = sum((r - mean) ** 2 for r in rewards) / (len(rewards) - 1)
+        stds.append(math.sqrt(variance))
+    return sum(stds) / len(stds) if stds else 0.0
+
+
 def advantages_by_record(records: list[RolloutRecord]) -> list[float]:
     grouped: dict[int, list[float]] = {}
     for record in records:
@@ -409,6 +430,7 @@ async def run(args: argparse.Namespace) -> None:
             "step": 0,
             "num_rollouts": len(records),
             "rollout_seconds": time.perf_counter() - t0,
+            "within_group_reward_std": within_group_reward_std(records),
             **reward_stats(records),
         }
         append_jsonl(metrics_path, row)
@@ -483,6 +505,7 @@ async def run(args: argparse.Namespace) -> None:
                 "step": step,
                 "num_rollouts": len(records),
                 "rollout_seconds": rollout_seconds,
+                "within_group_reward_std": within_group_reward_std(records),
                 "trainer_job_id": getattr(service, "trainer_job_id", None),
                 "deployment_id": getattr(service, "deployment_id", None),
                 **stats,
@@ -549,12 +572,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--weight-decay", type=float, default=0.01)
     parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument("--top-p", type=float, default=1.0)
-    parser.add_argument("--max-tokens", type=int, default=32)
+    parser.add_argument("--max-tokens", type=int, default=512)
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--min-a", type=int, default=10)
-    parser.add_argument("--max-a", type=int, default=99)
-    parser.add_argument("--min-b", type=int, default=2)
-    parser.add_argument("--max-b", type=int, default=9)
+    parser.add_argument("--min-a", type=int, default=100)
+    parser.add_argument("--max-a", type=int, default=999)
+    parser.add_argument("--min-b", type=int, default=100)
+    parser.add_argument("--max-b", type=int, default=999)
     parser.add_argument("--debug-samples", type=int, default=0)
     parser.add_argument(
         "--enable-thinking",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,7 @@
               { "group": "Overview", "pages": ["v6/build/overview", "v6/core/protocol"] },
               { "group": "Core", "pages": ["v6/core/environment", "v6/core/tasks", "v6/core/capabilities", "v6/core/agents", "v6/core/runtime", "v6/core/graders", "v6/core/advice", "v6/core/training", "v6/core/types", "v6/core/cli"] },
               { "group": "Advanced", "pages": ["v6/advanced/extending", "v6/advanced/robots", "v6/advanced/harbor-convert"] },
-              { "group": "Cookbooks", "pages": ["v6/cookbooks/coding-agent", "v6/cookbooks/ops-diagnostics", "v6/cookbooks/a2a-chat", "v6/cookbooks/robot-benchmark"] },
+              { "group": "Cookbooks", "pages": ["v6/cookbooks/index", "v6/cookbooks/coding-agent", "v6/cookbooks/ops-diagnostics", "v6/cookbooks/a2a-chat", "v6/cookbooks/robot-benchmark"] },
               { "group": "More", "pages": ["v6/more/faq", "v6/more/migrate-v6", "v6/more/contributing"] }
             ]
           }

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -120,6 +120,24 @@ needed in the template. Cite [Capabilities](/v6/core/capabilities).
 
 ---
 
+## Start from a template
+
+`hud init` scaffolds a new environment. Pass `--preset <id>` to start from a
+ready-made template instead of the blank scaffold (omit it for an interactive
+picker):
+
+```bash
+hud init my-env --preset browser
+```
+
+Available presets: `blank`, `browser`, `cua` (computer-use desktop),
+`deepresearch`, `coding`, `ml`, `ml-triage`, `verilog`, `autonomous-businesses`,
+`gdpval`, `worldsim`, `robot`, `videogamebench`, and `arc-agi-3`. Each downloads
+a complete, runnable starting point you adapt — prefer it over hand-writing an
+environment from scratch. Cite [Quickstart](/v6/start/quickstart).
+
+---
+
 ## Local iteration and process model
 
 `hud eval env.py model` is the canonical test loop — no cloud account, docker,

--- a/docs/v6/cookbooks/index.mdx
+++ b/docs/v6/cookbooks/index.mdx
@@ -1,0 +1,51 @@
+---
+title: "Cookbooks"
+description: "Complete, runnable examples you can copy and adapt."
+icon: "book-open"
+---
+
+Cookbooks are complete, runnable examples — each one is a small project you can
+copy and adapt. They all live in the
+[`cookbooks/`](https://github.com/hud-evals/hud-python/tree/main/cookbooks)
+directory of the SDK repo. The ones below with a walkthrough have a full guide
+here; the rest are best read straight from the source.
+
+## Walkthroughs
+
+<CardGroup cols={2}>
+  <Card title="Coding agent" icon="code" href="/v6/cookbooks/coding-agent">
+    Run a coding agent against a shell + files environment, graded by tests.
+    Source: [`cookbooks/codex-coding`](https://github.com/hud-evals/hud-python/tree/main/cookbooks/codex-coding).
+  </Card>
+  <Card title="A2A chat" icon="plug" href="/v6/cookbooks/a2a-chat">
+    Serve a chat task over the A2A protocol and talk to it from any client.
+    Source: [`cookbooks/a2a-chat`](https://github.com/hud-evals/hud-python/tree/main/cookbooks/a2a-chat).
+  </Card>
+  <Card title="Ops diagnostics" icon="stethoscope" href="/v6/cookbooks/ops-diagnostics">
+    An investigation task where the agent integrates evidence into a diagnosis.
+  </Card>
+  <Card title="Robot benchmark" icon="robot" href="/v6/cookbooks/robot-benchmark">
+    Run a VLA policy against a containerized robot sim, graded by task success.
+  </Card>
+</CardGroup>
+
+## More runnable examples
+
+These ship in the repo without a separate walkthrough — read the README in each
+directory to run them.
+
+<CardGroup cols={2}>
+  <Card title="RL training" icon="dumbbell" href="https://github.com/hud-evals/hud-python/tree/main/cookbooks/rl-training">
+    On-policy RL: roll out a taskset with the current weights, train on the
+    resulting trajectories, and serve the updated weights for the next rollout —
+    all under one trainable model string.
+  </Card>
+  <Card title="Connect Four self-play" icon="table-cells" href="https://github.com/hud-evals/hud-python/tree/main/cookbooks/connect4-selfplay">
+    Symmetric self-play GRPO on a 6×7 Connect Four board, training both sides
+    from a single rollout.
+  </Card>
+  <Card title="Fireworks RL training" icon="fire" href="https://github.com/hud-evals/hud-python/tree/main/cookbooks/fireworks-rl-training">
+    The RL loop driven through the Fireworks Training API instead of the HUD
+    training service.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary

- Add a **Cookbooks index page** (`docs/v6/cookbooks/index.mdx`) that links every runnable cookbook (coding-agent, ops-diagnostics, a2a-chat, robot-benchmark, rl-training, connect4-selfplay, fireworks-rl-training), and register it in `docs.json`.
- **Calibrate the `fireworks-rl-training` cookbook so it actually learns.** It previously saturated (uniform reward → zero within-group spread → no GRPO gradient). Now it:
  - reports `within_group_reward_std` (the spread GRPO actually trains on, vs. the misleading overall mean), and
  - ships calibrated defaults (3-digit × 3-digit, `--max-tokens 512`) that produce a real within-group signal (`reward_mean ≈ 0.47`, `within_group_reward_std ≈ 0.20` on Qwen3 8B).
  - README calibration guidance updated to match (within-group calibration, managed vs inference backends, reasoning/token-budget note).
- **Skill:** note `hud init --preset` starter templates.

## Test plan

- [ ] `docs.json` validates and the Cookbooks group renders the new index page.
- [ ] `uv run train.py --calibrate-only --calibration-backend managed` reports non-zero `within_group_reward_std` with the shipped defaults.
- [ ] A short `uv run train.py --steps 2 ...` run produces non-zero policy loss (verified locally end-to-end).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and cookbook defaults/metrics; training behavior changes are localized to example defaults and observability, not core SDK paths.
> 
> **Overview**
> Adds a **Cookbooks** hub page (`docs/v6/cookbooks/index.mdx`) and wires it into `docs.json`, linking walkthroughs and repo-only examples (including Fireworks RL). **`docs/skill.md`** documents `hud init --preset` starter templates.
> 
> The **Fireworks RL training** cookbook is recalibrated so GRPO has a real signal: new **`within_group_reward_std`** metric in `train.py` (logged on calibrate/train), **default task knobs** shifted to 3-digit × 3-digit and `--max-tokens 512`, and **README** rewritten around within-group spread, managed vs inference calibration, Qwen3 thinking/token budget, and updated preview-account notes (trainer works; LoRA blocked; hotload timeouts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a011496efa6d46a9cbf0218d35f11e54d2d3e523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->