### PR TITLE
[codex] update cookbooks index title

### DIFF
--- a/docs/v6/cookbooks/index.mdx
+++ b/docs/v6/cookbooks/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Cookbooks"
+title: "Cookbooks: Agents, RL, and Benchmarks"
 description: "Complete, runnable cookbook examples you can copy and adapt: coding agents, A2A chat, ops diagnostics, robot benchmarks, RL training, and more."
 icon: "book-open"
 ---


### PR DESCRIPTION
## Summary
- Update the cookbooks index page title to `Cookbooks: Agents, RL, and Benchmarks`.
- Keep the current SEO description from #468, avoiding the conflicted Mintlify branch.

## Validation
- `git diff --check -- docs/v6/cookbooks/index.mdx` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation metadata only; no runtime or API impact.
> 
> **Overview**
> Updates the Mintlify frontmatter **title** on the v6 cookbooks index from `Cookbooks` to **`Cookbooks: Agents, RL, and Benchmarks`**, aligning the page heading with the topics covered in the existing description and cards.
> 
> No body copy, links, or SEO **description** change—only the displayed page title in docs metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d702ef2b071ce6f73ae9ac5c973f4cb04820a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->