### PR TITLE
[codex] fix openai-compatible workspace tools

### DIFF
--- a/hud/agents/openai_compatible/agent.py
+++ b/hud/agents/openai_compatible/agent.py
@@ -17,11 +17,13 @@ from hud.types import MCPToolCall, MCPToolResult
 from hud.utils import gateway
 
 from .tools import (
+    BashTool,
+    EditTool,
     GlobTool,
     GrepTool,
-    ListTool,
     OpenAICompatibleMCPProxyTool,
     ReadTool,
+    WriteTool,
 )
 from .tools.base import format_chat_result
 
@@ -41,10 +43,12 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
     """OpenAI-compatible agent using the chat.completions protocol."""
 
     tool_catalog = (
+        BashTool,
         ReadTool,
-        GrepTool,
         GlobTool,
-        ListTool,
+        GrepTool,
+        EditTool,
+        WriteTool,
         OpenAICompatibleMCPProxyTool,
     )
 

--- a/hud/agents/openai_compatible/tools/__init__.py
+++ b/hud/agents/openai_compatible/tools/__init__.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
-from .filesystem import GlobTool, GrepTool, ListTool, ReadTool
+from .filesystem import BashTool, EditTool, GlobTool, GrepTool, ReadTool, WriteTool
 from .mcp_proxy import OpenAICompatibleMCPProxyTool
 
 __all__ = [
+    "BashTool",
+    "EditTool",
     "GlobTool",
     "GrepTool",
-    "ListTool",
     "OpenAICompatibleMCPProxyTool",
     "ReadTool",
+    "WriteTool",
 ]

--- a/hud/agents/openai_compatible/tools/filesystem.py
+++ b/hud/agents/openai_compatible/tools/filesystem.py
@@ -1,15 +1,19 @@
-"""OpenAI-compatible filesystem tools — backed by SSHClient."""
+"""OpenAI-compatible OpenCode-style workspace tools backed by SSHClient."""
 
 from __future__ import annotations
 
+import math
+import posixpath
 import shlex
 from typing import Any, ClassVar
 
 import mcp.types as mcp_types
 
 from hud.agents.tools import SSHTool
-from hud.agents.tools.base import AgentToolSpec, result_text
+from hud.agents.tools.base import AgentToolSpec, result_text, tool_err
 from hud.types import MCPToolResult
+
+DEFAULT_READ_LIMIT = 2000
 
 
 class _FilesystemTool(SSHTool):
@@ -34,16 +38,26 @@ class _FilesystemTool(SSHTool):
 
 class ReadTool(_FilesystemTool):
     name = "read"
-    description = "Reads a file from the local filesystem. Use offset and limit for pagination."
+    description = (
+        "Reads a file or directory from the workspace. Use offset and limit for pagination."
+    )
     parameters: ClassVar[dict[str, Any]] = {
         "type": "object",
         "properties": {
-            "filePath": {"type": "string", "description": "Absolute path to the file to read."},
+            "filePath": {
+                "type": "string",
+                "description": "The absolute path to the file or directory to read.",
+            },
             "offset": {
                 "type": "integer",
-                "description": "0-based line offset to start reading from.",
+                "description": "The line number to start reading from (1-indexed).",
+                "minimum": 0,
             },
-            "limit": {"type": "integer", "description": "Maximum number of lines to read."},
+            "limit": {
+                "type": "integer",
+                "description": "The maximum number of lines to read (defaults to 2000).",
+                "minimum": 1,
+            },
         },
         "required": ["filePath"],
     }
@@ -52,19 +66,205 @@ class ReadTool(_FilesystemTool):
         path = arguments.get("filePath")
         if not isinstance(path, str) or not path:
             raise ValueError("filePath is required")
+        offset = _read_offset(arguments.get("offset"))
+        limit = _positive_int(arguments.get("limit"), default=DEFAULT_READ_LIMIT, name="limit")
+        if not (await self.bash(f"test -d {shlex.quote(path)}")).isError:
+            return await self._read_directory(path, offset=offset, limit=limit)
         result = await self.file_read(path)
         if result.isError:
             return result
-        offset = arguments.get("offset")
-        limit = arguments.get("limit")
-        if isinstance(offset, int) and offset >= 0:
-            lines = result_text(result).splitlines(keepends=True)
-            end = offset + limit if isinstance(limit, int) and limit > 0 else len(lines)
-            sliced = lines[offset:end]
-            return MCPToolResult(
-                content=[mcp_types.TextContent(type="text", text="".join(sliced))],
+        text = result_text(result)
+        lines = text.splitlines()
+        start = offset - 1
+        if start > len(lines) and not (len(lines) == 0 and offset == 1):
+            return tool_err(f"Offset {offset} is out of range for this file ({len(lines)} lines)")
+        sliced = lines[start : start + limit]
+        last = offset + len(sliced) - 1
+        more = last < len(lines)
+        body = [
+            f"<path>{path}</path>",
+            "<type>file</type>",
+            "<content>",
+            *[f"{i + offset}: {line}" for i, line in enumerate(sliced)],
+        ]
+        if more:
+            body.append(
+                f"\n(Showing lines {offset}-{last} of {len(lines)}. "
+                f"Use offset={last + 1} to continue.)"
             )
-        return result
+        else:
+            body.append(f"\n(End of file - total {len(lines)} lines)")
+        body.append("</content>")
+        return MCPToolResult(content=[mcp_types.TextContent(type="text", text="\n".join(body))])
+
+    async def _read_directory(self, path: str, *, offset: int, limit: int) -> MCPToolResult:
+        result = await self.file_list(path)
+        if result.isError:
+            return result
+        entries = result_text(result).splitlines()
+        if entries == ["(empty)"]:
+            entries = []
+        start = offset - 1
+        sliced = entries[start : start + limit]
+        truncated = start + len(sliced) < len(entries)
+        body = [
+            f"<path>{path}</path>",
+            "<type>directory</type>",
+            "<entries>",
+            *sliced,
+        ]
+        if truncated:
+            body.append(
+                f"\n(Showing {len(sliced)} of {len(entries)} entries. "
+                f"Use offset={offset + len(sliced)} to continue.)"
+            )
+        else:
+            body.append(f"\n({len(entries)} entries)")
+        body.append("</entries>")
+        return MCPToolResult(content=[mcp_types.TextContent(type="text", text="\n".join(body))])
+
+
+class BashTool(_FilesystemTool):
+    name = "bash"
+    description = (
+        "Executes a shell command in the workspace. Prefer read, grep, glob, edit, "
+        "and write for filesystem operations."
+    )
+    parameters: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "command": {"type": "string", "description": "The command to execute."},
+            "timeout": {
+                "type": "integer",
+                "description": "Optional timeout in milliseconds.",
+                "minimum": 1,
+            },
+            "workdir": {
+                "type": "string",
+                "description": "The working directory to run the command in.",
+            },
+        },
+        "required": ["command"],
+    }
+
+    async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
+        command = arguments.get("command")
+        if not isinstance(command, str) or not command:
+            raise ValueError("command is required")
+        timeout = arguments.get("timeout")
+        if timeout is not None:
+            if not isinstance(timeout, int) or timeout < 1:
+                raise ValueError("timeout must be a positive integer")
+            seconds = max(1, math.ceil(timeout / 1000))
+            command = f"timeout {seconds}s bash -lc {shlex.quote(command)}"
+        workdir = arguments.get("workdir")
+        if isinstance(workdir, str) and workdir:
+            command = f"cd {shlex.quote(workdir)} && {command}"
+        return await self.bash(command)
+
+
+class EditTool(_FilesystemTool):
+    name = "edit"
+    description = (
+        "Replaces text within a file. Use oldString as exact literal context. "
+        "Set replaceAll to true to replace every occurrence."
+    )
+    parameters: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "filePath": {
+                "type": "string",
+                "description": "The absolute path to the file to modify.",
+            },
+            "oldString": {"type": "string", "description": "The text to replace."},
+            "newString": {
+                "type": "string",
+                "description": "The text to replace it with (must be different from oldString).",
+            },
+            "replaceAll": {
+                "type": "boolean",
+                "description": "Replace all occurrences of oldString (default false).",
+            },
+        },
+        "required": ["filePath", "oldString", "newString"],
+    }
+
+    async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
+        path = arguments.get("filePath")
+        if not isinstance(path, str) or not path:
+            raise ValueError("filePath is required")
+        old = arguments.get("oldString")
+        new = arguments.get("newString")
+        if not isinstance(old, str):
+            raise ValueError("oldString is required")
+        if not isinstance(new, str):
+            raise ValueError("newString is required")
+        if old == new:
+            return tool_err("No changes to apply: oldString and newString are identical.")
+        if old == "":
+            exists = not (await self.bash(f"test -e {shlex.quote(path)}")).isError
+            if exists:
+                return tool_err(
+                    "oldString cannot be empty when editing an existing file. "
+                    "Provide exact text to replace, or use write for full-file replacement."
+                )
+            mkdir = await self._ensure_parent(path)
+            if mkdir.isError:
+                return mkdir
+            return await self.file_write(path, new)
+
+        existing = await self.file_read(path)
+        if existing.isError:
+            return existing
+        text = result_text(existing)
+        count = text.count(old)
+        if count == 0:
+            return tool_err(f"oldString not found in {path}")
+        replace_all = arguments.get("replaceAll") is True
+        if count > 1 and not replace_all:
+            return tool_err(f"oldString matches {count} times in {path}; set replaceAll to true")
+        next_text = text.replace(old, new) if replace_all else text.replace(old, new, 1)
+        return await self.file_write(path, next_text)
+
+    async def _ensure_parent(self, path: str) -> MCPToolResult:
+        parent = posixpath.dirname(path)
+        if not parent or parent in {".", "/"}:
+            return MCPToolResult(content=[])
+        return await self.bash(f"mkdir -p {shlex.quote(parent)}")
+
+
+class WriteTool(_FilesystemTool):
+    name = "write"
+    description = "Creates or overwrites a file with the provided content."
+    parameters: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The content to write to the file."},
+            "filePath": {
+                "type": "string",
+                "description": "The absolute path to the file to write.",
+            },
+        },
+        "required": ["content", "filePath"],
+    }
+
+    async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
+        path = arguments.get("filePath")
+        if not isinstance(path, str) or not path:
+            raise ValueError("filePath is required")
+        content = arguments.get("content")
+        if not isinstance(content, str):
+            raise ValueError("content is required")
+        mkdir = await self._ensure_parent(path)
+        if mkdir.isError:
+            return mkdir
+        return await self.file_write(path, content)
+
+    async def _ensure_parent(self, path: str) -> MCPToolResult:
+        parent = posixpath.dirname(path)
+        if not parent or parent in {".", "/"}:
+            return MCPToolResult(content=[])
+        return await self.bash(f"mkdir -p {shlex.quote(parent)}")
 
 
 class GrepTool(_FilesystemTool):
@@ -115,24 +315,18 @@ class GlobTool(_FilesystemTool):
         return await self.bash(f"find {shlex.quote(str(path))} -name {shlex.quote(pattern)}")
 
 
-class ListTool(_FilesystemTool):
-    name = "list"
-    description = "Lists files and directories in a given path."
-    parameters: ClassVar[dict[str, Any]] = {
-        "type": "object",
-        "properties": {
-            "path": {"type": "string", "description": "Directory to list."},
-            "ignore": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Glob patterns to ignore.",
-            },
-        },
-    }
-
-    async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
-        path = arguments.get("path") or "."
-        return await self.file_list(str(path))
+def _positive_int(value: Any, *, default: int, name: str) -> int:
+    if value is None:
+        return default
+    if not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
 
 
-__all__ = ["GlobTool", "GrepTool", "ListTool", "ReadTool"]
+def _read_offset(value: Any) -> int:
+    if value is None or value == 0:
+        return 1
+    return _positive_int(value, default=1, name="offset")
+
+
+__all__ = ["BashTool", "EditTool", "GlobTool", "GrepTool", "ReadTool", "WriteTool"]

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -7,16 +7,19 @@ client and assert the command translation + result shape, fully offline.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+import shlex
+from typing import Any, cast
 
 import pytest
 
 from hud.agents.claude.tools.coding import ClaudeBashTool, ClaudeTextEditorTool
 from hud.agents.gemini.tools.coding import GeminiEditTool, GeminiShellTool
 from hud.agents.openai.tools.coding import OpenAIShellTool
-
-if TYPE_CHECKING:
-    from hud.capabilities import SSHClient
+from hud.agents.openai_compatible.agent import OpenAIChatAgent
+from hud.agents.openai_compatible.tools import BashTool, EditTool, ReadTool, WriteTool
+from hud.agents.tools.base import result_text
+from hud.agents.types import OpenAIChatConfig
+from hud.capabilities import Capability, SSHClient
 
 
 class _Completed:
@@ -61,6 +64,21 @@ class _FakeSFTP:
     def open(self, path: str, mode: str) -> _FakeOpenFile:
         return _FakeOpenFile(self._store, path, mode)
 
+    async def listdir(self, path: str) -> list[str]:
+        prefix = path.rstrip("/")
+        if not prefix:
+            prefix = "/"
+        if prefix != "/":
+            prefix += "/"
+        names: set[str] = set()
+        for file_path in self._store:
+            if not file_path.startswith(prefix):
+                continue
+            rest = file_path[len(prefix) :]
+            if rest:
+                names.add(rest.split("/", 1)[0])
+        return sorted(names)
+
 
 class _Conn:
     def __init__(self, completed: _Completed, store: dict[str, bytes]) -> None:
@@ -70,13 +88,26 @@ class _Conn:
 
     async def run(self, command: str, check: bool = False) -> _Completed:
         self.commands.append(command)
+        parts = shlex.split(command)
+        if len(parts) == 3 and parts[:2] in (["test", "-d"], ["test", "-e"]):
+            path = parts[2]
+            exists = path in self._store or any(
+                file_path.startswith(path.rstrip("/") + "/") for file_path in self._store
+            )
+            if parts[1] == "-d":
+                exists = any(
+                    file_path.startswith(path.rstrip("/") + "/") for file_path in self._store
+                )
+            return _Completed(exit_status=0 if exists else 1)
+        if len(parts) >= 3 and parts[:2] == ["mkdir", "-p"]:
+            return _Completed(exit_status=0)
         return self._completed
 
     def start_sftp_client(self) -> _FakeSFTP:
         return _FakeSFTP(self._store)
 
 
-class _FakeSSH:
+class _FakeSSH(SSHClient):
     """Duck-typed ``SSHClient``: ``conn.run`` (bash) + ``conn.start_sftp_client`` (files)."""
 
     def __init__(
@@ -87,7 +118,10 @@ class _FakeSSH:
         files: dict[str, bytes] | None = None,
     ) -> None:
         self.files: dict[str, bytes] = files or {}
-        self.conn = _Conn(_Completed(stdout=stdout, exit_status=exit_status), self.files)
+        super().__init__(
+            Capability(name="shell", protocol="ssh/2", url="ssh://localhost:22"),
+            cast("Any", _Conn(_Completed(stdout=stdout, exit_status=exit_status), self.files)),
+        )
 
 
 def _ssh(**kwargs: Any) -> SSHClient:
@@ -96,6 +130,11 @@ def _ssh(**kwargs: Any) -> SSHClient:
 
 def _commands(tool: Any) -> list[str]:
     return tool.client.conn.commands
+
+
+class _OpenAIChatAgentForTest(OpenAIChatAgent):
+    async def build_tools_for_test(self, ssh: SSHClient) -> tuple[dict[str, Any], list[Any]]:
+        return await self._build_tools({"ssh": ssh})
 
 
 # ─── OpenAI shell ─────────────────────────────────────────────────────
@@ -133,6 +172,96 @@ async def test_openai_shell_rejects_non_list_commands_without_running() -> None:
 def test_openai_shell_to_params_is_shell_type() -> None:
     tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
     assert tool.to_params()["type"] == "shell"
+
+
+# ─── OpenAI-compatible OpenCode workspace tools ───────────────────────
+
+
+async def test_openai_compatible_catalog_matches_opencode_workspace_tools() -> None:
+    agent = _OpenAIChatAgentForTest(
+        OpenAIChatConfig(model="qwen3.6-plus", model_client=cast("Any", object()))
+    )
+
+    tools, params = await agent.build_tools_for_test(_ssh())
+
+    assert list(tools) == ["bash", "read", "glob", "grep", "edit", "write"]
+    assert [param["function"]["name"] for param in params] == [
+        "bash",
+        "read",
+        "glob",
+        "grep",
+        "edit",
+        "write",
+    ]
+
+
+async def test_openai_compatible_bash_uses_workdir_and_timeout() -> None:
+    tool = BashTool(spec=BashTool.default_spec("qwen"), client=_ssh())
+
+    await tool.execute({"command": "echo hi", "workdir": "/tmp/my dir", "timeout": 2500})
+
+    assert _commands(tool) == ["cd '/tmp/my dir' && timeout 3s bash -lc 'echo hi'"]
+
+
+async def test_openai_compatible_write_stores_file_via_workspace_sftp() -> None:
+    ssh = _FakeSSH()
+    tool = WriteTool(spec=WriteTool.default_spec("qwen"), client=cast("SSHClient", ssh))
+
+    result = await tool.execute({"filePath": "/REPORT.md", "content": "done"})
+
+    assert result.isError is False
+    assert ssh.files["/REPORT.md"] == b"done"
+
+
+async def test_openai_compatible_edit_rewrites_unique_match() -> None:
+    ssh = _FakeSSH(files={"/f.txt": b"hello old world"})
+    tool = EditTool(spec=EditTool.default_spec("qwen"), client=cast("SSHClient", ssh))
+
+    result = await tool.execute(
+        {"filePath": "/f.txt", "oldString": "old", "newString": "new"},
+    )
+
+    assert result.isError is False
+    assert ssh.files["/f.txt"] == b"hello new world"
+
+
+async def test_openai_compatible_edit_rejects_ambiguous_match() -> None:
+    ssh = _FakeSSH(files={"/f.txt": b"a a a"})
+    tool = EditTool(spec=EditTool.default_spec("qwen"), client=cast("SSHClient", ssh))
+
+    result = await tool.execute(
+        {"filePath": "/f.txt", "oldString": "a", "newString": "b"},
+    )
+
+    assert result.isError is True
+    assert ssh.files["/f.txt"] == b"a a a"
+
+
+async def test_openai_compatible_read_lists_directories() -> None:
+    tool = ReadTool(
+        spec=ReadTool.default_spec("qwen"),
+        client=_ssh(files={"/work/a.txt": b"a", "/work/nested/b.txt": b"b"}),
+    )
+
+    result = await tool.execute({"filePath": "/work"})
+
+    text = result_text(result)
+    assert "<type>directory</type>" in text
+    assert "a.txt" in text
+    assert "nested" in text
+
+
+async def test_openai_compatible_read_accepts_zero_offset_for_first_page() -> None:
+    tool = ReadTool(
+        spec=ReadTool.default_spec("qwen"),
+        client=_ssh(files={"/f.txt": b"alpha\nbeta\n"}),
+    )
+
+    result = await tool.execute({"filePath": "/f.txt", "offset": 0, "limit": 1})
+
+    text = result_text(result)
+    assert "1: alpha" in text
+    assert "2: beta" not in text
 
 
 # ─── Gemini shell ─────────────────────────────────────────────────────

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -13,14 +13,18 @@ the atom and return a :class:`Job`.
 from __future__ import annotations
 
 import asyncio
+import json
 import textwrap
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import mcp.types as mcp_types
 import pytest
 
 from hud.agents.base import Agent
+from hud.agents.openai_compatible import OpenAIChatAgent
+from hud.agents.types import OpenAIChatConfig
 from hud.environment import Environment
 from hud.eval import Job, LocalRuntime, Task, Taskset
 from hud.eval.run import Run, rollout
@@ -63,6 +67,44 @@ class _FnAgent(Agent):
         run.trace.content = self._fn(run.prompt)
 
 
+class _SequencedCompletions:
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = responses
+        self.requests: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.requests.append(kwargs)
+        return self._responses.pop(0)
+
+
+class _FakeOpenAI:
+    def __init__(self, responses: list[Any]) -> None:
+        self.chat = SimpleNamespace(completions=_SequencedCompletions(responses))
+
+
+def _chat_response(content: str, tool_calls: list[Any] | None = None) -> Any:
+    message = SimpleNamespace(
+        content=content,
+        tool_calls=tool_calls or [],
+        refusal=None,
+        model_dump=lambda exclude_none=True: {"role": "assistant", "content": content},
+    )
+    choice = SimpleNamespace(message=message, finish_reason="stop", logprobs=None)
+    return SimpleNamespace(
+        choices=[choice],
+        model="fake-openai-compatible",
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1, prompt_tokens_details=None),
+    )
+
+
+def _tool_call(name: str, arguments: str) -> Any:
+    return SimpleNamespace(
+        type="function",
+        id=f"call_{name}",
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
 def _add_task(a: int, b: int) -> Task:
     """A pure data row; the env it names is defined by the spawned file."""
     return Task(env="sums", id="add", args={"a": a, "b": b})
@@ -84,6 +126,54 @@ async def test_rollout_returns_graded_run_with_trace_id(env_file: Path) -> None:
     # The factual placement record: the runtime this run executed against.
     assert run.runtime is not None
     assert run.runtime.startswith("tcp://127.0.0.1:")
+
+
+async def test_openai_compatible_write_reaches_workspace_grader(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    report = workspace / "REPORT.md"
+    env = Environment("opencode_report")
+    env.workspace(workspace, guest_path=str(workspace))
+
+    @env.initialize
+    async def seed() -> None:
+        workspace.mkdir(parents=True, exist_ok=True)
+        report.unlink(missing_ok=True)
+
+    @env.template()
+    async def write_report():
+        yield "Write PASS to REPORT.md."
+        yield 1.0 if report.exists() and report.read_text().strip() == "PASS" else 0.0
+
+    model_client = _FakeOpenAI(
+        [
+            _chat_response(
+                "",
+                [_tool_call("write", json.dumps({"filePath": str(report), "content": "PASS"}))],
+            ),
+            _chat_response("done"),
+        ]
+    )
+    agent = OpenAIChatAgent(
+        OpenAIChatConfig(model="qwen3.6-plus", model_client=model_client, max_steps=4)
+    )
+
+    run = await rollout(
+        Task(env="opencode_report", id="write_report"),
+        agent,
+        runtime=lambda _task: _local(env),
+    )
+
+    assert run.reward == 1.0
+    assert report.read_text() == "PASS"
+    tools = model_client.chat.completions.requests[0]["extra_body"]["tools"]
+    assert [tool["function"]["name"] for tool in tools] == [
+        "bash",
+        "read",
+        "glob",
+        "grep",
+        "edit",
+        "write",
+    ]
 
 
 async def test_mid_run_failure_keeps_the_real_run_and_its_evidence(env_file: Path) -> None:


### PR DESCRIPTION
## Summary

Expose an OpenCode-style workspace tool surface for `OpenAIChatAgent`: `bash`, `read`, `glob`, `grep`, `edit`, and `write`.

## Root Cause

OpenAI-compatible providers were only receiving read/search/list tools over `ssh/2`, so file-deliverable tasks could inspect the workspace but could not reliably write the graded artifact. Some provider-side write attempts therefore never reached the HUD workspace filesystem.

## Changes

- Added SSH/SFTP-backed `bash`, `edit`, and `write` tools for the OpenAI-compatible harness.
- Updated `read` to handle both files and directories with OpenCode-style 1-indexed pagination.
- Removed the advertised `list` tool from the OpenAI-compatible catalog so the exposed workspace surface matches OpenCode's build-agent file tool set.
- Added provider-tool regression coverage and a small rollout regression that verifies a deterministic OpenAI-compatible `write` tool call reaches the same workspace file that the grader reads.

## Actual Evals

Both evals used a local HUD environment with `env.workspace(...)`, a prompt to create `REPORT.md`, and a grader that checks the file from the environment process.

- Kimi K2.6: https://hud.ai/jobs/517898ebc5ce44b0bcf2392df963a2cb, reward `1.000`
- Qwen 3.6 Plus: https://hud.ai/jobs/c3c3e8a2cf4c452bb86bc79e76745311, reward `1.000`

Eval environment used:

```python
from pathlib import Path

from hud import Environment

ROOT = Path("workspace").resolve()
REPORT = ROOT / "REPORT.md"

env = Environment("opencode_real_eval")
env.workspace(ROOT, guest_path=str(ROOT))


@env.initialize
async def seed():
    ROOT.mkdir(parents=True, exist_ok=True)
    if REPORT.exists():
        REPORT.unlink()


@env.template()
async def write_report():
    yield (
        f"Create {REPORT} with exactly this content and nothing else:\n\n"
        "PASS\n\n"
        "When the file is written, respond with done."
    )
    yield 1.0 if REPORT.exists() and REPORT.read_text().strip() == "PASS" else 0.0


tasks = [write_report()]
```

Commands, run from a directory containing that `env.py`:

```bash
HUD_API_URL=https://api.beta.hud.ai HUD_GATEWAY_URL=https://inference.beta.hud.ai uv run --no-sync hud eval env.py kimi-k2.6 --max-steps 8 -y -v

HUD_API_URL=https://api.beta.hud.ai HUD_GATEWAY_URL=https://inference.beta.hud.ai uv run --no-sync hud eval env.py openai_compatible --model qwen3.6-plus --max-steps 8 -y -v --gateway
```

## Validation

From `packages/hud-python`:

```bash
uv run --no-sync pytest hud/agents/tests hud/eval/tests/test_rollout.py
uv run --no-sync ruff check hud/agents/openai_compatible hud/agents/tests/test_provider_native_tools.py hud/eval/tests/test_rollout.py
uv run --no-sync ruff format --check hud/agents/openai_compatible hud/agents/tests/test_provider_native_tools.py hud/eval/tests/test_rollout.py
uv run --no-sync pyright hud/agents/openai_compatible hud/agents/tests/test_provider_native_tools.py
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds remote shell execution and broad file write/edit capabilities on the eval workspace SSH channel; behavior is well-tested but affects how OpenAI-compatible runs mutate graded environments.
> 
> **Overview**
> **OpenAI-compatible agents** now advertise an OpenCode-style workspace surface (`bash`, `read`, `glob`, `grep`, `edit`, `write`) instead of read/search-only tools plus **`list`**, so models can create and modify graded artifacts on the SSH workspace.
> 
> **`read`** now treats directories like files (via `test -d`), uses **1-indexed** pagination with a default line limit, and returns structured tagged output with continuation hints. New **`bash`**, **`edit`**, and **`write`** tools run over the existing `SSHTool` path (shell + SFTP), including optional `workdir`/`timeout` for bash and guarded string-replace semantics for **`edit`**.
> 
> Coverage adds offline provider-tool tests for the catalog and command/file behavior, plus a **rollout** test that a fake `write` tool call lands in the same workspace file the grader reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bac30219e8ef415972c47cc0c3734e591a73f6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->