### PR TITLE
feat: enhance parameter annotation resolution in task signatures

### DIFF
--- a/hud/environment/env.py
+++ b/hud/environment/env.py
@@ -98,7 +98,7 @@ class _TaskFactory(Generic[P]):
         #: Type the agent must produce (``None`` = plain text). Drives answer
         #: deserialization into ``Answer[T]``.
         self.return_type = returns
-        self.sig = inspect.signature(func)
+        self.sig = inspect.signature(func, eval_str=True)
         functools.update_wrapper(self, func)
 
     def manifest_entry(self) -> dict[str, Any]:

--- a/hud/environment/tests/test_manifest.py
+++ b/hud/environment/tests/test_manifest.py
@@ -7,6 +7,8 @@ are the agent's declared I/O types.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 from hud.environment import Environment
@@ -15,6 +17,14 @@ from hud.environment import Environment
 class _Point(BaseModel):
     x: int
     y: int
+
+
+class _Payload(BaseModel):
+    text: str
+
+
+_Mode = Literal["easy", "hard"]
+_Retries = int | None
 
 
 def test_args_schema_captures_params_defaults_and_required() -> None:
@@ -86,3 +96,19 @@ def test_input_and_returns_schemas_still_published() -> None:
     assert entry["input"]["properties"]["x"]["type"] == "integer"
     assert entry["returns"]["properties"]["y"]["type"] == "integer"
     assert entry["args"]["properties"] == {}
+
+
+def test_args_schema_resolves_postponed_rich_annotations() -> None:
+    env = Environment("manifests")
+
+    @env.template()
+    async def rich(mode: _Mode, payload: _Payload, retries: _Retries = None):
+        yield "go"
+        yield 1.0
+
+    assert callable(rich)
+    schema = env.tasks["rich"].manifest_entry()["args"]
+    assert schema["properties"]["mode"]["enum"] == ["easy", "hard"]
+    assert schema["properties"]["retries"]["default"] is None
+    assert "$ref" in schema["properties"]["payload"]
+    assert set(schema["required"]) == {"mode", "payload"}

--- a/hud/environment/tests/test_server.py
+++ b/hud/environment/tests/test_server.py
@@ -7,7 +7,10 @@ object, nor a ``{"score": ...}`` dict) instead of silently grading 0.0.
 
 from __future__ import annotations
 
+from typing import Literal
+
 import pytest
+from pydantic import BaseModel
 
 from hud.clients import HudProtocolError
 from hud.environment import Answer, Environment
@@ -15,6 +18,13 @@ from hud.eval import Run
 from hud.graders import EvaluationResult
 
 from .conftest import served
+
+
+class _Payload(BaseModel):
+    text: str
+
+
+_Mode = Literal["upper", "lower"]
 
 
 async def test_dict_grade_without_numeric_score_errors_loudly() -> None:
@@ -79,3 +89,34 @@ def test_answer_holds_parsed_content_and_raw_string() -> None:
     answer = Answer(content={"final": "42"}, raw='{"final": "42"}')
     assert answer.content == {"final": "42"}
     assert answer.raw == '{"final": "42"}'
+
+
+async def test_start_coerces_postponed_rich_annotations() -> None:
+    env = Environment("coerce")
+
+    @env.template()
+    async def typed(mode: _Mode, payload: _Payload, retries: int | None = None):
+        if mode == "upper":
+            prompt = payload.text.upper()
+        elif mode == "lower":
+            prompt = payload.text.lower()
+        else:
+            raise ValueError(f"unexpected mode: {mode!r}")
+        if retries is not None:
+            prompt += "!" * retries
+        yield prompt
+        yield 1.0
+
+    assert callable(typed)
+    async with served(env) as client:
+        async with Run(
+            client,
+            "typed",
+            {
+                "mode": '"upper"',
+                "payload": '{"text":"hello"}',
+                "retries": "3",
+            },
+        ) as run:
+            run.trace.content = "x"
+        assert run.prompt == "HELLO!!!"


### PR DESCRIPTION
## Problem

`@env.template` breaks `hud deploy` / sync introspection when env files use `from __future__ import annotations` and template params use rich types (`Literal`, aliases, Pydantic models, unions).  
Failure surfaces as `TaskArgs is not fully defined`.

## Cause

`_TaskFactory` stored a raw `inspect.signature(func)`.  
With postponed annotations, that signature keeps annotation strings, and those unresolved strings were consumed by both manifest schema generation and start-time arg coercion.

## Solution

Use an evaluated signature at construction time:

- In `_TaskFactory.__init__`, changed to `inspect.signature(func, eval_str=True)`.
- Existing callers keep using `task.sig`, but now they get real runtime types.
- This fixes both manifest args schema generation and runtime coercion without adding new signature APIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line signature evaluation change with targeted tests; improves typing/introspection without altering wire protocol or auth paths.
> 
> **Overview**
> Fixes **`hud deploy` / sync** failures (`TaskArgs is not fully defined`) when env modules use **`from __future__ import annotations`** and `@env.template` parameters use rich types (`Literal`, aliases, Pydantic models, unions).
> 
> **`_TaskFactory`** now stores **`inspect.signature(func, eval_str=True)`** instead of a raw signature, so **`task.sig`** exposes resolved runtime types for both **`tasks.list` args JSON Schema** (`_args_json_schema`) and **wire `tasks.start` arg coercion** (`_coerce_args` in `TaskRunner`).
> 
> Adds tests that postponed annotations produce correct manifest enums/`$ref`/defaults and that a full **`Run`** coerces string wire args into typed template parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ac044c18849207f7e69f6dba0c2d5e021912d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->