### PR TITLE
chore: release v0.6.8

### DIFF
--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.8.dev1"
+    assert hud.__version__ == "0.6.8"

--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.8.dev1"
+__version__ = "0.6.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hud-python"
-version = "0.6.8.dev1"
+version = "0.6.8"
 description = "SDK for the HUD platform."
 readme = "README.md"
 requires-python = ">=3.11, <3.13"


### PR DESCRIPTION
## Summary

Bump the version from `0.6.8.dev1` to `0.6.8` to cut the release.

`main` has been at `0.6.8.dev1` since 2026-06-24, so the two notable
changes already merged there are not yet in any PyPI release (latest is
`0.6.7`):

- openai-compatible workspace tools: `bash`, `edit`, `write` (`bac30219`)
- workspace file tracking enabled by default (`5e4a42b3`)

This drops the `.dev1` suffix so those ship in a real `0.6.8`.

## Changes

- `pyproject.toml`: `version = "0.6.8"`
- `hud/version.py`: `__version__ = "0.6.8"`
- `hud/tests/test_version.py`: assertion updated to `0.6.8`

## Test plan

- [ ] `uv run pytest hud/tests/test_version.py`
- [ ] Confirm the release/publish workflow tags and uploads `0.6.8` to PyPI after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-string-only change with no runtime logic; risk is limited to release tagging/PyPI publishing if the workflow is misconfigured.
> 
> **Overview**
> Cuts the **0.6.8** release by changing the package version from `0.6.8.dev1` to `0.6.8` everywhere it is defined.
> 
> `pyproject.toml` and `hud/version.py` now declare `0.6.8`, and `hud/tests/test_version.py` asserts the same so the import-time version stays in sync for publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8054ad9b271df9f48351b77f923fa64928578fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->