### PR TITLE
fix(agents): malformed tool-call JSON no longer kills the rollout

### DIFF
--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -64,7 +64,8 @@ agent = ClaudeAgent(ClaudeConfig(model="claude-sonnet-4-5", max_steps=30))
 Each config lives in `hud.agents.types`. `OpenAIChatAgent` speaks the OpenAI Chat Completions API, so it
 points at any compatible server (vLLM, a local model) via `base_url`; `ClaudeSDKAgent` runs the `claude`
 CLI over an `ssh` capability, against the env's filesystem. Every knob (`model`, `max_steps`,
-`system_prompt`, `citations_enabled`) lives on the config; `__call__(run)` takes only the run.
+`system_prompt`, `citations_enabled`, `stop_on`) lives on the config; `__call__(run)`
+takes only the run.
 
 ## create_agent {#create-agent}
 

--- a/docs/v6/reference/types.mdx
+++ b/docs/v6/reference/types.mdx
@@ -84,6 +84,7 @@ unit of training data. Every recorded step also streams to the platform as one s
 |-------|------|-------------|
 | `steps` | `list[Step]` | The ordered trajectory. |
 | `status` | `"completed" \| "error" \| "cancelled" \| None` | How the run ended (`trace.is_error` reads it). |
+| `stop_reason` | `"done" \| "max_steps" \| "length" \| "timeout" \| "malformed_tool_call" \| None` | Why the rollout stopped (`trace.is_truncated` reads it: anything but `"done"` means a limit cut it off). |
 | `content` | `str \| None` | The final answer (graded). |
 | `trace_id` | `str \| None` | Keys server-side trajectories. |
 

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -318,12 +318,16 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
                 completion_tokens=response.usage.output_tokens,
                 cached_tokens=response.usage.input_tokens_details.cached_tokens,
             )
+        # The Responses API has no finish_reason; truncation surfaces as
+        # incomplete_details.reason ("max_output_tokens" / "content_filter").
+        incomplete = response.incomplete_details
         return AgentStep(
             content="".join(text_chunks),
             reasoning="\n".join(reasoning_chunks) if reasoning_chunks else None,
             citations=citations,
             tool_calls=tool_calls,
             done=not tool_calls,
+            finish_reason=incomplete.reason if incomplete is not None else None,
             model=response.model,
             usage=usage,
         )

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -24,7 +23,7 @@ from openai.types.responses.response_input_param import (
 )
 from openai.types.shared_params.reasoning import Reasoning  # noqa: TC002
 
-from hud.agents.tool_agent import RunState, ToolAgent
+from hud.agents.tool_agent import RunState, ToolAgent, parse_tool_arguments
 from hud.agents.types import AgentStep, Citation, OpenAIConfig, Usage
 from hud.settings import settings
 from hud.types import MCPToolCall, MCPToolResult
@@ -273,7 +272,9 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
                     tool_calls.append(
                         MCPToolCall(
                             name=item.name or "",
-                            arguments=json.loads(item.arguments),
+                            arguments=parse_tool_arguments(
+                                item.arguments, tool_name=item.name or ""
+                            ),
                             id=item.call_id,
                         )
                     )

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -23,7 +24,7 @@ from openai.types.responses.response_input_param import (
 )
 from openai.types.shared_params.reasoning import Reasoning  # noqa: TC002
 
-from hud.agents.tool_agent import RunState, ToolAgent, parse_tool_arguments
+from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentStep, Citation, OpenAIConfig, Usage
 from hud.settings import settings
 from hud.types import MCPToolCall, MCPToolResult
@@ -269,14 +270,17 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
                         "".join(summary.text for summary in item.summary),
                     )
                 case "function_call":
-                    tool_calls.append(
-                        MCPToolCall(
-                            name=item.name or "",
-                            arguments=parse_tool_arguments(
-                                item.arguments, tool_name=item.name or ""
-                            ),
-                            id=item.call_id,
+                    fn_arguments: dict[str, Any] | str
+                    try:
+                        parsed = json.loads(item.arguments or "{}")
+                        fn_arguments = (
+                            cast("dict[str, Any]", parsed) if isinstance(parsed, dict) else {}
                         )
+                    except json.JSONDecodeError as e:
+                        logger.warning("Malformed tool-call arguments for %s: %s", item.name, e)
+                        fn_arguments = item.arguments
+                    tool_calls.append(
+                        MCPToolCall(name=item.name or "", arguments=fn_arguments, id=item.call_id)
                     )
                 case "computer_call":
                     if item.actions:

--- a/hud/agents/openai_compatible/agent.py
+++ b/hud/agents/openai_compatible/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
@@ -9,12 +10,7 @@ from typing import TYPE_CHECKING, Any, cast
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
-from hud.agents.tool_agent import (
-    MALFORMED_TOOL_ARGS_KEY,
-    RunState,
-    ToolAgent,
-    parse_tool_arguments,
-)
+from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentStep, OpenAIChatConfig, Sample, Usage
 from hud.settings import settings
 from hud.types import MCPToolCall, MCPToolResult
@@ -174,14 +170,23 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
         choice = response.choices[0]
         message = choice.message
         function_calls = [tc for tc in message.tool_calls or [] if tc.type == "function"]
-        tool_calls: list[MCPToolCall] = [
-            MCPToolCall(
-                id=tc.id,
-                name=tc.function.name,
-                arguments=parse_tool_arguments(tc.function.arguments, tool_name=tc.function.name),
+        tool_calls: list[MCPToolCall] = []
+        recorded_calls: list[dict[str, Any]] = []
+        for tc in function_calls:
+            name, raw = tc.function.name, tc.function.arguments
+            arguments: dict[str, Any] | str
+            try:
+                parsed = json.loads(raw or "{}")
+                arguments = cast("dict[str, Any]", parsed) if isinstance(parsed, dict) else {}
+                recorded = raw
+            except json.JSONDecodeError as e:
+                logger.warning("Malformed tool-call arguments for %s: %s", name, e)
+                arguments = raw
+                recorded = "{}"  # replayed history must stay parseable
+            tool_calls.append(MCPToolCall(id=tc.id, name=name, arguments=arguments))
+            recorded_calls.append(
+                {"id": tc.id, "type": "function", "function": {"name": name, "arguments": recorded}}
             )
-            for tc in function_calls
-        ]
 
         assistant_message = message.model_dump(exclude_none=True)
         reasoning_content = getattr(message, "reasoning_content", None)
@@ -193,24 +198,7 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
             if value := getattr(message, field_name, None):
                 assistant_message[field_name] = value
         if function_calls:
-            assistant_message["tool_calls"] = [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.function.name,
-                        # Replaying a malformed arguments string 500s some backends (Qwen/vLLM
-                        # re-parse it when templating history); record "{}" instead — the raw
-                        # string rides in the sentinel and the trace.
-                        "arguments": (
-                            "{}"
-                            if MALFORMED_TOOL_ARGS_KEY in (call.arguments or {})
-                            else tc.function.arguments
-                        ),
-                    },
-                }
-                for tc, call in zip(function_calls, tool_calls, strict=True)
-            ]
+            assistant_message["tool_calls"] = recorded_calls
         messages.append(cast("ChatCompletionMessageParam", assistant_message))
 
         sample: Sample | None = None

--- a/hud/agents/openai_compatible/agent.py
+++ b/hud/agents/openai_compatible/agent.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
@@ -10,7 +9,12 @@ from typing import TYPE_CHECKING, Any, cast
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
 
-from hud.agents.tool_agent import RunState, ToolAgent
+from hud.agents.tool_agent import (
+    MALFORMED_TOOL_ARGS_KEY,
+    RunState,
+    ToolAgent,
+    parse_tool_arguments,
+)
 from hud.agents.types import AgentStep, OpenAIChatConfig, Sample, Usage
 from hud.settings import settings
 from hud.types import MCPToolCall, MCPToolResult
@@ -170,6 +174,14 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
         choice = response.choices[0]
         message = choice.message
         function_calls = [tc for tc in message.tool_calls or [] if tc.type == "function"]
+        tool_calls: list[MCPToolCall] = [
+            MCPToolCall(
+                id=tc.id,
+                name=tc.function.name,
+                arguments=parse_tool_arguments(tc.function.arguments, tool_name=tc.function.name),
+            )
+            for tc in function_calls
+        ]
 
         assistant_message = message.model_dump(exclude_none=True)
         reasoning_content = getattr(message, "reasoning_content", None)
@@ -187,10 +199,17 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
                     "type": "function",
                     "function": {
                         "name": tc.function.name,
-                        "arguments": tc.function.arguments,
+                        # Replaying a malformed arguments string 500s some backends (Qwen/vLLM
+                        # re-parse it when templating history); record "{}" instead — the raw
+                        # string rides in the sentinel and the trace.
+                        "arguments": (
+                            "{}"
+                            if MALFORMED_TOOL_ARGS_KEY in (call.arguments or {})
+                            else tc.function.arguments
+                        ),
                     },
                 }
-                for tc in function_calls
+                for tc, call in zip(function_calls, tool_calls, strict=True)
             ]
         messages.append(cast("ChatCompletionMessageParam", assistant_message))
 
@@ -218,15 +237,6 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
                 else:
                     chat_state.continuation_token_ids = None
                     chat_state.continuation_message_count = None
-
-        tool_calls: list[MCPToolCall] = []
-        for tc in function_calls:
-            provider_name = tc.function.name
-            raw_args = json.loads(tc.function.arguments or "{}")
-            arguments = cast("dict[str, Any]", raw_args) if isinstance(raw_args, dict) else {}
-            tool_calls.append(
-                MCPToolCall(id=tc.id, name=provider_name, arguments=arguments),
-            )
 
         usage: Usage | None = None
         if response.usage is not None:

--- a/hud/agents/tests/test_openai_agent.py
+++ b/hud/agents/tests/test_openai_agent.py
@@ -39,9 +39,17 @@ def test_format_message_shapes_user_text() -> None:
     assert msg["role"] == "user"
 
 
-def _api_response(id: str, output: list[Any], usage: Any = None) -> Any:
+def _api_response(
+    id: str, output: list[Any], usage: Any = None, incomplete_details: Any = None
+) -> Any:
     """A fake Responses-API payload: output items plus the response envelope."""
-    return SimpleNamespace(id=id, output=output, model="gpt-test-v1", usage=usage)
+    return SimpleNamespace(
+        id=id,
+        output=output,
+        model="gpt-test-v1",
+        usage=usage,
+        incomplete_details=incomplete_details,
+    )
 
 
 async def test_get_response_parses_text_and_function_call() -> None:
@@ -92,6 +100,19 @@ async def test_get_response_done_when_no_tool_calls() -> None:
     assert result.done is True
     assert result.tool_calls == []
     assert result.usage is None  # provider omitted usage
+    assert result.finish_reason is None
+
+
+async def test_get_response_surfaces_token_cap_truncation() -> None:
+    # Responses has no finish_reason; incomplete_details.reason carries the cap.
+    response = _api_response(
+        "resp_3", [], incomplete_details=SimpleNamespace(reason="max_output_tokens")
+    )
+    agent = _agent(response)
+    state = OpenAIRunState(messages=[agent._format_message("user", "hi")])
+
+    result = await agent.get_response(state)
+    assert result.finish_reason == "max_output_tokens"
 
 
 async def test_get_response_short_circuits_on_consumed_messages() -> None:

--- a/hud/agents/tests/test_openai_compatible_agent.py
+++ b/hud/agents/tests/test_openai_compatible_agent.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, cast
 
+import mcp.types as mcp_types
+
 from hud.agents.openai_compatible.agent import OpenAIChatAgent, OpenAIChatRunState
 from hud.agents.types import OpenAIChatConfig
 
@@ -81,3 +83,48 @@ async def test_get_response_error_path() -> None:
     result = await agent.get_response(_state(agent))
     assert result.done is True
     assert result.error is not None and "boom" in result.error
+
+
+async def test_get_response_malformed_tool_args_do_not_crash() -> None:
+    """Truncated arguments must yield a dispatchable sentinel call, not a rollout-killing
+    JSONDecodeError (live Qwen failure: 'Unterminated string starting at line 1 column 13')."""
+    from hud.agents.tool_agent import MALFORMED_TOOL_ARGS_KEY
+
+    tc = SimpleNamespace(
+        type="function",
+        id="c1",
+        function=SimpleNamespace(name="bash", arguments='{"command": "'),
+    )
+    agent = _agent(_response("", [tc]))
+    state = _state(agent)
+    result = await agent.get_response(state)
+    assert result.error is None
+    assert [c.name for c in result.tool_calls] == ["bash"]
+    assert result.tool_calls[0].id == "c1"  # provider still gets a result
+    assert MALFORMED_TOOL_ARGS_KEY in (result.tool_calls[0].arguments or {})
+    assert result.done is False  # the loop continues
+    # the RECORDED assistant message must replay "{}" — a raw malformed arguments string 500s
+    # some backends (Qwen/vLLM re-parse it when templating history)
+    recorded = state.messages[-1]
+    assert recorded["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
+async def test_dispatch_returns_error_result_for_malformed_args() -> None:
+    from hud.agents.tool_agent import MALFORMED_TOOL_ARGS_KEY
+    from hud.types import MCPToolCall
+
+    agent = _agent(_response("", []))
+    state = _state(agent)
+    state.tools = {}
+    call = MCPToolCall(
+        id="c1",
+        name="bash",
+        arguments={MALFORMED_TOOL_ARGS_KEY: "Unterminated string starting at: line 1 column 13"},
+    )
+    result = await agent._dispatch_call(call, state)
+    assert result.isError is True
+    content = result.content[0]
+    assert isinstance(content, mcp_types.TextContent)
+    text = content.text
+    assert "not valid JSON" in text and "Re-issue" in text
+    assert "Unterminated string" in text

--- a/hud/agents/tests/test_openai_compatible_agent.py
+++ b/hud/agents/tests/test_openai_compatible_agent.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, cast
 
-import mcp.types as mcp_types
-
 from hud.agents.openai_compatible.agent import OpenAIChatAgent, OpenAIChatRunState
 from hud.agents.types import OpenAIChatConfig
 
@@ -34,11 +32,21 @@ def _agent(response: Any, error: Exception | None = None) -> OpenAIChatAgent:
 
 
 def _response(content: str, tool_calls: list[Any]) -> Any:
+    dump: dict[str, Any] = {"role": "assistant", "content": content}
+    if tool_calls:
+        dump["tool_calls"] = [
+            {
+                "id": tc.id,
+                "type": "function",
+                "function": {"name": tc.function.name, "arguments": tc.function.arguments},
+            }
+            for tc in tool_calls
+        ]
     message = SimpleNamespace(
         content=content,
         tool_calls=tool_calls,
         refusal=None,
-        model_dump=lambda exclude_none=True: {"role": "assistant", "content": content},
+        model_dump=lambda exclude_none=True: dump,
     )
     choice = SimpleNamespace(message=message, finish_reason="stop", logprobs=None)
     return SimpleNamespace(
@@ -85,11 +93,9 @@ async def test_get_response_error_path() -> None:
     assert result.error is not None and "boom" in result.error
 
 
-async def test_get_response_malformed_tool_args_do_not_crash() -> None:
-    """Truncated arguments must yield a dispatchable sentinel call, not a rollout-killing
-    JSONDecodeError (live Qwen failure: 'Unterminated string starting at line 1 column 13')."""
-    from hud.agents.tool_agent import MALFORMED_TOOL_ARGS_KEY
-
+async def test_get_response_malformed_tool_args() -> None:
+    """Unparseable arguments (e.g. truncated at the token limit) yield a call carrying
+    the raw string, and the recorded message replays "{}" so history stays parseable."""
     tc = SimpleNamespace(
         type="function",
         id="c1",
@@ -99,32 +105,9 @@ async def test_get_response_malformed_tool_args_do_not_crash() -> None:
     state = _state(agent)
     result = await agent.get_response(state)
     assert result.error is None
-    assert [c.name for c in result.tool_calls] == ["bash"]
-    assert result.tool_calls[0].id == "c1"  # provider still gets a result
-    assert MALFORMED_TOOL_ARGS_KEY in (result.tool_calls[0].arguments or {})
-    assert result.done is False  # the loop continues
-    # the RECORDED assistant message must replay "{}" — a raw malformed arguments string 500s
-    # some backends (Qwen/vLLM re-parse it when templating history)
+    assert result.done is False
+    (call,) = result.tool_calls
+    assert call.id == "c1"
+    assert call.arguments == '{"command": "'
     recorded = state.messages[-1]
     assert recorded["tool_calls"][0]["function"]["arguments"] == "{}"
-
-
-async def test_dispatch_returns_error_result_for_malformed_args() -> None:
-    from hud.agents.tool_agent import MALFORMED_TOOL_ARGS_KEY
-    from hud.types import MCPToolCall
-
-    agent = _agent(_response("", []))
-    state = _state(agent)
-    state.tools = {}
-    call = MCPToolCall(
-        id="c1",
-        name="bash",
-        arguments={MALFORMED_TOOL_ARGS_KEY: "Unterminated string starting at: line 1 column 13"},
-    )
-    result = await agent._dispatch_call(call, state)
-    assert result.isError is True
-    content = result.content[0]
-    assert isinstance(content, mcp_types.TextContent)
-    text = content.text
-    assert "not valid JSON" in text and "Re-issue" in text
-    assert "Unterminated string" in text

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -33,8 +33,8 @@ class _FakeRun:
 class DictAgent(ToolAgent[_Msg, AgentConfig]):
     """Minimal concrete ToolAgent over plain-dict messages."""
 
-    def __init__(self, turns: list[AgentStep]) -> None:
-        self.config = AgentConfig(model="test-model")
+    def __init__(self, turns: list[AgentStep], **config: Any) -> None:
+        self.config = AgentConfig(model="test-model", **config)
         self._turns = list(turns)
 
     async def _initialize_state(self, *, prompt: Any) -> RunState[_Msg]:
@@ -85,6 +85,18 @@ async def test_dispatch_unknown_tool_returns_error_result() -> None:
     assert result.isError is True
 
 
+async def test_dispatch_unparsed_arguments_returns_error_result() -> None:
+    # A call whose provider arguments never parsed is answered, not executed.
+    agent = DictAgent([])
+    call = MCPToolCall(name="bash", arguments='{"command": "')
+    result = await agent._dispatch_call(call, RunState())
+    assert result.isError is True
+    content = result.content[0]
+    assert isinstance(content, mcp_types.TextContent)
+    assert "not executed" in content.text
+    assert '{"command": "' in content.text  # the raw prefix re-anchors the model
+
+
 async def test_loop_finishes_on_done_response() -> None:
     agent = DictAgent([AgentStep(content="final answer", done=True)])
     run = _FakeRun()
@@ -94,6 +106,8 @@ async def test_loop_finishes_on_done_response() -> None:
     assert run.trace.status == "completed"
     assert run.trace.content == "final answer"
     assert run.trace.is_error is False
+    assert run.trace.stop_reason == "done"
+    assert run.trace.is_truncated is False
     # The agent turn was recorded directly, with loop-stamped fallbacks.
     (step,) = run.trace.steps
     assert isinstance(step, AgentStep)
@@ -139,6 +153,88 @@ async def test_loop_max_steps_is_normal_termination() -> None:
 
     assert run.trace.is_error is False
     assert run.trace.status == "completed"
-    assert run.trace.extra.get("stop_reason") == "max_steps"
+    assert run.trace.stop_reason == "max_steps"
+    assert run.trace.is_truncated is True
     # No synthetic error step — the trajectory ends on the real agent/tool steps.
     assert all(step.source != "system" for step in run.trace.steps)
+
+
+async def test_loop_marks_length_finish_as_truncated() -> None:
+    # A final turn cut off at the provider token cap (e.g. mid-tool-call) ends the
+    # rollout normally but is a truncation, not a natural finish.
+    agent = DictAgent([AgentStep(content="partial", done=True, finish_reason="length")])
+    run = _FakeRun()
+
+    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+
+    assert run.trace.status == "completed"
+    assert run.trace.stop_reason == "length"
+    assert run.trace.is_truncated is True
+
+
+async def test_loop_answers_malformed_call_by_default() -> None:
+    # Default "retry": the malformed call gets an error result and the loop continues.
+    agent = DictAgent(
+        [
+            AgentStep(
+                content="",
+                done=False,
+                tool_calls=[MCPToolCall(name="bash", arguments='{"command": "')],
+            ),
+            AgentStep(content="recovered", done=True),
+        ]
+    )
+    run = _FakeRun()
+
+    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+
+    assert run.trace.content == "recovered"
+    tool_step = run.trace.steps[1]
+    assert isinstance(tool_step, ToolStep)
+    assert tool_step.result is not None
+    assert tool_step.result.isError is True
+
+
+async def test_loop_stops_on_malformed_call_when_configured() -> None:
+    # The rollout ends at the malformed-call turn with nothing dispatched, and the
+    # fired condition is the recorded stop reason.
+    agent = DictAgent(
+        [
+            AgentStep(
+                content="",
+                done=False,
+                tool_calls=[MCPToolCall(name="bash", arguments='{"command": "')],
+            )
+        ],
+        stop_on={"malformed_tool_call"},
+    )
+    run = _FakeRun()
+
+    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+
+    assert run.trace.status == "completed"
+    assert run.trace.stop_reason == "malformed_tool_call"
+    assert run.trace.is_truncated is True
+    assert all(not isinstance(step, ToolStep) for step in run.trace.steps)
+
+
+async def test_loop_stops_on_length_when_configured() -> None:
+    # A token-capped turn ends the rollout even when its tool calls parsed.
+    agent = DictAgent(
+        [
+            AgentStep(
+                content="",
+                done=False,
+                finish_reason="length",
+                tool_calls=[MCPToolCall(name="bash", arguments={"command": "ls"})],
+            )
+        ],
+        stop_on={"length", "malformed_tool_call"},
+    )
+    run = _FakeRun()
+
+    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+
+    assert run.trace.stop_reason == "length"
+    assert run.trace.is_truncated is True
+    assert all(not isinstance(step, ToolStep) for step in run.trace.steps)

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -161,15 +161,17 @@ async def test_loop_max_steps_is_normal_termination() -> None:
 
 async def test_loop_marks_length_finish_as_truncated() -> None:
     # A final turn cut off at the provider token cap (e.g. mid-tool-call) ends the
-    # rollout normally but is a truncation, not a natural finish.
-    agent = DictAgent([AgentStep(content="partial", done=True, finish_reason="length")])
-    run = _FakeRun()
+    # rollout normally but is a truncation, not a natural finish — across every
+    # provider's finish-reason vocabulary.
+    for finish_reason in ("length", "max_output_tokens", "max_tokens", "MAX_TOKENS"):
+        agent = DictAgent([AgentStep(content="partial", done=True, finish_reason=finish_reason)])
+        run = _FakeRun()
 
-    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+        await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
 
-    assert run.trace.status == "completed"
-    assert run.trace.stop_reason == "length"
-    assert run.trace.is_truncated is True
+        assert run.trace.status == "completed"
+        assert run.trace.stop_reason == "length"
+        assert run.trace.is_truncated is True
 
 
 async def test_loop_answers_malformed_call_by_default() -> None:

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -18,6 +18,7 @@ mutable state.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from abc import abstractmethod
 from dataclasses import dataclass, field
@@ -39,6 +40,20 @@ if TYPE_CHECKING:
     from hud.eval.run import Run
 
 logger = logging.getLogger(__name__)
+
+# Tool calls whose arguments never parsed as JSON (usually a completion truncated at the token
+# limit): _dispatch_call answers the call id with an error result so the model can re-issue.
+MALFORMED_TOOL_ARGS_KEY = "__hud_malformed_tool_arguments__"
+
+
+def parse_tool_arguments(raw: str | None, *, tool_name: str) -> dict[str, Any]:
+    try:
+        parsed = json.loads(raw or "{}")
+    except json.JSONDecodeError as e:
+        logger.warning("Malformed tool-call arguments for %s: %s", tool_name, e)
+        return {MALFORMED_TOOL_ARGS_KEY: f"{e} in arguments: {(raw or '')[:200]!r}"}
+    return cast("dict[str, Any]", parsed) if isinstance(parsed, dict) else {}
+
 
 MessageT = TypeVar("MessageT")
 ConfigT = TypeVar("ConfigT", bound="AgentConfig")
@@ -242,6 +257,22 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
         call: MCPToolCall,
         state: RunState[MessageT],
     ) -> MCPToolResult:
+        args_maybe = call.arguments if isinstance(call.arguments, dict) else {}
+        if MALFORMED_TOOL_ARGS_KEY in args_maybe:
+            return MCPToolResult(
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text=(
+                            f"tool error: arguments for {call.name!r} were not valid JSON "
+                            f"(response likely truncated at the output-token limit): "
+                            f"{args_maybe[MALFORMED_TOOL_ARGS_KEY]}. "
+                            f"Re-issue the tool call with complete JSON arguments."
+                        ),
+                    )
+                ],
+                isError=True,
+            )
         tool = state.tools.get(call.name)
         if tool is None:
             return MCPToolResult(

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -40,8 +40,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Output-token-cap finish reasons: OpenAI "length", Claude "max_tokens", Gemini "MAX_TOKENS".
-TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "MAX_TOKENS"})
+# Output-token-cap finish reasons: OpenAI chat "length", Responses "max_output_tokens",
+# Claude "max_tokens", Gemini "MAX_TOKENS".
+TRUNCATION_FINISH_REASONS = frozenset({"length", "max_output_tokens", "max_tokens", "MAX_TOKENS"})
 
 MessageT = TypeVar("MessageT")
 ConfigT = TypeVar("ConfigT", bound="AgentConfig")

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -18,7 +18,6 @@ mutable state.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 from abc import abstractmethod
 from dataclasses import dataclass, field
@@ -31,7 +30,7 @@ from hud.agents.misc import auto_respond
 from hud.agents.tools.base import AgentTool
 from hud.agents.types import AgentStep, ToolStep
 from hud.capabilities import MCPClient
-from hud.types import AgentType, MCPToolCall, MCPToolResult, Step
+from hud.types import AgentType, MCPToolCall, MCPToolResult, Step, StopCondition
 from hud.utils.time import now_iso
 
 if TYPE_CHECKING:
@@ -41,19 +40,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Tool calls whose arguments never parsed as JSON (usually a completion truncated at the token
-# limit): _dispatch_call answers the call id with an error result so the model can re-issue.
-MALFORMED_TOOL_ARGS_KEY = "__hud_malformed_tool_arguments__"
-
-
-def parse_tool_arguments(raw: str | None, *, tool_name: str) -> dict[str, Any]:
-    try:
-        parsed = json.loads(raw or "{}")
-    except json.JSONDecodeError as e:
-        logger.warning("Malformed tool-call arguments for %s: %s", tool_name, e)
-        return {MALFORMED_TOOL_ARGS_KEY: f"{e} in arguments: {(raw or '')[:200]!r}"}
-    return cast("dict[str, Any]", parsed) if isinstance(parsed, dict) else {}
-
+# Output-token-cap finish reasons: OpenAI "length", Claude "max_tokens", Gemini "MAX_TOKENS".
+TRUNCATION_FINISH_REASONS = frozenset({"length", "max_tokens", "MAX_TOKENS"})
 
 MessageT = TypeVar("MessageT")
 ConfigT = TypeVar("ConfigT", bound="AgentConfig")
@@ -198,6 +186,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
         try:
             step: AgentStep | None = None
             hit_max = False
+            stopped: StopCondition | None = None
 
             for turn in range(1, max_steps + 1):
                 logger.info("step %d/%d", turn, max_steps)
@@ -227,6 +216,9 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                         continue
                     break
 
+                if (stopped := self._stop_condition(step)) is not None:
+                    break
+
                 for call in step.tool_calls:
                     call_started_at = now_iso()
                     result = await self._dispatch_call(call, state)
@@ -244,7 +236,14 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
 
             trace.content = step.content if step else None
             trace.status = "error" if step is not None and step.error else "completed"
-            trace.extra["stop_reason"] = "max_steps" if hit_max else "done"
+            if stopped is not None:
+                trace.stop_reason = stopped
+            elif hit_max:
+                trace.stop_reason = "max_steps"
+            elif step is not None and step.finish_reason in TRUNCATION_FINISH_REASONS:
+                trace.stop_reason = "length"
+            else:
+                trace.stop_reason = "done"
         except (TimeoutError, asyncio.CancelledError, KeyboardInterrupt):
             raise
         except Exception as exc:
@@ -252,22 +251,31 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
             trace.status = "error"
             run.record(Step(source="system", error=str(exc)))
 
+    def _stop_condition(self, step: AgentStep) -> StopCondition | None:
+        """The first configured stop condition this turn trips, if any."""
+        stop_on = self.config.stop_on
+        if "length" in stop_on and step.finish_reason in TRUNCATION_FINISH_REASONS:
+            return "length"
+        if "malformed_tool_call" in stop_on and any(
+            isinstance(call.arguments, str) for call in step.tool_calls
+        ):
+            return "malformed_tool_call"
+        return None
+
     async def _dispatch_call(
         self,
         call: MCPToolCall,
         state: RunState[MessageT],
     ) -> MCPToolResult:
-        args_maybe = call.arguments if isinstance(call.arguments, dict) else {}
-        if MALFORMED_TOOL_ARGS_KEY in args_maybe:
+        if isinstance(call.arguments, str):
             return MCPToolResult(
                 content=[
                     mcp_types.TextContent(
                         type="text",
                         text=(
-                            f"tool error: arguments for {call.name!r} were not valid JSON "
-                            f"(response likely truncated at the output-token limit): "
-                            f"{args_maybe[MALFORMED_TOOL_ARGS_KEY]}. "
-                            f"Re-issue the tool call with complete JSON arguments."
+                            f"the arguments for this {call.name!r} call arrived incomplete "
+                            f"(cut off mid-generation or invalid JSON), so it was not executed. "
+                            f"Received: {call.arguments[:200]!r}. Re-issue the call in full."
                         ),
                     )
                 ],
@@ -279,7 +287,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                 content=[mcp_types.TextContent(type="text", text=f"unknown tool: {call.name!r}")],
                 isError=True,
             )
-        args = call.arguments if isinstance(call.arguments, dict) else {}
+        args = call.arguments or {}
         try:
             return await tool.execute(args)
         except (TimeoutError, asyncio.CancelledError):

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -35,6 +35,7 @@ from hud.types import (
     RobotStepSource,
     Step,
     StepSource,
+    StopCondition,
     Trace,
 )
 from hud.utils.serialization import json_safe_value
@@ -50,6 +51,9 @@ class AgentConfig(BaseModel):
     max_steps: int = 10
     system_prompt: str | None = None
     citations_enabled: bool = False
+    #: Conditions that end the rollout instead of being answered with an error
+    #: result the model can react to; training configs typically stop on both.
+    stop_on: set[StopCondition] = Field(default_factory=set[StopCondition])
     hosted_tools: list[HostedTool[object]] = Field(default_factory=list[HostedTool[object]])
 
     model_name: str = "Agent"

--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -133,8 +133,9 @@ async def trace_exit(run: Run) -> None:
             # reports a trace-level error.
             "error": run.trace.error if run.trace.is_error else None,
             "evaluation_result": run.evaluation or None,
-            # Trajectory metadata (e.g. ``stop_reason``: max_steps vs done) the
-            # platform stores on the trace for display; never load-bearing.
+            "stop_reason": run.trace.stop_reason,
+            # Trajectory metadata the platform stores on the trace for display;
+            # never load-bearing.
             "metadata": run.trace.extra or None,
         },
     )

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -375,7 +375,7 @@ async def rollout(
                                 "rollout agent loop timed out after %.0fs; grading partial",
                                 rollout_timeout,
                             )
-                            run.trace.extra["stop_reason"] = "timeout"
+                            run.trace.stop_reason = "timeout"
                             run.record(
                                 Step(
                                     source="system",

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -46,13 +46,16 @@ def _run_with(trace_id: str, *, extra: dict[str, Any]) -> Run:
     return run
 
 
-async def test_trace_exit_propagates_stop_reason_as_metadata(recorder: _Recorder) -> None:
-    await job_mod.trace_exit(_run_with("abc", extra={"stop_reason": "max_steps"}))
+async def test_trace_exit_propagates_stop_reason(recorder: _Recorder) -> None:
+    run = _run_with("abc", extra={})
+    run.trace.stop_reason = "max_steps"
+    await job_mod.trace_exit(run)
 
     assert len(recorder.calls) == 1
     path, body = recorder.calls[0]
     assert path == "/trace/abc/exit"
-    assert body["metadata"] == {"stop_reason": "max_steps"}
+    assert body["stop_reason"] == "max_steps"
+    assert "metadata" not in body
 
 
 async def test_trace_exit_omits_metadata_when_extra_empty(recorder: _Recorder) -> None:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -332,7 +332,7 @@ async def test_agent_loop_timeout_grades_the_partial_trajectory() -> None:
     # recorded, so it is graded rather than discarded as a zero-reward cancel.
     assert run.reward == 1.0
     assert run.trace.status == "completed"
-    assert run.trace.extra.get("stop_reason") == "timeout"
+    assert run.trace.stop_reason == "timeout"
     assert run.trace_id is not None
 
 

--- a/hud/types.py
+++ b/hud/types.py
@@ -22,7 +22,7 @@ import contextlib
 import json
 import uuid
 from enum import Enum
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeAlias, TypeVar, cast
 
 import mcp.types as types
 from mcp.types import CallToolRequestParams, CallToolResult
@@ -134,6 +134,9 @@ class MCPToolCall(CallToolRequestParams):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))  # Unique identifier for reference
     annotation: str | None = None  # Optional explanation of why this action is taken
     provider_name: str | None = None  # Original provider tool name when it differs from MCP name
+    #: Widened to admit the raw provider string when it didn't parse as JSON;
+    #: a str is never executed — dispatch answers it with an error result.
+    arguments: dict[str, Any] | str | None = None
 
     def __str__(self) -> str:
         """Format tool call as plain text."""
@@ -296,6 +299,13 @@ class Step(BaseModel):
 
 TraceStatus: TypeAlias = Literal["completed", "error", "cancelled"]
 
+#: Why the rollout stopped; anything but "done" means a limit cut it off.
+StopReason: TypeAlias = Literal["done", "max_steps", "length", "timeout", "malformed_tool_call"]
+
+#: The configurable subset of stop reasons (``AgentConfig.stop_on``): policy
+#: conditions the loop may either stop on or answer with an error result.
+StopCondition: TypeAlias = Literal["length", "malformed_tool_call"]
+
 
 class Trace(BaseModel):
     """The agent's trajectory for one rollout — ordered ``Step``s that ship as spans.
@@ -320,6 +330,7 @@ class Trace(BaseModel):
     steps: list[SerializeAsAny[Step]] = Field(default_factory=list[Step])
 
     status: TraceStatus | None = None
+    stop_reason: StopReason | None = None
     content: str | None = Field(default=None)
 
     # Trajectory metadata that has no structured home (provider session info,
@@ -360,6 +371,11 @@ class Trace(BaseModel):
         return self.status == "error"
 
     @property
+    def is_truncated(self) -> bool:
+        """Whether a limit (step budget, token cap, timeout) cut the rollout off."""
+        return self.stop_reason is not None and self.stop_reason != "done"
+
+    @property
     def error(self) -> str | None:
         """The most recent step error, if any (errors live on steps)."""
         return self.final(lambda step: step.error)
@@ -398,6 +414,8 @@ __all__ = [
     "MCPToolResult",
     "Step",
     "StepSource",
+    "StopCondition",
+    "StopReason",
     "TaskCall",
     "Trace",
     "TraceStatus",

--- a/hud/utils/hud_console.py
+++ b/hud/utils/hud_console.py
@@ -390,7 +390,7 @@ class HUDConsole:
 
         return result
 
-    def format_tool_call(self, name: str, arguments: dict[str, Any] | None = None) -> str:
+    def format_tool_call(self, name: str, arguments: dict[str, Any] | str | None = None) -> str:
         """Format a tool call in compact HUD style.
 
         Args:


### PR DESCRIPTION
A completion cut off mid-arguments raised `JSONDecodeError` from the bare `json.loads` in `get_response`, erroring the whole trace (`Unterminated string starting at: line 1 column 13`). Truncated arguments happen for reasons the client cannot distinguish — output-token caps, or a provider finalizing a stalled generation into a 200 — so the SDK must survive them.

- **Parse failures ride on the call.** `MCPToolCall.arguments` widens to `dict | str | None`: a `str` is the raw provider string that didn't parse as JSON and is never executed. `_dispatch_call` answers such calls with an `isError` result so every call id gets a reply and the model can re-issue — the default behavior. The recorded chat history replays `"{}"` for those calls (backends that re-parse history 500 on broken argument strings), while the untouched response stays on the recorded step for debugging.
- **Stop conditions are config.** `AgentConfig.stop_on: set[StopCondition]` (default empty). Training configs set `{"length", "malformed_tool_call"}` to end the rollout cleanly at the offending turn — nothing dispatched, no errored trace, truncation zeroes out through normal grading.
- **`Trace.stop_reason` is a typed field** (`done | max_steps | length | timeout | malformed_tool_call`) written by the loop, with token-cap finish reasons normalized across provider vocabularies (`length`/`max_tokens`/`MAX_TOKENS`); `Trace.is_truncated` derives from it, and it reports on trace exit as a first-class key.

Applied to both the chat.completions and Responses parse sites. Tests exercise both policy modes through the loop lifecycle, dispatch, history recording, and `stop_reason`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core agent loop dispatch, parsing, and trace metadata used for grading and platform reporting; behavior shifts from hard failures to recoverable errors with optional early stop.
> 
> **Overview**
> **Truncated or invalid tool-call JSON** no longer crashes the agent loop. OpenAI Responses and Chat Completions parsers catch `JSONDecodeError`, keep the raw argument string on `MCPToolCall`, and the tool loop answers those calls with an error result so the model can retry. Chat history replays `"{}"` for broken arguments so re-parsed backends stay valid.
> 
> **`AgentConfig.stop_on`** (`length`, `malformed_tool_call`) can end the rollout at that turn instead of dispatching tools—intended for training configs. **`Trace.stop_reason`** is now a first-class field (`done`, `max_steps`, `length`, `timeout`, `malformed_tool_call`) with **`is_truncated`** derived from it; token-cap finish reasons are normalized across providers. Timeouts and trace exit reporting use `stop_reason` directly rather than `trace.extra`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f8c6d7a1989aaf4328ed747472587e69e0a06fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->