### PR TITLE
fix(file_format): cover jsonl in addition to json for taskset definitions

### DIFF
--- a/integrations/harbor.py
+++ b/integrations/harbor.py
@@ -350,7 +350,7 @@ def _write_environment(
     shutil.copytree(source_dir, env_out, ignore=_make_ignore(out_root))
 
     # Drop any copied taskset files and the source Dockerfile name we don't use.
-    for stale in env_out.glob("*.json"):
+    for stale in env_out.glob("*.json*"):
         stale.unlink()
     for name in ("Dockerfile.hud", "dockerfile"):
         leftover = env_out / name


### PR DESCRIPTION
- tasksets can be exported in `jsonl` format too, in addition to `json` format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line glob change in Harbor export cleanup only; no auth, runtime, or grading behavior changes.
> 
> **Overview**
> Harbor export copies the env build context into each task’s `environment/` folder and already removes copied HUD taskset definition files so they don’t end up in the image.
> 
> The cleanup glob is widened from `*.json` to `*.json*`, so **`.jsonl` taskset exports** (and other `json`-prefixed names) are removed the same way as plain `.json` files when the source tasks file lives in that build context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c970f79de891c6b3a1e339b6adb6d75c185d3aed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->