### PR TITLE
Rename the PyPI distribution from hud-python to hud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,18 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Build and publish to PyPi
+      - name: Build and publish 'hud' to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           uv build
           uv publish
+
+      # 'hud-python' is an empty shim that depends on 'hud' (the package was
+      # renamed). Published in lockstep so old install commands keep working.
+      - name: Build and publish 'hud-python' shim to PyPI
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          uv build shim
+          uv publish shim/dist/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We welcome contributions to the HUD SDK! This guide covers how to get started.
 ## Quick Start
 
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/YOUR-USERNAME/hud-python`
+2. Clone your fork: `git clone https://github.com/YOUR-USERNAME/hud-python` (the repo keeps its historical name; the PyPI package is `hud`)
 3. Install [uv](https://docs.astral.sh/uv/) and set up dev dependencies:
    ```bash
    cd hud-python

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ HUD is a platform for building RL environments for AI agents, across coding, bro
 
 To learn more, see the [documentation](https://docs.hud.ai) and [environment reference](https://docs.hud.ai/v6/reference/environment).
 
-[![PyPI](https://img.shields.io/pypi/v/hud-python?style=flat-square)](https://pypi.org/project/hud-python/)
+[![PyPI](https://img.shields.io/pypi/v/hud?style=flat-square)](https://pypi.org/project/hud/)
 [![License](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE)
 [![Add docs to Cursor](https://img.shields.io/badge/Add%20docs%20to-Cursor-black?style=flat-square)](https://cursor.com/en/install-mcp?name=docs-hud-python&config=eyJ1cmwiOiJodHRwczovL2RvY3MuaHVkLmFpL21jcCJ9)
 [![Discord](https://img.shields.io/discord/1327447144772407390?label=Discord&logo=discord&style=flat-square)](https://discord.gg/wkjtmHYYjm)
@@ -22,11 +22,13 @@ To learn more, see the [documentation](https://docs.hud.ai) and [environment ref
 
 ```bash
 # Install the CLI (recommended)
-uv tool install hud-python --python 3.12
+uv tool install hud --python 3.12
 
 # …or as a library
-pip install hud-python
+pip install hud
 ```
+
+> Previously published as [`hud-python`](https://pypi.org/project/hud-python/), which now just installs `hud`. The import and CLI names are unchanged.
 
 Get your API key at [hud.ai/project/api-keys](https://hud.ai/project/api-keys) and set it:
 

--- a/cookbooks/a2a-chat/pyproject.toml
+++ b/cookbooks/a2a-chat/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Serve a HUD chat task over the A2A protocol (cookbook)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "hud-python",
+    "hud",
     # The scripts are written against the 0.3.x server API.
     "a2a-sdk==0.3.26",
 ]
@@ -13,6 +13,6 @@ dependencies = [
 package = false
 
 # Track the SDK from this repo. If you copied this folder out, delete this
-# block to use the released hud-python from PyPI.
+# block to use the released hud from PyPI.
 [tool.uv.sources]
-hud-python = { path = "../..", editable = true }
+hud = { path = "../..", editable = true }

--- a/cookbooks/codex-coding/pyproject.toml
+++ b/cookbooks/codex-coding/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Build your own Codex with the HUD SDK (cookbook)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "hud-python",
+    "hud",
     "python-dotenv",
 ]
 
@@ -12,6 +12,6 @@ dependencies = [
 package = false
 
 # Track the SDK from this repo. If you copied this folder out, delete this
-# block to use the released hud-python from PyPI.
+# block to use the released hud from PyPI.
 [tool.uv.sources]
-hud-python = { path = "../..", editable = true }
+hud = { path = "../..", editable = true }

--- a/cookbooks/fireworks-rl-training/pyproject.toml
+++ b/cookbooks/fireworks-rl-training/pyproject.toml
@@ -5,7 +5,7 @@ description = "Direct Fireworks Training API RL loop over HUD-style arithmetic t
 requires-python = ">=3.11,<3.13"
 dependencies = [
     "fireworks-ai[training]",
-    "hud-python",
+    "hud",
     "matplotlib",
     "python-dotenv",
     "torch>=2",
@@ -16,4 +16,4 @@ dependencies = [
 package = false
 
 [tool.uv.sources]
-hud-python = { path = "../..", editable = true }
+hud = { path = "../..", editable = true }

--- a/cookbooks/rl-training/ppo_custom_loss.py
+++ b/cookbooks/rl-training/ppo_custom_loss.py
@@ -16,7 +16,7 @@ long and short trajectories contribute evenly.
     uv run ppo_custom_loss.py --steps 10   # set MODEL below (pick one with `hud models`)
 
 Requires torch (declared in this cookbook's pyproject; in the SDK it is the
-``hud-python[train]`` extra).
+``hud[train]`` extra).
 """
 
 from __future__ import annotations

--- a/cookbooks/rl-training/pyproject.toml
+++ b/cookbooks/rl-training/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "On-policy RL training with the HUD SDK (cookbook)"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "hud-python",
+    "hud",
     "python-dotenv",
     # ppo_custom_loss.py computes its loss client-side with torch autograd.
     # simple_train.py (built-in loss) does not need it.
@@ -15,6 +15,6 @@ dependencies = [
 package = false
 
 # Track the SDK from this repo. If you copied this folder out, delete this
-# block to use the released hud-python from PyPI.
+# block to use the released hud from PyPI.
 [tool.uv.sources]
-hud-python = { path = "../..", editable = true }
+hud = { path = "../..", editable = true }

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -220,7 +220,7 @@ Get the opponent's tokens from the gateway call with `extra_body={"return_token_
 await trainer.set_head(checkpoint_id)   # or: hud models head <slug> --set <id>
 ```
 
-**Custom loss / primitives.** Author the loss yourself (e.g. double-sided IS) with `forward_backward_custom` — the service returns per-token tensors, your torch function makes the gradients (needs `pip install 'hud-python[train]'`). Drop to `forward_backward` + `optim_step` directly when you want the `forward_backward` metrics or gradient accumulation (`num_substeps`) in between; `step` is just the two chained.
+**Custom loss / primitives.** Author the loss yourself (e.g. double-sided IS) with `forward_backward_custom` — the service returns per-token tensors, your torch function makes the gradients (needs `pip install 'hud[train]'`). Drop to `forward_backward` + `optim_step` directly when you want the `forward_backward` metrics or gradient accumulation (`num_substeps`) in between; `step` is just the two chained.
 
 ---
 

--- a/docs/v6/advanced/robots.mdx
+++ b/docs/v6/advanced/robots.mdx
@@ -23,10 +23,10 @@ Everything below ships behind the `robot` extra (pulls in numpy + openpi-client)
 
 <CodeGroup>
 ```bash uv
-uv add 'hud-python[robot]'
+uv add 'hud[robot]'
 ```
 ```bash pip
-pip install 'hud-python[robot]'
+pip install 'hud[robot]'
 ```
 </CodeGroup>
 

--- a/docs/v6/more/contributing.mdx
+++ b/docs/v6/more/contributing.mdx
@@ -21,7 +21,7 @@ We welcome contributions to the HUD SDK!
 3. **Install in development mode**:
    ```bash
    uv pip install -e ".[dev]"
-   uv tool install --force --from "." hud-python --refresh
+   uv tool install --force --from "." hud --refresh
    ```
 
 ## Development Workflows

--- a/docs/v6/more/faq.mdx
+++ b/docs/v6/more/faq.mdx
@@ -40,10 +40,10 @@ No - not to build environments, write tasks, or run evals. Inference happens thr
 </Accordion>
 
 <Accordion title="My environment imports a package hud can't find - why?">
-A globally installed CLI (`uv tool install hud-python`) runs in its **own** Python environment, so it can't see packages from your project's venv (e.g. `playwright` in your env's dependencies). Inside a project with its own deps, add `hud-python` to the project and run it from the venv:
+A globally installed CLI (`uv tool install hud`) runs in its **own** Python environment, so it can't see packages from your project's venv (e.g. `playwright` in your env's dependencies). Inside a project with its own deps, add `hud` to the project and run it from the venv:
 
 ```bash
-uv add hud-python
+uv add hud
 uv run hud eval tasks.py claude
 ```
 </Accordion>

--- a/docs/v6/reference/cli.mdx
+++ b/docs/v6/reference/cli.mdx
@@ -4,7 +4,7 @@ description: "Reference for the hud command-line interface: init, dev, run, eval
 icon: "terminal"
 ---
 
-Install the CLI with `uv tool install hud-python --python 3.12`. Authenticate once with `hud set HUD_API_KEY=...`.
+Install the CLI with `uv tool install hud --python 3.12`. Authenticate once with `hud set HUD_API_KEY=...`.
 
 ## Build & iterate
 

--- a/docs/v6/reference/training.mdx
+++ b/docs/v6/reference/training.mdx
@@ -148,7 +148,7 @@ the defaults (`None`) unless a provider documents a key.
 
 `forward_backward_custom` runs the current-policy forward pass server-side, hands you per-token tensors,
 runs your loss locally (torch autograd), and ships the per-token gradients back. Requires torch
-(`pip install 'hud-python[train]'`).
+(`pip install 'hud[train]'`).
 
 ```python
 import torch

--- a/docs/v6/start/quickstart.mdx
+++ b/docs/v6/start/quickstart.mdx
@@ -16,10 +16,10 @@ The rest of this page walks the setup path by hand.
 
 <CodeGroup>
 ```bash uv
-uv tool install hud-python --python 3.12
+uv tool install hud --python 3.12
 ```
 ```bash pip
-pip install hud-python
+pip install hud
 ```
 </CodeGroup>
 

--- a/hud/__init__.py
+++ b/hud/__init__.py
@@ -1,4 +1,4 @@
-"""hud-python.
+"""hud.
 
 tools for building, evaluating, and training AI agents.
 """
@@ -64,3 +64,38 @@ try:
     from .version import __version__
 except ImportError:
     __version__ = "unknown"
+
+
+def _warn_legacy_hud_python() -> None:
+    """Warn when a pre-rename hud-python install sits alongside this package.
+
+    The SDK was published as ``hud-python`` before the rename to ``hud``.
+    ``hud-python`` releases older than the rename ship their own copy of the
+    ``hud`` package, so installing both makes the installer silently overwrite
+    one with the other. Post-rename ``hud-python`` releases are empty shims
+    that just depend on ``hud`` and are fine to have installed.
+    """
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as _dist_version
+
+    try:
+        legacy = _dist_version("hud-python")
+        _dist_version("hud")
+    except PackageNotFoundError:
+        return
+
+    from packaging.version import Version
+
+    if Version(legacy) < Version("0.6.9"):
+        import warnings
+
+        warnings.warn(
+            f"Both 'hud' and a pre-rename 'hud-python' ({legacy}) are installed; they ship "
+            "the same 'hud' package and overwrite each other. Run 'pip uninstall hud-python' "
+            "and then reinstall 'hud'.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+
+
+_warn_legacy_hud_python()

--- a/hud/agents/__init__.py
+++ b/hud/agents/__init__.py
@@ -135,7 +135,7 @@ def __getattr__(name: str) -> object:
         value = getattr(import_module(module_name), symbol)
     except ModuleNotFoundError as exc:
         raise ImportError(
-            f"{name} requires the agents extra. Install with: pip install 'hud-python[agents]'"
+            f"{name} requires the agents extra. Install with: pip install 'hud[agents]'"
         ) from exc
     globals()[name] = value
     return value

--- a/hud/agents/browser_use/__init__.py
+++ b/hud/agents/browser_use/__init__.py
@@ -1,4 +1,4 @@
-"""browser-use SDK integration (optional dependency ``hud-python[browseruse]``)."""
+"""browser-use SDK integration (optional dependency ``hud[browseruse]``)."""
 
 from .agent import BrowserUseAgent, BrowserUseConfig
 

--- a/hud/agents/browser_use/agent.py
+++ b/hud/agents/browser_use/agent.py
@@ -10,7 +10,7 @@ agent uses ``client.binding(...)`` (wire data) rather than ``client.open(...)``
 The agent is stateless w.r.t. the env: it holds only config and is driven by
 ``await agent(run)``, receiving the run handle per call. ``browser-use`` is an
 optional dependency
-(``hud-python[browseruse]``), imported lazily inside ``rollout``.
+(``hud[browseruse]``), imported lazily inside ``rollout``.
 """
 
 from __future__ import annotations

--- a/hud/agents/robot/__init__.py
+++ b/hud/agents/robot/__init__.py
@@ -17,7 +17,7 @@ Per-tick platform tracing is emitted by the loop itself: each step records an
 :class:`~hud.agents.types.ObservationStep`, and each re-inference an
 :class:`~hud.agents.types.InferenceStep`, so runs stream live into the HUD trace viewer.
 
-This subpackage needs the ``robot`` extra (``pip install 'hud-python[robot]'``) for
+This subpackage needs the ``robot`` extra (``pip install 'hud[robot]'``) for
 ``numpy`` + ``msgpack``; importing :mod:`hud.agents` alone never pulls them in.
 """
 

--- a/hud/agents/robot/video.py
+++ b/hud/agents/robot/video.py
@@ -195,7 +195,7 @@ class VideoStreamer:
             importlib.import_module("av")
         except Exception as exc:
             raise RuntimeError(
-                "robot video streaming requires PyAV — `pip install 'hud-python[robot]'`"
+                "robot video streaming requires PyAV — `pip install 'hud[robot]'`"
             ) from exc
         self._fps = fps
         self._trace_id = trace_id

--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -67,10 +67,10 @@ def test_missing_provider_dependency_points_at_agents_extra(
     if "ClaudeAgent" in vars(hud.agents):  # drop any cached lazy export
         monkeypatch.delitem(hud.agents.__dict__, "ClaudeAgent")
 
-    with pytest.raises(ImportError, match=r"hud-python\[agents\]"):
+    with pytest.raises(ImportError, match=r"hud\[agents\]"):
         _ = hud.agents.ClaudeAgent
 
-    with pytest.raises(ImportError, match=r"hud-python\[agents\]"):
+    with pytest.raises(ImportError, match=r"hud\[agents\]"):
         _ = AgentType.CLAUDE.cls
 
 

--- a/hud/cli/templates.py
+++ b/hud/cli/templates.py
@@ -134,7 +134,7 @@ PYPROJECT_TOML = """\
 name = "{name}"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = ["hud-python"]
+dependencies = ["hud"]
 
 [tool.uv]
 package = false

--- a/hud/cli/utils/version_check.py
+++ b/hud/cli/utils/version_check.py
@@ -1,10 +1,10 @@
 """Version checking utilities for HUD CLI.
 
-This module handles checking for updates to the hud-python package
+This module handles checking for updates to the hud package
 and prompting users to upgrade when a new version is available.
 
 Features:
-- Checks PyPI for the latest version of hud-python
+- Checks PyPI for the latest version of hud
 - Caches results for 6 hours to avoid excessive API calls
 - Displays a friendly prompt when an update is available
 - Can be disabled with HUD_SKIP_VERSION_CHECK=1 environment variable
@@ -41,7 +41,7 @@ VERSION_CACHE_FILE = CACHE_DIR / "version_check.json"
 CACHE_DURATION = 6 * 60 * 60
 
 # PyPI API URL for package info
-PYPI_URL = "https://pypi.org/pypi/hud-python/json"
+PYPI_URL = "https://pypi.org/pypi/hud/json"
 
 
 class VersionInfo(NamedTuple):
@@ -62,7 +62,7 @@ def _is_in_virtualenv() -> bool:
 
 
 def _get_current_version() -> str:
-    """Get the currently installed version of hud-python."""
+    """Get the currently installed version of hud."""
     try:
         from hud import __version__
 
@@ -166,7 +166,7 @@ def _compare_versions(current: str, latest: str) -> bool:
 
 
 def check_for_updates() -> VersionInfo | None:
-    """Check for updates to hud-python.
+    """Check for updates to hud.
 
     This function checks PyPI for the latest version and caches the result
     for 6 hours to avoid excessive API calls.
@@ -238,12 +238,12 @@ def display_update_prompt(console: HUDConsole | None = None) -> None:
         info = check_for_updates()
         if info and info.is_outdated:
             if _is_in_virtualenv():
-                upgrade_cmd = "uv sync --upgrade-package hud-python"
+                upgrade_cmd = "uv sync --upgrade-package hud"
             else:
-                upgrade_cmd = "uv tool upgrade hud-python"
+                upgrade_cmd = "uv tool upgrade hud"
 
             console.print(
-                f"[yellow]🆕 A new version of hud-python is available: "
+                f"[yellow]🆕 A new version of hud is available: "
                 f"[bold cyan]{escape(info.latest)}[/bold cyan] "
                 f"(current: [dim]{escape(info.current)}[/dim])\n"
                 f"   Run: [bold yellow]{escape(upgrade_cmd)}[/bold yellow] to update[/yellow]"

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.8"
+    assert hud.__version__ == "0.6.9"

--- a/hud/train/client.py
+++ b/hud/train/client.py
@@ -188,13 +188,13 @@ class TrainingClient(BaseTrainingClient):
         ``forward`` → run ``loss_fn`` locally (torch autograd) → ship per-token
         gradients to ``backward``. Any differentiable loss over π_θ and the
         :class:`DatumTensors` scalars works (e.g. GLM double-sided IS). Requires
-        torch (``pip install 'hud-python[train]'``).
+        torch (``pip install 'hud[train]'``).
         """
         try:
             import torch
         except ImportError as exc:
             raise ImportError(
-                "forward_backward_custom requires torch; install 'hud-python[train]'"
+                "forward_backward_custom requires torch; install 'hud[train]'"
             ) from exc
 
         forward = await self.forward(trajectories, group_size=group_size, reward_scale=reward_scale)

--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.8"
+__version__ = "0.6.9"

--- a/integrations/tests/test_harbor.py
+++ b/integrations/tests/test_harbor.py
@@ -93,7 +93,7 @@ tasks = [solve(n=2)]
 
 _DOCKERFILE = """\
 FROM python:3.11-slim
-RUN pip install hud-python
+RUN pip install hud
 COPY env.py ./
 CMD ["hud", "serve", "env:env"]
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "hud-python"
-version = "0.6.8"
+name = "hud"
+version = "0.6.9"
 description = "SDK for the HUD platform."
 readme = "README.md"
 requires-python = ">=3.11, <3.13"
@@ -110,7 +110,7 @@ packages = ["hud"]
 
 [project.optional-dependencies]
 # AI providers (openai, anthropic, google-genai) are now core dependencies; this
-# extra is kept empty so `hud-python[agents]` and the `agent` alias still resolve.
+# extra is kept empty so `hud[agents]` and the `agent` alias still resolve.
 agents = []
 
 # AWS Bedrock support for ClaudeAgent
@@ -120,7 +120,7 @@ bedrock = [
 
 # Development dependencies - includes testing, linting, and automation tools
 dev = [
-    "hud-python[agents]",  # Include agents for dev
+    "hud[agents]",  # Include agents for dev
     "dotenv>=0.9.9",
     # Testing and linting
     "ruff >=0.11.8, <0.15.0",
@@ -132,7 +132,7 @@ dev = [
 ]
 
 # Alias for backwards compatibility
-agent = ["hud-python[agents]"]
+agent = ["hud[agents]"]
 browseruse = [
     "browser-use>=0.11.13",
 ]

--- a/shim/README.md
+++ b/shim/README.md
@@ -1,0 +1,29 @@
+# hud-python → hud
+
+The HUD SDK is now published on PyPI as [`hud`](https://pypi.org/project/hud/).
+The import name (`import hud`) and the CLI (`hud`) are unchanged — only the
+package name on PyPI moved.
+
+This package is an empty shim that depends on `hud`, so existing installs and
+requirements files keep working. Please migrate at your convenience:
+
+```bash
+# instead of
+pip install hud-python
+uv tool install hud-python
+
+# use
+pip install hud
+uv tool install hud
+```
+
+And replace `hud-python` with `hud` in `pyproject.toml`, `requirements.txt`,
+Dockerfiles, and CI configs.
+
+Note: if you have a pre-rename `hud-python` (< 0.6.9) already installed, run
+`pip uninstall hud-python` before installing `hud` — both ship the same
+top-level `hud` package and would overwrite each other. Upgrading in place
+(`pip install -U hud-python`) is also safe: it moves you onto this shim.
+
+Docs: [docs.hud.ai](https://docs.hud.ai) · Source:
+[github.com/hud-evals/hud-python](https://github.com/hud-evals/hud-python)

--- a/shim/pyproject.toml
+++ b/shim/pyproject.toml
@@ -1,0 +1,52 @@
+[project]
+name = "hud-python"
+version = "0.6.9"
+description = "The HUD SDK was renamed to 'hud'. This package just installs it."
+readme = "README.md"
+requires-python = ">=3.11, <3.13"
+authors = [
+{ name = "HUD", email = "founders@hud.ai" },
+]
+license = { text = "MIT" }
+dependencies = [
+    "hud>=0.6.9,<0.7",
+]
+classifiers = [
+    "Development Status :: 7 - Inactive",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/hud-evals/hud-python"
+"Bug Tracker" = "https://github.com/hud-evals/hud-python/issues"
+"Documentation" = "https://docs.hud.ai"
+
+# Entry points reference modules provided by the 'hud' dependency, so
+# `uv tool install hud-python` / `uv tool upgrade hud-python` keep producing
+# working executables after the rename.
+[project.scripts]
+hud = "hud.cli:main"
+hud-python = "hud.cli:main"
+
+# Pass-through extras so `pip install 'hud-python[robot]'` etc. keep resolving.
+[project.optional-dependencies]
+agents = ["hud[agents]"]
+agent = ["hud[agent]"]
+bedrock = ["hud[bedrock]"]
+browseruse = ["hud[browseruse]"]
+daytona = ["hud[daytona]"]
+dev = ["hud[dev]"]
+modal = ["hud[modal]"]
+robot = ["hud[robot]"]
+train = ["hud[train]"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+# Metapackage: no files of its own, everything comes from the 'hud' dependency.
+[tool.hatch.build.targets.wheel]
+bypass-selection = true


### PR DESCRIPTION
## Summary

We now own the `hud` name on PyPI. The import (`import hud`) and the CLI (`hud`) have always been `hud` — this makes the distribution name match. Follows the standard PEP 423 rename pattern (publish under the new name; old name becomes a forwarding shim).

- `pyproject.toml`: distribution renamed to `hud`, version bumped to 0.6.9 (first release under the new name; must sort above every published `hud-python` release so bare installs of the old name resolve to the shim).
- New `shim/`: an empty `hud-python` metapackage that depends on `hud>=0.6.9,<0.7`, with pass-through extras (`hud-python[robot]` -> `hud[robot]`, etc.) and the same console scripts so `uv tool install/upgrade hud-python` keeps producing working executables.
- `release.yml` publishes both packages in lockstep.
- `hud/__init__.py` warns at import when a pre-rename `hud-python` (<0.6.9) is installed alongside `hud`: both ship the same top-level `hud` package and installers silently overwrite each other (nondeterministically under uv parallel installs).
- Self-references updated: CLI version check (PyPI URL + upgrade commands), `hud init` project template, optional-extra error messages/docstrings, cookbook pyprojects (`tool.uv.sources` key must match the new name), README/docs install commands.
- GitHub repo URLs are untouched (repo keeps its name); docs pages that reference the repo path are unchanged.

## Migration notes (for the release announcement)

- `pip install -U hud-python` is safe and moves users onto the shim.
- Users installing `hud` into an env that already has old `hud-python` should `pip uninstall hud-python` first (the import-time warning also says this).
- PyPI side before tagging a release: the `hud` project has one foreign release (0.3b2 from 2016, previous owner) that should be deleted, and the publish token must cover both projects.

## Test plan

- [x] `uv build` + `uv build shim` produce `hud-0.6.9` and `hud_python-0.6.9` artifacts
- [x] Scratch venv: installing the shim wheel pulls `hud`, `import hud` works, `hud --version` reports 0.6.9, no legacy warning fires (shim >= 0.6.9)
- [x] `ruff check` / `ruff format --check` clean
- [x] Targeted tests pass (`hud/agents/tests/test_base.py` extras-error regex, `integrations/tests/test_harbor.py`)
- [x] Full suite/pyright: remaining failures reproduce identically on clean `origin/main` on Windows (pytest capture teardown noise, POSIX-only `os.killpg`/`SIGKILL` pyright errors) — pre-existing, unrelated
- [ ] After merge: create the GitHub release and confirm both packages publish; verify `pip install hud` and `pip install hud-python` on PyPI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release and install paths change (two PyPI projects, version ordering for shim resolution); runtime behavior is mostly unchanged aside from a new import warning for mixed legacy installs.
> 
> **Overview**
> Renames the PyPI distribution from **`hud-python`** to **`hud`** (version **0.6.9**); **`import hud`** and the **`hud`** CLI are unchanged.
> 
> Adds a **`shim/`** metapackage that still publishes as **`hud-python`**, depends on **`hud>=0.6.9`**, forwards optional extras and console scripts, and is built/published alongside **`hud`** in **`release.yml`**.
> 
> On import, **`hud`** warns when a pre-0.6.9 **`hud-python`** install is present alongside **`hud`** (both ship the same top-level package). Docs, cookbooks, **`hud init`** template, CLI PyPI version check, and install/extra error strings now say **`hud`** instead of **`hud-python`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e82f932d492c1291bad9bfbd7e83367517dcf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->