### PR TITLE
feat(openai): update to support GPT-5.6 and require openai>=2.45.0

### DIFF
--- a/cookbooks/codex-coding/codex_agent.py
+++ b/cookbooks/codex-coding/codex_agent.py
@@ -37,6 +37,7 @@ CODEX_MODELS = {
     "gpt-5.1",
     "gpt-5.3-codex",
     "gpt-5.4",
+    "gpt-5.6",
 }
 
 PROMPT_TEMPLATE = """You are a skilled software developer. Complete the following task:

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,17 @@ title: "Changelog"
 description: "Product updates and release notes for the HUD SDK and platform, covering new features, CLI commands, integrations, and UI changes by release date."
 ---
 
+<Update label="July 14, 2026">
+## GPT-5.6 Support
+
+- **GPT-5.6 family** — `gpt-5.6` (Sol), `gpt-5.6-terra`, and `gpt-5.6-luna` are available through the
+  HUD gateway and `create_agent`. `OpenAIAgent` now defaults to `gpt-5.6`.
+- **Reasoning controls** — GPT-5.6 reasoning passes through `OpenAIConfig.reasoning` unchanged: effort
+  levels `none` through `xhigh` and `max`, and `mode` (`standard` or `pro`).
+- **OpenAI SDK floor** — the SDK now requires `openai>=2.45.0` (Responses API function-call outputs use
+  the current content-item types).
+</Update>
+
 <Update label="May 6, 2026">
 ## Models, Tasksets, Templates & Sharing
 

--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -56,7 +56,7 @@ agent = ClaudeAgent(ClaudeConfig(model="claude-sonnet-4-5", max_steps=30))
 | Agent | Config | Default model |
 |-------|--------|---------------|
 | `ClaudeAgent` | `ClaudeConfig` | `claude-sonnet-4-6` |
-| `OpenAIAgent` | `OpenAIConfig` | `gpt-5.5` |
+| `OpenAIAgent` | `OpenAIConfig` | `gpt-5.6` |
 | `GeminiAgent` | `GeminiConfig` | `gemini-3-pro-preview` |
 | `OpenAIChatAgent` | `OpenAIChatConfig` | `gpt-5.4-mini` |
 | `ClaudeSDKAgent` | `ClaudeSDKConfig` | `claude-sonnet-4-6` |

--- a/hud/agents/openai/tools/base.py
+++ b/hud/agents/openai/tools/base.py
@@ -12,7 +12,6 @@ from openai.types.responses import (
     ResponseInputFileContentParam,
     ResponseInputImageContentParam,
     ResponseInputTextContentParam,
-    ResponseInputTextParam,
 )
 from openai.types.responses.response_input_param import FunctionCallOutput, ResponseInputItemParam
 
@@ -76,7 +75,7 @@ def format_openai_result(call: MCPToolCall, result: MCPToolResult) -> ResponseIn
                 logger.warning("Unknown content block type: %s", type(block))
 
     if not output_items:
-        output_items.append(ResponseInputTextParam(type="input_text", text=""))
+        output_items.append(ResponseInputTextContentParam(type="input_text", text=""))
 
     return cast(
         "ResponseInputItemParam",

--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -79,7 +79,7 @@ def test_missing_provider_dependency_points_at_agents_extra(
 
 
 @pytest.fixture(autouse=True)
-def _gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("hud.agents.settings.api_key", "test-key")
 
 

--- a/hud/agents/tests/test_openai_agent.py
+++ b/hud/agents/tests/test_openai_agent.py
@@ -11,7 +11,9 @@ from typing import Any, cast
 from openai.types.responses import ResponseOutputText
 
 from hud.agents.openai.agent import OpenAIAgent, OpenAIRunState
+from hud.agents.openai.tools.base import format_openai_result
 from hud.agents.types import OpenAIConfig
+from hud.types import MCPToolCall, MCPToolResult
 
 
 class FakeResponses:
@@ -37,6 +39,17 @@ def test_format_message_shapes_user_text() -> None:
     agent = _agent(SimpleNamespace(id="r", output=[]))
     msg = cast("dict[str, Any]", agent._format_message("user", "hello"))
     assert msg["role"] == "user"
+
+
+def test_format_openai_result_empty_output_emits_one_text_item() -> None:
+    # The Responses API rejects a function_call_output with an empty output
+    # list, so a contentless tool result must still produce one input_text item.
+    call = MCPToolCall(id="call_1", name="noop")
+    formatted = cast("dict[str, Any]", format_openai_result(call, MCPToolResult(content=[])))
+
+    assert formatted["type"] == "function_call_output"
+    assert formatted["call_id"] == "call_1"
+    assert formatted["output"] == [{"type": "input_text", "text": ""}]
 
 
 def _api_response(

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -103,7 +103,7 @@ class OpenAIConfig(AgentConfig):
     """Configuration for OpenAIAgent."""
 
     model_name: str = "OpenAI"
-    model: str = Field(default="gpt-5.5", validation_alias=_model_alias)
+    model: str = Field(default="gpt-5.6", validation_alias=_model_alias)
     max_output_tokens: int | None = None
     temperature: float | None = None
     reasoning: Any = None  # openai Reasoning

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -119,6 +119,7 @@ class AgentPreset:
 _AGENT_PRESETS: list[AgentPreset] = [
     AgentPreset("Claude Sonnet 4.6", AgentType.CLAUDE, "claude-sonnet-4-6"),
     AgentPreset("Claude Opus 4.8", AgentType.CLAUDE, "claude-opus-4-8"),
+    AgentPreset("GPT-5.6", AgentType.OPENAI, "gpt-5.6"),
     AgentPreset("GPT-5.5", AgentType.OPENAI, "gpt-5.5"),
     AgentPreset("Gemini 3.1 Pro (Preview)", AgentType.GEMINI, "gemini-3.1-pro-preview"),
     AgentPreset(
@@ -176,7 +177,7 @@ _DEFAULT_CONFIG_TEMPLATE = """# HUD Eval Configuration
 # use_computer_beta = true
 
 [openai]
-# model = "gpt-5.5"
+# model = "gpt-5.6"
 # temperature = 0.7
 # max_output_tokens = 4096
 

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -123,6 +123,7 @@ def test_create_agent_hosted_spec_preserves_training_config(
             }
         },
     )
+    assert isinstance(agent, OpenAIChatAgent)
     assert agent.config.model_client is None
     assert agent.oai is client
 

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -249,7 +249,9 @@ async def test_local_runtime_startup_failure_kills_spawned_children(tmp_path: Pa
 
     try:
         with pytest.raises(RuntimeError, match="startup boom"):
-            async with SubprocessRuntime(env_file, ready_timeout=2.0)(Task(env="leaky", id="noop")):
+            async with SubprocessRuntime(env_file, ready_timeout=30.0)(
+                Task(env="leaky", id="noop")
+            ):
                 pass
         pid = int(pid_file.read_text())
         assert await _wait_for_pid_inactive(pid)

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from importlib.metadata import version
 
+
 def test_import():
     """Test that the package can be imported."""
     import hud

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from importlib.metadata import version
 
 def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.9"
+    assert hud.__version__ == version("hud")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "mcp>=1.24.0,<2.0",
     "fastmcp==3.0.2",
     # For all inference agents
-    "openai==2.44.0",
+    "openai>=2.45.0",
     "anthropic>=0.78.0",
     "google-genai",
     # CLI dependencies


### PR DESCRIPTION
## Summary

Replaces the temporary `openai==2.44.0` pin with an intentional `openai>=2.45.0` floor and adds GPT-5.6 support (HUD-1923).

### OpenAI SDK upgrade

- `openai==2.44.0` → `openai>=2.45.0`. The pin was an emergency response to 2.45.0 narrowing `ResponseFunctionCallOutputItemListParam`; this upgrade absorbs that change properly.
- Empty function-call outputs now use `ResponseInputTextContentParam` (the content-item type every other branch of `format_openai_result` already appends) instead of the no-longer-valid `ResponseInputTextParam`.
- Regression test: a contentless tool result still emits exactly one `input_text` content item.

### GPT-5.6 support

- `OpenAIConfig` default model: `gpt-5.5` → `gpt-5.6` (upstream alias for `gpt-5.6-sol`).
- `hud eval` interactive presets: GPT-5.6 added, GPT-5.5 retained.
- Codex cookbook: `gpt-5.6` added to the native shell/apply_patch allowlist (per its model page).
- Parameter audit: no agent changes needed — `reasoning`, `text`, and `tool_choice` pass through untyped, and openai 2.45.0 already types the new effort levels (`xhigh`, `max`) and `reasoning.mode` (`standard`/`pro`).
- Docs: default-model table and changelog updated.

## Testing

- `uv run pyright` — 0 errors on openai 2.45.0
- `uv run pytest -q` — 677 passed on Python 3.12 and 3.11
- `uv run ruff format --check` / `ruff check` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the OpenAI Responses API wire format and default model routing for all gateway OpenAI evals; SDK floor change affects every install but is covered by targeted tests.
> 
> **Overview**
> Adds **GPT-5.6** as the default for `OpenAIAgent` (`OpenAIConfig`, `hud eval` presets, Codex cookbook allowlist) and documents the model family in the changelog and agents reference.
> 
> Bumps the **OpenAI SDK** dependency from a pinned `2.44.0` to **`openai>=2.45.0`**, aligning function-call output formatting with the newer Responses API types: empty tool results now emit `ResponseInputTextContentParam` instead of the removed `ResponseInputTextParam`, with a regression test ensuring a single `input_text` item when content is empty.
> 
> Minor test hygiene: autouse gateway fixture rename, explicit `OpenAIChatAgent` check in hosted spec test, and `__version__` asserted via `importlib.metadata.version("hud")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3229f19b041a26ef1ba4220b45e63146f1c773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->