### PR TITLE
fix: correct pip migration guidance and cutover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      # Fail before anything is built or published if pyproject.toml,
+      # shim/pyproject.toml, or hud/version.py disagree on the version.
+      - name: Verify the hud-python shim is in lockstep with hud
+        run: uv run --no-project --python 3.12 scripts/check_shim_lockstep.py
+
       - name: Build and publish 'hud' to PyPI
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ uv tool install hud --python 3.12
 pip install hud
 ```
 
-> Previously published as [`hud-python`](https://pypi.org/project/hud-python/), which now just installs `hud`. The import and CLI names are unchanged.
+> Previously published as [`hud-python`](https://pypi.org/project/hud-python/), which now just installs `hud`. The import and CLI names are unchanged. uv upgrades handle the rename in place; pip users with an existing install should run `pip uninstall -y hud-python` first, then `pip install hud`.
 
 Get your API key at [hud.ai/project/api-keys](https://hud.ai/project/api-keys) and set it:
 

--- a/hud/__init__.py
+++ b/hud/__init__.py
@@ -91,8 +91,10 @@ def _warn_legacy_hud_python() -> None:
 
         warnings.warn(
             f"Both 'hud' and a pre-rename 'hud-python' ({legacy}) are installed; they ship "
-            "the same 'hud' package and overwrite each other. Run 'pip uninstall hud-python' "
-            "and then reinstall 'hud'.",
+            "the same 'hud' package and overwrite each other. Run "
+            "'pip uninstall -y hud-python' and then 'pip install --force-reinstall "
+            "--no-deps hud' (a plain reinstall is a no-op: pip already considers "
+            "'hud' installed).",
             RuntimeWarning,
             stacklevel=3,
         )

--- a/hud/_entry.py
+++ b/hud/_entry.py
@@ -1,0 +1,35 @@
+"""Console-script entry point that survives the hud-python → hud rename.
+
+``pip install -U hud-python`` across the rename installs the renamed ``hud``
+distribution first, then deletes the shared ``hud/`` files while removing the
+old ``hud-python`` (pip removes every path on the old distribution's RECORD).
+What survives imports as an empty namespace package — plus any file that is
+new in the renamed release, like this one. Routing the console scripts through
+here turns that broken state into an actionable message instead of a bare
+``ModuleNotFoundError``. This module must never gain heavy imports and must
+not be moved or renamed while pre-rename installs remain in the wild.
+"""
+
+from __future__ import annotations
+
+import sys
+
+_RECOVERY_MESSAGE = """\
+Your 'hud' installation is missing its files. This happens when pip upgrades
+'hud-python' in place across its rename to 'hud': pip installs 'hud' first,
+then deletes the files it shares with the old 'hud-python'. Recover with:
+
+    python -m pip install --force-reinstall --no-deps hud
+"""
+
+
+def main() -> None:
+    import hud
+
+    if getattr(hud, "__file__", None) is None:
+        sys.stderr.write(_RECOVERY_MESSAGE)
+        raise SystemExit(1)
+
+    from hud.cli import main as cli_main
+
+    cli_main()

--- a/hud/tests/test_entry.py
+++ b/hud/tests/test_entry.py
@@ -1,0 +1,46 @@
+"""Tests for the hud._entry console-script guard."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import hud._entry
+
+
+def test_console_entry_runs_the_cli() -> None:
+    code = "import sys; sys.argv = ['hud', '--help']; from hud._entry import main; main()"
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HUD_SKIP_VERSION_CHECK": "1"},
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage" in result.stdout
+
+
+def test_gutted_install_reports_recovery_command(tmp_path: Path) -> None:
+    # Reproduce what `pip install -U hud-python` leaves behind when upgrading
+    # across the rename: pip deletes every file on the old distribution's
+    # RECORD, so hud/ survives only as a namespace package holding files that
+    # are new in the renamed release — such as _entry.py.
+    site = tmp_path / "site-packages"
+    (site / "hud").mkdir(parents=True)
+    shutil.copy(Path(hud._entry.__file__), site / "hud" / "_entry.py")
+
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", "from hud._entry import main; main()"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+        env={**os.environ, "PYTHONPATH": str(site)},
+        check=False,
+    )
+    assert result.returncode == 1
+    assert "pip install --force-reinstall --no-deps hud" in result.stderr
+    assert "Traceback" not in result.stderr

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,11 @@ classifiers = [
 "Bug Tracker" = "https://github.com/hud-evals/hud-python/issues"
 "Documentation" = "https://docs.hud.ai"
 
+# Routed through hud._entry so an environment gutted by a pip in-place upgrade
+# across the hud-python -> hud rename reports its recovery command.
 [project.scripts]
-hud = "hud.cli:main"
-hud-python = "hud.cli:main"
+hud = "hud._entry:main"
+hud-python = "hud._entry:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/check_shim_lockstep.py
+++ b/scripts/check_shim_lockstep.py
@@ -1,0 +1,54 @@
+"""Fail the release when the hud-python shim falls out of lockstep with hud.
+
+Four values carry the release: the version in pyproject.toml, the version in
+shim/pyproject.toml, the floor/cap of the shim's 'hud' dependency, and
+__version__ in hud/version.py. Publishing them out of sync half-breaks a
+release — PyPI rejects the duplicate shim upload only after 'hud' has already
+gone out. Run by release.yml before anything is built or published.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def main() -> None:
+    root = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+    shim = tomllib.loads((ROOT / "shim" / "pyproject.toml").read_text())["project"]
+    version = root["version"]
+
+    problems: list[str] = []
+
+    if shim["version"] != version:
+        problems.append(f"shim/pyproject.toml version {shim['version']} != {version}")
+
+    code = re.search(r'__version__ = "([^"]+)"', (ROOT / "hud" / "version.py").read_text())
+    if code is None or code.group(1) != version:
+        found = code.group(1) if code else "<missing>"
+        problems.append(f"hud/version.py __version__ {found} != {version}")
+
+    # The shim must pull the matching hud release, capped at the next minor so
+    # a stale shim can never drag in a hud it was not published against.
+    major, minor = version.split(".")[:2]
+    expected_dep = f"hud>={version},<{major}.{int(minor) + 1}"
+    deps = [d.replace(" ", "") for d in shim["dependencies"]]
+    if deps != [expected_dep]:
+        problems.append(f"shim dependencies {deps} != ['{expected_dep}']")
+
+    if shim["requires-python"] != root["requires-python"]:
+        problems.append(
+            f"shim requires-python {shim['requires-python']!r} != {root['requires-python']!r}"
+        )
+
+    if problems:
+        sys.exit("shim lockstep check failed:\n  " + "\n  ".join(problems))
+    print(f"lockstep OK: hud=={version}, shim depends on '{expected_dep}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/shim/README.md
+++ b/shim/README.md
@@ -20,10 +20,27 @@ uv tool install hud
 And replace `hud-python` with `hud` in `pyproject.toml`, `requirements.txt`,
 Dockerfiles, and CI configs.
 
-Note: if you have a pre-rename `hud-python` (< 0.6.9) already installed, run
-`pip uninstall hud-python` before installing `hud` — both ship the same
-top-level `hud` package and would overwrite each other. Upgrading in place
-(`pip install -U hud-python`) is also safe: it moves you onto this shim.
+uv upgrades handle the rename in place: `uv sync --upgrade-package hud-python`,
+`uv tool upgrade hud-python`, and `uv pip install -U hud-python` all land on
+this shim plus `hud` cleanly.
+
+pip in-place upgrades do not. Pre-rename `hud-python` (< 0.6.9) and `hud` ship
+the same top-level `hud` package, and `pip install -U hud-python` installs
+`hud` first, then deletes its files while removing the old `hud-python`. In an
+environment that already has `hud-python`, uninstall first:
+
+```bash
+python -m pip uninstall -y hud-python
+python -m pip install hud
+```
+
+If an in-place pip upgrade already broke an environment (`pip list` shows
+`hud`, but importing it fails or the CLI reports `No module named 'hud.cli'`),
+recover with:
+
+```bash
+python -m pip install --force-reinstall --no-deps hud
+```
 
 Docs: [docs.hud.ai](https://docs.hud.ai) · Source:
 [github.com/hud-evals/hud-python](https://github.com/hud-evals/hud-python)

--- a/shim/pyproject.toml
+++ b/shim/pyproject.toml
@@ -26,10 +26,12 @@ classifiers = [
 
 # Entry points reference modules provided by the 'hud' dependency, so
 # `uv tool install hud-python` / `uv tool upgrade hud-python` keep producing
-# working executables after the rename.
+# working executables after the rename. They route through hud._entry, which
+# survives a pip in-place upgrade across the rename and reports the recovery
+# command instead of a bare ModuleNotFoundError.
 [project.scripts]
-hud = "hud.cli:main"
-hud-python = "hud.cli:main"
+hud = "hud._entry:main"
+hud-python = "hud._entry:main"
 
 # Pass-through extras so `pip install 'hud-python[robot]'` etc. keep resolving.
 [project.optional-dependencies]


### PR DESCRIPTION
pip in-place upgrades across the rename are NOT safe, contrary to the shim README: `pip install -U hud-python` installs the renamed 'hud' first, then deletes the shared hud/* files while removing the old hud-python (verified with pip 26.1.2; all uv paths are clean). After that, a plain `pip install hud` is a no-op, so the mixed-install warning's remedy also never repaired anything.

- shim/README + root README: uninstall-first migration for pip and the --force-reinstall recovery command; drop the false "-U is safe" claim
- hud/__init__: the mixed-install warning names the working recovery command
- hud/_entry: console scripts route through a module that is new in the renamed release, so it survives the gutting and reports the recovery command instead of a bare ModuleNotFoundError
- release.yml + scripts/check_shim_lockstep.py: fail the release before publishing if pyproject.toml, shim/pyproject.toml, or hud/version.py disagree on the version, the shim's dependency range, or requires-python

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how all users invoke the CLI and how pip upgrades behave at the packaging boundary; mistakes could break installs or publish mismatched wheels, but scope is limited to migration/entry points and release checks with tests for the guard.
> 
> **Overview**
> Corrects **pip** migration guidance for the `hud-python` → `hud` rename: in-place `pip install -U hud-python` can leave a broken install (shared `hud/` files removed), so docs now recommend uninstall-first and document recovery via `pip install --force-reinstall --no-deps hud`; **uv** in-place upgrades remain fine.
> 
> Adds **`hud._entry`** as the console entry for `hud` and `hud-python` (main package and shim). When the package is gutted to a namespace-only `hud`, the CLI prints the recovery steps instead of a bare `ModuleNotFoundError`. The mixed-install warning in `hud/__init__.py` is updated to match.
> 
> Release workflow runs **`scripts/check_shim_lockstep.py`** before PyPI publish so root `pyproject.toml`, shim version/dependency/`requires-python`, and `hud/version.py` stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a2c119bdd95ba8f33f90d0a98a45dd16c2754dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->