### PR TITLE
feat(environment): workspace shell_uid privilege wall, external SSH credentials, SFTP removal

### DIFF
--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -47,7 +47,7 @@ Bind every daemon to `127.0.0.1`: the environment exposes a single control port,
 ### `ssh` - a sandboxed shell
 
 ```text
-Capability.ssh(*, name="shell", url, user="agent", host_pubkey, client_key=None, client_key_path=None, shell=None)
+Capability.ssh(*, name="shell", url, user="agent", host_pubkey, client_key=None, client_key_path=None, shell=None, cwd=None)
 ```
 
 The shell case is built in via [`Workspace`](#workspace), so you rarely call this factory directly. [`env.workspace(root)`](/v6/reference/environment#methods) starts a workspace, publishes its `ssh` capability, and stops it with the env.
@@ -61,6 +61,7 @@ The shell case is built in via [`Workspace`](#workspace), so you rarely call thi
 | `client_key` | `str \| None` | Private key *content*; authenticates across a container boundary. |
 | `client_key_path` | `str \| None` | Path to a key file; only works when client and daemon share a filesystem. |
 | `shell` | `str \| None` | Remote shell type (`bash` / `powershell` / `cmd`); auto-detected from `sys.platform`. |
+| `cwd` | `str \| None` | Absolute path sessions start in (the served workspace). File helpers anchor absolute paths to it. |
 
 ### `mcp` - your own tools
 
@@ -263,15 +264,13 @@ Spinning up a capability is the environment side. The harness side is the mirror
 | `RFBClient` | `rfb/3.8` |
 | `RobotClient` | `openpi/0` - joins the registry on first open (the `robot` extra: numpy/openpi-client) |
 
-`SSHClient` file helpers use SSH exec commands rather than an SFTP subsystem. Use `await ssh.write_text(path, content)`, `await ssh.read_text(path)`, and `await ssh.listdir(path)` for workspace files; use `ssh.conn.run(...)` for commands.
-
 The bundled provider agents open these automatically based on which capabilities the manifest advertises (see [Agents](/v6/reference/agents)). To write your own harness, attach to the capability you need and define your tool spec.
 
 ## Workspace
 
 A `Workspace` is not itself a capability - it's the built-in workspace daemon. It serves `ssh` for agent access and, when enabled, file tracking for rollout telemetry. For `mcp`, `cdp`, and `rfb` you stand up the daemon yourself.
 
-Concretely it's a directory plus a `bwrap`-isolated SSH exec server. Shell commands and file operations run through the same exec channel; `Workspace` does not expose SFTP or SCP. [`env.workspace(root, ...)`](/v6/reference/environment#methods) wires its whole lifecycle; construction is pure data, with keys, sockets, and the root directory materializing only at serve time. To run one outside an env, drive its lifecycle directly and publish `ws.capability()`:
+Concretely it's a directory plus a `bwrap`-isolated SSH exec server. Shell commands and file operations run through the same exec channel. [`env.workspace(root, ...)`](/v6/reference/environment#methods) wires its whole lifecycle; construction is pure data, with keys, sockets, and the root directory materializing only at serve time. To run one outside an env, drive its lifecycle directly and publish `ws.capability()`:
 
 ```python
 from hud.environment import Environment, Workspace

--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -8,7 +8,7 @@ A **capability** is a connection the environment exposes; a harness attaches its
 
 | Protocol | Wire id | What it exposes | Spun up with |
 |----------|---------|-----------------|--------------|
-| `ssh`  | `ssh/2` | Shell + files (bash, SFTP) in a sandboxed workspace | `Workspace` (built in) |
+| `ssh`  | `ssh/2` | Shell commands and file operations in a sandboxed workspace | `Workspace` (built in) |
 | `mcp`  | `mcp/2025-11-25` | Your own tools over the Model Context Protocol | `fastmcp` |
 | `cdp`  | `cdp/1.3` | Browser control over the Chrome DevTools Protocol | Chromium (`playwright`) |
 | `rfb`  | `rfb/3.8` | Full computer-use over VNC: screen + keyboard/mouse | `Xvfb` + `x11vnc` |
@@ -257,11 +257,13 @@ Spinning up a capability is the environment side. The harness side is the mirror
 
 | Client | Protocol |
 |--------|----------|
-| `SSHClient` | `ssh/2` (raw `asyncssh` connection via `.conn`) |
+| `SSHClient` | `ssh/2` (`.conn` for commands/forwarding; `.read_text()`, `.write_text()`, and `.listdir()` for files) |
 | `MCPClient` | `mcp/2025-11-25` |
 | `CDPClient` | `cdp/1.3` |
 | `RFBClient` | `rfb/3.8` |
 | `RobotClient` | `openpi/0` - joins the registry on first open (the `robot` extra: numpy/openpi-client) |
+
+`SSHClient` file helpers use SSH exec commands rather than an SFTP subsystem. Use `await ssh.write_text(path, content)`, `await ssh.read_text(path)`, and `await ssh.listdir(path)` for workspace files; use `ssh.conn.run(...)` for commands.
 
 The bundled provider agents open these automatically based on which capabilities the manifest advertises (see [Agents](/v6/reference/agents)). To write your own harness, attach to the capability you need and define your tool spec.
 
@@ -269,7 +271,7 @@ The bundled provider agents open these automatically based on which capabilities
 
 A `Workspace` is not itself a capability - it's the built-in workspace daemon. It serves `ssh` for agent access and, when enabled, file tracking for rollout telemetry. For `mcp`, `cdp`, and `rfb` you stand up the daemon yourself.
 
-Concretely it's a directory plus a `bwrap`-isolated SSH server (bash + chroot'd SFTP). [`env.workspace(root, ...)`](/v6/reference/environment#methods) wires its whole lifecycle; construction is pure data, with keys, sockets, and the root directory materializing only at serve time. To run one outside an env, drive its lifecycle directly and publish `ws.capability()`:
+Concretely it's a directory plus a `bwrap`-isolated SSH exec server. Shell commands and file operations run through the same exec channel; `Workspace` does not expose SFTP or SCP. [`env.workspace(root, ...)`](/v6/reference/environment#methods) wires its whole lifecycle; construction is pure data, with keys, sockets, and the root directory materializing only at serve time. To run one outside an env, drive its lifecycle directly and publish `ws.capability()`:
 
 ```python
 from hud.environment import Environment, Workspace
@@ -302,6 +304,7 @@ Use a relative path (`"workspace"`, created next to `env.py`). Sandbox isolation
 | `host` | `str` | SSH bind host. Default `"127.0.0.1"`. |
 | `port` | `int` | SSH bind port (`0` binds an ephemeral port). Default `0`. |
 | `user` | `str` | SSH username. Default `"agent"`. |
+| `shell_uid` | `int \| None` | When serving as root, run every agent command as this uid/gid with cleared supplementary groups. Default `None`. |
 | `host_key_path` | `Path \| None` | Reuse a host key instead of generating one. |
 | `authorized_client_keys` | `list[Path] \| None` | Authorize specific client public keys. |
 | `track_files` | `bool` | Serve file-tracking telemetry over the workspace lifecycle. Constructor default `False`; `env.workspace(...)` defaults it to `HUD_FILE_TRACKING_ENABLED` (on). |

--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -303,7 +303,7 @@ Use a relative path (`"workspace"`, created next to `env.py`). Sandbox isolation
 | `host` | `str` | SSH bind host. Default `"127.0.0.1"`. |
 | `port` | `int` | SSH bind port (`0` binds an ephemeral port). Default `0`. |
 | `user` | `str` | SSH username. Default `"agent"`. |
-| `shell_uid` | `int \| None` | When serving as root, run every agent command as this uid/gid with cleared supplementary groups. Default `None`. |
+| `shell_uid` | `int \| None` | When serving as root, run every agent command as this uid/gid with cleared supplementary groups and `no_new_privs`. Default `None`. |
 | `host_key_path` | `Path \| None` | Reuse a host key instead of generating one. |
 | `authorized_client_keys` | `list[Path] \| None` | Authorize specific client public keys. |
 | `track_files` | `bool` | Serve file-tracking telemetry over the workspace lifecycle. Constructor default `False`; `env.workspace(...)` defaults it to `HUD_FILE_TRACKING_ENABLED` (on). |

--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -133,12 +133,7 @@ class ClaudeSDKAgent(Agent):
 
         mcp_config_path = await self._write_mcp_config()
 
-        # Write prompt to file via SFTP — avoids all shell quoting issues.
-        async with (
-            self._ssh.conn.start_sftp_client() as sftp,
-            sftp.open(".hud_prompt.txt", "wb") as f,
-        ):
-            await f.write(prompt.encode("utf-8"))
+        await self._ssh.write_text(".hud_prompt.txt", prompt)
 
         run_cmd = self._build_cli_command(
             prompt=prompt,
@@ -151,11 +146,7 @@ class ClaudeSDKAgent(Agent):
         if invocation.script_name is not None:
             assert invocation.script_body is not None
             # cmd.exe mangles inline quotes, so the command rides a batch file.
-            async with (
-                self._ssh.conn.start_sftp_client() as sftp,
-                sftp.open(invocation.script_name, "wb") as f,
-            ):
-                await f.write(invocation.script_body.encode("utf-8"))
+            await self._ssh.write_text(invocation.script_name, invocation.script_body)
 
         full_cmd = invocation.command
         logger.info("SSH exec claude CLI (%d chars)", len(full_cmd))
@@ -202,17 +193,14 @@ class ClaudeSDKAgent(Agent):
         return env
 
     async def _write_mcp_config(self) -> str | None:
-        """Write MCP config via SFTP and return the file path, or None."""
+        """Write MCP config into the workspace and return its path."""
         if not self._mcp_servers or self._ssh is None:
             return None
         mcp_json = json.dumps({"mcpServers": self._mcp_servers}, indent=2)
-        # Write into the workspace root (SFTP is chrooted there).
-        sftp_path = ".hud_mcp_config.json"
-        async with self._ssh.conn.start_sftp_client() as sftp, sftp.open(sftp_path, "wb") as f:
-            await f.write(mcp_json.encode("utf-8"))
-        # Return the absolute path the CLI will see (cwd = workspace root).
-        logger.info("Wrote MCP config via SFTP")
-        return sftp_path
+        path = ".hud_mcp_config.json"
+        await self._ssh.write_text(path, mcp_json)
+        logger.info("Wrote MCP config")
+        return path
 
     def _build_cli_command(
         self,

--- a/hud/agents/claude/tools/coding.py
+++ b/hud/agents/claude/tools/coding.py
@@ -67,7 +67,7 @@ class ClaudeBashTool(SSHTool):
 
 
 class ClaudeTextEditorTool(SSHTool):
-    """Claude's native ``text_editor_20250728`` schema, executed over SFTP."""
+    """Claude's native ``text_editor_20250728`` schema, executed over SSH."""
 
     name = "str_replace_based_edit_tool"
 

--- a/hud/agents/openai_compatible/tools/filesystem.py
+++ b/hud/agents/openai_compatible/tools/filesystem.py
@@ -66,6 +66,9 @@ class ReadTool(_FilesystemTool):
         path = arguments.get("filePath")
         if not isinstance(path, str) or not path:
             raise ValueError("filePath is required")
+        # Map once so the directory predicate and the file read agree on
+        # the same workspace-anchored path.
+        path = self.client.map_path(path)
         offset = _read_offset(arguments.get("offset"))
         limit = _positive_int(arguments.get("limit"), default=DEFAULT_READ_LIMIT, name="limit")
         if not (await self.bash(f"test -d {shlex.quote(path)}")).isError:
@@ -193,6 +196,9 @@ class EditTool(_FilesystemTool):
         path = arguments.get("filePath")
         if not isinstance(path, str) or not path:
             raise ValueError("filePath is required")
+        # Map once so existence checks, mkdir, and the write all target
+        # the same workspace-anchored path.
+        path = self.client.map_path(path)
         old = arguments.get("oldString")
         new = arguments.get("newString")
         if not isinstance(old, str):
@@ -252,6 +258,7 @@ class WriteTool(_FilesystemTool):
         path = arguments.get("filePath")
         if not isinstance(path, str) or not path:
             raise ValueError("filePath is required")
+        path = self.client.map_path(path)
         content = arguments.get("content")
         if not isinstance(content, str):
             raise ValueError("content is required")
@@ -287,8 +294,8 @@ class GrepTool(_FilesystemTool):
         pattern = arguments.get("pattern")
         if not isinstance(pattern, str):
             raise ValueError("pattern is required")
-        path = arguments.get("path") or "."
-        cmd = f"grep -rn {shlex.quote(pattern)} {shlex.quote(str(path))}"
+        path = self.client.map_path(str(arguments.get("path") or "."))
+        cmd = f"grep -rn {shlex.quote(pattern)} {shlex.quote(path)}"
         include = arguments.get("include")
         if isinstance(include, str) and include:
             cmd += f" --include={shlex.quote(include)}"
@@ -311,8 +318,8 @@ class GlobTool(_FilesystemTool):
         pattern = arguments.get("pattern")
         if not isinstance(pattern, str):
             raise ValueError("pattern is required")
-        path = arguments.get("path") or "."
-        return await self.bash(f"find {shlex.quote(str(path))} -name {shlex.quote(pattern)}")
+        path = self.client.map_path(str(arguments.get("path") or "."))
+        return await self.bash(f"find {shlex.quote(path)} -name {shlex.quote(pattern)}")
 
 
 def _positive_int(value: Any, *, default: int, name: str) -> int:

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -10,12 +10,15 @@ rejected by the remote shell (and silently fails under PowerShell), so the
 
 from __future__ import annotations
 
+import base64
+import re
 from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
 
 from hud.agents.claude.sdk.agent import ClaudeSDKAgent, build_remote_invocation
+from hud.capabilities import Capability, SSHClient
 
 # ─── build_remote_invocation (pure) ───────────────────────────────────
 
@@ -42,45 +45,28 @@ def test_posix_shell_runs_inline_with_install_check() -> None:
 # ─── _exec end-to-end over a fake SSH workspace ────────────────────────
 
 
-class _FakeFile:
-    def __init__(self, name: str, sink: dict[str, bytes]) -> None:
-        self._name = name
-        self._sink = sink
-
-    async def __aenter__(self) -> _FakeFile:
-        return self
-
-    async def __aexit__(self, *exc: Any) -> None:
-        return None
-
-    async def write(self, data: bytes) -> None:
-        self._sink[self._name] = self._sink.get(self._name, b"") + data
-
-
-class _FakeSFTP:
-    def __init__(self, sink: dict[str, bytes]) -> None:
-        self._sink = sink
-
-    async def __aenter__(self) -> _FakeSFTP:
-        return self
-
-    async def __aexit__(self, *exc: Any) -> None:
-        return None
-
-    def open(self, name: str, mode: str) -> _FakeFile:
-        return _FakeFile(name, self._sink)
-
-
 class _FakeConn:
     def __init__(self, sink: dict[str, bytes], result: Any) -> None:
         self._sink = sink
         self._result = result
         self.ran: list[str] = []
+        self.write_commands: list[str] = []
 
-    def start_sftp_client(self) -> _FakeSFTP:
-        return _FakeSFTP(self._sink)
-
-    async def run(self, cmd: str, *, check: bool = True) -> Any:
+    async def run(self, cmd: str, *, input: str | None = None, check: bool = True) -> Any:
+        if input is not None or cmd.startswith("powershell "):
+            self.write_commands.append(cmd)
+            name = next(
+                path
+                for path in (".hud_prompt.txt", ".hud_run.bat", ".hud_mcp_config.json")
+                if path in cmd
+            )
+            if input is not None:
+                self._sink[name] = input.encode()
+            elif match := re.search(r"FromBase64String\('([^']+)'\)", cmd):
+                self._sink[name] += base64.b64decode(match.group(1))
+            else:
+                self._sink[name] = b""
+            return SimpleNamespace(stdout="", stderr="", exit_status=0)
         self.ran.append(cmd)
         return self._result
 
@@ -100,7 +86,13 @@ _STREAM_JSON = (
 
 def _agent_with_conn(shell: str, conn: _FakeConn) -> ClaudeSDKAgent:
     agent = ClaudeSDKAgent()
-    agent._ssh = cast("Any", SimpleNamespace(conn=conn))
+    capability = Capability(
+        name="shell",
+        protocol="ssh/2",
+        url="ssh://localhost:22",
+        params={"shell": shell},
+    )
+    agent._ssh = SSHClient(capability, cast("Any", conn))
     agent._shell = shell
     return agent
 
@@ -114,6 +106,7 @@ async def test_exec_on_windows_writes_batch_and_execs_via_cmd() -> None:
     await agent._exec(run, prompt="build it", max_steps=5)
 
     assert conn.ran == ["cmd /c .hud_run.bat"]
+    assert all(command.startswith("powershell ") for command in conn.write_commands)
     assert sink[".hud_run.bat"].startswith(b"@echo off\r\n")
     assert sink[".hud_prompt.txt"] == b"build it"
     assert run.trace.status == "completed"
@@ -129,6 +122,7 @@ async def test_exec_on_bash_runs_inline_without_batch() -> None:
     await agent._exec(run, prompt="build it", max_steps=5)
 
     assert ".hud_run.bat" not in sink
+    assert conn.write_commands == ["cat > .hud_prompt.txt"]
     assert len(conn.ran) == 1
     assert "install.sh" in conn.ran[0]
     assert "claude" in conn.ran[0]

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -62,14 +62,17 @@ class _FakeConn:
     ) -> Any:
         if input is not None or cmd.startswith("powershell "):
             self.write_commands.append(cmd)
+            script = cmd
+            if match := re.search(r"-EncodedCommand (\S+)", cmd):
+                script = base64.b64decode(match.group(1)).decode("utf-16-le")
             name = next(
                 path
                 for path in (".hud_prompt.txt", ".hud_run.bat", ".hud_mcp_config.json")
-                if path in cmd
+                if path in script
             )
             if input is not None:
                 self._sink[name] = input.encode()
-            elif match := re.search(r"FromBase64String\('([^']+)'\)", cmd):
+            elif match := re.search(r"FromBase64String\('([^']+)'\)", script):
                 self._sink[name] += base64.b64decode(match.group(1))
             else:
                 self._sink[name] = b""

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -52,7 +52,14 @@ class _FakeConn:
         self.ran: list[str] = []
         self.write_commands: list[str] = []
 
-    async def run(self, cmd: str, *, input: str | None = None, check: bool = True) -> Any:
+    async def run(
+        self,
+        cmd: str,
+        *,
+        input: str | None = None,
+        check: bool = True,
+        encoding: str | None = "utf-8",
+    ) -> Any:
         if input is not None or cmd.startswith("powershell "):
             self.write_commands.append(cmd)
             name = next(

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -79,10 +79,12 @@ class _FakeSSH(SSHClient):
         stdout: str = "ok",
         exit_status: int = 0,
         files: dict[str, bytes] | None = None,
+        cwd: str | None = None,
     ) -> None:
         self.files: dict[str, bytes] = files or {}
+        params = {"cwd": cwd} if cwd else {}
         super().__init__(
-            Capability(name="shell", protocol="ssh/2", url="ssh://localhost:22"),
+            Capability(name="shell", protocol="ssh/2", url="ssh://localhost:22", params=params),
             cast("Any", _Conn(_Completed(stdout=stdout, exit_status=exit_status), self.files)),
         )
 
@@ -174,6 +176,19 @@ async def test_openai_compatible_write_stores_file_via_ssh_exec() -> None:
 
     assert result.isError is False
     assert ssh.files["/REPORT.md"] == b"done"
+
+
+async def test_absolute_paths_anchor_to_the_capability_cwd() -> None:
+    """The old SFTP chroot resolved ``/REPORT.md`` against the workspace root;
+    exec-channel file helpers must keep that contract via the capability cwd."""
+    ssh = _FakeSSH(cwd="/workspace", files={"/workspace/f.txt": b"inside"})
+    tool = WriteTool(spec=WriteTool.default_spec("qwen"), client=cast("SSHClient", ssh))
+
+    await tool.execute({"filePath": "/REPORT.md", "content": "done"})
+
+    assert ssh.files["/workspace/REPORT.md"] == b"done"
+    # Paths already inside the workspace are untouched.
+    assert await cast("SSHClient", ssh).read_text("/workspace/f.txt") == "inside"
 
 
 async def test_openai_compatible_edit_rewrites_unique_match() -> None:

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -206,6 +206,24 @@ def test_map_path_clamps_traversal_like_a_chroot() -> None:
     assert ssh.map_path(".") == "/workspace"
 
 
+def test_map_path_handles_windows_native_paths() -> None:
+    """The workspace publishes cwd via as_posix(); callers pass native
+    backslash paths, and NTFS compares case-insensitively."""
+    cap = Capability(
+        name="shell",
+        protocol="ssh/2",
+        url="ssh://localhost:22",
+        params={"shell": "powershell", "cwd": "C:/work"},
+    )
+    ssh = SSHClient(cap, cast("Any", None))
+    assert ssh.map_path("C:\\work\\file.txt") == "C:/work/file.txt"
+    assert ssh.map_path("C:\\Work\\sub\\f.txt") == "C:/work/sub/f.txt"
+    assert ssh.map_path("D:\\other\\f.txt") == "C:/work/other/f.txt"
+    assert ssh.map_path("\\temp\\f.txt") == "C:/work/temp/f.txt"
+    assert ssh.map_path("sub\\f.txt") == "C:/work/sub/f.txt"
+    assert ssh.map_path("C:\\work\\..\\secrets.txt") == "C:/work/secrets.txt"
+
+
 async def test_read_maps_the_directory_predicate_and_listing_together() -> None:
     """`test -d`, listing, and reads must agree on the anchored path, or
     absolute workspace dirs are misclassified as files."""

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -36,7 +36,12 @@ class _Conn:
         self.commands: list[str] = []
 
     async def run(
-        self, command: str, *, input: str | None = None, check: bool = False
+        self,
+        command: str,
+        *,
+        input: str | None = None,
+        check: bool = False,
+        encoding: str | None = "utf-8",
     ) -> _Completed:
         self.commands.append(command)
         parts = shlex.split(command)
@@ -189,6 +194,30 @@ async def test_absolute_paths_anchor_to_the_capability_cwd() -> None:
     assert ssh.files["/workspace/REPORT.md"] == b"done"
     # Paths already inside the workspace are untouched.
     assert await cast("SSHClient", ssh).read_text("/workspace/f.txt") == "inside"
+
+
+def test_map_path_clamps_traversal_like_a_chroot() -> None:
+    ssh = cast("SSHClient", _FakeSSH(cwd="/workspace"))
+    assert ssh.map_path("/workspace/../etc/passwd") == "/workspace/etc/passwd"
+    assert ssh.map_path("/../etc/passwd") == "/workspace/etc/passwd"
+    assert ssh.map_path("../../etc/passwd") == "/workspace/etc/passwd"
+    assert ssh.map_path("a/../b.txt") == "/workspace/b.txt"
+    assert ssh.map_path("/") == "/workspace"
+    assert ssh.map_path(".") == "/workspace"
+
+
+async def test_read_maps_the_directory_predicate_and_listing_together() -> None:
+    """`test -d`, listing, and reads must agree on the anchored path, or
+    absolute workspace dirs are misclassified as files."""
+    ssh = _FakeSSH(cwd="/workspace", files={"/workspace/pkg/mod.py": b"x = 1\n"})
+    tool = ReadTool(spec=ReadTool.default_spec("qwen"), client=cast("SSHClient", ssh))
+
+    result = await tool.execute({"filePath": "/pkg"})
+
+    text = result_text(result)
+    assert "<type>directory</type>" in text
+    assert "mod.py" in text
+    assert "test -d /workspace/pkg" in cast("Any", ssh).conn.commands
 
 
 async def test_openai_compatible_edit_rewrites_unique_match() -> None:

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -29,66 +29,32 @@ class _Completed:
         self.exit_status = exit_status
 
 
-class _FakeOpenFile:
-    def __init__(self, store: dict[str, bytes], path: str, mode: str) -> None:
-        self._store = store
-        self._path = path
-        self._mode = mode
-        self._written = b""
-
-    async def __aenter__(self) -> _FakeOpenFile:
-        return self
-
-    async def __aexit__(self, *_: object) -> bool:
-        if "w" in self._mode:
-            self._store[self._path] = self._written
-        return False
-
-    async def read(self) -> bytes:
-        return self._store.get(self._path, b"")
-
-    async def write(self, data: bytes) -> None:
-        self._written += data
-
-
-class _FakeSFTP:
-    def __init__(self, store: dict[str, bytes]) -> None:
-        self._store = store
-
-    async def __aenter__(self) -> _FakeSFTP:
-        return self
-
-    async def __aexit__(self, *_: object) -> bool:
-        return False
-
-    def open(self, path: str, mode: str) -> _FakeOpenFile:
-        return _FakeOpenFile(self._store, path, mode)
-
-    async def listdir(self, path: str) -> list[str]:
-        prefix = path.rstrip("/")
-        if not prefix:
-            prefix = "/"
-        if prefix != "/":
-            prefix += "/"
-        names: set[str] = set()
-        for file_path in self._store:
-            if not file_path.startswith(prefix):
-                continue
-            rest = file_path[len(prefix) :]
-            if rest:
-                names.add(rest.split("/", 1)[0])
-        return sorted(names)
-
-
 class _Conn:
     def __init__(self, completed: _Completed, store: dict[str, bytes]) -> None:
         self._completed = completed
         self._store = store
         self.commands: list[str] = []
 
-    async def run(self, command: str, check: bool = False) -> _Completed:
+    async def run(
+        self, command: str, *, input: str | None = None, check: bool = False
+    ) -> _Completed:
         self.commands.append(command)
         parts = shlex.split(command)
+        if len(parts) == 3 and parts[:2] == ["cat", "--"]:
+            return _Completed(stdout=self._store.get(parts[2], b"").decode())
+        if len(parts) == 3 and parts[:2] == ["cat", ">"]:
+            assert input is not None
+            self._store[parts[2]] = input.encode()
+            return _Completed()
+        if len(parts) == 4 and parts[:3] == ["ls", "-1A", "--"]:
+            prefix = parts[3].rstrip("/")
+            prefix = "/" if not prefix else prefix + "/"
+            names = {
+                rest.split("/", 1)[0]
+                for file_path in self._store
+                if file_path.startswith(prefix) and (rest := file_path[len(prefix) :])
+            }
+            return _Completed(stdout="\n".join(sorted(names)))
         if len(parts) == 3 and parts[:2] in (["test", "-d"], ["test", "-e"]):
             path = parts[2]
             exists = path in self._store or any(
@@ -103,12 +69,9 @@ class _Conn:
             return _Completed(exit_status=0)
         return self._completed
 
-    def start_sftp_client(self) -> _FakeSFTP:
-        return _FakeSFTP(self._store)
-
 
 class _FakeSSH(SSHClient):
-    """Duck-typed ``SSHClient``: ``conn.run`` (bash) + ``conn.start_sftp_client`` (files)."""
+    """SSH client with an in-memory exec-channel filesystem."""
 
     def __init__(
         self,
@@ -203,7 +166,7 @@ async def test_openai_compatible_bash_uses_workdir_and_timeout() -> None:
     assert _commands(tool) == ["cd '/tmp/my dir' && timeout 3s bash -lc 'echo hi'"]
 
 
-async def test_openai_compatible_write_stores_file_via_workspace_sftp() -> None:
+async def test_openai_compatible_write_stores_file_via_ssh_exec() -> None:
     ssh = _FakeSSH()
     tool = WriteTool(spec=WriteTool.default_spec("qwen"), client=cast("SSHClient", ssh))
 
@@ -325,7 +288,7 @@ def test_claude_bash_to_params_carries_native_schema() -> None:
     assert params == {"type": "bash_20250124", "name": "bash"}
 
 
-# ─── editor tools over SFTP ───────────────────────────────────────────
+# ─── editor tools over SSH exec ───────────────────────────────────────
 
 
 async def test_claude_text_editor_creates_file() -> None:

--- a/hud/agents/tools/ssh.py
+++ b/hud/agents/tools/ssh.py
@@ -7,8 +7,6 @@ differs between providers.
 
 from __future__ import annotations
 
-from typing import cast
-
 import mcp.types as mcp_types
 
 from hud.agents.tools.base import AgentTool
@@ -38,26 +36,17 @@ class SSHTool(AgentTool[SSHClient]):
         )
 
     async def file_read(self, path: str) -> MCPToolResult:
-        """Read a file via SFTP."""
-        async with self.client.conn.start_sftp_client() as sftp, sftp.open(path, "rb") as f:
-            raw = cast("bytes | str", await f.read())
-        data = raw.encode("utf-8", errors="replace") if isinstance(raw, str) else raw
-        return tool_ok(data.decode("utf-8", errors="replace"))
+        """Read a text file through SSH exec."""
+        return tool_ok(await self.client.read_text(path))
 
     async def file_write(self, path: str, content: str) -> MCPToolResult:
-        """Write a file via SFTP (overwrites)."""
-        async with self.client.conn.start_sftp_client() as sftp, sftp.open(path, "wb") as f:
-            await f.write(content.encode("utf-8"))
+        """Write a text file through SSH exec."""
+        await self.client.write_text(path, content)
         return tool_ok(f"wrote {len(content)} bytes to {path}")
 
     async def file_list(self, path: str = "/") -> MCPToolResult:
-        """List directory entries via SFTP."""
-        async with self.client.conn.start_sftp_client() as sftp:
-            entries = cast("list[bytes | str]", await sftp.listdir(path))
-        names = sorted(
-            (e if isinstance(e, str) else e.decode("utf-8", errors="replace")) for e in entries
-        )
-        names = [n for n in names if n not in (".", "..")]
+        """List directory entries through SSH exec."""
+        names = await self.client.listdir(path)
         return tool_ok("\n".join(names) if names else "(empty)")
 
 

--- a/hud/capabilities/base.py
+++ b/hud/capabilities/base.py
@@ -78,6 +78,7 @@ class Capability:
         client_key: str | None = None,
         client_key_path: str | os.PathLike[str] | None = None,
         shell: str | None = None,
+        cwd: str | None = None,
     ) -> Capability:
         """``ssh/2`` — SSH daemon with publickey auth.
 
@@ -87,7 +88,8 @@ class Capability:
         and daemon share a filesystem. ``shell`` declares the remote shell
         type (``bash``, ``powershell``, ``cmd``). Defaults to auto-detect
         from ``sys.platform`` at construction time. Agents read this to
-        format commands correctly.
+        format commands correctly. ``cwd`` is the absolute path sessions
+        start in (the served workspace); clients anchor file paths to it.
         """
         normalized = normalize_url(url, default_scheme="ssh", default_port=22)
         if shell is None:
@@ -97,6 +99,8 @@ class Capability:
             params["client_key"] = client_key
         if client_key_path is not None:
             params["client_key_path"] = os.fspath(client_key_path)
+        if cwd is not None:
+            params["cwd"] = cwd
         return cls(name=name, protocol="ssh/2", url=normalized, params=params)
 
     @classmethod

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -47,8 +47,25 @@ class SSHClient(CapabilityClient):
         """Raw asyncssh connection for commands and port forwarding."""
         return self._conn
 
+    def _map_path(self, path: str) -> str:
+        """Anchor absolute paths to the session cwd (the served workspace).
+
+        The old SFTP subsystem was chrooted, so harness tools address files as
+        ``/REPORT.md`` meaning workspace-relative. The exec channel sees the
+        real filesystem; replicate the chroot by prefixing absolute paths with
+        the capability's ``cwd`` unless they already point inside it. Relative
+        paths resolve against the session cwd natively.
+        """
+        cwd = str(self.capability.params.get("cwd", "")).rstrip("/")
+        if not cwd or not path.startswith("/"):
+            return path
+        if path == cwd or path.startswith(cwd + "/"):
+            return path
+        return cwd + path
+
     async def read_text(self, path: str) -> str:
         """Read a UTF-8 text file through the exec channel."""
+        path = self._map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
             command = (
@@ -62,6 +79,7 @@ class SSHClient(CapabilityClient):
 
     async def write_text(self, path: str, content: str) -> None:
         """Write UTF-8 text through the exec channel without command interpolation."""
+        path = self._map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
             await self._conn.run(
@@ -85,6 +103,7 @@ class SSHClient(CapabilityClient):
 
     async def listdir(self, path: str) -> list[str]:
         """List direct children through the exec channel."""
+        path = self._map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
             command = (

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import shlex
 from typing import Any, ClassVar, Self
 from urllib.parse import urlsplit
 
@@ -42,12 +44,73 @@ class SSHClient(CapabilityClient):
 
     @property
     def conn(self) -> asyncssh.SSHClientConnection:
-        """Raw asyncssh connection — use for ``run``, SFTP, port forwarding, etc."""
+        """Raw asyncssh connection for commands and port forwarding."""
         return self._conn
+
+    async def read_text(self, path: str) -> str:
+        """Read a UTF-8 text file through the exec channel."""
+        if self._is_windows:
+            quoted = _powershell_quote(path)
+            command = (
+                "powershell -NoProfile -NonInteractive -Command "
+                f'"[Convert]::ToBase64String([IO.File]::ReadAllBytes({quoted}))"'
+            )
+            result = await self._conn.run(command, check=True)
+            return base64.b64decode(_stdout(result)).decode("utf-8", errors="replace")
+        result = await self._conn.run(f"cat -- {shlex.quote(path)}", check=True)
+        return _stdout(result)
+
+    async def write_text(self, path: str, content: str) -> None:
+        """Write UTF-8 text through the exec channel without command interpolation."""
+        if self._is_windows:
+            quoted = _powershell_quote(path)
+            await self._conn.run(
+                "powershell -NoProfile -NonInteractive -Command "
+                f'"[IO.File]::WriteAllBytes({quoted},[byte[]]@())"',
+                check=True,
+            )
+            raw = content.encode("utf-8")
+            for offset in range(0, len(raw), 6144):
+                payload = base64.b64encode(raw[offset : offset + 6144]).decode("ascii")
+                await self._conn.run(
+                    "powershell -NoProfile -NonInteractive -Command "
+                    f"\"$b=[Convert]::FromBase64String('{payload}');"
+                    f"$f=[IO.File]::Open({quoted},[IO.FileMode]::Append,"
+                    "[IO.FileAccess]::Write,[IO.FileShare]::Read);"
+                    'try{$f.Write($b,0,$b.Length)}finally{$f.Dispose()}"',
+                    check=True,
+                )
+            return
+        await self._conn.run(f"cat > {shlex.quote(path)}", input=content, check=True)
+
+    async def listdir(self, path: str) -> list[str]:
+        """List direct children through the exec channel."""
+        if self._is_windows:
+            quoted = _powershell_quote(path)
+            command = (
+                "powershell -NoProfile -NonInteractive -Command "
+                f'"Get-ChildItem -Force -Name -LiteralPath {quoted}"'
+            )
+        else:
+            command = f"ls -1A -- {shlex.quote(path)}"
+        result = await self._conn.run(command, check=True)
+        return sorted(line for line in _stdout(result).splitlines() if line not in (".", ".."))
+
+    @property
+    def _is_windows(self) -> bool:
+        return self.capability.params.get("shell") in ("cmd", "powershell")
 
     async def close(self) -> None:
         self._conn.close()
         await self._conn.wait_closed()
+
+
+def _stdout(result: asyncssh.SSHCompletedProcess) -> str:
+    return result.stdout if isinstance(result.stdout, str) else ""
+
+
+def _powershell_quote(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
 
 
 __all__ = ["SSHClient"]

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import posixpath
 import shlex
 from typing import Any, ClassVar, Self
 from urllib.parse import urlsplit
@@ -47,25 +48,26 @@ class SSHClient(CapabilityClient):
         """Raw asyncssh connection for commands and port forwarding."""
         return self._conn
 
-    def _map_path(self, path: str) -> str:
-        """Anchor absolute paths to the session cwd (the served workspace).
+    def map_path(self, path: str) -> str:
+        """Anchor a path to the session cwd (the served workspace).
 
         The old SFTP subsystem was chrooted, so harness tools address files as
         ``/REPORT.md`` meaning workspace-relative. The exec channel sees the
-        real filesystem; replicate the chroot by prefixing absolute paths with
-        the capability's ``cwd`` unless they already point inside it. Relative
-        paths resolve against the session cwd natively.
+        real filesystem; replicate the chroot: strip the cwd prefix if present,
+        normalize the remainder against ``/`` (clamping ``..`` at the root,
+        exactly as a chroot does), and re-anchor under the cwd. Idempotent.
         """
         cwd = str(self.capability.params.get("cwd", "")).rstrip("/")
-        if not cwd or not path.startswith("/"):
+        if not cwd:
             return path
         if path == cwd or path.startswith(cwd + "/"):
-            return path
-        return cwd + path
+            path = path[len(cwd) :]
+        normalized = posixpath.normpath("/" + path.lstrip("/"))
+        return cwd if normalized == "/" else cwd + normalized
 
     async def read_text(self, path: str) -> str:
         """Read a UTF-8 text file through the exec channel."""
-        path = self._map_path(path)
+        path = self.map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
             command = (
@@ -74,12 +76,14 @@ class SSHClient(CapabilityClient):
             )
             result = await self._conn.run(command, check=True)
             return base64.b64decode(_stdout(result)).decode("utf-8", errors="replace")
-        result = await self._conn.run(f"cat -- {shlex.quote(path)}", check=True)
-        return _stdout(result)
+        # encoding=None transports raw bytes: a strict connection-level UTF-8
+        # decode would raise on files with invalid UTF-8 instead of replacing.
+        result = await self._conn.run(f"cat -- {shlex.quote(path)}", check=True, encoding=None)
+        return _decode(result.stdout)
 
     async def write_text(self, path: str, content: str) -> None:
         """Write UTF-8 text through the exec channel without command interpolation."""
-        path = self._map_path(path)
+        path = self.map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
             await self._conn.run(
@@ -103,17 +107,20 @@ class SSHClient(CapabilityClient):
 
     async def listdir(self, path: str) -> list[str]:
         """List direct children through the exec channel."""
-        path = self._map_path(path)
+        path = self.map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
             command = (
                 "powershell -NoProfile -NonInteractive -Command "
                 f'"Get-ChildItem -Force -Name -LiteralPath {quoted}"'
             )
+            result = await self._conn.run(command, check=True)
+            listing = _stdout(result)
         else:
             command = f"ls -1A -- {shlex.quote(path)}"
-        result = await self._conn.run(command, check=True)
-        return sorted(line for line in _stdout(result).splitlines() if line not in (".", ".."))
+            result = await self._conn.run(command, check=True, encoding=None)
+            listing = _decode(result.stdout)
+        return sorted(line for line in listing.splitlines() if line not in (".", ".."))
 
     @property
     def _is_windows(self) -> bool:
@@ -126,6 +133,12 @@ class SSHClient(CapabilityClient):
 
 def _stdout(result: asyncssh.SSHCompletedProcess) -> str:
     return result.stdout if isinstance(result.stdout, str) else ""
+
+
+def _decode(raw: object) -> str:
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return raw if isinstance(raw, str) else ""
 
 
 def _powershell_quote(value: str) -> str:

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -80,11 +80,8 @@ class SSHClient(CapabilityClient):
         path = self.map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
-            command = (
-                "powershell -NoProfile -NonInteractive -Command "
-                f'"[Convert]::ToBase64String([IO.File]::ReadAllBytes({quoted}))"'
-            )
-            result = await self._conn.run(command, check=True)
+            script = f"[Convert]::ToBase64String([IO.File]::ReadAllBytes({quoted}))"
+            result = await self._conn.run(_powershell(script), check=True)
             return base64.b64decode(_stdout(result)).decode("utf-8", errors="replace")
         # encoding=None transports raw bytes: a strict connection-level UTF-8
         # decode would raise on files with invalid UTF-8 instead of replacing.
@@ -96,22 +93,18 @@ class SSHClient(CapabilityClient):
         path = self.map_path(path)
         if self._is_windows:
             quoted = _powershell_quote(path)
-            await self._conn.run(
-                "powershell -NoProfile -NonInteractive -Command "
-                f'"[IO.File]::WriteAllBytes({quoted},[byte[]]@())"',
-                check=True,
-            )
+            truncate = f"[IO.File]::WriteAllBytes({quoted},[byte[]]@())"
+            await self._conn.run(_powershell(truncate), check=True)
             raw = content.encode("utf-8")
             for offset in range(0, len(raw), 6144):
                 payload = base64.b64encode(raw[offset : offset + 6144]).decode("ascii")
-                await self._conn.run(
-                    "powershell -NoProfile -NonInteractive -Command "
-                    f"\"$b=[Convert]::FromBase64String('{payload}');"
+                script = (
+                    f"$b=[Convert]::FromBase64String('{payload}');"
                     f"$f=[IO.File]::Open({quoted},[IO.FileMode]::Append,"
                     "[IO.FileAccess]::Write,[IO.FileShare]::Read);"
-                    'try{$f.Write($b,0,$b.Length)}finally{$f.Dispose()}"',
-                    check=True,
+                    "try{$f.Write($b,0,$b.Length)}finally{$f.Dispose()}"
                 )
+                await self._conn.run(_powershell(script), check=True)
             return
         await self._conn.run(f"cat > {shlex.quote(path)}", input=content, check=True)
 
@@ -119,12 +112,8 @@ class SSHClient(CapabilityClient):
         """List direct children through the exec channel."""
         path = self.map_path(path)
         if self._is_windows:
-            quoted = _powershell_quote(path)
-            command = (
-                "powershell -NoProfile -NonInteractive -Command "
-                f'"Get-ChildItem -Force -Name -LiteralPath {quoted}"'
-            )
-            result = await self._conn.run(command, check=True)
+            script = f"Get-ChildItem -Force -Name -LiteralPath {_powershell_quote(path)}"
+            result = await self._conn.run(_powershell(script), check=True)
             listing = _stdout(result)
         else:
             command = f"ls -1A -- {shlex.quote(path)}"
@@ -139,6 +128,19 @@ class SSHClient(CapabilityClient):
     async def close(self) -> None:
         self._conn.close()
         await self._conn.wait_closed()
+
+
+def _powershell(script: str) -> str:
+    """Wrap a script for remote execution with no quoting at all.
+
+    ``-Command "..."`` breaks against the built-in Windows workspace: its exec
+    handler splits with ``shlex.split(posix=False)`` (quotes retained) and
+    ``subprocess`` re-quotes, so PowerShell sees a string literal instead of a
+    script. ``-EncodedCommand`` carries the script as base64 UTF-16LE — no
+    quotes to mangle anywhere.
+    """
+    encoded = base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+    return f"powershell -NoProfile -NonInteractive -EncodedCommand {encoded}"
 
 
 def _stdout(result: asyncssh.SSHCompletedProcess) -> str:

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -60,7 +60,17 @@ class SSHClient(CapabilityClient):
         cwd = str(self.capability.params.get("cwd", "")).rstrip("/")
         if not cwd:
             return path
-        if path == cwd or path.startswith(cwd + "/"):
+        if self._is_windows:
+            # The workspace publishes cwd via as_posix() (e.g. "C:/work") but
+            # callers pass native paths ("C:\work\file.txt"); NTFS paths are
+            # case-insensitive.
+            path = path.replace("\\", "/")
+            if path.lower() == cwd.lower() or path.lower().startswith(cwd.lower() + "/"):
+                path = path[len(cwd) :]
+            elif len(path) >= 2 and path[1] == ":" and path[0].isalpha():
+                # Drive-absolute outside the workspace: anchor like the chroot.
+                path = path[2:]
+        elif path == cwd or path.startswith(cwd + "/"):
             path = path[len(cwd) :]
         normalized = posixpath.normpath("/" + path.lstrip("/"))
         return cwd if normalized == "/" else cwd + normalized

--- a/hud/environment/file_tracker.py
+++ b/hud/environment/file_tracker.py
@@ -44,7 +44,7 @@ DEFAULT_EXCLUDE_PATTERNS: tuple[str, ...] = (
     ".hg",
     ".svn",
     ".jj",
-    # The Workspace's own SSH credential dir, materialized under root at serve time.
+    # HUD CLI state written into env dirs (e.g. deploy's .hud/config.json).
     ".hud/",
     "*.so",
     "*.o",

--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -52,8 +52,8 @@ async def test_serving_publishes_the_workspace_capability(
         assert cap.url.startswith("ssh://")
         assert cap.params["host_pubkey"].startswith("ssh-ed25519")
         assert client.binding("filetracking").protocol == "filetracking/1"
-        ssh_dir = tmp_path / "root" / ".hud" / "ssh"
-        assert any(ssh_dir.rglob("host_ed25519"))
+        # Key material lives outside the served root (the agent's surface).
+        assert not (tmp_path / "root" / ".hud").exists()
 
 
 async def test_workspace_file_tracking_can_be_opted_out(

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -42,7 +42,8 @@ async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
         # The daemon still works from the external credentials.
         async with await _connect(ws) as conn:
             result = await conn.run("echo ok")
-            assert result.stdout is not None and "ok" in result.stdout
+            stdout = result.stdout
+            assert isinstance(stdout, str) and "ok" in stdout
     finally:
         await ws.stop()
     assert not key_path.exists()

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 import tempfile
 from pathlib import Path
@@ -10,7 +9,8 @@ from pathlib import Path
 import asyncssh
 import pytest
 
-from hud.environment.workspace import Workspace, _PrefixSFTPServer
+from hud.capabilities import SSHClient
+from hud.environment.workspace import Workspace
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX workspace semantics")
 
@@ -30,8 +30,7 @@ async def _connect(ws: Workspace) -> asyncssh.SSHClientConnection:
 
 @pytest.mark.asyncio
 async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
-    """The root is the agent's surface (shell cwd, SFTP chroot); key material
-    must not be readable or writable through it."""
+    """The agent's shell root must not contain its SSH key material."""
     ws = Workspace(tmp_path / "root")
     await ws.start()
     try:
@@ -50,55 +49,29 @@ async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sftp_writes_are_handed_to_the_shell_uid(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """SFTP runs in the serving process; when privileges are dropped, files it
-    creates must end up owned by the dropped uid."""
-    claimed: list[tuple[str, int, int]] = []
-    monkeypatch.setattr(os, "chown", lambda p, u, g: claimed.append((os.fsdecode(p), u, g)))
-    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
-
-    ws = Workspace(tmp_path / "root", shell_uid=1000)
+async def test_sftp_subsystem_is_not_served(tmp_path: Path) -> None:
+    ws = Workspace(tmp_path / "root")
     await ws.start()
     try:
-        async with await _connect(ws) as conn, conn.start_sftp_client() as sftp:
-            local = tmp_path / "hello.txt"
-            local.write_text("hi")
-            await sftp.put(str(local), "/hello.txt")
-            await sftp.mkdir("/subdir")
+        async with await _connect(ws) as conn:
+            with pytest.raises(asyncssh.ChannelOpenError):
+                await conn.start_sftp_client()
     finally:
         await ws.stop()
-
-    owners = {Path(path).name: (uid, gid) for path, uid, gid in claimed}
-    assert owners.get("hello.txt") == (1000, 1000)
-    assert owners.get("subdir") == (1000, 1000)
-    # The workspace root itself is handed over so the dropped uid can write to it.
-    assert owners.get("root") == (1000, 1000)
 
 
 @pytest.mark.asyncio
-async def test_sftp_overwrites_do_not_rechown(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    claimed: list[str] = []
-    monkeypatch.setattr(os, "chown", lambda p, u, g: claimed.append(os.fsdecode(p)))
-    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
-
-    root = tmp_path / "root"
-    root.mkdir()
-    (root / "existing.txt").write_text("before")
-    ws = Workspace(root, shell_uid=1000)
+async def test_file_operations_use_the_exec_channel(tmp_path: Path) -> None:
+    ws = Workspace(tmp_path / "root")
     await ws.start()
-    claimed.clear()  # ignore the root chown done at prepare time
     try:
-        async with await _connect(ws) as conn, conn.start_sftp_client() as sftp:
-            local = tmp_path / "existing.txt"
-            local.write_text("after")
-            await sftp.put(str(local), "/existing.txt")
+        async with await _connect(ws) as conn:
+            client = SSHClient(ws.capability(), conn)
+            await client.write_text("hello world.txt", "héllo\n")
+            assert await client.read_text("hello world.txt") == "héllo\n"
+            assert await client.listdir(".") == ["hello world.txt"]
     finally:
         await ws.stop()
-    assert claimed == []
 
 
 @pytest.mark.asyncio
@@ -115,45 +88,6 @@ async def test_dropped_session_env_excludes_server_secrets(
     assert "HUD_API_KEY" not in session_env
     assert session_env["CUSTOM"] == "1"
     assert "PATH" in session_env
-
-
-def _sftp_server(root: Path, *, chown_uid: int | None) -> _PrefixSFTPServer:
-    # map_path doesn't touch the channel; None is enough to exercise it.
-    return _PrefixSFTPServer(
-        None,  # type: ignore[arg-type]
-        chroot=str(root).encode(),
-        guest_prefix=b"/workspace",
-        chown_uid=chown_uid,
-    )
-
-
-def test_sftp_map_path_blocks_symlink_escape_under_the_wall(tmp_path: Path) -> None:
-    """Every SFTP op resolves paths through map_path; under the wall it must
-    refuse ones whose real target escapes the workspace (e.g. an on-disk
-    ``escape -> /host/secret`` the dropped shell created), which a raw
-    ``open`` would otherwise follow as root."""
-    root = tmp_path / "root"
-    root.mkdir()
-    secret = tmp_path / "secret.txt"
-    secret.write_text("host-only")
-    (root / "escape").symlink_to(secret)
-    (root / "ok.txt").write_text("inside")
-
-    srv = _sftp_server(root, chown_uid=1000)
-    with pytest.raises(asyncssh.SFTPNoSuchFile):
-        srv.map_path(b"/escape")
-    # Paths that stay inside are unaffected.
-    assert srv.map_path(b"/ok.txt") == str(root / "ok.txt").encode()
-
-
-def test_sftp_map_path_leaves_escape_to_asyncssh_without_the_wall(tmp_path: Path) -> None:
-    """Without the wall, the containment guard is off — asyncssh's own
-    prefix chroot governs, so behavior for normal workspaces is unchanged."""
-    root = tmp_path / "root"
-    root.mkdir()
-    (root / "escape").symlink_to(tmp_path / "secret.txt")
-    srv = _sftp_server(root, chown_uid=None)
-    assert srv.map_path(b"/escape") == str(root / "escape").encode()
 
 
 def test_bwrap_drops_host_env_when_walled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import asyncssh
 import pytest
 
-from hud.environment.workspace import Workspace
+from hud.environment.workspace import Workspace, _PrefixSFTPServer
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX workspace semantics")
 
@@ -115,6 +115,70 @@ async def test_dropped_session_env_excludes_server_secrets(
     assert "HUD_API_KEY" not in session_env
     assert session_env["CUSTOM"] == "1"
     assert "PATH" in session_env
+
+
+def _sftp_server(root: Path, *, chown_uid: int | None) -> _PrefixSFTPServer:
+    # map_path doesn't touch the channel; None is enough to exercise it.
+    return _PrefixSFTPServer(
+        None,  # type: ignore[arg-type]
+        chroot=str(root).encode(),
+        guest_prefix=b"/workspace",
+        chown_uid=chown_uid,
+    )
+
+
+def test_sftp_map_path_blocks_symlink_escape_under_the_wall(tmp_path: Path) -> None:
+    """Every SFTP op resolves paths through map_path; under the wall it must
+    refuse ones whose real target escapes the workspace (e.g. an on-disk
+    ``escape -> /host/secret`` the dropped shell created), which a raw
+    ``open`` would otherwise follow as root."""
+    root = tmp_path / "root"
+    root.mkdir()
+    secret = tmp_path / "secret.txt"
+    secret.write_text("host-only")
+    (root / "escape").symlink_to(secret)
+    (root / "ok.txt").write_text("inside")
+
+    srv = _sftp_server(root, chown_uid=1000)
+    with pytest.raises(asyncssh.SFTPNoSuchFile):
+        srv.map_path(b"/escape")
+    # Paths that stay inside are unaffected.
+    assert srv.map_path(b"/ok.txt") == str(root / "ok.txt").encode()
+
+
+def test_sftp_map_path_leaves_escape_to_asyncssh_without_the_wall(tmp_path: Path) -> None:
+    """Without the wall, the containment guard is off — asyncssh's own
+    prefix chroot governs, so behavior for normal workspaces is unchanged."""
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "escape").symlink_to(tmp_path / "secret.txt")
+    srv = _sftp_server(root, chown_uid=None)
+    assert srv.map_path(b"/escape") == str(root / "escape").encode()
+
+
+def test_bwrap_drops_host_env_when_walled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bwrap path must not re-inject host secrets via --setenv."""
+    monkeypatch.setenv("HUD_API_KEY", "super-secret")
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
+
+    ws = Workspace(tmp_path / "root", shell_uid=1000, env={"CUSTOM": "1"})
+    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    argv = ws.shell_argv("echo hi")
+
+    setenv_keys = {argv[i + 1] for i, tok in enumerate(argv) if tok == "--setenv"}
+    assert "HUD_API_KEY" not in setenv_keys
+    assert "CUSTOM" in setenv_keys and "PATH" in setenv_keys
+
+
+def test_bwrap_inherits_host_env_when_not_walled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HUD_SENTINEL", "visible")
+    ws = Workspace(tmp_path / "root")
+    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    argv = ws.bwrap_argv(["bash", "-lc", "true"])
+    setenv_keys = {argv[i + 1] for i, tok in enumerate(argv) if tok == "--setenv"}
+    assert "HUD_SENTINEL" in setenv_keys
 
 
 def test_shell_uid_wraps_sessions_in_setpriv(

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -147,7 +147,22 @@ def test_shell_uid_wraps_sessions_in_setpriv(
         "--clear-groups",
         "--",
     ]
+    # The session env rides `env -i` *inside* the setpriv wrapper, so it only
+    # takes effect after the drop.
+    assert argv[7].endswith("/env") and argv[8] == "-i"
     assert "echo hi" in argv
+
+
+def test_caller_env_is_injected_only_after_the_drop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An agent-influenced var like LD_PRELOAD must not be in the environment
+    of the root-run setpriv; it may only reach the post-drop shell."""
+    _wall(monkeypatch)
+    ws = Workspace(tmp_path / "root", shell_uid=1000, env={"LD_PRELOAD": "/workspace/evil.so"})
+    argv = ws.shell_argv("echo hi")
+    assert argv[0] == "/usr/bin/setpriv"
+    assert "LD_PRELOAD=/workspace/evil.so" in argv[argv.index("-i") :]
 
 
 @pytest.mark.asyncio

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -1,0 +1,126 @@
+"""Workspace contract tests: credential placement and the shell_uid wall."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import asyncssh
+import pytest
+
+from hud.environment.workspace import Workspace
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX workspace semantics")
+
+
+async def _connect(ws: Workspace) -> asyncssh.SSHClientConnection:
+    host, port = ws.ssh_url.removeprefix("ssh://").split(":")
+    key_path = ws.ssh_client_key_path
+    assert key_path is not None
+    return await asyncssh.connect(
+        host,
+        int(port),
+        username=ws.ssh_user,
+        client_keys=[str(key_path)],
+        known_hosts=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
+    """The root is the agent's surface (shell cwd, SFTP chroot); key material
+    must not be readable or writable through it."""
+    ws = Workspace(tmp_path / "root")
+    await ws.start()
+    try:
+        key_path = ws.ssh_client_key_path
+        assert key_path is not None
+        assert not key_path.is_relative_to(ws.root)
+        assert not (ws.root / ".hud").exists()
+        # The daemon still works from the external credentials.
+        async with await _connect(ws) as conn:
+            result = await conn.run("echo ok")
+            assert result.stdout is not None and "ok" in result.stdout
+    finally:
+        await ws.stop()
+    assert not key_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_sftp_writes_are_handed_to_the_shell_uid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SFTP runs in the serving process; with shell_uid set (and the server
+    root), files it creates must end up owned by the dropped uid."""
+    claimed: list[tuple[str, int, int]] = []
+    monkeypatch.setattr(os, "chown", lambda p, u, g: claimed.append((os.fsdecode(p), u, g)))
+    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: True)
+
+    ws = Workspace(tmp_path / "root", shell_uid=1000)
+    await ws.start()
+    try:
+        async with await _connect(ws) as conn, conn.start_sftp_client() as sftp:
+            local = tmp_path / "hello.txt"
+            local.write_text("hi")
+            await sftp.put(str(local), "/hello.txt")
+            await sftp.mkdir("/subdir")
+    finally:
+        await ws.stop()
+
+    owners = {Path(path).name: (uid, gid) for path, uid, gid in claimed}
+    assert owners.get("hello.txt") == (1000, 1000)
+    assert owners.get("subdir") == (1000, 1000)
+
+
+@pytest.mark.asyncio
+async def test_sftp_overwrites_do_not_rechown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    claimed: list[str] = []
+    monkeypatch.setattr(os, "chown", lambda p, u, g: claimed.append(os.fsdecode(p)))
+    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: True)
+
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "existing.txt").write_text("before")
+    ws = Workspace(root, shell_uid=1000)
+    await ws.start()
+    try:
+        async with await _connect(ws) as conn, conn.start_sftp_client() as sftp:
+            local = tmp_path / "existing.txt"
+            local.write_text("after")
+            await sftp.put(str(local), "/existing.txt")
+    finally:
+        await ws.stop()
+    assert claimed == []
+
+
+def test_shell_uid_wraps_sessions_in_setpriv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: True)
+    ws = Workspace(tmp_path / "root", shell_uid=1000)
+    argv = ws.shell_argv("echo hi")
+    assert argv[:7] == ["setpriv", "--reuid", "1000", "--regid", "1000", "--clear-groups", "--"]
+    assert "echo hi" in argv
+
+
+def test_shell_uid_is_a_noop_off_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: False)
+    ws = Workspace(tmp_path / "root", shell_uid=1000)
+    assert "setpriv" not in ws.shell_argv("echo hi")
+    assert "setpriv" not in ws.shell_argv("echo hi", cwd=str(tmp_path))
+
+
+def test_without_shell_uid_argv_is_unchanged(tmp_path: Path) -> None:
+    ws = Workspace(tmp_path / "root")
+    assert "setpriv" not in ws.shell_argv("echo hi")
+
+
+def test_credentials_dir_is_private(tmp_path: Path) -> None:
+    ws = Workspace(tmp_path / "root")
+    creds = ws._credentials_dir()
+    assert creds.is_relative_to(Path(tempfile.gettempdir()))
+    assert (creds.stat().st_mode & 0o777) == 0o700

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -138,18 +138,20 @@ def test_shell_uid_wraps_sessions_in_setpriv(
     argv = ws.shell_argv("echo hi")
     # Absolute path: a bare name would resolve through the session PATH,
     # which the agent can influence — that lookup happens before the drop.
-    assert argv[:7] == [
+    # --no-new-privs: a setuid binary must not let the shell regain root.
+    assert argv[:8] == [
         "/usr/bin/setpriv",
         "--reuid",
         "1000",
         "--regid",
         "1000",
         "--clear-groups",
+        "--no-new-privs",
         "--",
     ]
     # The session env rides `env -i` *inside* the setpriv wrapper, so it only
     # takes effect after the drop.
-    assert argv[7].endswith("/env") and argv[8] == "-i"
+    assert argv[8].endswith("/env") and argv[9] == "-i"
     assert "echo hi" in argv
 
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -53,11 +53,11 @@ async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
 async def test_sftp_writes_are_handed_to_the_shell_uid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """SFTP runs in the serving process; with shell_uid set (and the server
-    root), files it creates must end up owned by the dropped uid."""
+    """SFTP runs in the serving process; when privileges are dropped, files it
+    creates must end up owned by the dropped uid."""
     claimed: list[tuple[str, int, int]] = []
     monkeypatch.setattr(os, "chown", lambda p, u, g: claimed.append((os.fsdecode(p), u, g)))
-    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: True)
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
 
     ws = Workspace(tmp_path / "root", shell_uid=1000)
     await ws.start()
@@ -73,6 +73,8 @@ async def test_sftp_writes_are_handed_to_the_shell_uid(
     owners = {Path(path).name: (uid, gid) for path, uid, gid in claimed}
     assert owners.get("hello.txt") == (1000, 1000)
     assert owners.get("subdir") == (1000, 1000)
+    # The workspace root itself is handed over so the dropped uid can write to it.
+    assert owners.get("root") == (1000, 1000)
 
 
 @pytest.mark.asyncio
@@ -81,13 +83,14 @@ async def test_sftp_overwrites_do_not_rechown(
 ) -> None:
     claimed: list[str] = []
     monkeypatch.setattr(os, "chown", lambda p, u, g: claimed.append(os.fsdecode(p)))
-    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: True)
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
 
     root = tmp_path / "root"
     root.mkdir()
     (root / "existing.txt").write_text("before")
     ws = Workspace(root, shell_uid=1000)
     await ws.start()
+    claimed.clear()  # ignore the root chown done at prepare time
     try:
         async with await _connect(ws) as conn, conn.start_sftp_client() as sftp:
             local = tmp_path / "existing.txt"
@@ -98,10 +101,26 @@ async def test_sftp_overwrites_do_not_rechown(
     assert claimed == []
 
 
+@pytest.mark.asyncio
+async def test_dropped_session_env_excludes_server_secrets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dropped shell must not inherit the server's environment (secrets)."""
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
+    monkeypatch.setenv("HUD_API_KEY", "super-secret")
+
+    ws = Workspace(tmp_path / "root", shell_uid=1000, env={"CUSTOM": "1"})
+    session_env = ws._session_env()
+    assert session_env is not None
+    assert "HUD_API_KEY" not in session_env
+    assert session_env["CUSTOM"] == "1"
+    assert "PATH" in session_env
+
+
 def test_shell_uid_wraps_sessions_in_setpriv(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: True)
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
     ws = Workspace(tmp_path / "root", shell_uid=1000)
     argv = ws.shell_argv("echo hi")
     assert argv[:7] == ["setpriv", "--reuid", "1000", "--regid", "1000", "--clear-groups", "--"]
@@ -109,10 +128,10 @@ def test_shell_uid_wraps_sessions_in_setpriv(
 
 
 def test_shell_uid_is_a_noop_off_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("hud.environment.workspace._serving_as_root", lambda: False)
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: False)
     ws = Workspace(tmp_path / "root", shell_uid=1000)
     assert "setpriv" not in ws.shell_argv("echo hi")
-    assert "setpriv" not in ws.shell_argv("echo hi", cwd=str(tmp_path))
+    assert ws._session_env() is None
 
 
 def test_without_shell_uid_argv_is_unchanged(tmp_path: Path) -> None:
@@ -120,8 +139,24 @@ def test_without_shell_uid_argv_is_unchanged(tmp_path: Path) -> None:
     assert "setpriv" not in ws.shell_argv("echo hi")
 
 
-def test_credentials_dir_is_private(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_root_without_working_drop_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Serving as root while unable to drop must refuse rather than run agents
+    as root."""
+    monkeypatch.setattr("hud.environment.workspace._is_root", lambda: True)
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: False)
+    ws = Workspace(tmp_path / "root", shell_uid=1000)
+    with pytest.raises(RuntimeError, match="privileges cannot be dropped"):
+        await ws.start()
+
+
+def test_credentials_dir_is_private_and_unpredictable(tmp_path: Path) -> None:
     ws = Workspace(tmp_path / "root")
     creds = ws._credentials_dir()
     assert creds.is_relative_to(Path(tempfile.gettempdir()))
+    assert not creds.is_relative_to(ws.root)
+    # mkdtemp yields 0700 and a fresh name each call (no shared parent to hijack).
     assert (creds.stat().st_mode & 0o777) == 0o700
+    assert ws._credentials_dir() == creds  # cached per instance

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -70,8 +71,18 @@ async def test_file_operations_use_the_exec_channel(tmp_path: Path) -> None:
             await client.write_text("hello world.txt", "héllo\n")
             assert await client.read_text("hello world.txt") == "héllo\n"
             assert await client.listdir(".") == ["hello world.txt"]
+            # Absolute paths anchor to the workspace, like the old SFTP chroot.
+            await client.write_text("/REPORT.md", "done")
+            assert (tmp_path / "root" / "REPORT.md").read_text() == "done"
+            assert await client.read_text("/REPORT.md") == "done"
+            assert "REPORT.md" in await client.listdir("/")
     finally:
         await ws.stop()
+
+
+def _wall(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
+    monkeypatch.setattr(Workspace, "_setpriv", lambda self: "/usr/bin/setpriv")
 
 
 @pytest.mark.asyncio
@@ -79,7 +90,7 @@ async def test_dropped_session_env_excludes_server_secrets(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A dropped shell must not inherit the server's environment (secrets)."""
-    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
+    _wall(monkeypatch)
     monkeypatch.setenv("HUD_API_KEY", "super-secret")
 
     ws = Workspace(tmp_path / "root", shell_uid=1000, env={"CUSTOM": "1"})
@@ -88,20 +99,24 @@ async def test_dropped_session_env_excludes_server_secrets(
     assert "HUD_API_KEY" not in session_env
     assert session_env["CUSTOM"] == "1"
     assert "PATH" in session_env
+    # The server's HOME (/root) is unreadable by the dropped uid.
+    assert session_env["HOME"] == ws._guest_path
 
 
 def test_bwrap_drops_host_env_when_walled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The bwrap path must not re-inject host secrets via --setenv."""
+    """The bwrap path must not re-inject host secrets via --setenv, while
+    per-call env overrides still reach the sandbox."""
     monkeypatch.setenv("HUD_API_KEY", "super-secret")
-    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
+    _wall(monkeypatch)
 
     ws = Workspace(tmp_path / "root", shell_uid=1000, env={"CUSTOM": "1"})
     monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
-    argv = ws.shell_argv("echo hi")
+    argv = ws.shell_argv("echo hi", env={"PER_CALL": "1"})
 
     setenv_keys = {argv[i + 1] for i, tok in enumerate(argv) if tok == "--setenv"}
     assert "HUD_API_KEY" not in setenv_keys
     assert "CUSTOM" in setenv_keys and "PATH" in setenv_keys
+    assert "PER_CALL" in setenv_keys
 
 
 def test_bwrap_inherits_host_env_when_not_walled(
@@ -118,11 +133,44 @@ def test_bwrap_inherits_host_env_when_not_walled(
 def test_shell_uid_wraps_sessions_in_setpriv(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(Workspace, "_drops_privileges", lambda self: True)
+    _wall(monkeypatch)
     ws = Workspace(tmp_path / "root", shell_uid=1000)
     argv = ws.shell_argv("echo hi")
-    assert argv[:7] == ["setpriv", "--reuid", "1000", "--regid", "1000", "--clear-groups", "--"]
+    # Absolute path: a bare name would resolve through the session PATH,
+    # which the agent can influence — that lookup happens before the drop.
+    assert argv[:7] == [
+        "/usr/bin/setpriv",
+        "--reuid",
+        "1000",
+        "--regid",
+        "1000",
+        "--clear-groups",
+        "--",
+    ]
     assert "echo hi" in argv
+
+
+@pytest.mark.asyncio
+async def test_wall_hands_preexisting_contents_to_the_dropped_uid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Contents baked in before serve (e.g. a Docker COPY as root) must become
+    editable from the dropped shell, not just the top-level directory."""
+    _wall(monkeypatch)
+    handed: list[str] = []
+    monkeypatch.setattr(os, "lchown", lambda p, u, g: handed.append(os.fsdecode(p)))
+
+    root = tmp_path / "root"
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "mod.py").write_text("x = 1\n")
+
+    ws = Workspace(root, shell_uid=1000)
+    await ws.start()
+    try:
+        names = {Path(p).name for p in handed}
+        assert {"root", "pkg", "mod.py"} <= names
+    finally:
+        await ws.stop()
 
 
 def test_shell_uid_is_a_noop_off_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -176,6 +176,11 @@ async def test_wall_hands_preexisting_contents_to_the_dropped_uid(
     _wall(monkeypatch)
     handed: list[str] = []
     monkeypatch.setattr(os, "lchown", lambda p, u, g: handed.append(os.fsdecode(p)))
+    monkeypatch.setattr(
+        os,
+        "chown",
+        lambda p, u, g, dir_fd=None, follow_symlinks=True: handed.append(os.fsdecode(p)),
+    )
 
     root = tmp_path / "root"
     (root / "pkg").mkdir(parents=True)
@@ -188,6 +193,23 @@ async def test_wall_hands_preexisting_contents_to_the_dropped_uid(
         assert {"root", "pkg", "mod.py"} <= names
     finally:
         await ws.stop()
+
+
+@pytest.mark.asyncio
+async def test_wall_handoff_failure_refuses_to_serve(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A partial ownership handoff silently breaks the workspace contract;
+    the server must fail loudly instead of serving root-owned files."""
+    _wall(monkeypatch)
+
+    def deny(p: object, u: int, g: int) -> None:
+        raise PermissionError("operation not permitted")
+
+    monkeypatch.setattr(os, "lchown", deny)
+    ws = Workspace(tmp_path / "root", shell_uid=1000)
+    with pytest.raises(PermissionError):
+        await ws.start()
 
 
 def test_shell_uid_is_a_noop_off_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -44,10 +44,13 @@ class _PrefixSFTPServer(asyncssh.SFTPServer):
     otherwise resolve to ``<root>/workspace/...`` and fail. Strip the guest
     prefix first so SFTP and bash agree on what ``/workspace`` means.
 
-    SFTP is handled by the serving process itself, so with ``shell_uid`` set
-    (shell sessions dropped to that uid) files created here would otherwise be
-    owned by the server's user and un-editable from the shell; *chown_uid*
-    hands anything this session creates to that uid.
+    SFTP is handled by the serving process itself (as root when ``shell_uid``
+    drops shell sessions), so *chown_uid* hands anything a session creates to
+    that uid — otherwise the files would be root-owned and un-editable from
+    the dropped shell. Under the wall it also refuses paths that resolve
+    outside the workspace: asyncssh's chroot is prefix-based and follows
+    symlinks, so an agent could otherwise create ``link -> /`` and read host
+    files (including the relocated SSH keys) through the root server process.
     """
 
     def __init__(
@@ -68,7 +71,24 @@ class _PrefixSFTPServer(asyncssh.SFTPServer):
                 path = b"/"
             elif path.startswith(self._guest_prefix + b"/"):
                 path = path[len(self._guest_prefix) :]
-        return super().map_path(path)
+        mapped = super().map_path(path)
+        self._ensure_within_chroot(mapped)
+        return mapped
+
+    def _ensure_within_chroot(self, mapped: bytes) -> None:
+        """Reject operations whose real path escapes the workspace.
+
+        Only enforced under the privilege wall (``chown_uid`` set); normal
+        workspaces keep asyncssh's prefix-only chroot so legitimate outward
+        symlinks in a repo still work. This is a best-effort guard, not a
+        kernel boundary — SFTP runs in-process, so a symlink swapped between
+        this check and the syscall is a residual TOCTOU risk.
+        """
+        if self._chown_uid is None or not self._chroot:
+            return
+        real = os.path.realpath(mapped)
+        if real != self._chroot and not real.startswith(self._chroot + b"/"):
+            raise asyncssh.SFTPNoSuchFile("path escapes the workspace")
 
     def _claim(self, real_path: bytes) -> None:
         if self._chown_uid is None:
@@ -438,12 +458,19 @@ class Workspace:
         *,
         cwd: str | None = None,
         env: Mapping[str, str] | None = None,
+        inherit_host_env: bool = True,
     ) -> list[str]:
-        """Argv that runs ``command`` inside bwrap. Raises if bwrap unavailable."""
+        """Argv that runs ``command`` inside bwrap. Raises if bwrap unavailable.
+
+        bwrap ``--clearenv`` then re-injects ``full_env`` via ``--setenv``, so
+        with ``inherit_host_env=False`` the host environment (server secrets)
+        is left out and only ``self.env`` + ``env`` reach the sandbox.
+        """
         if self._bwrap is None:
             raise RuntimeError("bwrap not available on this host")
         target_cwd = cwd if cwd is not None else self._guest_path
-        full_env = {**os.environ, **self.env, **(env or {})}
+        base_env = dict(os.environ) if inherit_host_env else {}
+        full_env = {**base_env, **self.env, **(env or {})}
         argv: list[str] = [
             self._bwrap,
             "--die-with-parent",
@@ -489,7 +516,14 @@ class Workspace:
             return ["cmd.exe"]
         if self._bwrap is not None:
             inner: list[str] | str = ["bash", "-lc", command] if command else ["bash", "-l"]
-            argv = self.bwrap_argv(inner, cwd=cwd, env=env)
+            if self._drops_privileges():
+                # Don't let bwrap re-inject host secrets via --setenv; feed it
+                # the same minimal environment as the non-bwrap dropped shell.
+                argv = self.bwrap_argv(
+                    inner, cwd=cwd, env=self._session_env() or {}, inherit_host_env=False
+                )
+            else:
+                argv = self.bwrap_argv(inner, cwd=cwd, env=env)
         elif command is not None:
             argv = ["bash", "-lc", command]
         else:

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -218,16 +218,20 @@ class Workspace:
         if self._drops_privileges():
             # The workspace is the agent's surface: hand the whole tree to the
             # dropped uid, or contents baked in as root (e.g. a Docker COPY)
-            # stay un-editable from the dropped shell. lchown so an in-tree
-            # symlink can't redirect the chown outside the workspace.
+            # stay un-editable from the dropped shell. fwalk + dir_fd-relative
+            # no-follow chown is the kernel boundary: a symlink swapped in
+            # mid-walk can't redirect ownership outside the workspace. Failures
+            # raise — a partial handoff would silently break the documented
+            # guarantee that the agent can edit its workspace.
             assert self._shell_uid is not None
             uid = self._shell_uid
-            with contextlib.suppress(OSError):
-                os.lchown(self.root, uid, uid)
-            for dirpath, dirnames, filenames in os.walk(self.root):
+            os.lchown(self.root, uid, uid)
+            for _dirpath, dirnames, filenames, dirfd in os.fwalk(self.root):
                 for entry in (*dirnames, *filenames):
-                    with contextlib.suppress(OSError):
-                        os.lchown(os.path.join(dirpath, entry), uid, uid)
+                    # A concurrent session may unlink entries mid-walk; a
+                    # vanished path needs no handoff.
+                    with contextlib.suppress(FileNotFoundError):
+                        os.chown(entry, uid, uid, dir_fd=dirfd, follow_symlinks=False)
         self._host_key, self._host_pubkey_str = self._load_or_generate_host_key()
         self._authorized_keys_path = self._ensure_authorized_keys_file()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -9,9 +9,10 @@ import os
 import shutil
 import socket
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import asyncssh
 
@@ -30,6 +31,10 @@ LOGGER = logging.getLogger("hud.environment.workspace")
 _warned_no_bwrap = False
 
 
+def _serving_as_root() -> bool:
+    return sys.platform != "win32" and hasattr(os, "geteuid") and os.geteuid() == 0
+
+
 class _PrefixSFTPServer(asyncssh.SFTPServer):
     """Chroot SFTP whose root is also addressable as the guest mount path.
 
@@ -38,13 +43,24 @@ class _PrefixSFTPServer(asyncssh.SFTPServer):
     The chroot already makes the root ``/``, so a leading ``/workspace`` would
     otherwise resolve to ``<root>/workspace/...`` and fail. Strip the guest
     prefix first so SFTP and bash agree on what ``/workspace`` means.
+
+    SFTP is handled by the serving process itself, so with ``shell_uid`` set
+    (shell sessions dropped to that uid) files created here would otherwise be
+    owned by the server's user and un-editable from the shell; *chown_uid*
+    hands anything this session creates to that uid.
     """
 
     def __init__(
-        self, chan: asyncssh.SSHServerChannel[bytes], *, chroot: bytes, guest_prefix: bytes
+        self,
+        chan: asyncssh.SSHServerChannel[bytes],
+        *,
+        chroot: bytes,
+        guest_prefix: bytes,
+        chown_uid: int | None = None,
     ) -> None:
         super().__init__(chan, chroot=chroot)
         self._guest_prefix = guest_prefix.rstrip(b"/")
+        self._chown_uid = chown_uid
 
     def map_path(self, path: bytes) -> bytes:
         if self._guest_prefix and self._guest_prefix not in (b"", b"/"):
@@ -53,6 +69,26 @@ class _PrefixSFTPServer(asyncssh.SFTPServer):
             elif path.startswith(self._guest_prefix + b"/"):
                 path = path[len(self._guest_prefix) :]
         return super().map_path(path)
+
+    def _claim(self, real_path: bytes) -> None:
+        if self._chown_uid is None:
+            return
+        # Best-effort: chown needs root; without it the file already belongs
+        # to the (non-dropped) session user anyway.
+        with contextlib.suppress(OSError):
+            os.chown(real_path, self._chown_uid, self._chown_uid)
+
+    def open(self, path: bytes, pflags: int, attrs: asyncssh.SFTPAttrs) -> Any:
+        real_path = self.map_path(path)
+        created = not os.path.lexists(real_path)
+        result = super().open(path, pflags, attrs)
+        if created and os.path.lexists(real_path):
+            self._claim(real_path)
+        return result
+
+    def mkdir(self, path: bytes, attrs: asyncssh.SFTPAttrs) -> None:
+        super().mkdir(path, attrs)
+        self._claim(self.map_path(path))
 
 
 # ─────────────────────────── mount declarations ───────────────────────────
@@ -116,6 +152,11 @@ class Workspace:
     data — keys, sockets, and the root directory materialize only at serve
     time. Drive it directly (``start()`` / :meth:`capability` / ``stop()``)
     to publish the capability yourself.
+
+    ``shell_uid`` drops agent sessions to that uid when the serving process
+    is root (``setpriv`` for shell sessions; SFTP-created files are chowned
+    to it) — the privilege wall for substrates where bwrap is unavailable and
+    the env process holds secrets the agent must not read. No-op off root.
     """
 
     def __init__(
@@ -135,6 +176,7 @@ class Workspace:
         host_key_path: Path | None = None,
         authorized_client_keys: list[Path] | None = None,
         track_files: bool = False,
+        shell_uid: int | None = None,
     ) -> None:
         self.root: Path = Path(root).resolve()
         # Unique id for this instance's credential subdirectory so parallel
@@ -164,6 +206,7 @@ class Workspace:
         self._ssh_host = host
         self._ssh_port = port
         self._ssh_user = user
+        self._shell_uid = shell_uid
         self._ssh_host_key_path = host_key_path
         self._ssh_authorized_client_keys = list(authorized_client_keys or [])
         self._acceptor: asyncssh.SSHAcceptor | None = None
@@ -288,7 +331,9 @@ class Workspace:
         self._sock = None
         self._bound_host = None
         self._bound_port = None
-        shutil.rmtree(self.root / ".hud" / "ssh" / self._cred_id, ignore_errors=True)
+        shutil.rmtree(
+            Path(tempfile.gettempdir()) / "hud-workspace-creds" / self._cred_id, ignore_errors=True
+        )
 
     # ─── ssh accessors / capability ───────────────────────────────────
 
@@ -406,23 +451,37 @@ class Workspace:
         cwd: str | None = None,
         env: Mapping[str, str] | None = None,
     ) -> list[str]:
-        """Per-session shell argv (bwrap'd if available, else host shell)."""
-        if self._bwrap is not None:
-            inner: list[str] | str = ["bash", "-lc", command] if command else ["bash", "-l"]
-            return self.bwrap_argv(inner, cwd=cwd, env=env)
+        """Per-session shell argv (bwrap'd if available, else host shell).
+
+        With ``shell_uid`` set and the serving process running as root, the
+        whole session is wrapped in ``setpriv`` to drop to that uid.
+        """
         if sys.platform == "win32":
             if command is not None:
                 return ["cmd.exe", "/c", command]
             return ["cmd.exe"]
-        if command is not None:
-            return ["bash", "-lc", command]
-        return ["bash", "-l"]
+        if self._bwrap is not None:
+            inner: list[str] | str = ["bash", "-lc", command] if command else ["bash", "-l"]
+            argv = self.bwrap_argv(inner, cwd=cwd, env=env)
+        elif command is not None:
+            argv = ["bash", "-lc", command]
+        else:
+            argv = ["bash", "-l"]
+        if self._shell_uid is not None and _serving_as_root():
+            uid = str(self._shell_uid)
+            argv = ["setpriv", "--reuid", uid, "--regid", uid, "--clear-groups", "--", *argv]
+        return argv
 
     # ─── ssh server internals ─────────────────────────────────────────
 
     def _credentials_dir(self) -> Path:
-        d = self.root / ".hud" / "ssh" / self._cred_id
+        """Key material lives outside the served root: the root is the agent's
+        surface (shell cwd, SFTP chroot, diff tracking), so secrets don't
+        belong in it."""
+        d = Path(tempfile.gettempdir()) / "hud-workspace-creds" / self._cred_id
         d.mkdir(parents=True, exist_ok=True)
+        with contextlib.suppress(OSError):
+            os.chmod(d, 0o700)
         return d
 
     def _load_or_generate_host_key(self) -> tuple[asyncssh.SSHKey, str]:
@@ -573,6 +632,7 @@ class Workspace:
             chan,
             chroot=str(self.root).encode(),
             guest_prefix=self._guest_path.encode(),
+            chown_uid=self._shell_uid if _serving_as_root() else None,
         )
 
 

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -467,6 +467,13 @@ class Workspace:
         else:
             argv = ["bash", "-l"]
         if self._drops_privileges():
+            if self._bwrap is None:
+                # The session env (self.env + per-call overrides) is injected
+                # only *after* the drop: vars like LD_PRELOAD in it must never
+                # be in the environment of the root-run setpriv itself.
+                session = {**(self._session_env() or {}), **(env or {})}
+                env_bin = shutil.which("env") or "/usr/bin/env"
+                argv = [env_bin, "-i", *[f"{k}={v}" for k, v in session.items()], *argv]
             setpriv = self._setpriv()
             assert setpriv is not None  # guaranteed by _drops_privileges
             uid = str(self._shell_uid)
@@ -522,13 +529,14 @@ class Workspace:
         return auth_path
 
     def _session_env(self) -> dict[str, str] | None:
-        """Environment for a shell session (non-bwrap path).
+        """Environment the agent's shell session sees.
 
         When dropping privileges, the child would otherwise inherit the
         server's full environment — including any secrets the env process
         holds (the reason ``shell_uid`` exists) — so build a minimal, safe
-        environment from scratch. Otherwise preserve the inherited-env
-        behavior, layering ``self.env`` overrides.
+        environment from scratch. It reaches the shell only *after* the drop
+        (``env -i`` inside setpriv, or bwrap ``--setenv``). Otherwise preserve
+        the inherited-env behavior, layering ``self.env`` overrides.
         """
         if self._drops_privileges():
             base = {
@@ -543,7 +551,15 @@ class Workspace:
 
     async def _handle_process(self, process: asyncssh.SSHServerProcess[bytes]) -> None:
         argv = self.shell_argv(process.command)
-        proc_env = self._session_env()
+        if self._drops_privileges():
+            # The pre-drop processes (setpriv, bwrap) run as root; caller env
+            # like an LD_PRELOAD in self.env must not load into them. The
+            # session env is injected after the drop by shell_argv.
+            proc_env: dict[str, str] | None = {
+                "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+            }
+        else:
+            proc_env = self._session_env()
 
         if sys.platform == "win32":
             # On Windows, asyncio.create_subprocess_exec uses the ProactorEventLoop's

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -477,7 +477,20 @@ class Workspace:
             setpriv = self._setpriv()
             assert setpriv is not None  # guaranteed by _drops_privileges
             uid = str(self._shell_uid)
-            argv = [setpriv, "--reuid", uid, "--regid", uid, "--clear-groups", "--", *argv]
+            # --no-new-privs: without it a setuid binary (or passwordless
+            # sudo) inside the workspace would let the dropped shell regain
+            # root and read the secrets the wall protects.
+            argv = [
+                setpriv,
+                "--reuid",
+                uid,
+                "--regid",
+                uid,
+                "--clear-groups",
+                "--no-new-privs",
+                "--",
+                *argv,
+            ]
         return argv
 
     # ─── ssh server internals ─────────────────────────────────────────

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger("hud.environment.workspace")
 _warned_no_bwrap = False
 
 
-def _serving_as_root() -> bool:
+def _is_root() -> bool:
     return sys.platform != "win32" and hasattr(os, "geteuid") and os.geteuid() == 0
 
 
@@ -179,9 +179,8 @@ class Workspace:
         shell_uid: int | None = None,
     ) -> None:
         self.root: Path = Path(root).resolve()
-        # Unique id for this instance's credential subdirectory so parallel
-        # Workspace objects sharing the same root don't race on key generation.
-        self._cred_id = os.urandom(8).hex()
+        # Per-instance credential dir, materialized lazily (see _credentials_dir).
+        self._cred_dir: Path | None = None
 
         # Path the root is mounted at inside the sandbox (and the default cwd).
         # Defaults to /workspace; set to the root's real path for callers that
@@ -226,10 +225,31 @@ class Workspace:
         self._ft_host: str | None = None
         self._ft_port: int | None = None
 
+    def _drops_privileges(self) -> bool:
+        """Whether sessions are dropped to ``shell_uid`` on this host.
+
+        Only when serving as root on Linux with ``setpriv`` present —
+        ``setpriv`` is a util-linux command and the drop is meaningless off
+        root. Off root the option is a documented no-op.
+        """
+        return (
+            self._shell_uid is not None
+            and _is_root()
+            and sys.platform == "linux"
+            and shutil.which("setpriv") is not None
+        )
+
     def _prepare_runtime(self) -> None:
         """Materialize filesystem credentials and bind the SSH socket."""
         if self._sock is not None:
             return
+        if self._shell_uid is not None and _is_root() and not self._drops_privileges():
+            # Fail closed: serving as root while unable to drop would run every
+            # agent shell as root, exactly what shell_uid exists to prevent.
+            raise RuntimeError(
+                "shell_uid is set and the server is root, but privileges cannot be dropped "
+                "(setpriv is required on Linux). Refusing to serve agent shells as root."
+            )
         if self._bwrap is None and sys.platform != "win32":
             # Once per process: repeating this for every Workspace is noise, and
             # on macOS (no bubblewrap exists) it is an expected state.
@@ -242,6 +262,13 @@ class Workspace:
                     "Install bubblewrap, or run inside a Linux container that has it.",
                 )
         self.root.mkdir(parents=True, exist_ok=True)
+        if self._drops_privileges():
+            # The dropped uid must be able to create entries in its own
+            # workspace; the root is otherwise owned by root:root at 0755.
+            # Non-recursive: pre-existing contents are the caller's to own.
+            assert self._shell_uid is not None
+            with contextlib.suppress(OSError):
+                os.chown(self.root, self._shell_uid, self._shell_uid)
         self._host_key, self._host_pubkey_str = self._load_or_generate_host_key()
         self._authorized_keys_path = self._ensure_authorized_keys_file()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -331,9 +358,9 @@ class Workspace:
         self._sock = None
         self._bound_host = None
         self._bound_port = None
-        shutil.rmtree(
-            Path(tempfile.gettempdir()) / "hud-workspace-creds" / self._cred_id, ignore_errors=True
-        )
+        if self._cred_dir is not None:
+            shutil.rmtree(self._cred_dir, ignore_errors=True)
+            self._cred_dir = None
 
     # ─── ssh accessors / capability ───────────────────────────────────
 
@@ -467,7 +494,7 @@ class Workspace:
             argv = ["bash", "-lc", command]
         else:
             argv = ["bash", "-l"]
-        if self._shell_uid is not None and _serving_as_root():
+        if self._drops_privileges():
             uid = str(self._shell_uid)
             argv = ["setpriv", "--reuid", uid, "--regid", uid, "--clear-groups", "--", *argv]
         return argv
@@ -477,12 +504,15 @@ class Workspace:
     def _credentials_dir(self) -> Path:
         """Key material lives outside the served root: the root is the agent's
         surface (shell cwd, SFTP chroot, diff tracking), so secrets don't
-        belong in it."""
-        d = Path(tempfile.gettempdir()) / "hud-workspace-creds" / self._cred_id
-        d.mkdir(parents=True, exist_ok=True)
-        with contextlib.suppress(OSError):
-            os.chmod(d, 0o700)
-        return d
+        belong in it.
+
+        ``mkdtemp`` creates a fresh 0700 directory with an unpredictable name
+        atomically, so a local user can't pre-place a symlink at the path to
+        redirect the private keys the server writes here.
+        """
+        if self._cred_dir is None:
+            self._cred_dir = Path(tempfile.mkdtemp(prefix="hud-workspace-creds-"))
+        return self._cred_dir
 
     def _load_or_generate_host_key(self) -> tuple[asyncssh.SSHKey, str]:
         if self._ssh_host_key_path is not None:
@@ -518,11 +548,27 @@ class Workspace:
         auth_path.write_text("\n".join(pub_lines) + "\n", encoding="ascii")
         return auth_path
 
+    def _session_env(self) -> dict[str, str] | None:
+        """Environment for a shell session (non-bwrap path).
+
+        When dropping privileges, the child would otherwise inherit the
+        server's full environment — including any secrets the env process
+        holds (the reason ``shell_uid`` exists) — so build a minimal, safe
+        environment from scratch. Otherwise preserve the inherited-env
+        behavior, layering ``self.env`` overrides.
+        """
+        if self._drops_privileges():
+            base = {
+                "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+                "HOME": os.environ.get("HOME", "/tmp"),  # noqa: S108 - overridden by self.env
+                "TERM": os.environ.get("TERM", "xterm"),
+            }
+            return {**base, **self.env}
+        return {**os.environ, **self.env} if self.env else None
+
     async def _handle_process(self, process: asyncssh.SSHServerProcess[bytes]) -> None:
         argv = self.shell_argv(process.command)
-        # Merge workspace env overrides so callers can inject PATH / env vars even
-        # when bwrap is unavailable (bwrap_argv handles this itself via --setenv).
-        proc_env: dict[str, str] | None = {**os.environ, **self.env} if self.env else None
+        proc_env = self._session_env()
 
         if sys.platform == "win32":
             # On Windows, asyncio.create_subprocess_exec uses the ProactorEventLoop's
@@ -632,7 +678,7 @@ class Workspace:
             chan,
             chroot=str(self.root).encode(),
             guest_prefix=self._guest_path.encode(),
-            chown_uid=self._shell_uid if _serving_as_root() else None,
+            chown_uid=self._shell_uid if self._drops_privileges() else None,
         )
 
 

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -1,4 +1,4 @@
-"""Workspace: a directory + bwrap-isolated SSH server (bash + SFTP chroot)."""
+"""Workspace: a directory + bwrap-isolated SSH server."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 import asyncssh
 
@@ -33,82 +33,6 @@ _warned_no_bwrap = False
 
 def _is_root() -> bool:
     return sys.platform != "win32" and hasattr(os, "geteuid") and os.geteuid() == 0
-
-
-class _PrefixSFTPServer(asyncssh.SFTPServer):
-    """Chroot SFTP whose root is also addressable as the guest mount path.
-
-    ``bash`` runs at the guest mount (``/workspace`` via bwrap on Linux, or the
-    root dir on Windows), so agents naturally write to ``/workspace/env.py``.
-    The chroot already makes the root ``/``, so a leading ``/workspace`` would
-    otherwise resolve to ``<root>/workspace/...`` and fail. Strip the guest
-    prefix first so SFTP and bash agree on what ``/workspace`` means.
-
-    SFTP is handled by the serving process itself (as root when ``shell_uid``
-    drops shell sessions), so *chown_uid* hands anything a session creates to
-    that uid — otherwise the files would be root-owned and un-editable from
-    the dropped shell. Under the wall it also refuses paths that resolve
-    outside the workspace: asyncssh's chroot is prefix-based and follows
-    symlinks, so an agent could otherwise create ``link -> /`` and read host
-    files (including the relocated SSH keys) through the root server process.
-    """
-
-    def __init__(
-        self,
-        chan: asyncssh.SSHServerChannel[bytes],
-        *,
-        chroot: bytes,
-        guest_prefix: bytes,
-        chown_uid: int | None = None,
-    ) -> None:
-        super().__init__(chan, chroot=chroot)
-        self._guest_prefix = guest_prefix.rstrip(b"/")
-        self._chown_uid = chown_uid
-
-    def map_path(self, path: bytes) -> bytes:
-        if self._guest_prefix and self._guest_prefix not in (b"", b"/"):
-            if path == self._guest_prefix:
-                path = b"/"
-            elif path.startswith(self._guest_prefix + b"/"):
-                path = path[len(self._guest_prefix) :]
-        mapped = super().map_path(path)
-        self._ensure_within_chroot(mapped)
-        return mapped
-
-    def _ensure_within_chroot(self, mapped: bytes) -> None:
-        """Reject operations whose real path escapes the workspace.
-
-        Only enforced under the privilege wall (``chown_uid`` set); normal
-        workspaces keep asyncssh's prefix-only chroot so legitimate outward
-        symlinks in a repo still work. This is a best-effort guard, not a
-        kernel boundary — SFTP runs in-process, so a symlink swapped between
-        this check and the syscall is a residual TOCTOU risk.
-        """
-        if self._chown_uid is None or not self._chroot:
-            return
-        real = os.path.realpath(mapped)
-        if real != self._chroot and not real.startswith(self._chroot + b"/"):
-            raise asyncssh.SFTPNoSuchFile("path escapes the workspace")
-
-    def _claim(self, real_path: bytes) -> None:
-        if self._chown_uid is None:
-            return
-        # Best-effort: chown needs root; without it the file already belongs
-        # to the (non-dropped) session user anyway.
-        with contextlib.suppress(OSError):
-            os.chown(real_path, self._chown_uid, self._chown_uid)
-
-    def open(self, path: bytes, pflags: int, attrs: asyncssh.SFTPAttrs) -> Any:
-        real_path = self.map_path(path)
-        created = not os.path.lexists(real_path)
-        result = super().open(path, pflags, attrs)
-        if created and os.path.lexists(real_path):
-            self._claim(real_path)
-        return result
-
-    def mkdir(self, path: bytes, attrs: asyncssh.SFTPAttrs) -> None:
-        super().mkdir(path, attrs)
-        self._claim(self.map_path(path))
 
 
 # ─────────────────────────── mount declarations ───────────────────────────
@@ -164,7 +88,7 @@ _DEFAULT_USER = "agent"
 
 
 class Workspace:
-    """Directory + bwrap-isolated SSH (bash + chroot'd SFTP).
+    """Directory + bwrap-isolated SSH.
 
     The standard shell daemon: ``env.workspace(root)`` attaches one to an
     :class:`~hud.environment.Environment`, which starts it and publishes its
@@ -173,10 +97,10 @@ class Workspace:
     time. Drive it directly (``start()`` / :meth:`capability` / ``stop()``)
     to publish the capability yourself.
 
-    ``shell_uid`` drops agent sessions to that uid when the serving process
-    is root (``setpriv`` for shell sessions; SFTP-created files are chowned
-    to it) — the privilege wall for substrates where bwrap is unavailable and
-    the env process holds secrets the agent must not read. No-op off root.
+    ``shell_uid`` drops agent sessions to that uid with ``setpriv`` when the
+    serving process is root — the privilege wall for substrates where bwrap
+    is unavailable and the env process holds secrets the agent must not read.
+    No-op off root.
     """
 
     def __init__(
@@ -217,8 +141,8 @@ class Workspace:
         self._bwrap = shutil.which("bwrap")
         # Without bwrap there is no `/workspace` mount — the sandbox *is* the real
         # directory, so address it by its real path. Otherwise `cd /workspace`
-        # lands in a phantom dir and the editor/SFTP/bash disagree on where files
-        # are. Only override the default; respect an explicit guest_path.
+        # lands in a phantom dir and the editor/bash disagree on where files are.
+        # Only override the default; respect an explicit guest_path.
         if self._bwrap is None and guest_path == "/workspace":
             self._guest_path = self.root.as_posix()
         # ssh config
@@ -316,8 +240,6 @@ class Workspace:
             server_host_keys=[self._host_key],
             authorized_client_keys=str(self._authorized_keys_path),
             process_factory=self._handle_process,
-            sftp_factory=self._sftp_factory,
-            allow_scp=True,
             line_editor=False,
             keepalive_interval=30,
             encoding=None,
@@ -537,8 +459,7 @@ class Workspace:
 
     def _credentials_dir(self) -> Path:
         """Key material lives outside the served root: the root is the agent's
-        surface (shell cwd, SFTP chroot, diff tracking), so secrets don't
-        belong in it.
+        shell cwd and diff-tracking surface, so secrets don't belong in it.
 
         ``mkdtemp`` creates a fresh 0700 directory with an unpredictable name
         atomically, so a local user can't pre-place a symlink at the path to
@@ -691,29 +612,57 @@ class Workspace:
             process.exit(127)
             return
 
+        stdin = sub.process.stdin
+        stdout = sub.stdout
+        stderr = sub.stderr
+        assert stdin is not None
+        assert stdout is not None
+        assert stderr is not None
+
+        async def relay_stdin() -> None:
+            try:
+                while chunk := await process.stdin.read(65536):
+                    stdin.write(chunk)
+                    await stdin.drain()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+            finally:
+                stdin.close()
+
+        stdin_task = asyncio.create_task(relay_stdin())
+        stdout_task = asyncio.create_task(stdout.read())
+        stderr_task = asyncio.create_task(stderr.read())
         try:
-            stdout_data, stderr_data = await sub.communicate(
-                input=None,
-                max_wait=3600.0,
-            )
+            async with asyncio.timeout(3600.0):
+                _, stdout_data, stderr_data = await asyncio.gather(
+                    sub.wait(),
+                    stdout_task,
+                    stderr_task,
+                )
+            await sub.terminate()
+            stdin_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stdin_task
         except TimeoutError:
+            await sub.terminate()
+            stdin_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stdin_task
             process.stderr.write(b"workspace: command timed out after 3600s\n")
             process.exit(1)
             return
+        except BaseException:
+            await sub.terminate()
+            stdin_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stdin_task
+            raise
 
         if stdout_data:
             process.stdout.write(stdout_data)
         if stderr_data:
             process.stderr.write(stderr_data)
         process.exit(sub.returncode if sub.returncode is not None else 0)
-
-    def _sftp_factory(self, chan: asyncssh.SSHServerChannel[bytes]) -> asyncssh.SFTPServer:
-        return _PrefixSFTPServer(
-            chan,
-            chroot=str(self.root).encode(),
-            guest_prefix=self._guest_path.encode(),
-            chown_uid=self._shell_uid if self._drops_privileges() else None,
-        )
 
 
 __all__ = [

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -169,6 +169,15 @@ class Workspace:
         self._ft_host: str | None = None
         self._ft_port: int | None = None
 
+    def _setpriv(self) -> str | None:
+        """Absolute path to ``setpriv``, resolved via the *server's* PATH.
+
+        Sessions must exec it by absolute path: session env can carry an
+        agent-writable PATH, and a bare name resolved through it would run
+        an agent-planted binary as root before the drop happens.
+        """
+        return shutil.which("setpriv")
+
     def _drops_privileges(self) -> bool:
         """Whether sessions are dropped to ``shell_uid`` on this host.
 
@@ -180,7 +189,7 @@ class Workspace:
             self._shell_uid is not None
             and _is_root()
             and sys.platform == "linux"
-            and shutil.which("setpriv") is not None
+            and self._setpriv() is not None
         )
 
     def _prepare_runtime(self) -> None:
@@ -207,12 +216,18 @@ class Workspace:
                 )
         self.root.mkdir(parents=True, exist_ok=True)
         if self._drops_privileges():
-            # The dropped uid must be able to create entries in its own
-            # workspace; the root is otherwise owned by root:root at 0755.
-            # Non-recursive: pre-existing contents are the caller's to own.
+            # The workspace is the agent's surface: hand the whole tree to the
+            # dropped uid, or contents baked in as root (e.g. a Docker COPY)
+            # stay un-editable from the dropped shell. lchown so an in-tree
+            # symlink can't redirect the chown outside the workspace.
             assert self._shell_uid is not None
+            uid = self._shell_uid
             with contextlib.suppress(OSError):
-                os.chown(self.root, self._shell_uid, self._shell_uid)
+                os.lchown(self.root, uid, uid)
+            for dirpath, dirnames, filenames in os.walk(self.root):
+                for entry in (*dirnames, *filenames):
+                    with contextlib.suppress(OSError):
+                        os.lchown(os.path.join(dirpath, entry), uid, uid)
         self._host_key, self._host_pubkey_str = self._load_or_generate_host_key()
         self._authorized_keys_path = self._ensure_authorized_keys_file()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -349,6 +364,7 @@ class Workspace:
             host_pubkey=self.ssh_host_pubkey,
             client_key=key_path.read_text() if key_path else None,
             client_key_path=key_path,
+            cwd=self._guest_path,
         )
 
     @property
@@ -440,10 +456,10 @@ class Workspace:
             inner: list[str] | str = ["bash", "-lc", command] if command else ["bash", "-l"]
             if self._drops_privileges():
                 # Don't let bwrap re-inject host secrets via --setenv; feed it
-                # the same minimal environment as the non-bwrap dropped shell.
-                argv = self.bwrap_argv(
-                    inner, cwd=cwd, env=self._session_env() or {}, inherit_host_env=False
-                )
+                # the same minimal environment as the non-bwrap dropped shell,
+                # keeping explicit per-call overrides.
+                walled_env = {**(self._session_env() or {}), **(env or {})}
+                argv = self.bwrap_argv(inner, cwd=cwd, env=walled_env, inherit_host_env=False)
             else:
                 argv = self.bwrap_argv(inner, cwd=cwd, env=env)
         elif command is not None:
@@ -451,8 +467,10 @@ class Workspace:
         else:
             argv = ["bash", "-l"]
         if self._drops_privileges():
+            setpriv = self._setpriv()
+            assert setpriv is not None  # guaranteed by _drops_privileges
             uid = str(self._shell_uid)
-            argv = ["setpriv", "--reuid", uid, "--regid", uid, "--clear-groups", "--", *argv]
+            argv = [setpriv, "--reuid", uid, "--regid", uid, "--clear-groups", "--", *argv]
         return argv
 
     # ─── ssh server internals ─────────────────────────────────────────
@@ -515,7 +533,9 @@ class Workspace:
         if self._drops_privileges():
             base = {
                 "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
-                "HOME": os.environ.get("HOME", "/tmp"),  # noqa: S108 - overridden by self.env
+                # The server's HOME (/root) is unreadable by the dropped uid;
+                # the workspace is the one directory guaranteed writable.
+                "HOME": self._guest_path,
                 "TERM": os.environ.get("TERM", "xterm"),
             }
             return {**base, **self.env}

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.9"
+    assert hud.__version__ == "0.6.10"


### PR DESCRIPTION
## Summary
- `Workspace(shell_uid=...)`: a built-in privilege wall for substrates without bwrap. When the serving process is root, agent sessions are wrapped in `setpriv --reuid/--regid/--clear-groups` and get a minimal env (no host secrets); serving as root without a working drop fails closed. No-op off root; composes with bwrap; flows through `env.workspace(root, shell_uid=...)`.
- Workspace SSH credentials move out of the served root (`<root>/.hud/ssh/...`) into a private `tempdir/hud-workspace-creds/<id>` (mode 700, removed on `stop()`). The root is the agent's surface — shell cwd, file-tracking scan — so key material and `.hud` noise no longer live in it.
- The workspace no longer serves SFTP or SCP. SFTP ran in the serving process (as root under the wall), which needed chown hand-offs and a best-effort symlink guard with a residual TOCTOU. All file I/O now rides the already-dropped exec channel instead: `SSHClient` gains `read_text` / `write_text` / `listdir` exec helpers, and the Claude SDK harness and provider editor tools use them. The exec handler relays session stdin so `cat > file` writes work.

Replaces the `setpriv` subclass that coding envs (e.g. `hud-evals/coding-template`) have been copy-pasting, and deletes the SFTP security surface that subclass never covered.

## Test plan
- [x] `hud/environment/tests/test_workspace.py`: real asyncssh sessions verify credentials live outside the root (and auth still works), the SFTP subsystem is refused, file ops round-trip over the exec channel, dropped sessions exclude host secrets, setpriv wrapping on/off root, fail-closed on root without a working drop.
- [x] Claude SDK harness and provider-native tool tests updated to the exec-channel writes.
- [x] Full suite 687 passed; ruff + pyright clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large security-sensitive changes to workspace isolation, privilege dropping, and all agent file I/O over SSH; behavior must stay compatible with prior chroot/SFTP path semantics.
> 
> **Overview**
> **Workspace SSH is exec-only** — SFTP/SCP are dropped; shell and file I/O share the exec channel. SSH keys live in a private temp dir outside the served root, and optional **`shell_uid`** drops agent sessions via `setpriv` when the server runs as root (minimal env, fail-closed if drop isn’t possible).
> 
> **Harness file access moves to `SSHClient`** — new **`read_text` / `write_text` / `listdir`** and **`map_path`** (workspace `cwd` on the capability) preserve the old chroot-style paths. **`SSHTool`**, Claude SDK, and OpenAI-compatible filesystem tools use these instead of SFTP; the workspace relays session stdin so **`cat >`** writes work.
> 
> Docs and **`Capability.ssh(..., cwd=...)`** are updated; version **0.6.10**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25337480cdfe0d43586944426485afc4df1a6b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->