### PR TITLE
Track scenario setup file changes

### DIFF
--- a/hud/environment/env.py
+++ b/hud/environment/env.py
@@ -284,7 +284,7 @@ class Environment(LegacyEnvMixin):
 
         When ``track_files`` is set (defaulting to ``HUD_FILE_TRACKING_ENABLED``)
         the workspace also publishes an observation-only ``filetracking/1``
-        capability the rollout streams diffs from.
+        capability the rollout streams setup and agent diffs from.
         """
         if track_files is None:
             from hud.settings import settings

--- a/hud/environment/file_tracker.py
+++ b/hud/environment/file_tracker.py
@@ -149,6 +149,8 @@ class PatchEntry:
     patch: str  # unified diff text (placeholder for binary/redacted/over-limit)
     size_before: int = 0
     size_after: int = 0
+    content_hash_before: str | None = None
+    content_hash_after: str | None = None
 
 
 @dataclass
@@ -180,6 +182,8 @@ class DiffResult:
                     "patch": p.patch,
                     "size_before": p.size_before,
                     "size_after": p.size_after,
+                    "content_hash_before": p.content_hash_before,
+                    "content_hash_after": p.content_hash_after,
                 }
                 for p in self.patches
             ],
@@ -265,20 +269,25 @@ class FileTracker:
         )
         return snapshot
 
-    def advance_baseline(self) -> None:
-        """Re-scan and update the tracking baseline WITHOUT producing a diff.
-
-        Used after scenario setup (which writes many files that are not agent
-        edits), so subsequent diffs and final artifact capture start clean.
-        """
-        prev_count = len(self._previous_snapshot.files) if self._previous_snapshot else 0
-        snapshot = self._scan()
-        self._baseline_snapshot = snapshot
-        self._previous_snapshot = snapshot
-        if len(snapshot.files) != prev_count:
-            LOGGER.info(
-                "file diff baseline advanced: %d files (was %d)", len(snapshot.files), prev_count
+    def take_setup_snapshot(self) -> DiffResult:
+        """Capture setup changes and establish the agent-edit baseline."""
+        if self._previous_snapshot is None:
+            baseline = self.take_baseline()
+            return DiffResult(
+                patches=[],
+                snapshot_timestamp=baseline.timestamp,
+                scan_duration_ms=baseline.scan_duration_ms,
+                files_scanned=len(baseline.files),
+                files_changed=0,
             )
+
+        current = self._scan()
+        diff = self._diff(self._previous_snapshot, current)
+        # Setup and agent edits are separate layers. Even when the setup diff is
+        # capped, agent tracking must start from the complete post-setup state.
+        self._baseline_snapshot = current
+        self._previous_snapshot = current
+        return diff
 
     def take_snapshot(self) -> DiffResult:
         """Scan and diff against the previous snapshot, then advance the baseline."""
@@ -408,7 +417,7 @@ class FileTracker:
             payload["truncated"] = True
         return payload
 
-    def _capture_file(self, status: str, entry: FileEntry) -> dict[str, Any] | None:
+    def _capture_file(self, status: str | None, entry: FileEntry) -> dict[str, Any] | None:
         raw_path = self._root / entry.rel_path
         try:
             if raw_path.is_symlink():
@@ -425,27 +434,45 @@ class FileTracker:
         try:
             if not path.is_file():
                 return None
-            stat = path.stat()
-            if stat.st_size != entry.size or stat.st_size > self._MAX_CAPTURE_FILE_BYTES:
+            stat_before = path.stat()
+            if (
+                stat_before.st_size != entry.size
+                or stat_before.st_mtime_ns != entry.mtime_ns
+                or stat_before.st_size > self._MAX_CAPTURE_FILE_BYTES
+            ):
                 return None
             with path.open("rb") as f:
                 data = f.read()
+                stat_after = os.fstat(f.fileno())
         except (PermissionError, OSError):
             return None
 
-        if len(data) != entry.size:
+        if (
+            len(data) != entry.size
+            or stat_after.st_size != entry.size
+            or stat_after.st_mtime_ns != entry.mtime_ns
+            or stat_after.st_dev != stat_before.st_dev
+            or stat_after.st_ino != stat_before.st_ino
+        ):
+            return None
+
+        content_hash = hashlib.sha256(data).hexdigest()
+        if len(entry.content_hash) == 64 and content_hash != entry.content_hash:
             return None
 
         suffix = PurePosixPath(entry.rel_path).suffix.lower()
-        content_type = CAPTURE_CONTENT_TYPES.get(
-            suffix,
-            mimetypes.guess_type(entry.rel_path)[0] or "application/octet-stream",
-        )
-        return {
+        content_type = CAPTURE_CONTENT_TYPES.get(suffix) or mimetypes.guess_type(entry.rel_path)[0]
+        if content_type is None:
+            try:
+                data.decode("utf-8")
+            except UnicodeDecodeError:
+                content_type = "application/octet-stream"
+            else:
+                content_type = "text/plain" if b"\x00" not in data else "application/octet-stream"
+        result: dict[str, Any] = {
             "path": entry.rel_path,
-            "status": status,
             "size": entry.size,
-            "content_hash": hashlib.sha256(data).hexdigest(),
+            "content_hash": content_hash,
             "content_type": content_type,
             "file": {
                 "type": "file",
@@ -453,6 +480,9 @@ class FileTracker:
                 "media_type": content_type,
             },
         }
+        if status is not None:
+            result["status"] = status
+        return result
 
     # ─── scanning ─────────────────────────────────────────────────────
 
@@ -670,6 +700,8 @@ class FileTracker:
                     patch=patch_text,
                     size_before=size_before,
                     size_after=size_after,
+                    content_hash_before=old_entry.content_hash if old_entry else None,
+                    content_hash_after=new_entry.content_hash if new_entry else None,
                 )
             )
 
@@ -740,9 +772,12 @@ class _FileTrackingHandler:
                         elif method == "snapshot":
                             manifest = self._tracker.current_manifest()
                             result = {"files": manifest, "files_scanned": len(manifest)}
-                        elif method == "advance":
-                            await loop.run_in_executor(None, self._tracker.advance_baseline)
-                            result = {"advanced": True}
+                        elif method == "setup":
+                            setup = await loop.run_in_executor(
+                                None,
+                                self._tracker.take_setup_snapshot,
+                            )
+                            result = setup.to_dict()
                         elif method == "flush":
                             result = await loop.run_in_executor(None, self._tracker.flush_changes)
                         else:

--- a/hud/environment/tests/test_file_tracker.py
+++ b/hud/environment/tests/test_file_tracker.py
@@ -138,11 +138,11 @@ def test_vcs_config_files_are_redacted(tmp_path: Path) -> None:
     assert "new-token@example.com" not in patch.patch
 
 
-def test_capture_changed_deliverables_since_advanced_baseline(tmp_path: Path) -> None:
+def test_capture_changed_deliverables_since_setup_snapshot(tmp_path: Path) -> None:
     (tmp_path / "setup.xlsx").write_bytes(b"setup workbook")
     tracker = FileTracker(tmp_path)
     tracker.take_baseline()
-    tracker.advance_baseline()
+    tracker.take_setup_snapshot()
 
     (tmp_path / "analysis.py").write_text("print('tracked by diff')\n")
     (tmp_path / "notes.txt").write_text("tracked by diff\n")
@@ -277,6 +277,38 @@ def test_manifest_carries_paths_and_hashes(tmp_path: Path) -> None:
     assert len(entry["content_hash"]) == 64  # sha256 hex
 
 
+def test_setup_snapshot_returns_changes_and_resets_agent_baseline(tmp_path: Path) -> None:
+    source = tmp_path / "source.py"
+    source.write_text("before\n")
+    tracker = FileTracker(tmp_path)
+    initial = tracker.take_baseline()
+
+    source.write_text("after\n")
+    (tmp_path / "generated.txt").write_text("setup\n")
+    setup = tracker.take_setup_snapshot()
+
+    patches = {patch.rel_path: patch for patch in setup.patches}
+    assert set(patches) == {"generated.txt", "source.py"}
+    assert patches["source.py"].content_hash_before == initial.files["source.py"].content_hash
+    assert patches["source.py"].content_hash_after == tracker.current_manifest()[1]["content_hash"]
+    assert tracker.take_snapshot().files_changed == 0
+
+
+def test_setup_snapshot_keeps_complete_agent_baseline_when_diff_is_capped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+    (tmp_path / "generated.txt").write_text("setup\n")
+    monkeypatch.setattr(FileTracker, "_MAX_DIFF_BYTES", 0)
+
+    setup = tracker.take_setup_snapshot()
+
+    assert setup.truncated is True
+    assert setup.patches == []
+    assert tracker.take_snapshot().files_changed == 0
+
+
 def test_to_dict_shape_matches_wire_contract(tmp_path: Path) -> None:
     (tmp_path / "a.txt").write_text("1\n")
     tracker = FileTracker(tmp_path)
@@ -292,4 +324,12 @@ def test_to_dict_shape_matches_wire_contract(tmp_path: Path) -> None:
         "files_changed",
         "patches",
     }
-    assert set(payload["patches"][0]) == {"path", "status", "patch", "size_before", "size_after"}
+    assert set(payload["patches"][0]) == {
+        "path",
+        "status",
+        "patch",
+        "size_before",
+        "size_after",
+        "content_hash_before",
+        "content_hash_after",
+    }

--- a/hud/environment/tests/test_file_tracking.py
+++ b/hud/environment/tests/test_file_tracking.py
@@ -30,7 +30,7 @@ async def _call(
     return result
 
 
-async def test_diff_snapshot_advance_roundtrip(tmp_path: Path) -> None:
+async def test_diff_snapshot_setup_roundtrip(tmp_path: Path) -> None:
     (tmp_path / "a.txt").write_text("x\n")
     tracker = FileTracker(tmp_path)
     tracker.take_baseline()
@@ -55,9 +55,11 @@ async def test_diff_snapshot_advance_roundtrip(tmp_path: Path) -> None:
         snapshot = await _call(reader, writer, "snapshot")
         assert any(entry["path"] == "a.txt" for entry in snapshot["files"])
 
-        # advance() re-baselines without erroring.
+        # setup() emits scenario changes and starts a clean agent-edit layer.
         (tmp_path / "b.txt").write_text("z\n")
-        await _call(reader, writer, "advance")
+        setup = await _call(reader, writer, "setup")
+        assert setup["files_changed"] == 1
+        assert setup["patches"][0]["path"] == "b.txt"
         assert (await _call(reader, writer, "diff"))["files_changed"] == 0
 
         # flush() returns the trailing diff plus bounded changed deliverables.

--- a/hud/eval/file_tracking.py
+++ b/hud/eval/file_tracking.py
@@ -1,10 +1,10 @@
 """Rollout-level file-tracking observer.
 
 Wraps the agent loop: if the env published a ``filetracking/1`` capability and
-file tracking is on, open it, skip the scenario-setup churn, then sample diffs
-on a fixed interval. On teardown it flushes the trailing diff plus changed
-deliverable artifacts. Decoupled from the tool loop — spans are self-timestamped
-and the viewer correlates them to steps by time.
+file tracking is on, emit scenario setup as a distinct diff layer, then sample
+agent diffs on a fixed interval. On teardown it flushes the trailing diff plus
+changed deliverable artifacts. Decoupled from the tool loop — spans are
+self-timestamped and the viewer correlates them to steps by time.
 """
 
 from __future__ import annotations
@@ -44,6 +44,7 @@ _FILETRACKING_SCHEMA = "hud.filetracking.v1"
 _FileTrackingSpanName: TypeAlias = Literal[
     "filetracking.capture",
     "filetracking.diff",
+    "filetracking.setup",
     "filetracking.snapshot",
 ]
 
@@ -122,16 +123,18 @@ async def file_tracking_observer(client: HudClient) -> AsyncIterator[None]:
         yield
         return
 
-    # Open the capability, re-baseline past scenario setup (so the first emitted
-    # diff is the agent's, not setup churn), and emit the post-setup manifest as
-    # the reconstruction anchor (paths + hashes, no content). Tracking is
-    # observation-only, so any setup failure — a refused tunnel, a failed
-    # re-baseline (which would misattribute setup edits to the agent), or a
-    # missing anchor — skips tracking rather than breaking the agent loop.
+    # Capture scenario setup as its own layer, then emit the post-setup manifest
+    # that anchors the agent-edit timeline. Tracking is observation-only, so any
+    # setup failure skips tracking rather than breaking the agent loop.
     ft: FileTrackingClient | None = None
     try:
         ft = await FileTrackingClient.connect(cap)
-        await ft.call("advance")
+        setup = await ft.call("setup")
+        _emit_file_tracking(
+            "filetracking.setup",
+            setup,
+            started_at=now_iso(),
+        )
         _emit_file_tracking(
             "filetracking.snapshot",
             await ft.call("snapshot"),

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -358,9 +358,8 @@ async def rollout(
                 async with live:  # start on enter; grade on exit
                     run = live  # bound only once live: an earlier failure synthesizes
                     _phase = "agent loop"
-                    # File tracking (when enabled) streams workspace diffs to
-                    # telemetry for the duration of the agent loop; setup churn is
-                    # skipped because the run is already started here.
+                    # File tracking (when enabled) emits setup separately, then
+                    # streams workspace diffs for the duration of the agent loop.
                     async with file_tracking_observer(client):
                         try:
                             await _bounded(agent(run))

--- a/hud/eval/tests/test_file_tracking_observer.py
+++ b/hud/eval/tests/test_file_tracking_observer.py
@@ -1,9 +1,4 @@
-"""file_tracking_observer: setup must gate polling.
-
-The observer re-baselines past scenario setup and emits the manifest anchor
-before it starts streaming diffs. If that setup fails, it must not poll — a
-stale baseline would misattribute scenario-setup edits to the agent.
-"""
+"""file_tracking_observer: setup must gate polling."""
 
 from __future__ import annotations
 
@@ -26,12 +21,12 @@ class _FakeFt:
     def __init__(
         self,
         *,
-        advance_raises: bool = False,
+        setup_raises: bool = False,
         flush_result: dict[str, Any] | None = None,
     ) -> None:
-        self.advance_raises = advance_raises
+        self.setup_raises = setup_raises
         self.flush_result = flush_result
-        self.advance_calls = 0
+        self.setup_calls = 0
         self.snapshot_calls = 0
         self.diff_calls = 0
         self.flush_calls = 0
@@ -41,11 +36,11 @@ class _FakeFt:
         self.close_calls += 1
 
     async def call(self, method: str) -> dict[str, Any]:
-        if method == "advance":
-            self.advance_calls += 1
-            if self.advance_raises:
-                raise RuntimeError("advance boom")
-            return {"advanced": True}
+        if method == "setup":
+            self.setup_calls += 1
+            if self.setup_raises:
+                raise RuntimeError("setup boom")
+            return {"files_changed": 1, "patches": [{"path": "setup.txt"}]}
         if method == "snapshot":
             self.snapshot_calls += 1
             return {"files": [], "files_scanned": 0}
@@ -70,8 +65,9 @@ class _BoundClient:
 
 def _record_emitters(
     monkeypatch: pytest.MonkeyPatch,
-) -> tuple[list[Any], list[Any], list[Any]]:
+) -> tuple[list[Any], list[Any], list[Any], list[Any]]:
     diffs: list[Any] = []
+    setups: list[Any] = []
     snapshots: list[Any] = []
     captures: list[Any] = []
 
@@ -84,6 +80,8 @@ def _record_emitters(
     ) -> bool:
         if span_name == "filetracking.diff":
             diffs.append(payload)
+        elif span_name == "filetracking.setup":
+            setups.append(payload)
         elif span_name == "filetracking.snapshot":
             snapshots.append(payload)
         elif span_name == "filetracking.capture":
@@ -91,7 +89,7 @@ def _record_emitters(
         return True
 
     monkeypatch.setattr(observer, "_emit_file_tracking", _emit)
-    return diffs, snapshots, captures
+    return diffs, setups, snapshots, captures
 
 
 def _connects_to(monkeypatch: pytest.MonkeyPatch, ft: _FakeFt) -> None:
@@ -109,21 +107,21 @@ async def test_setup_failure_skips_polling(monkeypatch: pytest.MonkeyPatch) -> N
 
     monkeypatch.setattr(settings, "telemetry_enabled", True)
     monkeypatch.setattr(settings, "file_tracking_interval", 0.01)
-    diffs, snapshots, captures = _record_emitters(monkeypatch)
-    ft = _FakeFt(advance_raises=True)
+    diffs, setups, snapshots, captures = _record_emitters(monkeypatch)
+    ft = _FakeFt(setup_raises=True)
     _connects_to(monkeypatch, ft)
 
     async with observer.file_tracking_observer(_BoundClient()):  # type: ignore[arg-type]
         await asyncio.sleep(0.05)
 
-    assert ft.advance_calls == 1
-    # advance() raised, so the anchor snapshot and all diff polling are skipped.
+    assert ft.setup_calls == 1
     assert ft.snapshot_calls == 0
     assert ft.diff_calls == 0
     assert ft.flush_calls == 0
     assert ft.close_calls == 1
     assert diffs == []
     assert snapshots == []
+    assert setups == []
     assert captures == []
 
 
@@ -132,14 +130,15 @@ async def test_successful_setup_anchors_and_polls(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr(settings, "telemetry_enabled", True)
     monkeypatch.setattr(settings, "file_tracking_interval", 0.01)
-    diffs, snapshots, captures = _record_emitters(monkeypatch)
+    diffs, setups, snapshots, captures = _record_emitters(monkeypatch)
     ft = _FakeFt()
     _connects_to(monkeypatch, ft)
 
     async with observer.file_tracking_observer(_BoundClient()):  # type: ignore[arg-type]
         await asyncio.sleep(0.05)
 
-    assert ft.advance_calls == 1
+    assert ft.setup_calls == 1
+    assert setups == [{"files_changed": 1, "patches": [{"path": "setup.txt"}]}]
     assert len(snapshots) == 1  # manifest anchor emitted once
     assert ft.diff_calls >= 1
     assert ft.flush_calls == 1
@@ -162,7 +161,7 @@ async def test_flush_emits_skipped_capture_metadata(monkeypatch: pytest.MonkeyPa
     }
     monkeypatch.setattr(settings, "telemetry_enabled", True)
     monkeypatch.setattr(settings, "file_tracking_interval", 60.0)
-    diffs, snapshots, captures = _record_emitters(monkeypatch)
+    diffs, setups, snapshots, captures = _record_emitters(monkeypatch)
     ft = _FakeFt(flush_result={"diff": {"files_changed": 0, "patches": []}, "capture": capture})
     _connects_to(monkeypatch, ft)
 
@@ -171,6 +170,7 @@ async def test_flush_emits_skipped_capture_metadata(monkeypatch: pytest.MonkeyPa
 
     assert ft.flush_calls == 1
     assert len(snapshots) == 1
+    assert len(setups) == 1
     assert diffs == []
     assert captures == [capture]
 
@@ -179,7 +179,7 @@ async def test_connect_failure_does_not_break_the_rollout(monkeypatch: pytest.Mo
     from hud.settings import settings
 
     monkeypatch.setattr(settings, "telemetry_enabled", True)
-    diffs, snapshots, captures = _record_emitters(monkeypatch)
+    diffs, setups, snapshots, captures = _record_emitters(monkeypatch)
 
     class _FailingFileTrackingClient:
         @classmethod
@@ -197,6 +197,7 @@ async def test_connect_failure_does_not_break_the_rollout(monkeypatch: pytest.Mo
     assert ran
     assert diffs == []
     assert snapshots == []
+    assert setups == []
     assert captures == []
 
 

--- a/hud/settings.py
+++ b/hud/settings.py
@@ -161,8 +161,8 @@ class Settings(BaseSettings):
 
     file_tracking_enabled: bool = Field(
         default=True,
-        description="Publish a workspace's filetracking/1 capability and stream file-change "
-        "diffs plus artifacts to telemetry during a rollout. "
+        description="Publish a workspace's filetracking/1 capability and stream setup changes, "
+        "agent file-change diffs, and final artifacts to telemetry. "
         "Enabled by default; set HUD_FILE_TRACKING_ENABLED=false to opt out.",
         validation_alias="HUD_FILE_TRACKING_ENABLED",
     )


### PR DESCRIPTION
## Summary

- emit scenario setup file changes as a dedicated `filetracking.setup` telemetry layer
- keep the post-setup snapshot content-free while adding SHA-256 hashes before and after each patch
- harden final artifact capture against files changing during reads
- update focused file-tracking tests for the setup, snapshot, diff, and capture lifecycle.

## Impact

Consumers can reconstruct the workspace in layers:

1. build source
2. `filetracking.setup`
3. `filetracking.snapshot` hashes
4. `filetracking.diff`
5. final captured artifacts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout telemetry shape and the `filetracking/1` API (`advance` → `setup`), which downstream viewers must understand; capture logic is stricter but remains observation-only and failures still skip tracking without breaking the agent loop.
> 
> **Overview**
> **File tracking now separates scenario setup from agent edits.** The wire protocol replaces silent `advance` with `setup`, which returns a diff of setup-time changes and always rebaselines agent tracking on the full post-setup tree—even when that setup diff hits the byte cap.
> 
> **Telemetry consumers get a clearer timeline:** the rollout observer emits a `filetracking.setup` span, then the hash-only `filetracking.snapshot` anchor, then periodic `filetracking.diff` spans. Each patch includes `content_hash_before` and `content_hash_after` for reconstruction without rereading patch bodies.
> 
> **Final artifact capture** re-validates size, mtime, inode, and SHA-256 after read so files that change mid-capture are skipped instead of uploaded stale bytes; MIME typing falls back to UTF-8/plain detection when extension guessing fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f65f4a60ccf7bc34d54f17f0f350da5a04dbf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->