### PR TITLE
Release 0.6.11

### DIFF
--- a/hud/environment/file_tracker.py
+++ b/hud/environment/file_tracker.py
@@ -289,6 +289,12 @@ class FileTracker:
         self._previous_snapshot = current
         return diff
 
+    def advance_baseline(self) -> None:
+        """Establish the current filesystem state as the agent-edit baseline."""
+        current = self._scan()
+        self._baseline_snapshot = current
+        self._previous_snapshot = current
+
     def take_snapshot(self) -> DiffResult:
         """Scan and diff against the previous snapshot, then advance the baseline."""
         if self._previous_snapshot is None:
@@ -778,6 +784,9 @@ class _FileTrackingHandler:
                                 self._tracker.take_setup_snapshot,
                             )
                             result = setup.to_dict()
+                        elif method == "advance":
+                            await loop.run_in_executor(None, self._tracker.advance_baseline)
+                            result = {"advanced": True}
                         elif method == "flush":
                             result = await loop.run_in_executor(None, self._tracker.flush_changes)
                         else:

--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -51,7 +51,9 @@ async def test_serving_publishes_the_workspace_capability(
         assert cap.protocol == "ssh/2"
         assert cap.url.startswith("ssh://")
         assert cap.params["host_pubkey"].startswith("ssh-ed25519")
-        assert client.binding("filetracking").protocol == "filetracking/1"
+        filetracking = client.binding("filetracking")
+        assert filetracking.protocol == "filetracking/1"
+        assert filetracking.params == {"setup_diff": True}
         # Key material lives outside the served root (the agent's surface).
         assert not (tmp_path / "root" / ".hud").exists()
 

--- a/hud/environment/tests/test_file_tracking.py
+++ b/hud/environment/tests/test_file_tracking.py
@@ -55,6 +55,11 @@ async def test_diff_snapshot_setup_roundtrip(tmp_path: Path) -> None:
         snapshot = await _call(reader, writer, "snapshot")
         assert any(entry["path"] == "a.txt" for entry in snapshot["files"])
 
+        # advance() remains available to clients that predate setup diffs.
+        (tmp_path / "legacy.txt").write_text("legacy\n")
+        assert await _call(reader, writer, "advance") == {"advanced": True}
+        assert (await _call(reader, writer, "diff"))["files_changed"] == 0
+
         # setup() emits scenario changes and starts a clean agent-edit layer.
         (tmp_path / "b.txt").write_text("z\n")
         setup = await _call(reader, writer, "setup")

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -386,6 +386,7 @@ class Workspace:
             name=name,
             protocol="filetracking/1",
             url=f"tcp://{self._ft_host}:{self._ft_port}",
+            params={"setup_diff": True},
         )
 
     # ─── argv builders (public — useful if you want your own subprocess) ──

--- a/hud/eval/file_tracking.py
+++ b/hud/eval/file_tracking.py
@@ -1,10 +1,10 @@
 """Rollout-level file-tracking observer.
 
 Wraps the agent loop: if the env published a ``filetracking/1`` capability and
-file tracking is on, emit scenario setup as a distinct diff layer, then sample
-agent diffs on a fixed interval. On teardown it flushes the trailing diff plus
-changed deliverable artifacts. Decoupled from the tool loop — spans are
-self-timestamped and the viewer correlates them to steps by time.
+file tracking is on, capture scenario setup when the server advertises support,
+then sample agent diffs on a fixed interval. On teardown it flushes the trailing
+diff plus changed deliverable artifacts. Decoupled from the tool loop — spans
+are self-timestamped and the viewer correlates them to steps by time.
 """
 
 from __future__ import annotations
@@ -123,18 +123,20 @@ async def file_tracking_observer(client: HudClient) -> AsyncIterator[None]:
         yield
         return
 
-    # Capture scenario setup as its own layer, then emit the post-setup manifest
-    # that anchors the agent-edit timeline. Tracking is observation-only, so any
-    # setup failure skips tracking rather than breaking the agent loop.
+    # New servers expose setup changes; legacy filetracking/1 servers only know
+    # how to advance past setup. Both establish the same agent-edit baseline.
     ft: FileTrackingClient | None = None
     try:
         ft = await FileTrackingClient.connect(cap)
-        setup = await ft.call("setup")
-        _emit_file_tracking(
-            "filetracking.setup",
-            setup,
-            started_at=now_iso(),
-        )
+        if cap.params.get("setup_diff") is True:
+            setup = await ft.call("setup")
+            _emit_file_tracking(
+                "filetracking.setup",
+                setup,
+                started_at=now_iso(),
+            )
+        else:
+            await ft.call("advance")
         _emit_file_tracking(
             "filetracking.snapshot",
             await ft.call("snapshot"),

--- a/hud/eval/tests/test_file_tracking_observer.py
+++ b/hud/eval/tests/test_file_tracking_observer.py
@@ -14,7 +14,13 @@ from hud.telemetry.context import set_trace_context
 if TYPE_CHECKING:
     import pytest
 
-_CAP = Capability(name="filetracking", protocol="filetracking/1", url="tcp://127.0.0.1:1")
+_CAP = Capability(
+    name="filetracking",
+    protocol="filetracking/1",
+    url="tcp://127.0.0.1:1",
+    params={"setup_diff": True},
+)
+_LEGACY_CAP = Capability(name="filetracking", protocol="filetracking/1", url=_CAP.url)
 
 
 class _FakeFt:
@@ -26,6 +32,7 @@ class _FakeFt:
     ) -> None:
         self.setup_raises = setup_raises
         self.flush_result = flush_result
+        self.advance_calls = 0
         self.setup_calls = 0
         self.snapshot_calls = 0
         self.diff_calls = 0
@@ -36,6 +43,9 @@ class _FakeFt:
         self.close_calls += 1
 
     async def call(self, method: str) -> dict[str, Any]:
+        if method == "advance":
+            self.advance_calls += 1
+            return {"advanced": True}
         if method == "setup":
             self.setup_calls += 1
             if self.setup_raises:
@@ -59,8 +69,11 @@ class _FakeFt:
 
 
 class _BoundClient:
-    def binding(self, name: str) -> object:
-        return _CAP
+    def __init__(self, cap: Capability = _CAP) -> None:
+        self.cap = cap
+
+    def binding(self, name: str) -> Capability:
+        return self.cap
 
 
 def _record_emitters(
@@ -92,11 +105,15 @@ def _record_emitters(
     return diffs, setups, snapshots, captures
 
 
-def _connects_to(monkeypatch: pytest.MonkeyPatch, ft: _FakeFt) -> None:
+def _connects_to(
+    monkeypatch: pytest.MonkeyPatch,
+    ft: _FakeFt,
+    cap: Capability = _CAP,
+) -> None:
     class _FakeFileTrackingClient:
         @classmethod
-        async def connect(cls, cap: Capability) -> _FakeFt:
-            assert cap == _CAP
+        async def connect(cls, requested_cap: Capability) -> _FakeFt:
+            assert requested_cap == cap
             return ft
 
     monkeypatch.setattr(observer, "FileTrackingClient", _FakeFileTrackingClient)
@@ -145,6 +162,29 @@ async def test_successful_setup_anchors_and_polls(monkeypatch: pytest.MonkeyPatc
     assert ft.close_calls == 1
     assert diffs  # at least one diff streamed
     assert {"files_changed": 1, "patches": [{"path": "final.txt"}]} in diffs
+    assert captures == [{"files_captured": 1, "files": [{"path": "report.xlsx"}]}]
+
+
+async def test_legacy_server_advances_without_setup_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.settings import settings
+
+    monkeypatch.setattr(settings, "telemetry_enabled", True)
+    monkeypatch.setattr(settings, "file_tracking_interval", 60.0)
+    diffs, setups, snapshots, captures = _record_emitters(monkeypatch)
+    ft = _FakeFt()
+    _connects_to(monkeypatch, ft, _LEGACY_CAP)
+
+    async with observer.file_tracking_observer(_BoundClient(_LEGACY_CAP)):  # type: ignore[arg-type]
+        pass
+
+    assert ft.advance_calls == 1
+    assert ft.setup_calls == 0
+    assert ft.snapshot_calls == 1
+    assert setups == []
+    assert len(snapshots) == 1
+    assert diffs == [{"files_changed": 1, "patches": [{"path": "final.txt"}]}]
     assert captures == [{"files_captured": 1, "files": [{"path": "report.xlsx"}]}]
 
 

--- a/hud/tests/test_version.py
+++ b/hud/tests/test_version.py
@@ -5,4 +5,4 @@ def test_import():
     """Test that the package can be imported."""
     import hud
 
-    assert hud.__version__ == "0.6.10"
+    assert hud.__version__ == "0.6.11"

--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.10"
+__version__ = "0.6.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hud"
-version = "0.6.10"
+version = "0.6.11"
 description = "SDK for the HUD platform."
 readme = "README.md"
 requires-python = ">=3.11, <3.13"


### PR DESCRIPTION
## Summary

- bump the `hud` package from 0.6.10 to 0.6.11
- advertise setup-diff support through the existing `filetracking/1` capability parameters
- let new evaluators use legacy `advance` against previously deployed environments
- retain `advance` on new servers for older evaluators