### PR TITLE
fix(environment): keep the shell_uid handoff O(1) on the serving path

### DIFF
--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -303,7 +303,7 @@ Use a relative path (`"workspace"`, created next to `env.py`). Sandbox isolation
 | `host` | `str` | SSH bind host. Default `"127.0.0.1"`. |
 | `port` | `int` | SSH bind port (`0` binds an ephemeral port). Default `0`. |
 | `user` | `str` | SSH username. Default `"agent"`. |
-| `shell_uid` | `int \| None` | When serving as root, run every agent command as this uid/gid with cleared supplementary groups and `no_new_privs`. Default `None`. |
+| `shell_uid` | `int \| None` | When serving as root, run every agent command as this uid/gid with cleared supplementary groups and `no_new_privs`. Only the workspace directory itself is handed to the uid at start (O(1)); own pre-staged content via `COPY --chown` or task setup. Default `None`. |
 | `host_key_path` | `Path \| None` | Reuse a host key instead of generating one. |
 | `authorized_client_keys` | `list[Path] \| None` | Authorize specific client public keys. |
 | `track_files` | `bool` | Serve file-tracking telemetry over the workspace lifecycle. Constructor default `False`; `env.workspace(...)` defaults it to `HUD_FILE_TRACKING_ENABLED` (on). |

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -168,19 +168,17 @@ def test_caller_env_is_injected_only_after_the_drop(
 
 
 @pytest.mark.asyncio
-async def test_wall_hands_preexisting_contents_to_the_dropped_uid(
+async def test_wall_handoff_is_top_level_only_and_never_walks_the_tree(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Contents baked in before serve (e.g. a Docker COPY as root) must become
-    editable from the dropped shell, not just the top-level directory."""
+    """The handoff must be O(1): only the workspace dir is chowned. Recursing
+    over baked content (node_modules, a venv) on the serving path would delay
+    the control-port bind past the deploy readiness probe."""
     _wall(monkeypatch)
     handed: list[str] = []
     monkeypatch.setattr(os, "lchown", lambda p, u, g: handed.append(os.fsdecode(p)))
-    monkeypatch.setattr(
-        os,
-        "chown",
-        lambda p, u, g, dir_fd=None, follow_symlinks=True: handed.append(os.fsdecode(p)),
-    )
+    monkeypatch.setattr(os, "walk", lambda *a, **k: pytest.fail("handoff must not walk the tree"))
+    monkeypatch.setattr(os, "fwalk", lambda *a, **k: pytest.fail("handoff must not walk the tree"))
 
     root = tmp_path / "root"
     (root / "pkg").mkdir(parents=True)
@@ -189,8 +187,7 @@ async def test_wall_hands_preexisting_contents_to_the_dropped_uid(
     ws = Workspace(root, shell_uid=1000)
     await ws.start()
     try:
-        names = {Path(p).name for p in handed}
-        assert {"root", "pkg", "mod.py"} <= names
+        assert [Path(p).name for p in handed] == ["root"]
     finally:
         await ws.stop()
 
@@ -199,8 +196,8 @@ async def test_wall_hands_preexisting_contents_to_the_dropped_uid(
 async def test_wall_handoff_failure_refuses_to_serve(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A partial ownership handoff silently breaks the workspace contract;
-    the server must fail loudly instead of serving root-owned files."""
+    """A failed ownership handoff leaves a workspace the agent can't write;
+    the server must fail loudly instead of serving it."""
     _wall(monkeypatch)
 
     def deny(p: object, u: int, g: int) -> None:

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -100,7 +100,9 @@ class Workspace:
     ``shell_uid`` drops agent sessions to that uid with ``setpriv`` when the
     serving process is root — the privilege wall for substrates where bwrap
     is unavailable and the env process holds secrets the agent must not read.
-    No-op off root.
+    No-op off root. Only the workspace directory itself is handed to the uid
+    at start (O(1), on the serving path); pre-staged content is the author's
+    to own via ``COPY --chown`` or task setup.
     """
 
     def __init__(
@@ -216,22 +218,17 @@ class Workspace:
                 )
         self.root.mkdir(parents=True, exist_ok=True)
         if self._drops_privileges():
-            # The workspace is the agent's surface: hand the whole tree to the
-            # dropped uid, or contents baked in as root (e.g. a Docker COPY)
-            # stay un-editable from the dropped shell. fwalk + dir_fd-relative
-            # no-follow chown is the kernel boundary: a symlink swapped in
-            # mid-walk can't redirect ownership outside the workspace. Failures
-            # raise — a partial handoff would silently break the documented
-            # guarantee that the agent can edit its workspace.
+            # Make the workspace dir itself writable by the dropped uid so a
+            # fresh workspace is usable out of the box. This is O(1) and must
+            # stay that way: it runs on the serving path, before the control
+            # port binds. We deliberately do NOT recurse — a baked tree
+            # (node_modules, a venv, a dataset) can hold hundreds of thousands
+            # of files, and walking it here delays the bind past the deploy
+            # readiness probe. Ownership of pre-staged content is the env
+            # author's job, done where it's cheap and scoped: at build time
+            # (`COPY --chown`) or in task setup over just what was staged.
             assert self._shell_uid is not None
-            uid = self._shell_uid
-            os.lchown(self.root, uid, uid)
-            for _dirpath, dirnames, filenames, dirfd in os.fwalk(self.root):
-                for entry in (*dirnames, *filenames):
-                    # A concurrent session may unlink entries mid-walk; a
-                    # vanished path needs no handoff.
-                    with contextlib.suppress(FileNotFoundError):
-                        os.chown(entry, uid, uid, dir_fd=dirfd, follow_symlinks=False)
+            os.lchown(self.root, self._shell_uid, self._shell_uid)
         self._host_key, self._host_pubkey_str = self._load_or_generate_host_key()
         self._authorized_keys_path = self._ensure_authorized_keys_file()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
## Summary
- `Workspace.start()` ran a recursive `os.fwalk` chown over the whole workspace tree before binding the control port (landed in #496). For images that bake `node_modules`/venv/dataset-scale trees into the workspace, that walk takes 60s+ — the deploy introspection probe (60s port wait) times out and the build fails every time.
- The handoff is now O(1): only the workspace directory itself is chowned to `shell_uid` at start, and the contract test fails if `os.walk`/`os.fwalk` is ever called on the serving path. A failed handoff still raises rather than serving a workspace the agent can't write.
- Ownership of pre-staged content is the env author's job, done where it's cheap and scoped — `chown` in the build stage that stages the tree (`COPY --chown` / `&& chown -R` on the clone line) or task setup over just what root mutated, the way ml-template and coding-template do it. Docs updated to state this.

## Test plan
- [x] `hud/environment/tests/test_workspace.py` — new O(1) contract test (fails on any tree walk during `start()`), fail-loud handoff test updated; 14/14 pass.
- [x] ruff + pyright clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes privilege-wall behavior on the deploy hot path: agents may lose write access to root-owned pre-staged files unless images/tasks chown them, but startup reliability improves for large workspaces.
> 
> **Overview**
> **`Workspace.start()`** no longer recursively `chown`s the whole workspace tree when `shell_uid` is set. It only **`lchown`s the workspace root** before SSH binds, so large baked trees (`node_modules`, venvs, datasets) cannot block deploy readiness probes.
> 
> The **`shell_uid` contract** is narrowed: env authors must give the dropped user ownership of pre-staged files via **`COPY --chown`** or task setup, not rely on runtime recursion. Docs for `shell_uid` state this explicitly.
> 
> Tests now **assert the handoff never calls `os.walk`/`os.fwalk`** and only chowns the top-level directory; failed handoff still **raises** instead of serving an unusable workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7599935a0fe0f4d2262c01f63fe6411cd07b9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->