### PR TITLE
Declare exportable workspace paths

### DIFF
--- a/hud/environment/file_tracker.py
+++ b/hud/environment/file_tracker.py
@@ -367,6 +367,7 @@ class FileTracker:
         return [
             {"path": e.rel_path, "size": e.size, "content_hash": e.content_hash}
             for e in sorted(snapshot.files.values(), key=lambda e: e.rel_path)
+            if not e.redacted
         ]
 
     def _capture_artifacts(self, current: Snapshot) -> dict[str, Any]:

--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -53,7 +53,10 @@ async def test_serving_publishes_the_workspace_capability(
         assert cap.params["host_pubkey"].startswith("ssh-ed25519")
         filetracking = client.binding("filetracking")
         assert filetracking.protocol == "filetracking/1"
-        assert filetracking.params == {"setup_diff": True}
+        assert filetracking.params == {
+            "root": (tmp_path / "root").resolve().as_posix(),
+            "setup_diff": True,
+        }
         # Key material lives outside the served root (the agent's surface).
         assert not (tmp_path / "root" / ".hud").exists()
 

--- a/hud/environment/tests/test_file_tracker.py
+++ b/hud/environment/tests/test_file_tracker.py
@@ -105,6 +105,8 @@ def test_secret_files_are_tracked_but_content_is_never_emitted(tmp_path: Path) -
     tracker = FileTracker(tmp_path)
     tracker.take_baseline()
 
+    assert tracker.current_manifest() == []
+
     (tmp_path / ".env").write_text("API_KEY=supersecretvalue\nDB_PASSWORD=hunter2\n")
     diff = tracker.take_snapshot()
 

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -383,7 +383,7 @@ class Workspace:
             name=name,
             protocol="filetracking/1",
             url=f"tcp://{self._ft_host}:{self._ft_port}",
-            params={"setup_diff": True},
+            params={"root": self.root.as_posix(), "setup_diff": True},
         )
 
     # ─── argv builders (public — useful if you want your own subprocess) ──


### PR DESCRIPTION
## What changed

- declare the workspace root on the existing `filetracking/1` capability
- exclude credential-shaped paths from the existing snapshot manifest

## Why

Build introspection already calls `setup` and then `snapshot`. The platform builder only needs the declared root and export-safe path set to copy the post-setup workspace from the built image into its immutable S3 prefix.

The SDK does not upload file bytes, add an export path, change hashing semantics, or introduce another transfer protocol.

## Validation

- `uv run ruff format --check hud/environment/file_tracker.py hud/environment/workspace.py hud/environment/tests/test_capability_backing.py hud/environment/tests/test_file_tracker.py`
- `uv run ruff check hud/environment/file_tracker.py hud/environment/workspace.py hud/environment/tests/test_capability_backing.py hud/environment/tests/test_file_tracker.py`
- `uv run pyright hud/environment/file_tracker.py hud/environment/workspace.py`
- `uv run pytest hud/environment/tests -q` — 74 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest and capability metadata changes only; tightens secret exclusion and adds a declared root path with no auth or RPC behavior changes in this diff.
> 
> **Overview**
> **Post-setup workspace manifests** no longer list credential-shaped paths: `FileTracker.current_manifest()` skips entries marked `redacted`, so a `snapshot` RPC returns only verifiable, non-secret files (paths, sizes, hashes). Secret files remain in the tracker for change detection and redacted diffs, but they are not published as manifest rows.
> 
> The **`filetracking/1` capability** now includes the semantic workspace **`root`** (resolved POSIX path) in `params`, alongside `setup_diff`, so platform builders can locate the tracked tree on the host without inferring it from SSH cwd alone.
> 
> Tests lock in an empty manifest when only `.env` exists at baseline, and expect the served capability params to include `root`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df3e24370d975688eb6384e9a4a8862fabb4c04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->