### PR TITLE
ci: alert #alerts-github on CI and Release failures

### DIFF
--- a/.github/workflows/slack-alerts.yml
+++ b/.github/workflows/slack-alerts.yml
@@ -1,0 +1,26 @@
+name: Slack Alerts
+
+# Posts to #alerts-github when a monitored workflow fails. Requires the
+# SLACK_ALERTS_WEBHOOK_URL secret: a Slack incoming webhook bound to the
+# #alerts-github channel (Slack app > Incoming Webhooks).
+on:
+  workflow_run:
+    workflows: [CI, Release]
+    types: [completed]
+
+jobs:
+  notify:
+    # Alert on failed pushes to main, releases, and manual runs; stay quiet
+    # for pull request CI, which is visible on the PR itself.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        uses: slackapi/slack-github-action@v2
+        with:
+          webhook: ${{ secrets.SLACK_ALERTS_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":rotating_light: *${{ github.event.workflow_run.name }}* failed in `${{ github.repository }}` on `${{ github.event.workflow_run.head_branch }}` (triggered by ${{ github.event.workflow_run.actor.login }})\n<${{ github.event.workflow_run.html_url }}|View failed run>"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `Slack Alerts` workflow (HUD-2232) that posts to the `#alerts-github` Slack channel when a monitored workflow fails.

- Triggers via `workflow_run` on completion of `CI` and `Release`.
- Alerts only on **failures** from pushes to `main`, releases, and manual dispatches. Pull request CI failures are intentionally excluded — those are already visible on the PR itself.
- Posts via `slackapi/slack-github-action` using a Slack incoming webhook, so alerting is fully independent of the HUD platform.

## Required setup (one-time, org-level)

1. Create a Slack app (e.g. "GitHub Alerts") with **Incoming Webhooks** enabled and add a webhook bound to `#alerts-github`.
2. Store the webhook URL as a GitHub Actions secret named `SLACK_ALERTS_WEBHOOK_URL` — ideally at the **org** level so other repos can reuse it.

## Extending to staging/prod deploys

The staging/prod deploy workflows live in the platform repo, not here. Copy this same file there and swap the `workflows:` list to the deploy workflow names (e.g. `[Deploy Staging, Deploy Prod]`). With an org-level secret, no other changes are needed.

## Testing

- YAML validated and checked with `actionlint` (clean).
- Slack payload block verified to parse as valid YAML with representative values substituted.
- End-to-end delivery not verified: it requires the `SLACK_ALERTS_WEBHOOK_URL` secret and a real failed run on `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [HUD-2232](https://linear.app/h-u-d/issue/HUD-2232/add-github-alerts-into-alerts-github)

<div><a href="https://cursor.com/agents/bc-e05febda-3846-4fe1-a633-bb64923bc67d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e05febda-3846-4fe1-a633-bb64923bc67d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

