### PR TITLE
fix: prevent Daytona rollout failures (HUD-2206)

### DIFF
--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -664,7 +664,9 @@ class DaytonaRuntime:
         self.snapshot_name = snapshot_name
         # Default command serves on *port*, so the SSH forward target always
         # matches what's listening; override only for a non-default layout.
-        self.command = command or f"uv run hud serve env.py --host 0.0.0.0 --port {port}"
+        self.command = (
+            command or f'PATH="$PWD/.venv/bin:$PATH" hud serve env.py --host 0.0.0.0 --port {port}'
+        )
         self.workdir = workdir
         self.port = port
         self.ssh_host = ssh_host

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -664,7 +664,7 @@ class DaytonaRuntime:
         self.snapshot_name = snapshot_name
         # Default command serves on *port*, so the SSH forward target always
         # matches what's listening; override only for a non-default layout.
-        self.command = command or f"hud serve env.py --host 0.0.0.0 --port {port}"
+        self.command = command or f"uv run hud serve env.py --host 0.0.0.0 --port {port}"
         self.workdir = workdir
         self.port = port
         self.ssh_host = ssh_host
@@ -720,6 +720,7 @@ class DaytonaRuntime:
                 kwargs: dict[str, Any] = {
                     "image": Image.base(config.image),
                     "ephemeral": True,
+                    "auto_stop_interval": 0,
                 }
                 if daytona_resources is not None:
                     kwargs["resources"] = daytona_resources
@@ -751,6 +752,7 @@ class DaytonaRuntime:
                 sandbox_params = CreateSandboxFromSnapshotParams(
                     snapshot=self.snapshot_name,
                     ephemeral=True,
+                    auto_stop_interval=0,
                 )
 
             create_timeout = 120

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -656,7 +656,9 @@ async def test_daytona_runtime_config_flows_into_daytona_sdk(
     assert calls["execute"] == (
         "hud-serve",
         _SessionExecuteRequest(
-            command="cd /app && uv run hud serve env.py --host 0.0.0.0 --port 8765",
+            command=(
+                'cd /app && PATH="$PWD/.venv/bin:$PATH" hud serve env.py --host 0.0.0.0 --port 8765'
+            ),
             run_async=True,
         ),
     )

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -195,6 +195,7 @@ def _install_fake_modal(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
 class _CreateSandboxFromSnapshotParams:
     snapshot: str
     ephemeral: bool
+    auto_stop_interval: int
 
 
 @dataclass(frozen=True)
@@ -207,6 +208,7 @@ class _CreateSnapshotParams:
 class _CreateSandboxFromImageParams:
     image: object
     ephemeral: bool
+    auto_stop_interval: int
     resources: object | None = None
 
 
@@ -641,6 +643,7 @@ async def test_daytona_runtime_config_flows_into_daytona_sdk(
     assert create_params == _CreateSandboxFromImageParams(
         image=_DaytonaImage("img:tag"),
         ephemeral=True,
+        auto_stop_interval=0,
         resources=_DaytonaResources(
             cpu=2,
             memory=4,
@@ -653,7 +656,7 @@ async def test_daytona_runtime_config_flows_into_daytona_sdk(
     assert calls["execute"] == (
         "hud-serve",
         _SessionExecuteRequest(
-            command="cd /app && hud serve env.py --host 0.0.0.0 --port 8765",
+            command="cd /app && uv run hud serve env.py --host 0.0.0.0 --port 8765",
             run_async=True,
         ),
     )
@@ -692,9 +695,29 @@ async def test_daytona_task_runtime_config_overlays_provider_defaults(
     assert create_params == _CreateSandboxFromImageParams(
         image=_DaytonaImage("img:task"),
         ephemeral=True,
+        auto_stop_interval=0,
         resources=_DaytonaResources(cpu=2, memory=4),
     )
     assert create_timeout == 45
+
+
+async def test_daytona_snapshot_sandboxes_disable_auto_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_daytona(monkeypatch)
+
+    async with DaytonaRuntime("snapshot")(_row()):
+        pass
+
+    create_call = calls["create"]
+    assert isinstance(create_call, tuple)
+    create_params, create_timeout = create_call
+    assert create_params == _CreateSandboxFromSnapshotParams(
+        snapshot="snapshot",
+        ephemeral=True,
+        auto_stop_interval=0,
+    )
+    assert create_timeout == 120
 
 
 async def test_daytona_runtime_config_rejects_unsupported_fields(


### PR DESCRIPTION
## Summary

- Launch Daytona environment servers with `uv run hud serve` so scaffold images resolve the SDK from `/app/.venv` in fresh process sessions.
- Disable Daytona's inherited auto-stop interval for both image-backed and snapshot-backed ephemeral rollout sandboxes.
- Cover the injected serve command and both sandbox creation parameter shapes in provider tests.

## Root cause

Daytona process sessions start a fresh shell rather than running the image CMD, so `/app/.venv/bin` is not added to `PATH`. The previous injected `hud serve` command therefore failed for images produced by `hud init`, whose Dockerfile installs the SDK with `uv sync` and launches it through `uv run`.

Ephemeral sandboxes also inherited the organization default 15-minute auto-stop interval. Running processes do not count as activity, and stopping an ephemeral sandbox deletes it, so long rollouts could disappear mid-run. The provider already owns sandbox cleanup through its `finally` deletion path, so rollout sandboxes now set `auto_stop_interval=0`.

## Impact

Daytona rollouts built from standard HUD scaffold images start reliably and remain available until the rollout completes or fails, after which the provider deletes the sandbox.

## Validation

- `uv run --no-sync pytest hud/eval/tests/test_docker_provider.py -q` — 17 passed
- `uv run --no-sync ruff check hud/eval/runtime.py hud/eval/tests/test_docker_provider.py`
- `uv run --no-sync ruff format --check hud/eval/runtime.py hud/eval/tests/test_docker_provider.py`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Daytona sandbox lifecycle and startup commands for all Daytona rollouts; scoped to the Daytona provider with test coverage.
> 
> **Overview**
> Fixes **Daytona** rollout sandboxes failing to start or vanishing mid-run.
> 
> The default injected serve command now prepends **`PATH="$PWD/.venv/bin:$PATH"`** before `hud serve`, so scaffold images that install the SDK with `uv sync` can find `hud` in fresh Daytona process sessions (where `/app/.venv/bin` is not on `PATH`).
> 
> Image-backed and snapshot-backed ephemeral sandboxes now pass **`auto_stop_interval=0`**, so org default idle auto-stop does not tear down rollout boxes while the env server runs; cleanup stays on the provider’s delete path.
> 
> Provider tests assert the updated execute command, **`auto_stop_interval=0`** on both create param shapes, and add coverage for snapshot sandboxes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8841dc0165c460aad8deb7c8bbcefe1abb239f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->