### PR TITLE
fix(harbor): recognise multi-step tasks in the converter

### DIFF
--- a/integrations/harbor.py
+++ b/integrations/harbor.py
@@ -132,8 +132,30 @@ def _slugify(name: str) -> str:
     return re.sub(r"-+", "-", normalized).strip("-") or "harbor"
 
 
+def _read_task_config(task_dir: Path) -> dict[str, Any] | None:
+    try:
+        return tomllib.loads((task_dir / "task.toml").read_text("utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+
+def _task_has_instruction(task_dir: Path, config: dict[str, Any]) -> bool:
+    """A task carries its instruction at the root (single-step) or under each
+    ``steps/<name>/`` directory declared by a ``[[steps]]`` array (multi-step).
+    A multi-step task has no root ``instruction.md``, so both forms count."""
+    return (task_dir / "instruction.md").is_file() or bool(config.get("steps"))
+
+
 def _is_harbor_task(path: Path) -> bool:
-    return path.is_dir() and (path / "task.toml").exists() and (path / "instruction.md").exists()
+    if not path.is_dir() or not (path / "task.toml").exists():
+        return False
+    config = _read_task_config(path)
+    if config is None:
+        # An unparseable task.toml still identifies a single-step task by its
+        # root instruction.md; a multi-step task can only be told apart via the
+        # config, so drop it when the config is unreadable.
+        return (path / "instruction.md").is_file()
+    return _task_has_instruction(path, config)
 
 
 def _hash_directory(path: Path) -> str:
@@ -158,14 +180,18 @@ class _HarborTask:
 
 
 def _parse_task(task_dir: Path) -> _HarborTask | None:
-    if not (task_dir / "instruction.md").is_file():
-        LOGGER.warning("failed to read instruction.md in %s", task_dir)
-        return None
-    try:
-        config: dict[str, Any] = tomllib.loads((task_dir / "task.toml").read_text("utf-8"))
-    except (OSError, tomllib.TOMLDecodeError):
-        LOGGER.warning("failed to parse task.toml in %s", task_dir)
+    config = _read_task_config(task_dir)
+    if config is None:
+        # Unparseable config degrades gracefully for a single-step task (kept
+        # with an empty config); a multi-step task needs the config to be read.
+        if not (task_dir / "instruction.md").is_file():
+            LOGGER.warning("failed to parse task.toml in %s", task_dir)
+            return None
+        LOGGER.warning("failed to parse task.toml in %s; using empty config", task_dir)
         config = {}
+    elif not _task_has_instruction(task_dir, config):
+        LOGGER.warning("no instruction.md and no [[steps]] in %s", task_dir)
+        return None
     env_dir = task_dir / "environment"
     return _HarborTask(
         task_id=task_dir.name,

--- a/integrations/tests/conftest.py
+++ b/integrations/tests/conftest.py
@@ -76,6 +76,33 @@ def make_harbor_task(
     return task_dir
 
 
+def make_multi_step_task(
+    parent: Path,
+    name: str,
+    steps: tuple[str, ...] = ("plan", "implement"),
+    dockerfile: str | None = _SIMPLE_DOCKERFILE,
+) -> Path:
+    """Create a synthetic multi-step Harbor task: no root instruction.md; each
+    step under steps/<name>/ carries its own instruction, declared by a
+    [[steps]] array in task.toml."""
+    task_dir = parent / name
+    task_dir.mkdir(parents=True, exist_ok=True)
+    steps_toml = "".join(f'\n[[steps]]\nname = "{step}"\n' for step in steps)
+    (task_dir / "task.toml").write_text(_DEFAULT_TASK_TOML + steps_toml, encoding="utf-8")
+    if dockerfile is not None:
+        env_dir = task_dir / "environment"
+        env_dir.mkdir(exist_ok=True)
+        (env_dir / "Dockerfile").write_text(dockerfile, encoding="utf-8")
+    for step in steps:
+        step_dir = task_dir / "steps" / step
+        (step_dir / "tests").mkdir(parents=True, exist_ok=True)
+        (step_dir / "instruction.md").write_text(f"# {step}\n", encoding="utf-8")
+        (step_dir / "tests" / "test.sh").write_text(
+            '#!/bin/bash\necho "1.0" > /logs/verifier/reward.txt\n', encoding="utf-8"
+        )
+    return task_dir
+
+
 @pytest.fixture()
 def single_task(tmp_path: Path) -> Path:
     """A single standalone Harbor task directory."""

--- a/integrations/tests/test_harbor.py
+++ b/integrations/tests/test_harbor.py
@@ -9,7 +9,7 @@ import pytest
 
 from integrations.harbor import detect, export, load
 
-from .conftest import make_harbor_task
+from .conftest import make_harbor_task, make_multi_step_task
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -59,6 +59,36 @@ def test_load_rejects_dirs_without_harbor_tasks(tmp_path: Path) -> None:
     empty.mkdir()
     with pytest.raises(ValueError, match="no Harbor tasks"):
         load(empty)
+
+
+def test_detect_and_load_recognize_multi_step_tasks(tmp_path: Path) -> None:
+    # A multi-step task has no root instruction.md; its instructions live under
+    # steps/<name>/, declared by a [[steps]] array in task.toml.
+    task = make_multi_step_task(tmp_path, "multi")
+
+    assert detect(task)
+    assert {row.id for row in load(task)} == {"multi"}
+
+
+def test_load_keeps_multi_step_tasks_alongside_single_step(tmp_path: Path) -> None:
+    dataset = tmp_path / "bench"
+    dataset.mkdir()
+    make_harbor_task(dataset, "single")
+    make_multi_step_task(dataset, "multi")
+
+    assert {row.id for row in load(dataset)} == {"single", "multi"}
+
+
+def test_detect_rejects_task_toml_without_instruction_or_steps(tmp_path: Path) -> None:
+    # task.toml alone is not a task: it needs a root instruction.md (single-step)
+    # or a [[steps]] array (multi-step).
+    task = tmp_path / "bare"
+    task.mkdir()
+    (task / "task.toml").write_text('[metadata]\ncategory = "x"\n', encoding="utf-8")
+
+    assert not detect(task)
+    with pytest.raises(ValueError, match="no Harbor tasks"):
+        load(task)
 
 
 def test_load_skips_unparseable_toml_but_keeps_the_rest(tmp_path: Path) -> None:


### PR DESCRIPTION
`_is_harbor_task` requires a root `instruction.md`, so valid **multi-step** tasks aren't recognised — their instructions live under `steps/<name>/`, declared by a `[[steps]]` array in `task.toml`. `load()` then raises `no Harbor tasks found` or drops every task at parse.

Reproducible on Harbor's own `examples/tasks/hello-multi-step-simple`:
```
_is_harbor_task(): False
```
though Harbor's own tooling builds and runs it fine.

**Fix:** recognise a task by a parseable `task.toml` plus an instruction in either form — root `instruction.md` (single-step) or a `[[steps]]` array (multi-step). `_is_harbor_task` and `_parse_task` share the check.

**Behaviour note:** `_parse_task` now rejects an unparseable `task.toml` (previously tolerated with an empty config), since detection must read it.

**Tested:** 3 single-step + 2 multi-step tasks accepted; non-Harbor folder, `task.toml` without instruction/steps, and broken `task.toml` rejected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Harbor task discovery/parsing in the integration layer, with new tests; behavior change is limited to which task directory layouts are accepted.
> 
> **Overview**
> Harbor **load/detect** no longer treats a root `instruction.md` as mandatory. Tasks are valid when `task.toml` parses and either that file exists (**single-step**) or the config defines a **`[[steps]]`** array (**multi-step**, instructions under `steps/<name>/`).
> 
> `_read_task_config`, `_task_has_instruction`, and updated `_is_harbor_task` / `_parse_task` share that rule. **`task.toml` alone** (no root instruction and no steps) is excluded. **Broken `task.toml`** still loads only if a root `instruction.md` is present (empty config); multi-step dirs without parseable config are dropped because steps cannot be detected otherwise.
> 
> Tests add **`make_multi_step_task`** and cover detect/load for multi-step tasks, mixed datasets, and bare `task.toml` rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6ef2955dd2895da01891b1993a24b5721f358c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->