### PR TITLE
CI: run vendored template suites against the SDK checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,33 @@ jobs:
       - name: Run tests
         run: uv run --python ${{ matrix.python-version }} --with=".[dev]" pytest --cov --cov-report=''
 
+  templates:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        template: [coding, cua]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install template with the SDK from this checkout
+        working-directory: environments/${{ matrix.template }}
+        run: |
+          uv sync --all-extras
+          uv pip install -e ../..
+
+      - name: Run template checks
+        working-directory: environments/${{ matrix.template }}
+        run: |
+          uv run --no-sync ruff format . --check
+          uv run --no-sync ruff check .
+          uv run --no-sync pytest -q
+
   lint-ruff:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Stacked on #512.

Adds a `templates` CI job: for each of `environments/{coding,cua}`, `uv sync` the template's pinned dependencies, install the SDK from the checkout over the `hud` pin (editable), then run the template's own `ruff format --check`, `ruff check`, and `pytest`.

This makes template breakage an SDK PR failure rather than something discovered after release. The coding template's suite includes a full local rollout (serve → connect → run → grade, golden=1.0/baseline=0.0), so the v6 serving contract is exercised end to end on every PR. Docker-dependent tests self-skip; those move to the nightly/release-gate job in a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change with no runtime or SDK behavior modifications; risk is limited to longer CI runs or flaky template tests blocking merges.
> 
> **Overview**
> Adds a **`templates`** CI job that runs on every PR alongside the existing SDK test matrix.
> 
> For each vendored template (`environments/coding` and `environments/cua`), the job syncs the template’s pinned deps, **replaces the published `hud` pin with an editable install of the repo root** (`uv pip install -e ../..`), then runs that template’s **ruff format (check)**, **ruff check**, and **pytest**.
> 
> This turns template breakage into an SDK PR failure instead of a post-release discovery. The coding template’s pytest suite includes hermetic local rollout coverage (serve → connect → run → grade), so the v6 serving contract is exercised end-to-end on every PR; Docker-only integration tests are expected to skip in this job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b253c2437079ae4a55a517faf08c15cf2cea51b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

HUD-2276
