### PR TITLE
fix(harbor): restore task.toml [metadata] as Task columns on load

### DIFF
--- a/integrations/harbor.py
+++ b/integrations/harbor.py
@@ -122,8 +122,22 @@ def load(path: str | Path) -> Taskset:
     tasks: list[Task] = []
     for idx, group in enumerate(sorted_groups, start=1):
         env_name = base_name if len(sorted_groups) == 1 else f"{base_name}-g{idx}"
-        tasks.extend(Task(env=env_name, id=harbor_task.task_id) for harbor_task in group)
+        tasks.extend(
+            Task(env=env_name, id=harbor_task.task_id, columns=_columns(harbor_task.config))
+            for harbor_task in group
+        )
     return Taskset(base_name, tasks)
+
+
+def _columns(config: dict[str, Any]) -> dict[str, Any] | None:
+    """``task.toml``'s ``[metadata]`` table, surfaced as filterable task columns.
+
+    Harbor datasets carry their per-task ``category``/``difficulty``/``tags`` here, which is
+    what makes a converted dataset sliceable on the dashboard. ``None`` when absent, so a task
+    without metadata stays unset rather than gaining an empty column set.
+    """
+    metadata = config.get("metadata")
+    return dict(metadata) if isinstance(metadata, dict) and metadata else None
 
 
 def _slugify(name: str) -> str:

--- a/integrations/tests/test_harbor.py
+++ b/integrations/tests/test_harbor.py
@@ -36,6 +36,34 @@ def test_load_single_task_dir_maps_rows(single_task: Path) -> None:
     assert row.env == taskset.name
 
 
+def test_load_surfaces_task_toml_metadata_as_columns(single_task: Path) -> None:
+    row = load(single_task)["cancel-async-tasks"]
+
+    assert row.columns == {"category": "systems", "difficulty": "medium", "tags": ["bash", "linux"]}
+
+
+def test_load_leaves_columns_unset_without_metadata(tmp_path: Path) -> None:
+    task = make_harbor_task(tmp_path, "bare", task_toml='version = "1.0"\n')
+
+    assert load(task)["bare"].columns is None
+
+
+def test_load_dataset_carries_per_task_metadata(dataset_multi_env: Path) -> None:
+    """Grouping rows by build context must not blur one task's metadata into another's."""
+    taskset = load(dataset_multi_env)
+
+    assert taskset["cancel-async-tasks"].columns == {
+        "category": "systems",
+        "difficulty": "medium",
+        "tags": ["bash", "linux"],
+    }
+    assert taskset["caffe-cifar-10"].columns == {
+        "category": "machine-learning",
+        "difficulty": "hard",
+        "tags": ["python", "ml"],
+    }
+
+
 def test_load_dataset_shares_one_env_per_build_context(dataset_same_env: Path) -> None:
     taskset = load(dataset_same_env)
 


### PR DESCRIPTION
`load()` documents its rows as carrying `task.toml`'s `[metadata]` as columns, and `_HarborTask` still parses and stores the config for it, but the mapping was dropped in `5b7110a` ("Simplify the v6 contract surfaces") and nothing has read `config` since. Every row loaded from a Harbor dataset comes back with `columns=None`.

## Repro

Any Harbor dataset whose tasks carry a `[metadata]` table:

```python
from integrations.harbor import load

# task.toml:  [metadata] \n category = "networking" \n difficulty = "easy"
[row.columns for row in load("path/to/dataset")]
# -> [None, None]
```

## Impact

The failure is quiet. A converted terminal-bench-style dataset loses the `category` / `difficulty` / `tags` each task ships with, so results can't be filtered or grouped by them. Because the field is merely absent rather than wrong, nothing surfaces the loss — the docstring on `load()` still promises the behaviour, and `_HarborTask.config` is still populated for a consumer that no longer exists.

## Fix

Restore the mapping behind a small `_columns` helper. Metadata is left unset rather than emptied when a `task.toml` has no `[metadata]` table, so tasks without it don't gain an empty column set.

## Tests

Three tests, using the existing `conftest` fixtures (which already carry `[metadata]`):

- `test_load_surfaces_task_toml_metadata_as_columns` — metadata reaches `Task.columns`
- `test_load_leaves_columns_unset_without_metadata` — no `[metadata]` table stays `None`
- `test_load_dataset_carries_per_task_metadata` — metadata stays per-task across a dataset whose rows are grouped by build context

The first and third fail on current `main`:

```
FAILED integrations/tests/test_harbor.py::test_load_surfaces_task_toml_metadata_as_columns
FAILED integrations/tests/test_harbor.py::test_load_dataset_carries_per_task_metadata
2 failed, 1 passed
```

and pass with the fix:

```
uv run pytest integrations/tests/test_harbor.py -q   ->  19 passed
uv run ruff format . --check                         ->  258 files already formatted
uv run ruff check .                                  ->  All checks passed!
uv run pyright                                       ->  0 errors, 21 warnings  (parity with baseline)
```

The full suite is `725 passed` with 6 pre-existing failures in `test_workspace.py` / `test_capability_backing.py` around `setpriv` and shell-uid sandboxing. I verified those fail identically on an unmodified checkout on this machine, so they're unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Harbor loader fix with no auth, runtime, or export path changes; behavior matches existing Task.columns usage on sync/upload.
> 
> **Overview**
> Restores Harbor **`load()`** mapping so each row’s **`Task.columns`** comes from **`task.toml`**’s **`[metadata]`** table (e.g. `category`, `difficulty`, `tags`), matching the documented contract that was dropped in a prior simplification.
> 
> A new **`_columns`** helper copies **`[metadata]`** when present and returns **`None`** when it’s missing or empty, so tasks without metadata don’t get an empty column dict. Metadata stays **per task** when rows are grouped by shared **`environment/`** build context.
> 
> Adds three tests covering metadata surfacing, unset columns without **`[metadata]`**, and per-task metadata across grouped datasets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b97097772dc4d5554abbd16c7b8f956520045a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->