### PR TITLE
fix(eval): report task slugs with traces

### DIFF
--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -105,18 +105,26 @@ async def trace_enter(
     *,
     job_id: str | None,
     group_id: str | None,
+    task_slug: str,
     model: str | None = None,
 ) -> None:
     """Report that one rollout started.
 
-    ``model`` is the model string the agent will sample (when known); the
-    platform resolves it and attributes the trace immediately on enter.
+    ``task_slug`` identifies the logical task independently of the execution
+    environment. ``model`` is the model string the agent will sample (when
+    known); the platform resolves it and attributes the trace immediately on
+    enter.
     """
     if not _reporting_enabled():
         return
     await _report(
         f"/trace/{trace_id}/enter",
-        {"job_id": job_id, "group_id": group_id, "model": model},
+        {
+            "job_id": job_id,
+            "group_id": group_id,
+            "task_slug": task_slug,
+            "model": model,
+        },
     )
 
 

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -332,13 +332,12 @@ async def rollout(
     from hud.agents.tool_agent import ToolAgent
 
     agent_model = agent.config.model if isinstance(agent, ToolAgent) else None
-    task_slug = task.slug or task.default_slug()
     with set_trace_context(trace_id):
         await trace_enter(
             trace_id,
             job_id=job_id,
             group_id=group_id,
-            task_slug=task_slug,
+            task_slug=task.slug,
             model=agent_model,
         )
         run: Run | None = None
@@ -411,7 +410,7 @@ async def rollout(
         run.trace.trace_id = trace_id
         run.job_id = job_id
         run.group_id = group_id
-        run.slug = task_slug
+        run.slug = task.slug
         await trace_exit(run)
     return run
 

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -332,8 +332,15 @@ async def rollout(
     from hud.agents.tool_agent import ToolAgent
 
     agent_model = agent.config.model if isinstance(agent, ToolAgent) else None
+    task_slug = task.slug or task.default_slug()
     with set_trace_context(trace_id):
-        await trace_enter(trace_id, job_id=job_id, group_id=group_id, model=agent_model)
+        await trace_enter(
+            trace_id,
+            job_id=job_id,
+            group_id=group_id,
+            task_slug=task_slug,
+            model=agent_model,
+        )
         run: Run | None = None
         _phase = "provisioning"
 
@@ -404,7 +411,7 @@ async def rollout(
         run.trace.trace_id = trace_id
         run.job_id = job_id
         run.group_id = group_id
-        run.slug = task.slug or task.default_slug()
+        run.slug = task_slug
         await trace_exit(run)
     return run
 

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -1240,7 +1240,7 @@ class HostedRuntime:
             "job_id": str(uuid.UUID(job_id)),
             "env": task.env,
             "task": task.id,
-            "slug": task.slug or task.default_slug(),
+            "slug": task.slug,
             "args": task.args,
             "agent": spec,
         }

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -1240,6 +1240,7 @@ class HostedRuntime:
             "job_id": str(uuid.UUID(job_id)),
             "env": task.env,
             "task": task.id,
+            "slug": task.slug or task.default_slug(),
             "args": task.args,
             "agent": spec,
         }

--- a/hud/eval/sync.py
+++ b/hud/eval/sync.py
@@ -151,7 +151,7 @@ def task_upload_payload(task: Task) -> dict[str, Any]:
     manifest and validates `args` against the task's schema.
     """
     payload: dict[str, Any] = {
-        "name": task.slug or task.default_slug(),
+        "name": task.slug,
         "env": {"name": task.env},
         "task_id": task.id,
         "args": task.args,

--- a/hud/eval/task.py
+++ b/hud/eval/task.py
@@ -35,6 +35,19 @@ if TYPE_CHECKING:
     from .runtime import HostedRuntime, Provider
 
 
+def _default_slug(data: dict[str, Any]) -> str:
+    task_id = data.get("id")
+    if not isinstance(task_id, str):
+        return ""
+    args = data.get("args")
+    if not isinstance(args, dict) or not args:
+        return task_id
+    digest = hashlib.sha1(  # noqa: S324 - non-crypto, stable disambiguator
+        json.dumps(args, sort_keys=True, default=str).encode("utf-8"),
+    ).hexdigest()[:8]
+    return f"{task_id}-{digest}"
+
+
 class Task(BaseModel):
     """One concrete task: an env name plus data (id, args, metadata).
 
@@ -47,7 +60,7 @@ class Task(BaseModel):
     env: str = Field(min_length=1)
     id: str = Field(min_length=1)
     args: dict[str, Any] = Field(default_factory=dict)
-    slug: str | None = None
+    slug: str = Field(default_factory=_default_slug)
     validation: list[dict[str, Any]] | None = None
     agent_config: dict[str, Any] | None = None
     #: Arbitrary metadata fields surfaced as filterable columns / leaderboard
@@ -56,15 +69,6 @@ class Task(BaseModel):
     #: Optional row-level runtime construction input. Runtime adapters apply the
     #: supported subset into their native launch shape or reject it.
     runtime_config: RuntimeConfig | None = None
-
-    def default_slug(self) -> str:
-        """A stable slug from the task id, disambiguated by an args hash when present."""
-        if not self.args:
-            return self.id
-        digest = hashlib.sha1(  # noqa: S324 - non-crypto, stable disambiguator
-            json.dumps(self.args, sort_keys=True, default=str).encode("utf-8"),
-        ).hexdigest()[:8]
-        return f"{self.id}-{digest}"
 
     # ─── execution ────────────────────────────────────────────────────
 
@@ -89,7 +93,7 @@ class Task(BaseModel):
         """
         from .taskset import Taskset  # circular: taskset -> sync -> task
 
-        taskset = Taskset(self.default_slug(), [self])
+        taskset = Taskset(self.slug, [self])
         return await taskset.run(
             agent,
             runtime=runtime,

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -168,7 +168,7 @@ class Taskset:
         by_slug: dict[str, Task] = {}
         duplicates: set[str] = set()
         for task in tasks:
-            slug = task.slug or task.default_slug()
+            slug = task.slug
             if slug in by_slug:
                 duplicates.add(slug)
             by_slug[slug] = task

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -179,6 +179,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     task = Task(
         env="sums",
         id="add",
+        slug="sums-add",
         args={"a": 1, "b": 2},
         runtime_config=RuntimeConfig(
             image="registry.example/sums:latest",
@@ -202,6 +203,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert payload["job_id"] == str(uuid.UUID(job_id))
     assert payload["env"] == "sums"
     assert payload["task"] == "add"
+    assert payload["slug"] == "sums-add"
     assert payload["args"] == {"a": 1, "b": 2}
     assert payload["runtime_config"] == {
         "image": "registry.example/sums:latest",

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -46,6 +46,28 @@ def _run_with(trace_id: str, *, extra: dict[str, Any]) -> Run:
     return run
 
 
+async def test_trace_enter_reports_task_and_group_identity(recorder: _Recorder) -> None:
+    await job_mod.trace_enter(
+        "abc",
+        job_id="job-1",
+        group_id="group-1",
+        task_slug="fix-bug-3",
+        model="test-model",
+    )
+
+    assert recorder.calls == [
+        (
+            "/trace/abc/enter",
+            {
+                "job_id": "job-1",
+                "group_id": "group-1",
+                "task_slug": "fix-bug-3",
+                "model": "test-model",
+            },
+        )
+    ]
+
+
 async def test_trace_exit_propagates_stop_reason(recorder: _Recorder) -> None:
     run = _run_with("abc", extra={})
     run.trace.stop_reason = "max_steps"

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -44,17 +44,22 @@ def test_env_task_call_returns_public_task() -> None:
     assert runnable.env == "e"  # the row carries the env's name, not the object
 
 
-def test_default_slug_is_task_id_without_args() -> None:
+def test_slug_defaults_to_task_id_without_args() -> None:
     v = Task(env="e", id="solve")
-    assert v.default_slug() == "solve"
+    assert v.slug == "solve"
 
 
-def test_default_slug_is_deterministic_with_args() -> None:
+def test_slug_default_is_deterministic_with_args() -> None:
     a = Task(env="e", id="solve", args={"b": 2, "a": 1})
     b = Task(env="e", id="solve", args={"a": 1, "b": 2})  # key order differs
-    assert a.default_slug() == b.default_slug()  # stable: keys sorted
-    assert a.default_slug().startswith("solve-")
-    assert a.default_slug() != Task(env="e", id="solve", args={"a": 9}).default_slug()
+    assert a.slug == b.slug  # stable: keys sorted
+    assert a.slug.startswith("solve-")
+    assert a.slug != Task(env="e", id="solve", args={"a": 9}).slug
+
+
+def test_slug_rejects_none() -> None:
+    with pytest.raises(ValueError, match="slug"):
+        Task.model_validate({"env": "e", "id": "solve", "slug": None})
 
 
 # ─── the portable row shape ────────────────────────────────────────────
@@ -70,7 +75,8 @@ def test_env_serializes_as_name_reference() -> None:
 
 def test_compact_dump_omits_unset_metadata() -> None:
     data = Task(env="e", id="t").model_dump(exclude_none=True)
-    assert set(data) == {"env", "id", "args"}  # no None slug/validation/etc.
+    assert set(data) == {"env", "id", "args", "slug"}
+    assert data["slug"] == "t"
 
     data2 = Task(env="e", id="t", slug="s").model_dump(exclude_none=True)
     assert data2["slug"] == "s"

--- a/hud/integrations/harbor/_export.py
+++ b/hud/integrations/harbor/_export.py
@@ -395,7 +395,7 @@ async def _export_tasks(
         # A slug is user data that becomes a directory name: namespaced ids
         # ("suite/fix") would nest out of harbor.load()'s reach and ".." would
         # escape the output directory entirely.
-        declared = task.slug or task.default_slug()
+        declared = task.slug
         slug = _safe_component(declared)
         if slug in claimed:
             raise ValueError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     # Core dependencies - minimal for MCP servers and CLI
     "httpx>=0.23.0,<1",
     "packaging>=21.0",
-    "pydantic>=2.6,<3",
+    "pydantic>=2.10,<3",
     "pydantic-settings>=2.2,<3",
     # MCP dependencies
     "mcp>=1.24.0,<2.0",


### PR DESCRIPTION
## Summary

- materialize `Task.slug` during Pydantic validation, deriving a stable default from task id and args when omitted
- use the validated slug directly across tasksets, sync, local/cloud trace reporting, hosted rollout submissions, and Harbor export
- include `task_slug` in the trace-enter report for local and cloud execution
- cover default, explicit, and invalid slug behavior plus both reporting paths with focused tests

## Why

The trace reporting boundary carried execution identifiers but omitted logical task identity. Unlinked SDK traces therefore reached the platform with no stable task key and fell back to UUID-derived labels or `Unknown Task`.

This makes `task_slug` the portable task identity across execution environments while leaving `group_id` as execution-group identity. The model now guarantees that every valid `Task` has a slug, so consumers do not need independent fallback logic.

## Validation

- `uv run pytest -p no:cacheprovider hud/eval/tests/test_task.py hud/eval/tests/test_job.py hud/eval/tests/test_hosted.py` — 37 passed
- `uv run pyright` — 0 errors
- `uv run ruff check` on changed files
- `uv run ruff format` on changed files
- `uv lock --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wire contracts (`task_slug` on trace enter, `slug` on rollout submit) and make slug required on all tasks; platform must accept new fields, and older pydantic or clients assuming optional slug may need updates.
> 
> **Overview**
> **Every valid `Task` now has a materialized `slug`** at validation time (stable default from task id plus args hash when omitted), replacing optional `slug` and removed `default_slug()` fallbacks across the eval stack.
> 
> **Platform and local reporting** send logical task identity: `trace_enter` includes **`task_slug`**, hosted **`/rollouts/submit`** adds **`slug`**, and taskset upload/sync/Harbor export use **`task.slug`** directly for names and run receipts.
> 
> **Dependency:** `pydantic` minimum raised to **2.10** in `pyproject.toml`. Tests cover default/explicit/invalid slugs and both trace-enter and hosted submit payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 556fe6d287ed466be154ce7a38fbe3e5fa9d2bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->