### PR TITLE
fix(eval): reject empty task slugs

### DIFF
--- a/hud/eval/task.py
+++ b/hud/eval/task.py
@@ -60,7 +60,7 @@ class Task(BaseModel):
     env: str = Field(min_length=1)
     id: str = Field(min_length=1)
     args: dict[str, Any] = Field(default_factory=dict)
-    slug: str = Field(default_factory=_default_slug)
+    slug: str = Field(default_factory=_default_slug, min_length=1)
     validation: list[dict[str, Any]] | None = None
     agent_config: dict[str, Any] | None = None
     #: Arbitrary metadata fields surfaced as filterable columns / leaderboard

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -62,6 +62,11 @@ def test_slug_rejects_none() -> None:
         Task.model_validate({"env": "e", "id": "solve", "slug": None})
 
 
+def test_slug_rejects_empty_string() -> None:
+    with pytest.raises(ValueError, match="slug"):
+        Task(env="e", id="solve", slug="")
+
+
 # ─── the portable row shape ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- require explicit task slugs to contain at least one character
- add coverage for rejecting `slug=""`

## Why

The SDK reports `Task.slug` directly to trace and rollout endpoints.

## Impact

Default slug generation is unchanged. Explicit empty slugs now fail immediately during `Task` construction with the same Pydantic validation used for empty environment names and task IDs.

## Validation

- `uv run '--with=.[dev]' pytest hud/eval/tests/test_task.py` (18 passed)
- `uv run '--with=.[dev]' ruff check hud/eval/task.py hud/eval/tests/test_task.py`
- `uv run '--with=.[dev]' pyright hud/eval/task.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a1a7717f83e56f5602b1af39c6863a5dac705fae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->