### PR TITLE
fix(robot): preserve dataset paths and bound rollout cancellation

### DIFF
--- a/hud/agents/tests/test_robot_dataset_writer.py
+++ b/hud/agents/tests/test_robot_dataset_writer.py
@@ -98,7 +98,6 @@ def test_finalize_clears_all_datasets(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_nested_image_keys_stay_distinct(monkeypatch: pytest.MonkeyPatch) -> None:
-    """left/image + right/image must not both collapse to observation.images.image."""
     created = _install_fake_lerobot(monkeypatch)
     contract = {
         "robot_type": "stereo",
@@ -117,18 +116,21 @@ def test_nested_image_keys_stay_distinct(monkeypatch: pytest.MonkeyPatch) -> Non
         np.zeros(1, dtype=np.float32),
         task="t",
     )
+    writer.end_episode()
+
     features = created[0].create_kwargs["features"]
     assert "observation.images.left_image" in features
     assert "observation.images.right_image" in features
-    assert writer._frames[0]["observation.images.left_image"] is left  # pyright: ignore[reportPrivateUsage]
-    assert writer._frames[0]["observation.images.right_image"] is right  # pyright: ignore[reportPrivateUsage]
+    frame = created[0].add_frame.call_args.args[0]
+    assert frame["observation.images.left_image"] is left
+    assert frame["observation.images.right_image"] is right
 
 
 def test_duplicate_mapped_keys_raise() -> None:
     contract = {
         "robot_type": "bad",
         "features": {
-            # Same LeRobot slug after / → _ (or identical leaf under observation.state).
+            # Both wire names become the same LeRobot key after path flattening.
             "cam/rgb": {"role": "observation", "dtype": "image", "shape": [2, 2, 3]},
             "cam_rgb": {"role": "observation", "dtype": "image", "shape": [2, 2, 3]},
             "action": {"role": "action", "dtype": "float32", "shape": [1]},

--- a/hud/environment/tests/test_robot_regressions.py
+++ b/hud/environment/tests/test_robot_regressions.py
@@ -322,14 +322,12 @@ async def test_claim_rejects_empty_kwargs_after_nonempty_batch() -> None:
 
 
 @pytest.mark.asyncio
-async def test_release_uses_legacy_result_hook() -> None:
-    """Subclasses that override result() (not result_slots) still grade correctly."""
-
-    class _LegacyGrade(_StubBridge):
+async def test_release_uses_overridden_result() -> None:
+    class _CustomGrade(_StubBridge):
         def result(self) -> dict[str, Any]:
             return {"score": 0.42, "success": True, "total_reward": 3.0, "detail": "custom"}
 
-    bridge = _LegacyGrade()
+    bridge = _CustomGrade()
     ep = await bridge._claim_episode()
     grade = await bridge._release_episode(ep["token"])
     assert grade == {"score": 0.42, "success": True, "total_reward": 3.0, "detail": "custom"}

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -413,7 +413,6 @@ async def test_timeout_includes_grading() -> None:
 
 
 async def test_timeout_aborts_when_cancel_rpc_hangs(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A live-but-silent env must not stall the batch inside unbounded cancel."""
     from hud.clients.client import HudClient
 
     env = Environment("sums")


### PR DESCRIPTION
### Motivation

- Prevent nested camera observation names from colliding when mapped into LeRobot dataset keys so distinct wire paths like `left/image` and `right/image` remain addressable.
- Restore a clear scalar grading hook so single-env bridges can override `result()` while vectorized bridges continue to provide per-slot grades via `result_slots()`.
- Ensure rollout timeouts and caller cancellation always make progress even if a peer's best-effort `cancel()` RPC hangs by bounding that call.
- Tighten regression tests to exercise public writer lifecycle and observable behaviors instead of poking private buffers.

### Description

- Map full wire paths into LeRobot slugs by replacing `/` with `_` (e.g. `left/image` → `left_image`) and raise `ValueError` when two wire names would map to the same LeRobot key to avoid silent overwrites; implement in `hud/agents/robot/dataset.py` (key map + duplicate check).
- Change `DatasetWriter` tests to exercise `add()` → `end_episode()` and assert the actual committed frame via the mocked dataset's `add_frame` call rather than inspecting the writer's private `_frames` buffer (tests in `hud/agents/tests/test_robot_dataset_writer.py`).
- Restore `RobotBridge.result()` as the single-episode scalar grade customization point and make `result_slots()` broadcast `result()` by default for multi-slot/vectorized bridges (changes in `hud/environment/robot/bridge.py`).
- Bound the best-effort `HudClient.cancel()` with `asyncio.wait_for(..., timeout=2.0)` in the rollout cleanup paths so a hung cancel does not stall abort/teardown (changes in `hud/eval/run.py`).
- Rename/clarify a grading regression test to assert that an overridden `result()` is used (test tweak in `hud/environment/tests/test_robot_regressions.py`).
- Update docs to document the nested-camera naming contract mapping to `observation.images.<wire_path>` (docs change in `docs/v6/advanced/robots.mdx`).

### Testing

- Ran `python3.12 -m compileall -q` over the modified modules and it succeeded.  
- Ran `git diff --check` and local diffs/stat checks passed.  
- Attempted to run the focused pytest subset `uv run pytest -q hud/agents/tests/test_robot_dataset_writer.py hud/environment/tests/test_robot_regressions.py hud/eval/tests/test_rollout.py` but the environment could not download `pytest` from PyPI due to a network/proxy error, so the automated test run did not complete.  
- The changes include small, focused test updates that exercise the new public behaviors and should pass once CI or a local environment with network access runs the pytest suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6c3237f3fc83268388cd47ea9f4b1e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dataset key mapping and rollout teardown timing, which can affect existing robot contracts and timeout/cleanup behavior; grading hook semantics touch episode scoring for bridges.
> 
> **Overview**
> Keeps **distinct LeRobot dataset keys** for nested camera wire paths by flattening the full path (`left/image` → `observation.images.left_image`) and **raising** when two contract features would map to the same key, so stereo or multi-camera observations do not silently overwrite each other.
> 
> On rollout **timeout or cancellation**, **`HudClient.cancel()`** is wrapped in a **2s** `asyncio.wait_for` so a hung env RPC cannot block `abort` and stall batches (including robot slot cleanup).
> 
> **Robot bridge grading** stays on an overridden **`result()`** for custom scalar grades, with **`result_slots()`** defaulting to broadcasting that dict across slots.
> 
> **Tests** now drive **`DatasetWriter`** through **`add()` → `end_episode()`** and assert the frame passed to the mocked **`add_frame`**, instead of reading private `_frames`; a bridge regression test is renamed to **`test_release_uses_overridden_result`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 521a70cb477c5be9075604bb1d4fc9a35423f6ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->