### PR TITLE
fix(client): keep control sessions alive

### DIFF
--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
     from hud.eval.runtime import Runtime
 
 LOGGER = logging.getLogger("hud.clients")
+_CONTROL_HEARTBEAT_INTERVAL_SECONDS = 120.0
+_CONTROL_HEARTBEAT_TIMEOUT_SECONDS = 5.0
 
 #: protocol -> CapabilityClient subclass, for ``HudClient.open``.
 _CLIENT_REGISTRY: dict[str, type[CapabilityClient]] = {
@@ -99,6 +101,7 @@ class HudClient:
         #: raw stream pairs (no dialable endpoint): bindings pass through.
         self._endpoint = endpoint
         self._ids = itertools.count(1)
+        self._call_lock = asyncio.Lock()
         self._closed = False
         self.manifest: Manifest | None = None
         self._routes: dict[str, str] = {}
@@ -299,24 +302,45 @@ class HudClient:
 
     # ─── JSON-RPC plumbing ────────────────────────────────────────────
 
-    async def _call(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
-        msg_id = next(self._ids)
-        await send_frame(
-            self._writer,
-            {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params},
-        )
-        reply = await read_frame(self._reader)
-        if reply is None:
-            # Connection-level event, not a protocol error: the peer hung up
-            # without answering (e.g. a proxied port whose backend isn't up).
-            raise EOFError(f"env closed connection during {method!r}")
-        if "error" in reply:
-            err = reply["error"]
-            raise HudProtocolError(int(err.get("code", -32000)), str(err.get("message", "")))
-        result = reply.get("result")
-        if not isinstance(result, dict):
-            raise HudProtocolError(-32603, f"{method!r}: result was not an object")
-        return result
+    async def _call(
+        self,
+        method: str,
+        params: dict[str, Any],
+        *,
+        reply_timeout: float | None = None,
+    ) -> dict[str, Any]:
+        async with self._call_lock:
+            try:
+                async with asyncio.timeout(reply_timeout):
+                    msg_id = next(self._ids)
+                    await send_frame(
+                        self._writer,
+                        {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params},
+                    )
+                    reply = await read_frame(self._reader)
+                    if reply is None:
+                        raise EOFError(f"env closed connection during {method!r}")
+                    if reply.get("id") != msg_id:
+                        self.abort()
+                        raise HudProtocolError(
+                            -32603,
+                            f"{method!r}: reply id did not match request",
+                        )
+                    if "error" in reply:
+                        err = reply["error"]
+                        raise HudProtocolError(
+                            int(err.get("code", -32000)),
+                            str(err.get("message", "")),
+                        )
+                    result = reply.get("result")
+                    if not isinstance(result, dict):
+                        raise HudProtocolError(-32603, f"{method!r}: result was not an object")
+                    return result
+            except HudProtocolError:
+                raise
+            except BaseException:
+                self.abort()
+                raise
 
 
 # ─── module-level entry points ────────────────────────────────────────
@@ -401,10 +425,42 @@ async def connect(runtime: Runtime, *, ready_timeout: float = 240.0) -> AsyncIte
         parts.port or 0,
         ready_timeout=_runtime_ready_timeout(runtime, ready_timeout),
     )
+    owner = asyncio.current_task()
+    assert owner is not None
+    heartbeat_error: Exception | None = None
+
+    async def heartbeat() -> None:
+        nonlocal heartbeat_error
+        while True:
+            await asyncio.sleep(_CONTROL_HEARTBEAT_INTERVAL_SECONDS)
+            assert client.manifest is not None
+            try:
+                await client._call(
+                    "hello",
+                    {"session_id": client.manifest.session_id},
+                    reply_timeout=_CONTROL_HEARTBEAT_TIMEOUT_SECONDS,
+                )
+            except HudProtocolError as exc:
+                LOGGER.warning("control heartbeat failed: %s", exc)
+                return
+            except Exception as exc:
+                LOGGER.warning("control heartbeat failed: %s", exc)
+                heartbeat_error = exc
+                owner.cancel()
+                return
+
+    heartbeat_task = asyncio.create_task(heartbeat(), name="hud-control-heartbeat")
     try:
-        yield client
-    finally:
-        await client.close()
+        try:
+            yield client
+        finally:
+            heartbeat_task.cancel()
+            await asyncio.gather(heartbeat_task, return_exceptions=True)
+            await client.close()
+    except asyncio.CancelledError:
+        if heartbeat_error is not None:
+            raise heartbeat_error from None
+        raise
 
 
 __all__ = ["HudClient", "HudProtocolError", "Manifest", "ServerInfo", "connect"]

--- a/hud/clients/tests/test_connect.py
+++ b/hud/clients/tests/test_connect.py
@@ -54,6 +54,108 @@ async def test_connect_retries_through_accept_then_eof_until_the_env_serves() ->
     assert attempts == 3
 
 
+async def test_heartbeat_serializes_calls_without_aborting_on_protocol_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[dict[str, object]] = []
+    heartbeat_received = asyncio.Event()
+    release_heartbeat = asyncio.Event()
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            hello = await read_frame(reader)
+            assert hello is not None
+            requests.append(hello)
+            await send_frame(
+                writer,
+                {"jsonrpc": "2.0", "id": hello["id"], "result": HELLO_RESULT},
+            )
+
+            heartbeat = await read_frame(reader)
+            assert heartbeat is not None
+            requests.append(heartbeat)
+            heartbeat_received.set()
+            await release_heartbeat.wait()
+            await send_frame(
+                writer,
+                {
+                    "jsonrpc": "2.0",
+                    "id": heartbeat["id"],
+                    "error": {"code": -32601, "message": "heartbeat refused"},
+                },
+            )
+
+            grade = await read_frame(reader)
+            assert grade is not None
+            requests.append(grade)
+            await send_frame(
+                writer,
+                {"jsonrpc": "2.0", "id": grade["id"], "result": {"score": 1.0}},
+            )
+            await read_frame(reader)
+        finally:
+            writer.close()
+
+    monkeypatch.setattr(client_module, "_CONTROL_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        async with connect(Runtime(f"tcp://127.0.0.1:{port}")) as client:
+            await asyncio.wait_for(heartbeat_received.wait(), 1.0)
+            grade = asyncio.create_task(client.grade({"answer": "done"}))
+            await asyncio.sleep(0)
+            assert [request["method"] for request in requests] == ["hello", "hello"]
+            release_heartbeat.set()
+            assert await asyncio.wait_for(grade, 1.0) == {"score": 1.0}
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert [request["method"] for request in requests] == ["hello", "hello", "tasks.grade"]
+    assert requests[1]["params"] == {"session_id": "s-1"}
+
+
+async def test_heartbeat_transport_failure_interrupts_the_connection_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    heartbeat_received = asyncio.Event()
+    body_interrupted = asyncio.Event()
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            hello = await read_frame(reader)
+            assert hello is not None
+            await send_frame(
+                writer,
+                {"jsonrpc": "2.0", "id": hello["id"], "result": HELLO_RESULT},
+            )
+            heartbeat = await read_frame(reader)
+            assert heartbeat is not None
+            heartbeat_received.set()
+            await reader.read()
+        finally:
+            writer.close()
+
+    monkeypatch.setattr(client_module, "_CONTROL_HEARTBEAT_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(client_module, "_CONTROL_HEARTBEAT_TIMEOUT_SECONDS", 0.01)
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        with pytest.raises(TimeoutError):
+            async with connect(Runtime(f"tcp://127.0.0.1:{port}")):
+                await asyncio.wait_for(heartbeat_received.wait(), 1.0)
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    body_interrupted.set()
+                    raise
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert body_interrupted.is_set()
+
+
 async def test_connect_uses_runtime_ready_timeout_param(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What changed

- Keep HUD TCP control sessions active with a client-owned heartbeat every 120 seconds, reusing the existing `hello(session_id)` protocol.
- Serialize control RPCs so heartbeat and grading replies cannot be consumed out of order.
- Bound heartbeat replies to 5 seconds. Transport failures abort while the RPC lock is held; fully consumed HUD protocol errors only stop further heartbeats.
- Remove runtime-provider flags and rollout-level keepalive orchestration.

## Why

Long rollouts can leave the control connection idle between `tasks.start` and `tasks.grade`. The observed hosted failures resumed traffic after roughly 350 seconds and received a connection reset.

Connection liveness belongs to the client transport, independent of the runtime provider.

## Validation

- `uv run --with='.[dev]' pytest -q` — 961 passed, 9 deselected
- `uv run --with='.[dev]' ruff check .`
- `uv run --with='.[dev]' ruff format --check .`
- `uv run --with='.[dev]' pyright` — 0 errors; existing optional-import warnings only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core control-channel RPC behavior and long-session liveness for all `connect()` users; mistakes could break grading or leave connections in a bad state, but scope is localized to the client transport with new tests.
> 
> **Overview**
> Keeps long-lived TCP control sessions from dying during idle gaps (e.g. between `tasks.start` and `tasks.grade`) by sending a **120s** `hello(session_id)` heartbeat from `connect()`, with **5s** reply timeouts.
> 
> **Control RPC plumbing** is tightened: `_call` runs under an `asyncio.Lock`, optional `reply_timeout`, reply **id** validation, and `abort()` on transport mismatches or non-protocol failures so heartbeat and grading traffic cannot steal each other’s frames.
> 
> Heartbeat **protocol errors** only stop further heartbeats; **transport/timeouts** cancel the owning `connect()` body so callers see the real failure. Tests cover serialization with a slow heartbeat error and interruption on transport failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9fd7eefc690b0617d9bfa2b36ff58ed2b92eeee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->