### PR TITLE
feat(cookbooks): add Harbor Terminal-Bench runner

### DIFF
--- a/cookbooks/harbor-terminal-bench/README.md
+++ b/cookbooks/harbor-terminal-bench/README.md
@@ -1,0 +1,60 @@
+# Terminal-Bench on HUD
+
+Run [Harbor](https://github.com/harbor-framework/harbor)-format task directories —
+Terminal-Bench 2.0 and anything else in that layout — through the HUD runtime.
+The experimental `hud.integrations.harbor` adapter builds each task's own
+environment image, wraps it with the HUD control channel, and returns a
+`Taskset` you run like any other.
+
+## Run
+
+```bash
+uv run run.py ./terminal-bench
+```
+
+Run commands from this cookbook directory so uv uses its local project.
+
+By default, the runner uses each task's `solution/solve.sh` as an oracle. Run
+the oracle first to verify that the environment and verifier can produce the
+task's expected reward before evaluating a model.
+
+```bash
+# A real agent, once the oracle is clean
+uv run run.py ./terminal-bench --agent claude-sonnet-4-5
+
+# Just the ones you are debugging
+uv run run.py ./terminal-bench --task qemu-startup --task configure-git-webserver
+```
+
+Output is one row per task plus a mean over the tasks that actually finished:
+
+```
+task                                      reward  status
+configure-git-webserver                      1.0  completed
+qemu-startup                                 1.0  completed
+regex-log                                    1.0  completed
+
+scored 3/3 (errored 0), mean reward 1.00
+```
+
+Runs that end in `error` are reported separately from scored runs.
+
+## What you need
+
+- Docker. `DockerRuntime` gives every container the profile the in-image
+  workspace sandbox needs, so no extra flags.
+- Network, for the image builds and for whatever the tasks fetch.
+- `HUD_API_KEY` only when `--agent` names a model, for gateway inference.
+
+The first run builds two images per distinct environment (the task's own, then
+the HUD wrapper) and is slow; later runs reuse the layers.
+
+## Use a local SDK build
+
+The adapted image installs `hud` from PyPI by default. To use a local SDK
+build, build a wheel and pass it to the adapter:
+
+```bash
+uv build --wheel --out-dir /tmp/hud-wheel ../..
+uv run run.py ./terminal-bench --hud-requirement /tmp/hud-wheel/hud-*.whl
+```

--- a/cookbooks/harbor-terminal-bench/pyproject.toml
+++ b/cookbooks/harbor-terminal-bench/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "harbor-terminal-bench"
+version = "0.1.0"
+description = "Run Terminal-Bench (Harbor) tasks through the HUD runtime (cookbook)"
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "hud",
+]
+
+[tool.uv]
+package = false
+
+# Track the SDK from this repo. If you copied this folder out, delete this
+# block to use the released hud from PyPI.
+[tool.uv.sources]
+hud = { path = "../..", editable = true }

--- a/cookbooks/harbor-terminal-bench/run.py
+++ b/cookbooks/harbor-terminal-bench/run.py
@@ -1,0 +1,107 @@
+"""Run Harbor task directories through the HUD runtime.
+
+uv run run.py ./terminal-bench                    # every task, with the oracle
+uv run run.py ./terminal-bench --agent claude-sonnet-4-5
+uv run run.py ./terminal-bench --task qemu-startup --task regex-log
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from hud.agents import create_agent
+from hud.agents.base import Agent
+from hud.eval import DockerRuntime
+from hud.eval.run import Run
+from hud.integrations import harbor
+
+if TYPE_CHECKING:
+    from hud.capabilities import SSHClient
+
+
+def task_dirs(dataset: Path) -> list[Path]:
+    """The Harbor tasks under *dataset* — or *dataset* itself, if it is one."""
+    if (dataset / "task.toml").is_file():
+        return [dataset]
+    return sorted(child for child in dataset.iterdir() if (child / "task.toml").is_file())
+
+
+class Oracle(Agent):
+    """Run each task's ``solution/solve.sh`` instead of a model."""
+
+    def __init__(self, tasks: list[Path]) -> None:
+        self.solutions = {task.name: task / "solution" / "solve.sh" for task in tasks}
+
+    async def __call__(self, run: Run) -> None:
+        solution = self.solutions[run.task_id]
+        ssh = cast("SSHClient", await run.client.open("ssh/2"))
+        result = await ssh.conn.run(solution.read_text("utf-8"), check=True)
+        if result.exit_status is None:
+            raise RuntimeError("solution SSH channel closed without an exit status")
+        run.trace.content = "solution completed"
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("dataset", type=Path, help="a Harbor task dir, or a directory of them")
+    parser.add_argument(
+        "--task", action="append", default=[], metavar="ID", help="run only these task dirs"
+    )
+    parser.add_argument(
+        "--agent",
+        default="oracle",
+        help="'oracle' to run each task's own solution, else a model name",
+    )
+    parser.add_argument("--max-steps", type=int, default=40)
+    parser.add_argument("--max-concurrent", type=int, default=3)
+    parser.add_argument(
+        "--hud-requirement",
+        default="hud",
+        help="the HUD package requirement installed into the adapted image",
+    )
+    args = parser.parse_args()
+
+    wanted = set(args.task)
+    tasks = [task for task in task_dirs(args.dataset) if not wanted or task.name in wanted]
+    if not tasks:
+        raise SystemExit(f"no Harbor tasks in {args.dataset}")
+    if missing := wanted - {task.name for task in tasks}:
+        raise SystemExit(f"no such task: {', '.join(sorted(missing))}")
+    if args.agent == "oracle":
+        missing = [task.name for task in tasks if not (task / "solution" / "solve.sh").is_file()]
+        if missing:
+            raise SystemExit(f"tasks without solution/solve.sh: {', '.join(missing)}")
+
+    taskset = await harbor.adapt(
+        args.dataset,
+        task_ids=wanted or None,
+        hud_requirement=args.hud_requirement,
+    )
+
+    agent = (
+        Oracle(tasks)
+        if args.agent == "oracle"
+        else create_agent(args.agent, max_steps=args.max_steps)
+    )
+    job = await taskset.run(
+        agent,
+        runtime=DockerRuntime(),
+        max_concurrent=args.max_concurrent,
+    )
+
+    print(f"\n{'task':<40} {'reward':>7}  status")
+    for run in sorted(job.runs, key=lambda r: r.task_id):
+        print(f"{run.task_id:<40} {run.reward:>7}  {run.trace.status}")
+
+    errored = len(job.errors)
+    scored = len(job.runs) - errored
+    print(f"\nscored {scored}/{len(job.runs)} (errored {errored}), mean reward {job.reward:.2f}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/docs/v6/cookbooks/index.mdx
+++ b/docs/v6/cookbooks/index.mdx
@@ -36,6 +36,10 @@ These ship in the repo without a separate walkthrough. Read the README in each
 directory to run them.
 
 <CardGroup cols={2}>
+  <Card title="Harbor and Terminal-Bench" icon="ship" href="https://github.com/hud-evals/hud-python/tree/main/cookbooks/harbor-terminal-bench">
+    Adapt Harbor-format task directories, validate them with their reference
+    solutions, then run the same taskset against a model.
+  </Card>
   <Card title="RL training" icon="dumbbell" href="https://github.com/hud-evals/hud-python/tree/main/cookbooks/rl-training">
     On-policy RL: roll out a taskset with the current weights, train on the
     resulting trajectories, and serve the updated weights for the next rollout,

--- a/hud/integrations/harbor/adapt.py
+++ b/hud/integrations/harbor/adapt.py
@@ -14,7 +14,10 @@ import tomllib
 import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
@@ -204,6 +207,7 @@ class HarborTask:
 async def adapt(
     path: str | Path,
     *,
+    task_ids: Collection[str] | None = None,
     push: str | None = None,
     hud_requirement: str = "hud",
 ) -> Taskset:
@@ -220,6 +224,14 @@ async def adapt(
         dataset = root
     if not task_dirs:
         raise ValueError(f"no Harbor tasks found in {path}")
+    if task_ids is not None:
+        selected = set(task_ids)
+        available = {task_dir.name for task_dir in task_dirs}
+        if missing := selected - available:
+            raise ValueError(f"no such Harbor task: {', '.join(sorted(missing))}")
+        task_dirs = [task_dir for task_dir in task_dirs if task_dir.name in selected]
+        if not task_dirs:
+            raise ValueError("no Harbor tasks selected")
 
     tasks = []
     for task_dir in task_dirs:

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -466,6 +466,19 @@ async def test_distinct_environments_build_distinct_images(
     assert len([call for call in fake_docker if call[0] == "build"]) == 4
 
 
+async def test_task_selection_happens_before_validation_and_build(
+    tmp_path: Path,
+    fake_docker,
+) -> None:
+    make_harbor_task(tmp_path, "selected")
+    make_multi_step_task(tmp_path, "unsupported")
+
+    taskset = await harbor.adapt(tmp_path, task_ids={"selected"})
+
+    assert [task.id for task in taskset] == ["selected"]
+    assert len([call for call in fake_docker if call[0] == "build"]) == 2
+
+
 async def test_adapt_maps_resources_and_pushes_the_images(tmp_path: Path, fake_docker) -> None:
     task = make_harbor_task(tmp_path, "gpu")
     (task / "task.toml").write_text(


### PR DESCRIPTION
## Summary

- add a runnable cookbook for Harbor and Terminal-Bench task directories
- validate tasks with their reference solutions by default, or run a model-backed agent
- filter selected task directories before Harbor validation and image builds
- consume the packaged `hud.integrations.harbor` API without source-path manipulation
- add the cookbook to the SDK documentation index

## Stack

This PR targets #549 because the cookbook consumes the experimental Harbor integration packaged there. The cookbook and its small `task_ids` API addition remain separate from the package move.

## Validation

- `uv run --with='.[dev]' pytest -q hud/integrations/harbor/tests/test_contract.py` (39 passed)
- `uv run run.py --help` from `cookbooks/harbor-terminal-bench`
- Docker-backed oracle run of the Compose/separate-verifier fixture (reward `1.0`)
- Ruff check and format check
- Pyright on the Harbor integration and cookbook runner
