### PR TITLE
Refine architecture and simplification guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,18 +67,10 @@ Python `>=3.11, <3.13`.
 ## Code Quality Bar
 
 - Prefer direct, typed, maintainable code over clever or magical abstractions.
-- Be ambitious about simplification. Look for ways to delete whole branches,
-  helper layers, modes, and special cases while preserving behavior.
 - Fail fast and loudly. Avoid silent fallbacks, broad exception swallowing, and
   defensive branches that hide broken invariants.
 - Minimize branching. Every new `if`, `try`, compatibility path, or nullable mode
   should earn its keep.
-- Preserve documented public API and persisted behavior unless the task is an
-  intentional migration. Do not add compatibility layers for unshipped branch
-  work; replace the design cleanly.
-- Reuse canonical helpers and local abstractions before adding new ones.
-- Keep feature logic in the layer that owns the concept. Treat scattered
-  feature checks in shared paths as a design problem.
 - Prefer explicit contracts over optional, loosely shaped, or cast-heavy data.
 - Delete dead code. Do not keep obsolete paths around "just in case."
 - Keep comments rare and useful. Explain non-obvious intent, not what the next
@@ -90,6 +82,28 @@ Python `>=3.11, <3.13`.
   focused module to extract.
 - Avoid new core dependencies. If a dependency is only needed for optional
   provider, tool, or integration behavior, put it behind the relevant extra.
+
+## Architecture And Simplification
+
+- Before changing cross-module behavior, identify the layer that owns the concept.
+  Keep its policy and invariants there; other layers should translate or delegate.
+- Before introducing an abstraction, find the existing abstraction that owns the
+  same semantics. Reuse or extend it instead of building a partial copy elsewhere.
+- Reuse abstractions by meaning, not code similarity. Duplication is a reason to
+  inspect ownership, not automatic justification for a shared helper.
+- Prefer one canonical contract, data model, and execution path for each concept.
+  Express legitimate variation through owned configuration or policy rather than
+  parallel implementations.
+- Keep adapters thin: translate external representations into native SDK concepts
+  at the boundary, then use the normal implementation.
+- Add a helper, wrapper, or module only when it reduces total conceptual
+  complexity, centralizes an invariant, or provides meaningful reuse. Inline
+  ceremonial indirection.
+- Public APIs should expose stable user operations and domain concepts, not
+  internal construction stages or compatibility scaffolding.
+- Preserve observable behavior, persisted contracts, and security invariants, not
+  accidental internal structure. Prefer explicit migrations when architecture
+  requires a shipped contract to change.
 
 ## Typing And Imports
 


### PR DESCRIPTION
## Summary

- add durable guidance for architectural ownership and cross-module changes
- require reuse or extension of semantically matching abstractions before introducing parallel ones
- clarify canonical execution paths, thin adapters, and the standard for useful helpers
- replace weaker overlapping guidance instead of growing another policy layer

## Why

The existing code-quality guidance encouraged simplification and reuse, but did not clearly describe how to preserve ownership boundaries. That left room for integrations and adjacent modules to partially reimplement concepts already owned elsewhere in the SDK.

This change makes the architectural standard explicit while remaining implementation-agnostic.

## Impact

Documentation only. It gives contributors and coding agents a clearer basis for deciding where behavior belongs, when to reuse an abstraction, and when indirection creates more conceptual surface than it removes.

## Validation

- `git diff --check origin/main...HEAD`
- verified the branch contains only the intended `AGENTS.md` change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial guidance in AGENTS.md only; no runtime, API, or security changes.
> 
> **Overview**
> **Documentation-only** update to `AGENTS.md` that reframes how contributors should simplify and place cross-module behavior.
> 
> Several overlapping bullets are **removed** from **Code Quality Bar** (ambitious simplification, public API preservation, canonical helpers, feature ownership in shared paths). That material is **replaced** by a dedicated **Architecture And Simplification** section with clearer rules: own concepts in one layer, reuse semantically matching abstractions before parallel copies, one canonical contract/path per concept, thin adapters at boundaries, helpers only when they cut total complexity, public APIs as stable operations—not internal scaffolding, and preserve observable behavior while allowing explicit migrations when shipped contracts must change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa15d429ae8a82179cbb889153289f7a2970f9e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->