### PR TITLE
Compress computer-use screenshots to avoid oversized requests

### DIFF
--- a/hud/agents/claude/tools/computer.py
+++ b/hud/agents/claude/tools/computer.py
@@ -278,13 +278,13 @@ class ClaudeComputerTool(RFBTool):
             x0, y0, x1, y1 = (int(v) for v in region_seq)
         except (TypeError, ValueError):
             return tool_err("region must contain 4 integers")
-        png = await self.client.screenshot_png()
-        cropped = _crop_png(png, (x0, y0, x1, y1))
+        screenshot, mime_type = await self.client.screenshot_png(self.screenshot_mime_type)
+        cropped, mime_type = _crop_png(screenshot, (x0, y0, x1, y1), mime_type)
         return MCPToolResult(
             content=[
                 mcp_types.ImageContent(
                     type="image",
-                    mimeType="image/png",
+                    mimeType=mime_type,
                     data=base64.b64encode(cropped).decode("ascii"),
                 )
             ],
@@ -349,14 +349,21 @@ def _drag_path(arguments: dict[str, Any]) -> list[tuple[int, int]]:
     return path
 
 
-def _crop_png(png: bytes, region: tuple[int, int, int, int]) -> bytes:
+def _crop_png(
+    png: bytes,
+    region: tuple[int, int, int, int],
+    mime_type: str,
+) -> tuple[bytes, str]:
     from PIL import Image
 
     image = Image.open(BytesIO(png))
     cropped = image.crop(region)
     buf = BytesIO()
-    cropped.save(buf, format="PNG")
-    return buf.getvalue()
+    if mime_type == "image/webp":
+        cropped.save(buf, format="WEBP", quality=85)
+    else:
+        cropped.save(buf, format="PNG")
+    return buf.getvalue(), mime_type
 
 
 __all__ = ["CLAUDE_COMPUTER_SPECS", "ClaudeComputerTool"]

--- a/hud/agents/claude/tools/computer.py
+++ b/hud/agents/claude/tools/computer.py
@@ -278,8 +278,12 @@ class ClaudeComputerTool(RFBTool):
             x0, y0, x1, y1 = (int(v) for v in region_seq)
         except (TypeError, ValueError):
             return tool_err("region must contain 4 integers")
-        screenshot, mime_type = await self.client.screenshot_png(self.screenshot_mime_type)
-        cropped, mime_type = _crop_png(screenshot, (x0, y0, x1, y1), mime_type)
+        screenshot, _ = await self.client.screenshot_png("image/png")
+        cropped, mime_type = _crop_png(
+            screenshot,
+            (x0, y0, x1, y1),
+            self.screenshot_mime_type,
+        )
         return MCPToolResult(
             content=[
                 mcp_types.ImageContent(

--- a/hud/agents/claude/tools/tests/test_computer.py
+++ b/hud/agents/claude/tools/tests/test_computer.py
@@ -5,12 +5,18 @@ computer-use action dispatch (translation to RFB primitives), without a live VNC
 
 from __future__ import annotations
 
+from io import BytesIO
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import mcp.types as mcp_types
+from PIL import Image
 
 from hud.agents.claude.tools.computer import (
     CLAUDE_COMPUTER_SPECS,
     ClaudeComputerTool,
+    _crop_png,
     _hold_keys,
     _split_keys,
     _translate_key,
@@ -25,6 +31,7 @@ class RecordingComputer(ClaudeComputerTool):
 
     def __init__(self) -> None:
         self.calls: list[tuple[Any, ...]] = []
+        self.screenshot_mime_type = "image/webp"
         self.client = SimpleNamespace(width=200, height=100)
 
     async def screenshot(self) -> Any:
@@ -147,3 +154,27 @@ async def test_unsupported_action_errors() -> None:
     result = await tool.execute({"action": "frobnicate"})
     assert result.isError
     assert "unsupported" in result_text(result).lower()
+
+
+def test_crop_reports_encoded_mime_type() -> None:
+    source = BytesIO()
+    Image.effect_noise((128, 128), 100).convert("RGB").save(source, format="PNG")
+
+    cropped, mime_type = _crop_png(source.getvalue(), (0, 0, 128, 128), "image/webp")
+
+    assert mime_type == "image/webp"
+    assert cropped.startswith(b"RIFF")
+
+
+async def test_zoom_reports_encoded_mime_type() -> None:
+    tool = RecordingComputer()
+    tool.client.screenshot_png = AsyncMock(return_value=(b"png", "image/png"))
+
+    with patch(
+        "hud.agents.claude.tools.computer._crop_png",
+        return_value=(b"webp", "image/webp"),
+    ):
+        result = await tool._zoom({"region": [0, 0, 10, 10]})
+
+    image = next(block for block in result.content if isinstance(block, mcp_types.ImageContent))
+    assert image.mimeType == "image/webp"

--- a/hud/agents/claude/tools/tests/test_computer.py
+++ b/hud/agents/claude/tools/tests/test_computer.py
@@ -173,8 +173,10 @@ async def test_zoom_reports_encoded_mime_type() -> None:
     with patch(
         "hud.agents.claude.tools.computer._crop_png",
         return_value=(b"webp", "image/webp"),
-    ):
+    ) as crop:
         result = await tool._zoom({"region": [0, 0, 10, 10]})
 
+    tool.client.screenshot_png.assert_awaited_once_with("image/png")
+    crop.assert_called_once_with(b"png", (0, 0, 10, 10), "image/webp")
     image = next(block for block in result.content if isinstance(block, mcp_types.ImageContent))
     assert image.mimeType == "image/webp"

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -33,7 +33,7 @@ from hud.utils import gateway
 from .tools import OpenAIComputerTool, OpenAIMCPProxyTool, OpenAIShellTool
 from .tools.base import format_openai_result
 from .tools.coding import shell_output
-from .tools.computer import last_image_data
+from .tools.computer import last_image_content
 
 if TYPE_CHECKING:
     import mcp.types as mcp_types
@@ -104,8 +104,8 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
         tool = state.tools.get(call.name)
 
         if isinstance(tool, OpenAIComputerTool):
-            screenshot = last_image_data(result)
-            if not screenshot:
+            screenshot = last_image_content(result)
+            if screenshot is None:
                 logger.warning("Computer tool result missing screenshot for call %s", call.name)
                 return None
             output = ComputerCallOutput(
@@ -115,7 +115,9 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
                     "Any",
                     {
                         "type": "computer_screenshot",
-                        "image_url": f"data:image/png;base64,{screenshot}",
+                        "image_url": (
+                            f"data:{screenshot.mimeType or 'image/png'};base64,{screenshot.data}"
+                        ),
                         "detail": "original",
                     },
                 ),

--- a/hud/agents/openai/tools/computer.py
+++ b/hud/agents/openai/tools/computer.py
@@ -23,9 +23,15 @@ OPENAI_COMPUTER_SPEC = OpenAIToolSpec(
 
 def last_image_data(result: MCPToolResult) -> str | None:
     """Base64 data of the most recent screenshot block in a tool result."""
+    image = last_image_content(result)
+    return image.data if image is not None else None
+
+
+def last_image_content(result: MCPToolResult) -> mcp_types.ImageContent | None:
+    """Most recent screenshot block in a tool result."""
     for block in reversed(result.content):
         if isinstance(block, mcp_types.ImageContent):
-            return block.data
+            return block
     return None
 
 

--- a/hud/agents/tests/test_openai_agent.py
+++ b/hud/agents/tests/test_openai_agent.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any, cast
 
+import mcp.types as mcp_types
 from openai.types.responses import ResponseOutputText
 
 from hud.agents.openai.agent import OpenAIAgent, OpenAIRunState
 from hud.agents.openai.tools.base import format_openai_result
+from hud.agents.openai.tools.computer import OPENAI_COMPUTER_SPEC, OpenAIComputerTool
 from hud.agents.types import OpenAIConfig
 from hud.types import MCPToolCall, MCPToolResult
 
@@ -50,6 +52,28 @@ def test_format_openai_result_empty_output_emits_one_text_item() -> None:
     assert formatted["type"] == "function_call_output"
     assert formatted["call_id"] == "call_1"
     assert formatted["output"] == [{"type": "input_text", "text": ""}]
+
+
+def test_format_computer_result_preserves_screenshot_mime_type() -> None:
+    agent = _agent(SimpleNamespace(id="r", output=[]))
+    tool = OpenAIComputerTool(spec=OPENAI_COMPUTER_SPEC, client=cast("Any", object()))
+    state = OpenAIRunState(tools={"computer": tool})
+    result = MCPToolResult(
+        content=[
+            mcp_types.ImageContent(
+                type="image",
+                data="d2VicA==",
+                mimeType="image/webp",
+            ),
+        ],
+    )
+
+    formatted = cast(
+        "dict[str, Any]",
+        agent._format_result(MCPToolCall(id="call_1", name="computer"), result, state),
+    )
+
+    assert formatted["output"]["image_url"] == "data:image/webp;base64,d2VicA=="
 
 
 def _api_response(

--- a/hud/agents/tools/rfb.py
+++ b/hud/agents/tools/rfb.py
@@ -16,12 +16,14 @@ from typing import TYPE_CHECKING, Literal
 
 import mcp.types as mcp_types
 
-from hud.agents.tools.base import AgentTool
+from hud.agents.tools.base import AgentTool, AgentToolSpec
 from hud.capabilities import RFBClient
 from hud.types import MCPToolResult
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable
+
+    from hud.capabilities.rfb import ScreenshotMimeType
 
 
 #: VNC button index (asyncvnc uses 0 = left, 1 = middle, 2 = right, 3 = wheel-up, 4 = wheel-down).
@@ -33,6 +35,16 @@ class RFBTool(AgentTool[RFBClient]):
     """Capability base: tool driven by an ``RFBClient`` (VNC/RFB)."""
 
     client_type = RFBClient
+
+    def __init__(
+        self,
+        *,
+        spec: AgentToolSpec,
+        client: RFBClient,
+        screenshot_mime_type: ScreenshotMimeType = "image/webp",
+    ) -> None:
+        super().__init__(spec=spec, client=client)
+        self.screenshot_mime_type: ScreenshotMimeType = screenshot_mime_type
 
     # ─── geometry ────────────────────────────────────────────────────
 
@@ -47,14 +59,14 @@ class RFBTool(AgentTool[RFBClient]):
     # ─── framebuffer ─────────────────────────────────────────────────
 
     async def screenshot(self) -> MCPToolResult:
-        """Capture a PNG screenshot and return it as a single ``ImageContent`` block."""
-        png = await self.client.screenshot_png()
+        """Capture a screenshot and return it as a single ``ImageContent`` block."""
+        screenshot, mime_type = await self.client.screenshot_png(self.screenshot_mime_type)
         return MCPToolResult(
             content=[
                 mcp_types.ImageContent(
                     type="image",
-                    mimeType="image/png",
-                    data=base64.b64encode(png).decode("ascii"),
+                    mimeType=mime_type,
+                    data=base64.b64encode(screenshot).decode("ascii"),
                 )
             ],
         )

--- a/hud/capabilities/rfb.py
+++ b/hud/capabilities/rfb.py
@@ -1,6 +1,6 @@
 """RFBClient — asyncvnc connection wrapper.
 
-Thin wrapper exposing the live ``asyncvnc.Client`` plus PNG-encoded
+Thin wrapper exposing the live ``asyncvnc.Client`` plus encoded
 screenshots. Higher-level composites (click, type, drag) live on ``RFBTool``.
 
 Latency note
@@ -24,7 +24,7 @@ import contextlib
 import io
 import logging
 from contextlib import AsyncExitStack
-from typing import ClassVar, Self
+from typing import ClassVar, Literal, Self
 from urllib.parse import urlsplit
 
 import asyncvnc
@@ -33,6 +33,8 @@ from PIL import Image
 from .base import Capability, CapabilityClient
 
 LOGGER = logging.getLogger("hud.capabilities.rfb")
+
+ScreenshotMimeType = Literal["image/png", "image/webp"]
 
 
 class RFBClient(CapabilityClient):
@@ -110,15 +112,21 @@ class RFBClient(CapabilityClient):
     def height(self) -> int:
         return self._conn.video.height
 
-    async def screenshot_png(self) -> bytes:
-        """Capture the framebuffer as PNG bytes; reconnect+retry on desync."""
+    async def screenshot_png(
+        self,
+        mime_type: ScreenshotMimeType = "image/png",
+    ) -> tuple[bytes, ScreenshotMimeType]:
+        """Capture the framebuffer in the requested format; reconnect on desync."""
         for attempt in range(3):
             try:
                 rgba = await self._conn.screenshot()
                 image = Image.fromarray(rgba)
                 buf = io.BytesIO()
-                image.save(buf, format="PNG")
-                return buf.getvalue()
+                if mime_type == "image/webp":
+                    image.save(buf, format="WEBP", quality=85)
+                else:
+                    image.save(buf, format="PNG")
+                return buf.getvalue(), mime_type
             except (ValueError, ConnectionError, OSError, EOFError) as exc:
                 LOGGER.warning("screenshot failed (attempt %d): %s", attempt + 1, exc)
                 if attempt == 2:
@@ -134,4 +142,4 @@ class RFBClient(CapabilityClient):
         await self._exit_stack.aclose()
 
 
-__all__ = ["RFBClient"]
+__all__ = ["RFBClient", "ScreenshotMimeType"]

--- a/hud/capabilities/tests/test_rfb.py
+++ b/hud/capabilities/tests/test_rfb.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import mcp.types as mcp_types
+from PIL import Image
+
+from hud.agents.tools.rfb import RFBTool
+from hud.capabilities.rfb import RFBClient
+
+
+class RecordingRFBTool(RFBTool):
+    name = "rfb-test"
+    client: Any
+
+    def __init__(self) -> None:
+        self.screenshot_mime_type = "image/webp"
+        self.client = SimpleNamespace(
+            screenshot_png=AsyncMock(return_value=(b"webp", "image/webp")),
+        )
+
+    async def execute(self, arguments: dict[str, Any]) -> Any:
+        del arguments
+        raise NotImplementedError
+
+    def to_params(self) -> Any:
+        raise NotImplementedError
+
+
+async def test_screenshot_uses_requested_webp_mime_type() -> None:
+    client = object.__new__(RFBClient)
+    object.__setattr__(
+        client,
+        "_conn",
+        SimpleNamespace(
+            screenshot=AsyncMock(return_value=object()),
+        ),
+    )
+
+    with patch(
+        "hud.capabilities.rfb.Image.fromarray", return_value=Image.effect_noise((128, 128), 100)
+    ):
+        data, mime_type = await client.screenshot_png("image/webp")
+
+    assert mime_type == "image/webp"
+    assert data.startswith(b"RIFF")
+    assert data[8:12] == b"WEBP"
+
+
+async def test_screenshot_uses_requested_png_mime_type() -> None:
+    client = object.__new__(RFBClient)
+    object.__setattr__(
+        client,
+        "_conn",
+        SimpleNamespace(
+            screenshot=AsyncMock(return_value=object()),
+        ),
+    )
+
+    with patch("hud.capabilities.rfb.Image.fromarray", return_value=Image.new("RGB", (8, 8))):
+        data, mime_type = await client.screenshot_png("image/png")
+
+    assert mime_type == "image/png"
+    assert data.startswith(b"\x89PNG")
+
+
+async def test_screenshot_reports_encoded_mime_type() -> None:
+    tool = RecordingRFBTool()
+
+    result = await tool.screenshot()
+
+    image = result.content[0]
+    assert isinstance(image, mcp_types.ImageContent)
+    assert image.mimeType == "image/webp"


### PR DESCRIPTION
## What changed

- Encode RFB screenshots as quality-85 WebP when requested, while preserving PNG support.
- Return the actual screenshot MIME type through `RFBTool` and Claude computer zoom/crop results.
- Add focused regression coverage for WebP/PNG encoding and MIME propagation.

## Why

Full-resolution lossless PNG screenshots accumulate across computer-use turns and can exceed the provider request-body limit on visually heavy pages. WebP substantially reduces the request size without changing image dimensions or evicting screenshot history.

## Validation

- `uv run --extra dev pytest -q` — 883 passed
- Ruff format and lint passed
- Pyright passed with 0 errors; existing optional-dependency warnings remain

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared RFB screenshot path and how all computer-use providers package images in API requests; behavior change is intentional but could affect providers that assume PNG-only data URLs.
> 
> **Overview**
> Computer-use screenshots now default to **quality-85 WebP** instead of lossless PNG, with PNG still available when requested. The goal is smaller multi-turn request bodies on visually heavy pages without changing resolution or dropping screenshot history.
> 
> **RFB layer:** `RFBClient.screenshot_png` takes a `ScreenshotMimeType`, returns `(bytes, mime_type)`, and encodes WebP or PNG accordingly. `RFBTool` adds a `screenshot_mime_type` constructor option (default `image/webp`) and sets `ImageContent.mimeType` from the encoded format.
> 
> **Agent plumbing:** Claude **zoom** re-encodes crops via `_crop_png` using the tool’s configured MIME type. The OpenAI agent builds `data:` URLs from the image block’s `mimeType` (via `last_image_content`) instead of hardcoding `image/png`.
> 
> Regression tests cover WebP/PNG bytes, MIME on tool results, zoom, and OpenAI computer output formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808234474a6976f755d2b119d12401a1a47c9252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->