### PR TITLE
feat(harbor): support Compose environments and MCP servers

### DIFF
--- a/cookbooks/harbor-terminal-bench/README.md
+++ b/cookbooks/harbor-terminal-bench/README.md
@@ -21,6 +21,9 @@ uv run run.py ./terminal-bench --agent claude-sonnet-4-5
 
 # Just the ones you are debugging
 uv run run.py ./terminal-bench --task qemu-startup --task configure-git-webserver
+
+# A multi-container task with an MCP sidecar
+uv run run.py ./hello-mcp --agent claude-sonnet-4-5
 ```
 
 Output is one row per task plus a mean over the tasks that actually finished:
@@ -38,8 +41,8 @@ Runs that end in `error` are reported separately from scored runs.
 
 ## What you need
 
-- Docker. `DockerRuntime` gives every container the profile the in-image
-  workspace sandbox needs, so no extra flags.
+- Docker with Compose. The adapter records each generated Compose file in the task's
+  runtime configuration, and `DockerRuntime()` runs its authored dependencies and health checks.
 - Network, for the image builds and for whatever the tasks fetch.
 - `HUD_API_KEY` only when `--agent` names a model, for gateway inference.
 

--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -165,9 +165,9 @@ DaytonaRuntime(snapshot_name=None, *, image=None, command=None, workdir="/app", 
 
 Resources (cpu/memory/gpu) are fixed on the snapshot at build time. With `image`, a task's `runtime_config.resources` builds a sized variant under a suffixed name (`my-env-4cpu`); without `image`, an already-built snapshot cannot be resized.
 
-Compose environments run inside a managed Linux VM snapshot so the guest can start Docker. The
-selected Daytona region must have a Linux-VM runner available; select the region with
-`DAYTONA_TARGET` when the organization's default region does not.
+For Compose environments, Daytona runs the main service as the rollout sandbox and each sidecar
+as a linked sandbox. Sidecar images are resolved to reusable Daytona snapshots; a Linux-VM runner
+and nested Docker are not required.
 
 ### `HUDRuntime`
 

--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -50,8 +50,8 @@ To deploy an environment to the platform and run against it, see
 
 ## RuntimeConfig
 
-`RuntimeConfig` carries the construction hints a container-based runtime needs: which image, how much
-hardware, and what timeouts. Set it on the runtime (`runtime_config=`) or per row on
+`RuntimeConfig` carries the typed construction input a container-based runtime needs: an image or
+Compose file, hardware, and timeouts. Set it on the runtime (`runtime_config=`) or per row on
 [`Task.runtime_config`](/v6/reference/tasks#task); the runtime merges the two and applies what it
 supports.
 
@@ -63,11 +63,14 @@ RuntimeConfig(
     resources=RuntimeResources(cpu=4, memory_mb=8192, gpu=RuntimeGPU(type="A100", count=1)),
     limits=RuntimeLimits(startup_timeout_s=300, run_timeout_s=1800),
 )
+
+RuntimeConfig(compose="./compose.yaml")
 ```
 
 | Field | Description |
 |-------|-------------|
 | `image` | Image to run. |
+| `compose` | Path to a Compose file. Mutually exclusive with `image`. |
 | `resources` | `RuntimeResources(cpu, memory_mb, gpu=RuntimeGPU(type, count))`. |
 | `limits` | `RuntimeLimits(startup_timeout_s, run_timeout_s)`. |
 
@@ -121,7 +124,12 @@ DockerRuntime(image=None, *, port=8765, run_args=(), runtime_config=None)
 - **`image`** - image name to run; shorthand for `runtime_config.image`.
 - **`port`** - port the image's CMD serves inside the container (the scaffolded `Dockerfile.hud` serves `8765`).
 - **`run_args`** - extra `docker run` flags, e.g. `["--gpus", "all"]` or `["-e", "KEY=VAL"]`.
-- **`runtime_config`** - a `RuntimeConfig` (image, resources) for finer control.
+- **`runtime_config`** - a `RuntimeConfig` (image or Compose file, resources) for finer control.
+
+For Compose environments, the service named `main` must serve HUD's control channel on `port`.
+`DockerRuntime` starts the whole project and publishes only that service's control port. The Compose
+file belongs in `RuntimeConfig`; constructor-level `image` remains a compatibility shorthand for
+`runtime_config.image`.
 
 `DockerRuntime` always starts with HUD's compact seccomp profile and the system
 path configuration required by `Workspace`'s bubblewrap sessions. The profile
@@ -156,6 +164,10 @@ DaytonaRuntime(snapshot_name=None, *, image=None, command=None, workdir="/app", 
 - **`ssh_host`** / **`ssh_expires_minutes`** - SSH tunnel settings (Daytona exposes services over an SSH local-forward).
 
 Resources (cpu/memory/gpu) are fixed on the snapshot at build time. With `image`, a task's `runtime_config.resources` builds a sized variant under a suffixed name (`my-env-4cpu`); without `image`, an already-built snapshot cannot be resized.
+
+Compose environments run inside a managed Linux VM snapshot so the guest can start Docker. The
+selected Daytona region must have a Linux-VM runner available; select the region with
+`DAYTONA_TARGET` when the organization's default region does not.
 
 ### `HUDRuntime`
 

--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -99,7 +99,7 @@ class ClaudeSDKAgent(Agent):
             family = cap.protocol.split("/", 1)[0]
             if family == "mcp":
                 token = cap.params.get("auth_token")
-                transport = "http" if cap.url.startswith("http") else "sse"
+                transport = "http" if cap.params["transport"] == "streamable-http" else "sse"
                 server_config: dict[str, Any] = {"type": transport, "url": cap.url}
                 if token:
                     server_config["headers"] = {"Authorization": f"Bearer {token}"}

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 import base64
 import re
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any, Literal, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -150,3 +151,49 @@ async def test_exec_nonzero_exit_with_no_stdout_records_system_error() -> None:
     assert run.trace.status == "error"
     assert run.trace.extra["exit_status"] == 1
     assert run.steps[0].error == "boom"
+
+
+@pytest.mark.parametrize(
+    ("transport", "claude_type"),
+    [("streamable-http", "http"), ("sse", "sse")],
+)
+async def test_manifest_mcp_capability_is_written_for_remote_claude(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: Literal["streamable-http", "sse"],
+    claude_type: str,
+) -> None:
+    shell = Capability(
+        name="shell",
+        protocol="ssh/2",
+        url="ssh://localhost:22",
+        params={"shell": "bash"},
+    )
+    mcp = Capability.mcp(
+        name="database",
+        url="http://database:8000/mcp",
+        transport=transport,
+    )
+    ssh = SSHClient(shell, cast("Any", object()))
+
+    class Client:
+        manifest = SimpleNamespace(bindings=[shell, mcp])
+
+        async def open(self, ref: str) -> SSHClient:
+            assert ref == "ssh"
+            return ssh
+
+    agent = ClaudeSDKAgent()
+    execute = AsyncMock()
+    monkeypatch.setattr(agent, "_exec", execute)
+
+    await agent(
+        cast(
+            "Any",
+            SimpleNamespace(client=Client(), prompt_text="call the tool"),
+        )
+    )
+
+    assert agent._mcp_servers == {
+        "database": {"type": claude_type, "url": "http://database:8000/mcp"}
+    }
+    execute.assert_awaited_once()

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -7,14 +7,15 @@ scripted ``get_response`` so the loop, dispatch, and message formatting run offl
 
 from __future__ import annotations
 
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, cast
 
 import mcp.types as mcp_types
 
 from hud.agents.openai.tools.coding import OpenAIShellTool
 from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentConfig, AgentStep, ToolStep
-from hud.capabilities import SSHClient
+from hud.capabilities import Capability, CapabilityClient, MCPClient, SSHClient
 from hud.types import MCPToolCall, MCPToolResult, Step, Trace
 
 _Msg = dict[str, Any]
@@ -62,6 +63,34 @@ def test_init_subclass_derives_clients_from_catalog() -> None:
         tool_catalog = (OpenAIShellTool,)
 
     assert WithCatalog.clients == (SSHClient,)
+
+
+async def test_agent_opens_every_mcp_capability_by_name() -> None:
+    capabilities = [
+        Capability.mcp(name="database", url="http://database:8000/mcp"),
+        Capability.mcp(name="search", url="http://search:8000/mcp"),
+    ]
+    opened: list[str] = []
+
+    class Client:
+        manifest = SimpleNamespace(bindings=capabilities)
+
+        async def open(self, ref: str) -> CapabilityClient:
+            opened.append(ref)
+            return cast("CapabilityClient", object())
+
+    class MultiMCPAgent(DictAgent):
+        clients = (MCPClient,)
+
+    class LiveRun(_FakeRun):
+        def __init__(self) -> None:
+            super().__init__()
+            self.client = Client()
+            self.prompt_messages: list[Any] = []
+
+    await MultiMCPAgent([AgentStep(content="done", done=True)])(cast("Any", LiveRun()))
+
+    assert opened == ["database", "search"]
 
 
 # ─── initial messages / user text formatting ──────────────────────────

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -128,8 +128,8 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
         if manifest is not None:
             wanted = {cls.protocol for cls in type(self).clients}
             for cap in manifest.bindings:
-                if cap.protocol in wanted and cap.protocol not in connections:
-                    connections[cap.protocol] = await run.client.open(cap.protocol)
+                if cap.protocol in wanted:
+                    connections[cap.name] = await run.client.open(cap.name)
         state = await self._initialize_state(prompt=run.prompt_messages)
         state.tools, state.params = await self._build_tools(connections)
         await self._loop(

--- a/hud/capabilities/base.py
+++ b/hud/capabilities/base.py
@@ -7,7 +7,7 @@ import re
 import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Literal, Self
 from urllib.parse import urlsplit
 
 #: Matches the scheme prefix of a URL (RFC 3986).
@@ -58,11 +58,18 @@ class Capability:
 
     @classmethod
     def from_manifest(cls, data: dict[str, Any]) -> Capability:
+        protocol = data["protocol"]
+        url = data["url"]
+        params = dict(data["params"]) if "params" in data and data["params"] is not None else {}
+        if protocol.split("/", 1)[0] == "mcp" and "transport" not in params:
+            params["transport"] = (
+                "websocket" if urlsplit(url).scheme in {"ws", "wss"} else "streamable-http"
+            )
         return cls(
             name=data["name"],
-            protocol=data["protocol"],
-            url=data["url"],
-            params=dict(data.get("params") or {}),
+            protocol=protocol,
+            url=url,
+            params=params,
         )
 
     # ─── well-known protocol factories ─────────────────────────────────
@@ -152,6 +159,7 @@ class Capability:
         name: str = "tools",
         url: str,
         auth_token: str | None = None,
+        transport: Literal["sse", "streamable-http", "websocket"] | None = None,
     ) -> Capability:
         """``mcp/2025-11-25`` — MCP server (ws/wss/http/https; no stdio)."""
         m = SCHEME_RE.match(url)
@@ -165,7 +173,13 @@ class Capability:
             raise ValueError(
                 f"mcp/2025-11-25: only ws/wss/http/https URLs are supported, got {scheme!r}",
             )
-        params: dict[str, Any] = {}
+        if transport == "websocket" and scheme not in {"ws", "wss"}:
+            raise ValueError("mcp websocket transport requires a ws:// or wss:// URL")
+        if transport in {"sse", "streamable-http"} and scheme not in {"http", "https"}:
+            raise ValueError(f"mcp {transport} transport requires an http:// or https:// URL")
+        if transport is None:
+            transport = "websocket" if scheme in {"ws", "wss"} else "streamable-http"
+        params: dict[str, Any] = {"transport": transport}
         if auth_token is not None:
             params["auth_token"] = auth_token
         return cls(name=name, protocol="mcp/2025-11-25", url=normalized, params=params)

--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -15,6 +15,7 @@ import logging
 import math
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
+from functools import partial
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -62,12 +63,10 @@ class ServerInfo:
 class Manifest:
     """Env welcome frame returned by ``HudClient.hello()``.
 
-    ``bindings`` carry concrete, *client-reachable* connection data: the env
-    resolves backed declarations (materializing their daemons) when it
-    answers ``hello``, and the client transparently forwards any
-    substrate-local (loopback) address through the control port — so a
-    binding's url always works from here, whether the substrate is a local
-    child process or a container with one published port.
+    ``bindings`` are the environment-native addresses published by the
+    substrate. Agents executing inside that environment consume these raw
+    endpoints; controller-side consumers use :meth:`HudClient.binding` or
+    :meth:`HudClient.open`, which route them through the control channel.
     """
 
     session_id: str
@@ -102,6 +101,7 @@ class HudClient:
         self._ids = itertools.count(1)
         self._closed = False
         self.manifest: Manifest | None = None
+        self._routes: dict[str, str] = {}
         self._opened: dict[str, CapabilityClient] = {}
         self._forwarders: list[asyncio.Server] = []
         self._tunnels: set[asyncio.Task[None]] = set()
@@ -139,78 +139,70 @@ class HudClient:
     async def hello(self) -> Manifest:
         """Send ``hello``; cache and return the parsed ``Manifest``."""
         result = await self._call("hello", {})
-        env = result.get("env") or {}
-        bindings = [
-            await self._reachable(Capability.from_manifest(b))
-            for b in (result.get("bindings") or [])
-        ]
+        env = result["env"]
+        bindings = [Capability.from_manifest(binding) for binding in result["bindings"]]
         self.manifest = Manifest(
             session_id=result["session_id"],
             protocol_version=self.PROTOCOL_VERSION,
             server_info=ServerInfo(
-                name=env.get("name", "unknown"),
-                version=env.get("version", "0.0.0"),
+                name=env["name"],
+                version=env["version"],
             ),
             bindings=bindings,
         )
-        return self.manifest
+        self._routes.clear()
+        if self._endpoint is not None:
+            host, port = self._endpoint
 
-    # ─── capability tunneling ─────────────────────────────────────────
-    #
-    # A loopback address in the manifest is the *substrate's* loopback — the
-    # daemon the env resolved lives in its network namespace, which may not
-    # be ours (a container with one published port, a hosted sandbox). A
-    # non-loopback address is globally reachable and passes through. For the
-    # loopback case the client runs a local forwarder (``ssh -L`` style):
-    # each accepted connection is one fresh TCP connection to the control
-    # port, opened with a ``tunnel.open`` preface frame and spliced raw from
-    # there. The preface is transport-level routing (the server decides what
-    # a connection is from its first frame), not a session method.
-
-    async def _reachable(self, cap: Capability) -> Capability:
-        parts = urlsplit(cap.url)
-        if self._endpoint is None or parts.hostname not in ("127.0.0.1", "localhost", "::1"):
-            return cap
-        host, port = self._endpoint
-
-        async def forward(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-            task = asyncio.current_task()
-            assert task is not None
-            self._tunnels.add(task)
-            try:
+            async def forward(
+                capability: Capability,
+                reader: asyncio.StreamReader,
+                writer: asyncio.StreamWriter,
+            ) -> None:
+                task = asyncio.current_task()
+                assert task is not None
+                self._tunnels.add(task)
                 try:
-                    up_reader, up_writer = await asyncio.open_connection(host, port)
-                except OSError:
-                    writer.close()
-                    return
-                await send_frame(
-                    up_writer,
-                    {
-                        "jsonrpc": "2.0",
-                        "id": 1,
-                        "method": "tunnel.open",
-                        "params": {"capability": cap.name},
-                    },
-                )
-                opened = await read_frame(up_reader)
-                if opened is None or "error" in opened:
-                    LOGGER.warning("tunnel.open %r refused: %s", cap.name, opened)
-                    up_writer.close()
-                    writer.close()
-                    return
-                await splice((reader, writer), (up_reader, up_writer))
-            finally:
-                self._tunnels.discard(task)
+                    try:
+                        up_reader, up_writer = await asyncio.open_connection(host, port)
+                    except OSError:
+                        writer.close()
+                        return
+                    await send_frame(
+                        up_writer,
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "method": "tunnel.open",
+                            "params": {"capability": capability.name},
+                        },
+                    )
+                    opened = await read_frame(up_reader)
+                    if opened is None or "error" in opened:
+                        LOGGER.warning("tunnel.open %r refused: %s", capability.name, opened)
+                        up_writer.close()
+                        writer.close()
+                        return
+                    await splice((reader, writer), (up_reader, up_writer))
+                finally:
+                    self._tunnels.discard(task)
 
-        forwarder = await asyncio.start_server(forward, "127.0.0.1", 0)
-        self._forwarders.append(forwarder)
-        local_port = forwarder.sockets[0].getsockname()[1]
-        userinfo = f"{parts.username}@" if parts.username else ""
-        netloc = f"{userinfo}127.0.0.1:{local_port}"
-        return replace(
-            cap,
-            url=urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment)),
-        )
+            for capability in bindings:
+                forwarder = await asyncio.start_server(partial(forward, capability), "127.0.0.1", 0)
+                self._forwarders.append(forwarder)
+                local_port = forwarder.sockets[0].getsockname()[1]
+                parts = urlsplit(capability.url)
+                userinfo = f"{parts.username}@" if parts.username else ""
+                self._routes[capability.name] = urlunsplit(
+                    (
+                        parts.scheme,
+                        f"{userinfo}127.0.0.1:{local_port}",
+                        parts.path,
+                        parts.query,
+                        parts.fragment,
+                    )
+                )
+        return self.manifest
 
     # ─── capability access ────────────────────────────────────────────
     #
@@ -229,12 +221,20 @@ class HudClient:
         if self.manifest is None:
             raise RuntimeError("call hello() before accessing bindings")
         matches = [
-            c
-            for c in self.manifest.bindings
-            if ref in (c.name, c.protocol, c.protocol.split("/", 1)[0])
+            capability
+            for capability in self.manifest.bindings
+            if ref
+            in (
+                capability.name,
+                capability.protocol,
+                capability.protocol.split("/", 1)[0],
+            )
         ]
         if len(matches) == 1:
-            return matches[0]
+            capability = matches[0]
+            if capability.name in self._routes:
+                return replace(capability, url=self._routes[capability.name])
+            return capability
         if len(matches) > 1:
             names = ", ".join(f"{c.name} ({c.protocol})" for c in matches)
             raise KeyError(f"ambiguous capability {ref!r}; matches: {names}")

--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -17,6 +17,7 @@ import signal
 import subprocess
 import sys
 from typing import TYPE_CHECKING, cast
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -381,20 +382,22 @@ async def test_any_initialize_hook_can_publish_a_capability() -> None:
     assert torn_down  # env.stop() ran the shutdown hook
 
 
-async def test_loopback_declarations_are_forwarded_and_remote_ones_pass_through() -> None:
+async def test_manifest_keeps_environment_addresses_and_client_bindings_are_forwarded() -> None:
     local = Capability.cdp(name="browser", url="ws://127.0.0.1:9222")
     remote = Capability.ssh(name="box", url="ssh://box.example.com:22", host_pubkey="ssh-ed25519 x")
     env = Environment("mixed-env", capabilities=[local, remote])
 
     async with served(env) as client:
-        forwarded = client.binding("browser")
-        # Loopback means substrate-local: the client substitutes a local
-        # forwarder address, everything else about the capability intact.
-        assert forwarded.url != local.url
-        assert forwarded.url.startswith("ws://127.0.0.1:")
-        assert (forwarded.name, forwarded.protocol) == (local.name, local.protocol)
-        # Globally-reachable addresses are the client's to dial directly.
-        assert client.binding("box") == remote
+        assert client.manifest is not None
+        assert client.manifest.bindings == [local, remote]
+        for declared in (local, remote):
+            forwarded = client.binding(declared.name)
+            assert forwarded.url != declared.url
+            assert urlsplit(forwarded.url).hostname == "127.0.0.1"
+            assert (forwarded.name, forwarded.protocol) == (
+                declared.name,
+                declared.protocol,
+            )
 
 
 def test_a_capability_without_a_url_is_rejected() -> None:

--- a/hud/environment/tests/test_tunnel.py
+++ b/hud/environment/tests/test_tunnel.py
@@ -1,14 +1,13 @@
-"""Capability tunneling: substrate-local daemons reached through the control port.
+"""Capability tunneling: environment daemons reached through the control port.
 
-A capability whose resolved address is loopback lives in the substrate's
-network namespace — a container publishes only the control port, so the
-client can't dial it directly. Instead the manifest binding the client sees
-points at a local forwarder; each connection to it becomes one fresh
-connection to the control port, opened with a ``tunnel.open`` preface frame
-and spliced raw to the daemon. The preface is transport-level routing — a
-connection is a stream or a control session from its first frame, never
-upgraded mid-session. These tests drive that path end to end against a
-served env fronting a real TCP echo server.
+A capability address belongs to the environment's network. The raw manifest
+retains that address for processes executing there, while the client binding
+points at a local forwarder. Each connection to it becomes one fresh connection
+to the control port, opened with a ``tunnel.open`` preface frame and spliced raw
+to the daemon. The preface is transport-level routing — a connection is a stream
+or a control session from its first frame, never upgraded mid-session. These
+tests drive that path end to end against a served env fronting a real TCP echo
+server.
 """
 
 from __future__ import annotations
@@ -54,6 +53,8 @@ def _echo_env(port: int) -> Environment:
 
 async def test_bytes_round_trip_through_the_forwarded_binding(echo_port: int) -> None:
     async with served(_echo_env(echo_port)) as client:
+        assert client.manifest is not None
+        assert urlsplit(client.manifest.bindings[0].url).port == echo_port
         parts = urlsplit(client.binding("echo").url)
         assert parts.port != echo_port  # the binding points at the forwarder
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -24,7 +24,7 @@ import pytest
 from hud.capabilities import SSHClient
 from hud.environment import workspace as workspace_mod
 from hud.environment.egress import _field, _Unrelayable
-from hud.environment.workspace import Mount, Workspace
+from hud.environment.workspace import Bubblewrap, Mount, Workspace
 from hud.utils.process import ProcessResult
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX workspace semantics")
@@ -237,7 +237,7 @@ def test_bwrap_drops_host_env_when_walled(tmp_path: Path, monkeypatch: pytest.Mo
     _wall(monkeypatch)
 
     ws = Workspace(tmp_path / "root", shell_uid=1000, env={"CUSTOM": "1"})
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     argv = ws.shell_argv("echo hi", env={"PER_CALL": "1"})
 
     sandbox_env = _sandbox_env(argv)
@@ -252,7 +252,7 @@ def test_bwrap_inherits_host_env_when_not_walled(
 ) -> None:
     monkeypatch.setenv("SENTINEL", "visible")
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     argv = ws.bwrap_argv(["bash", "-lc", "true"])
     assert _sandbox_env(argv)["SENTINEL"] == "visible"
 
@@ -268,7 +268,7 @@ def test_the_harness_own_configuration_never_reaches_a_session(
     monkeypatch.setenv("ORDINARY", "kept")
     # What the task itself declares is the task's, HUD-shaped name or not.
     ws = Workspace(tmp_path / "root", env={"HUD_TASK_DECLARED": "mine"})
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
 
     for argv in (ws.shell_argv("echo hi"), ws.bwrap_argv(["true"]), ws.enter_argv(7, "echo hi")):
         session_env = _sandbox_env(argv)
@@ -306,7 +306,7 @@ def test_session_argv_runs_on_bubblewrap_0_4(
         env={"CUSTOM": "1"},
         mounts=(Mount("tmpfs", dst="/tests"),),
     )
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     _wall(monkeypatch)
 
     for argv in (ws.shell_argv("echo hi"), ws.shell_argv(), ws.bwrap_argv(["true"])):
@@ -319,7 +319,7 @@ def test_sessions_join_one_sandbox_rather_than_each_making_its_own(
     """Two commands must land in the same namespaces, or a process the first
     backgrounds is gone by the second."""
     ws = Workspace(tmp_path / "root", guest_path="/app", network=True)
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
 
     first = ws.enter_argv(4321, "start-a-server &")
     second = ws.enter_argv(4321, "curl localhost")
@@ -347,7 +347,7 @@ async def test_concurrent_sessions_share_one_sandbox(
     """An agent issues parallel tool calls; if each started its own sandbox,
     what one backgrounds would be invisible to the next."""
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     spawned = 0
 
     async def fake_spawn() -> int:
@@ -375,7 +375,7 @@ def test_a_sharing_sandbox_is_not_rejoined_by_network_namespace(
     shared = Workspace(tmp_path / "shared", network=True)
     severed = Workspace(tmp_path / "severed", network=False)
     for ws in (shared, severed):
-        monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+        monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
 
     assert "--net" not in shared.enter_argv(11, "true")
     assert "--net" in severed.enter_argv(11, "true")
@@ -387,7 +387,7 @@ def test_the_sandbox_reports_readiness_before_sessions_join_it(
     """bwrap names the child pid before that child has built its mount
     namespace, so the pid alone is not proof the sandbox can run anything."""
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     argv = ws.bwrap_argv(["sh", "-c", "echo ready"], info_fd=7)
 
     assert argv[argv.index("--info-fd") + 1] == "7"
@@ -409,7 +409,7 @@ def test_making_a_network_and_joining_it_are_the_same_question(
         (None, True, False),  # the substrate's network, as before
     ):
         ws = Workspace(tmp_path / "root", network=network, allowed_hosts=allowed)
-        monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+        monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
 
         assert ws.owns_netns is owns
         assert ("--unshare-net" in ws.bwrap_argv(["true"])) is owns
@@ -423,7 +423,7 @@ async def test_run_uses_fresh_mounts_and_shared_network_with_visitor_egress(
     monkeypatch.setenv("PATH", "/task/bin:/usr/bin")
     monkeypatch.setenv("HUD_API_KEY", "sk-secret")
     ws = Workspace(tmp_path / "root", env={"AGENT_ONLY": "secret"})
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
 
     @contextlib.asynccontextmanager
     async def visiting(allowed):
@@ -461,11 +461,35 @@ async def test_run_uses_fresh_mounts_and_shared_network_with_visitor_egress(
 
 
 @pytest.mark.asyncio
+async def test_staged_verifier_stays_in_the_parent_user_namespace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ws = Workspace(tmp_path / "root")
+    monkeypatch.setattr(
+        ws,
+        "_bwrap",
+        Bubblewrap("/usr/bin/bwrap", pid_unshare="/usr/bin/unshare"),
+    )
+    monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=121))
+    complete = AsyncMock(return_value=ProcessResult(0, b"passed", b""))
+    spawn = AsyncMock(return_value=SimpleNamespace(complete=complete))
+    monkeypatch.setattr(workspace_mod, "create_process_group_exec", spawn)
+
+    await ws.run(["test.sh"], identity=None)
+
+    assert spawn.await_args is not None
+    argv, _ = spawn.await_args
+    assert argv[argv.index("--target") + 1] == "121"
+    assert "--user" not in argv[: argv.index("--")]
+    assert argv[argv.index("--") + 1] == "/usr/bin/bwrap"
+
+
+@pytest.mark.asyncio
 async def test_run_can_use_a_fresh_no_network_sandbox(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     install_identity_map = AsyncMock(return_value=9)
     complete = AsyncMock(return_value=ProcessResult(0, b"isolated", b""))
     spawn = AsyncMock(return_value=SimpleNamespace(complete=complete))
@@ -499,7 +523,7 @@ async def test_an_isolated_command_keeps_the_image_environment(
     monkeypatch.setenv("PATH", "/task/bin:/usr/bin")
     monkeypatch.setenv("HUD_API_KEY", "sk-secret")
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     monkeypatch.setattr(workspace_mod, "install_identity_map", AsyncMock(return_value=9))
     complete = AsyncMock(return_value=ProcessResult(0, b"", b""))
     spawn = AsyncMock(return_value=SimpleNamespace(complete=complete))
@@ -518,7 +542,7 @@ async def test_failed_isolated_run_terminates_its_sandbox(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     process = SimpleNamespace(terminate=AsyncMock(), complete=AsyncMock())
     monkeypatch.setattr(
         workspace_mod,
@@ -543,7 +567,7 @@ async def test_failed_sandbox_start_discards_the_holder(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     failed_holder = SimpleNamespace(
         returncode=None,
         stdout=SimpleNamespace(readline=AsyncMock(return_value=b"ready\n")),
@@ -650,7 +674,7 @@ async def test_a_declared_peer_is_a_name_sessions_resolve(
     from hud.environment.egress import Peer
 
     ws = Workspace(tmp_path / "root", peers=[Peer("db", 5432)], allowed_hosts={"pypi.org"})
-    monkeypatch.setattr(ws, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     ws._prepare_runtime()
 
     argv = ws.bwrap_argv(["true"])
@@ -661,7 +685,7 @@ async def test_a_declared_peer_is_a_name_sessions_resolve(
     assert hosts.stat().st_mode & 0o044
 
     sharing = Workspace(tmp_path / "shared", peers=[Peer("db", 5432)], network=True)
-    monkeypatch.setattr(sharing, "_bwrap", "/usr/bin/bwrap")
+    monkeypatch.setattr(sharing, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     sharing._prepare_runtime()
     assert "/etc/hosts" not in sharing.bwrap_argv(["true"])
 
@@ -1055,6 +1079,69 @@ def test_usable_bwrap_reports_unusable_installs(monkeypatch) -> None:
     assert ws.usable_bwrap() is None
 
 
+def test_usable_bwrap_stages_pid_creation_when_direct_mounting_is_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess
+
+    from hud.environment import workspace as ws
+
+    monkeypatch.setattr(ws, "_bwrap_usable", None)
+    binaries = {
+        "bwrap": "/usr/bin/bwrap",
+        "unshare": "/usr/bin/unshare",
+        "true": "/usr/bin/true",
+    }
+    monkeypatch.setattr(ws.shutil, "which", binaries.get)
+    calls: list[list[str]] = []
+
+    def run(argv: list[str], **_: object) -> subprocess.CompletedProcess[bytes]:
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, int(len(calls) == 1), b"", b"blocked")
+
+    monkeypatch.setattr(ws.subprocess, "run", run)
+
+    assert ws.usable_bwrap() == Bubblewrap("/usr/bin/bwrap", pid_unshare="/usr/bin/unshare")
+    assert "--unshare-pid" in calls[0]
+    assert calls[1][:4] == [
+        "/usr/bin/unshare",
+        "--kill-child=KILL",
+        "--pid",
+        "--mount-proc",
+    ]
+    assert "--unshare-pid" not in calls[1]
+
+
+def test_staged_bwrap_keeps_user_isolation_and_uses_the_staged_proc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ws = Workspace(tmp_path / "root")
+    monkeypatch.setattr(
+        ws,
+        "_bwrap",
+        Bubblewrap("/usr/bin/bwrap", pid_unshare="/usr/bin/unshare"),
+    )
+
+    argv = ws.bwrap_argv(["true"])
+
+    assert argv[:5] == [
+        "/usr/bin/unshare",
+        "--kill-child=KILL",
+        "--pid",
+        "--mount-proc",
+        "/usr/bin/bwrap",
+    ]
+    assert "--unshare-user-try" in argv
+    assert "--unshare-pid" not in argv
+    assert "--proc" not in argv
+    assert "/proc" not in argv
+
+    joined = ws.bwrap_argv(["true"], isolate_processes=False, isolate_users=False)
+    assert joined[0] == "/usr/bin/bwrap"
+    assert "/usr/bin/unshare" not in joined
+    assert "--proc" not in joined
+
+
 def test_required_isolation_refuses_when_unavailable(monkeypatch, tmp_path) -> None:
     from hud.environment import workspace as ws
 
@@ -1089,6 +1176,39 @@ async def test_identity_map_reads_a_chunked_info_document() -> None:
         assert os.read(block_read, 1) == b"\n"  # the sandbox was released
     finally:
         writer.join()
+        for fd in (info_read, block_read, block_write):
+            with contextlib.suppress(OSError):
+                os.close(fd)
+
+
+@pytest.mark.asyncio
+async def test_identity_map_resolves_a_staged_sandbox_to_its_parent_pid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    info_read, info_write = os.pipe()
+    block_read, block_write = os.pipe()
+    os.write(info_write, b'{"child-pid": 14}')
+    os.close(info_write)
+    children = {
+        "/proc/100/task/100/children": "102 ",
+        "/proc/102/task/102/children": "121 ",
+    }
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        return children[str(path)]
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    try:
+        with mock.patch.object(workspace_mod, "_map_identities") as mapped:
+            pid = await workspace_mod.install_identity_map(
+                info_read,
+                block_write,
+                launcher_pid=100,
+            )
+        assert pid == 121
+        mapped.assert_called_once_with(121)
+        assert os.read(block_read, 1) == b"\n"
+    finally:
         for fd in (info_read, block_read, block_write):
             with contextlib.suppress(OSError):
                 os.close(fd)

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -39,58 +39,94 @@ LOGGER = logging.getLogger("hud.environment.workspace")
 
 _COMMAND_TIMEOUT = 3600.0
 
-# Set once the first Workspace logs the missing-bwrap notice (avoid per-instance spam).
-#: bwrap's usability is a property of the host/container, so probe once per
-#: process: an installed bwrap that cannot create namespaces would otherwise
-#: fail every session instead of falling back.
-_bwrap_usable: bool | None = None
+
+@dataclass(slots=True, frozen=True)
+class Bubblewrap:
+    path: str
+    pid_unshare: str | None = None
 
 
-def usable_bwrap() -> str | None:
-    """``bwrap``'s path if it can actually create namespaces here, else None."""
+# Set once the first Workspace probes the substrate (avoid per-instance work).
+_bwrap_usable: Bubblewrap | Literal[False] | None = None
+
+
+def usable_bwrap() -> Bubblewrap | None:
+    """A working bubblewrap launch mode for this substrate, if one exists."""
     global _bwrap_usable
+    if isinstance(_bwrap_usable, Bubblewrap):
+        return _bwrap_usable
+    if _bwrap_usable is False:
+        return None
+
     path = shutil.which("bwrap")
     if path is None:
         return None
     probe_binary = shutil.which("true")
     if probe_binary is None:
         return None
-    if _bwrap_usable is None:
-        try:
-            probe = subprocess.run(
-                # Mirrors a real session's *namespace* setup — mounting proc is
-                # what an unprivileged container blocks first. The whole root
-                # is bound so the probed binary keeps its loader; a narrower
-                # mount set fails for the wrong reason. It does not prove the
-                # installed bwrap parses every option a session passes, so
-                # bwrap_argv stays within what bubblewrap 0.4 understands.
+
+    direct = Bubblewrap(path)
+    launches = [
+        (
+            direct,
+            [
+                path,
+                "--unshare-user",
+                "--unshare-pid",
+                "--ro-bind",
+                "/",
+                "/",
+                "--proc",
+                "/proc",
+                "--",
+                probe_binary,
+            ],
+        )
+    ]
+    if unshare := shutil.which("unshare"):
+        staged = Bubblewrap(path, pid_unshare=unshare)
+        launches.append(
+            (
+                staged,
                 [
+                    unshare,
+                    "--kill-child=KILL",
+                    "--pid",
+                    "--mount-proc",
                     path,
-                    "--unshare-user-try",
-                    "--unshare-pid",
+                    "--unshare-user",
                     "--ro-bind",
                     "/",
                     "/",
-                    "--proc",
-                    "/proc",
                     "--",
                     probe_binary,
                 ],
+            )
+        )
+
+    failure = "unknown error"
+    for launch, argv in launches:
+        try:
+            probe = subprocess.run(
+                argv,
                 capture_output=True,
                 timeout=15,
                 check=False,
             )
-            _bwrap_usable = probe.returncode == 0
-            if not _bwrap_usable:
-                LOGGER.warning(
-                    "bwrap is installed but cannot create namespaces (%s); sessions will "
-                    "run WITHOUT isolation. The container runtime must allow "
-                    "unprivileged user namespaces to enable it.",
-                    probe.stderr.decode("utf-8", "replace").strip()[:120],
-                )
+            if probe.returncode == 0:
+                _bwrap_usable = launch
+                return launch
+            failure = probe.stderr.decode("utf-8", "replace").strip()[:120]
         except (OSError, subprocess.SubprocessError):
-            _bwrap_usable = False
-    return path if _bwrap_usable else None
+            continue
+
+    _bwrap_usable = False
+    LOGGER.warning(
+        "bwrap is installed but cannot create an isolated process namespace (%s); "
+        "sessions will run WITHOUT isolation.",
+        failure,
+    )
+    return None
 
 
 _warned_no_bwrap = False
@@ -188,7 +224,12 @@ def _env_argv(env: Mapping[str, str]) -> list[str]:
     return [env_bin, "-i", *(f"{k}={v}" for k, v in env.items())]
 
 
-async def install_identity_map(info_read: int, block_write: int) -> int:
+async def install_identity_map(
+    info_read: int,
+    block_write: int,
+    *,
+    launcher_pid: int | None = None,
+) -> int:
     """Map ids into a bwrap held at ``--userns-block-fd``, and release it.
 
     The counterpart to spawning with ``--info-fd``/``--userns-block-fd``:
@@ -207,6 +248,15 @@ async def install_identity_map(info_read: int, block_write: int) -> int:
                 json.loads(raw)
                 break
     pid = int(json.loads(raw)["child-pid"]) if raw else 0
+    if pid and launcher_pid is not None:
+        pid = launcher_pid
+        for _ in range(2):
+            children = Path(f"/proc/{pid}/task/{pid}/children").read_text().split()
+            if len(children) != 1:
+                raise RuntimeError(
+                    f"sandbox launcher {pid} has {len(children)} children; expected one"
+                )
+            pid = int(children[0])
     if pid:
         _map_identities(pid)
     os.write(block_write, b"\n")
@@ -730,6 +780,9 @@ class Workspace:
         no-network namespace instead. ``mounts`` can replace the session's
         mounts where an operation is allowed to see paths hidden from sessions.
         """
+        bwrap = self._bwrap
+        if bwrap is None:
+            raise RuntimeError("workspace commands require bwrap")
         current_identity = (os.geteuid(), os.getegid()) if hasattr(os, "geteuid") else None
         requested_identity = identity if isinstance(identity, tuple) else (identity, identity)
         if (
@@ -751,7 +804,7 @@ class Workspace:
                     nsenter,
                     "--target",
                     str(sandbox),
-                    "--user",
+                    *(("--user",) if bwrap.pid_unshare is None else ()),
                     *(("--net",) if self.owns_netns else ()),
                     "--preserve-credentials",
                     "--",
@@ -808,7 +861,11 @@ class Workspace:
             os.close(info_write)
             os.close(block_read)
             info_write = block_read = -1
-            await install_identity_map(info_read, block_write)
+            await install_identity_map(
+                info_read,
+                block_write,
+                launcher_pid=(process.process.pid if bwrap.pid_unshare is not None else None),
+            )
         except BaseException:
             if process is not None:
                 await process.terminate()
@@ -863,7 +920,8 @@ class Workspace:
         owns_netns = self.owns_netns if network is None else not network
         if not isolate_users and (info_fd is not None or userns_block_fd is not None):
             raise ValueError("identity-map descriptors require a fresh user namespace")
-        argv: list[str] = [self._bwrap, "--die-with-parent"]
+        staged_pid = isolate_processes and self._bwrap.pid_unshare is not None
+        argv: list[str] = [self._bwrap.path, "--die-with-parent"]
         if isolate_users:
             # Blocking means this side installs the map, so the namespace has
             # to be ours to map: --unshare-user, not the best-effort form.
@@ -874,7 +932,7 @@ class Workspace:
         if isolate_processes:
             argv.extend(
                 [
-                    "--unshare-pid",
+                    *(("--unshare-pid",) if not staged_pid else ()),
                     "--unshare-ipc",
                     "--unshare-uts",
                     "--unshare-cgroup-try",
@@ -886,8 +944,10 @@ class Workspace:
             argv.extend(["--info-fd", str(info_fd)])
         if userns_block_fd is not None:
             argv.extend(["--userns-block-fd", str(userns_block_fd)])
-        for m in self._system_mounts:
-            argv.extend(m.to_bwrap_args())
+        for mount in self._system_mounts:
+            if self._bwrap.pid_unshare is not None and mount.kind == "proc":
+                continue
+            argv.extend(mount.to_bwrap_args())
         argv.extend(["--bind", str(self.root), self._guest_path])
         for m in self.mounts if mounts is None else mounts:
             argv.extend(m.to_bwrap_args())
@@ -899,6 +959,15 @@ class Workspace:
         argv.extend(["--chdir", target_cwd])
         argv.append("--")
         argv.extend(_payload_argv(command, full_env, ctty=tty))
+        if staged_pid:
+            assert self._bwrap.pid_unshare is not None
+            argv = [
+                self._bwrap.pid_unshare,
+                "--kill-child=KILL",
+                "--pid",
+                "--mount-proc",
+                *argv,
+            ]
         return argv
 
     def enter_argv(
@@ -1061,6 +1130,8 @@ class Workspace:
         the holder: the pid that matters is the one *this* process can name,
         and bwrap is the only party that knows which of its forks that is.
         """
+        bwrap = self._bwrap
+        assert bwrap is not None
         try:
             read_fd, write_fd = os.pipe()
             block_read, block_write = os.pipe()
@@ -1084,7 +1155,11 @@ class Workspace:
                 write_fd = block_read = -1
                 # The sandbox is held at its own creation until its ids are
                 # mapped: nothing runs in it, and nothing joins it, before then.
-                pid = await install_identity_map(read_fd, block_write)
+                pid = await install_identity_map(
+                    read_fd,
+                    block_write,
+                    launcher_pid=(self._sandbox.pid if bwrap.pid_unshare is not None else None),
+                )
             finally:
                 os.close(read_fd)
                 os.close(block_write)

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -12,7 +12,8 @@ elsewhere) are the same code, differing only in the url.
   ``(task) -> Environment`` constructor.
 - :class:`SubprocessRuntime` — serve the row's env from a ``.py`` source in a
   child process, when the env should not share the orchestrator's fate.
-- :class:`DockerRuntime` — ``docker run``s an image whose CMD serves the channel.
+- :class:`DockerRuntime` — starts an image or Compose environment whose primary
+  service serves the channel.
 - ``Runtime(url)`` — the ``nullcontext`` of providers: yields itself, a
   *borrowed, shared* substrate provisioned elsewhere (env served anywhere —
   a cloud sandbox, another host — that this process connects to).
@@ -32,18 +33,22 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import logging
+import shlex
 import sys
+import tarfile
+import tempfile
 import uuid
 from collections import deque
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from hud.telemetry.context import get_current_trace_id
 from hud.types import Step
@@ -93,7 +98,7 @@ class RuntimeLimits(BaseModel):
 
 
 class RuntimeConfig(BaseModel):
-    """Portable task-environment launch requirements.
+    """Typed task-environment launch requirements.
 
     ``Task.runtime_config`` is requested construction input. ``Runtime.config``
     is the effective config used to construct a runtime.
@@ -102,15 +107,26 @@ class RuntimeConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     image: str | None = Field(default=None, min_length=1)
+    compose: Path | None = None
     resources: RuntimeResources | None = None
     limits: RuntimeLimits | None = None
+
+    @model_validator(mode="after")
+    def validate_source(self) -> Self:
+        if self.image is not None and self.compose is not None:
+            raise ValueError("runtime_config accepts either image or compose, not both")
+        return self
 
     def with_overrides(self, override: RuntimeConfig | None) -> RuntimeConfig:
         if override is None:
             return self
-        return RuntimeConfig.model_validate(
-            self.model_dump() | override.model_dump(exclude_unset=True)
-        )
+        config = self.model_dump()
+        changes = override.model_dump(exclude_unset=True)
+        if override.image is not None:
+            config["compose"] = None
+        elif override.compose is not None:
+            config["image"] = None
+        return RuntimeConfig.model_validate(config | changes)
 
     def request_payload(self) -> dict[str, Any]:
         return self.model_dump(mode="json", exclude_unset=True)
@@ -171,6 +187,22 @@ _DOCKER_SECURITY_ARGS = (
     "--security-opt",
     "systempaths=unconfined",
 )
+
+
+@contextlib.contextmanager
+def _compose_payload(
+    compose: Path,
+    override_data: dict[str, Any],
+) -> Iterator[tuple[Path, Path]]:
+    with tempfile.TemporaryDirectory(prefix="hud-compose-") as directory:
+        root = Path(directory)
+        archive = root / "project.tar.gz"
+        with tarfile.open(archive, "w:gz") as tar:
+            for entry in compose.parent.iterdir():
+                tar.add(entry, arcname=entry.name)
+        override = root / "override.json"
+        override.write_text(json.dumps(override_data), encoding="utf-8")
+        yield archive, override
 
 
 class LocalRuntime:
@@ -443,20 +475,11 @@ class SubprocessRuntime:
 
 
 class DockerRuntime:
-    """The container provider: each acquisition ``docker run``s a fresh *image*.
+    """Start a HUD environment from an image or a Docker Compose file.
 
-    The positional *image* is shorthand for ``runtime_config.image``. The image's
-    CMD serves the env's control channel on *port* inside the
-    container (the scaffolded ``Dockerfile.hud`` serves 8765). Each
-    acquisition publishes that port on an ephemeral loopback port, yields its
-    :class:`Runtime`, and force-removes the container on exit. *run_args* are
-    extra provider-specific ``docker run`` flags (``-e``, volumes). Every
-    container gets HUD's nested-workspace security profile so its environment
-    can use bubblewrap-backed :class:`~hud.environment.Workspace` sessions.
-
-    Acquisition returns as soon as the port mapping exists — the env may
-    still be importing behind it. Protocol-level readiness is the client's
-    job: ``connect`` retries the handshake until the channel answers.
+    An image is started with ``docker run``. A Compose file is started unchanged
+    except for a small provider override that publishes the ``main`` service's
+    control-channel port and applies HUD's nested-workspace security profile.
     """
 
     def __init__(
@@ -477,10 +500,85 @@ class DockerRuntime:
     @asynccontextmanager
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
-        if config.image is None:
-            raise ValueError("DockerRuntime requires runtime_config.image")
         if config.limits is not None and config.limits.model_dump(exclude_none=True):
             raise ValueError("DockerRuntime does not support runtime_config limits")
+        if config.compose is not None:
+            if self.run_args:
+                raise ValueError("DockerRuntime run_args apply only to image environments")
+            compose = config.compose.resolve()
+            resources = config.resources
+            if (
+                resources is not None
+                and resources.gpu is not None
+                and resources.gpu.type is not None
+            ):
+                raise ValueError("DockerRuntime cannot select Compose GPUs by type")
+            main: dict[str, Any] = {
+                "ports": [f"127.0.0.1::{self.port}"],
+                "security_opt": [
+                    f"seccomp={_DOCKER_SECCOMP_PROFILE}",
+                    "systempaths=unconfined",
+                ],
+            }
+            if resources is not None:
+                main.update(
+                    {
+                        key: value
+                        for key, value in (
+                            ("cpus", resources.cpu),
+                            (
+                                "mem_limit",
+                                f"{resources.memory_mb}m"
+                                if resources.memory_mb is not None
+                                else None,
+                            ),
+                            ("gpus", resources.gpu.count if resources.gpu is not None else None),
+                        )
+                        if value is not None
+                    }
+                )
+            project = f"hud-{uuid.uuid4().hex[:12]}"
+            with tempfile.TemporaryDirectory(prefix="hud-compose-") as directory:
+                override = Path(directory) / "compose.json"
+                override.write_text(json.dumps({"services": {"main": main}}), encoding="utf-8")
+                command = (
+                    "compose",
+                    "--project-name",
+                    project,
+                    "--file",
+                    str(compose),
+                    "--file",
+                    str(override),
+                )
+                try:
+                    await _docker(*command, "up", "--detach", "--build", "--remove-orphans")
+                    mapping, _ = await _docker(*command, "port", "main", str(self.port))
+                    if not mapping.strip():
+                        logs_out, logs_err = await _docker(
+                            *command, "logs", "--tail", "40", "main", check=False
+                        )
+                        raise RuntimeError(
+                            f"Compose main service exited before serving port {self.port}:\n"
+                            f"{(logs_err or logs_out).strip()}"
+                        )
+                    host_port = int(mapping.strip().splitlines()[0].rsplit(":", 1)[1])
+                    yield Runtime(
+                        f"tcp://127.0.0.1:{host_port}",
+                        config=config if config.model_dump(exclude_none=True) else None,
+                    )
+                finally:
+                    await _docker(
+                        *command,
+                        "down",
+                        "--volumes",
+                        "--remove-orphans",
+                        check=False,
+                    )
+            return
+        if config.image is None:
+            raise ValueError(
+                "DockerRuntime requires runtime_config.image or runtime_config.compose"
+            )
 
         resource_args: list[str] = []
         resources = config.resources
@@ -582,15 +680,21 @@ class ModalRuntime:
     @asynccontextmanager
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
+        compose = config.compose.resolve() if config.compose is not None else None
         import modal
 
         app = None
-        if config.image is not None:
+        if compose is not None:
+            image = modal.Image.from_registry("docker:28.3.3-dind")
+        elif config.image is not None:
             image = _modal_image_from_uri(modal, config.image)
         elif self.image_name is not None:
             image = modal.Image.from_name(self.image_name)
         elif self._image is None:
-            raise ValueError("ModalRuntime requires image=, image_name=, or runtime_config.image")
+            raise ValueError(
+                "ModalRuntime requires image=, image_name=, runtime_config.image, "
+                "or runtime_config.compose"
+            )
         else:
             if self._resolved is None:
                 async with self._image_lock:
@@ -626,18 +730,69 @@ class ModalRuntime:
             ready_timeout = config.limits.startup_timeout_s or ready_timeout
 
         sb = await modal.Sandbox.create.aio(
-            *self.command,
+            *(() if compose is not None else self.command),
             app=app,
             image=image,
-            workdir=self.workdir,
+            workdir=None if compose is not None else self.workdir,
             unencrypted_ports=[self.port],
-            readiness_probe=modal.Probe.with_tcp(self.port),
+            readiness_probe=(None if compose is not None else modal.Probe.with_tcp(self.port)),
             # Modal types both timeouts as int seconds; floats raise at proto encode.
             timeout=run_timeout,
+            **({"experimental_options": {"vm_runtime": True}} if compose is not None else {}),
             **sandbox_kwargs,
         )
         try:
-            await sb.wait_until_ready.aio(timeout=ready_timeout)
+            if compose is None:
+                await sb.wait_until_ready.aio(timeout=ready_timeout)
+            else:
+                main: dict[str, Any] = {
+                    "ports": [f"{self.port}:{self.port}"],
+                    "security_opt": [
+                        "seccomp=/hud/docker-seccomp.json",
+                        "systempaths=unconfined",
+                    ],
+                }
+                if resources is not None:
+                    main.update(
+                        {
+                            key: value
+                            for key, value in (
+                                ("cpus", resources.cpu),
+                                (
+                                    "mem_limit",
+                                    f"{resources.memory_mb}m"
+                                    if resources.memory_mb is not None
+                                    else None,
+                                ),
+                                (
+                                    "gpus",
+                                    resources.gpu.count if resources.gpu is not None else None,
+                                ),
+                            )
+                            if value is not None
+                        }
+                    )
+                with _compose_payload(compose, {"services": {"main": main}}) as (
+                    archive,
+                    override,
+                ):
+                    await sb.filesystem.copy_from_local.aio(archive, "/hud/project.tar.gz")
+                    await sb.filesystem.copy_from_local.aio(override, "/hud/override.json")
+                    await sb.filesystem.copy_from_local.aio(
+                        _DOCKER_SECCOMP_PROFILE, "/hud/docker-seccomp.json"
+                    )
+                command = (
+                    "mkdir -p /hud/project && "
+                    "tar -xzf /hud/project.tar.gz -C /hud/project && "
+                    "until docker info >/dev/null 2>&1; do sleep 1; done && "
+                    "docker compose --project-directory /hud/project "
+                    f"--file /hud/project/{shlex.quote(compose.name)} "
+                    "--file /hud/override.json up --detach --build --remove-orphans"
+                )
+                process = await sb.exec.aio("sh", "-c", command, timeout=ready_timeout)
+                if await process.wait.aio() != 0:
+                    error = (await process.stderr.read.aio()).strip()
+                    raise RuntimeError(f"Modal Compose startup failed: {error}")
             host, port = (await sb.tunnels.aio())[self.port].tcp_socket
             yield Runtime(
                 f"tcp://{host}:{port}",
@@ -646,6 +801,23 @@ class ModalRuntime:
             )
         finally:
             # check-free teardown: never shadow the run's own error.
+            if compose is not None:
+                with contextlib.suppress(Exception):
+                    process = await sb.exec.aio(
+                        "docker",
+                        "compose",
+                        "--project-directory",
+                        "/hud/project",
+                        "--file",
+                        f"/hud/project/{compose.name}",
+                        "--file",
+                        "/hud/override.json",
+                        "down",
+                        "--volumes",
+                        "--remove-orphans",
+                        timeout=30,
+                    )
+                    await process.wait.aio()
             with contextlib.suppress(Exception):
                 await sb.terminate.aio()
 
@@ -682,7 +854,7 @@ async def _snapshot_is_current(snapshot: Any, image: Any) -> bool:
 class DaytonaRuntime:
     """The Daytona provider: each acquisition creates a fresh sandbox from a snapshot.
 
-    The Daytona :class:`ModalRuntime` — boots a sandbox from a pre-built *snapshot*
+    The Daytona runtime boots a sandbox from a pre-built *snapshot*
     (the durable handle, the snapshot equivalent of Modal's image name), starts the
     env's control channel inside it, then reaches it over an SSH local-forward:
     Daytona exposes services only as HTTPS previews, but :func:`hud.clients.connect`
@@ -745,11 +917,13 @@ class DaytonaRuntime:
             GpuType,
             Image,
             Resources,
+            SandboxClass,
             SessionExecuteRequest,
         )
 
         async with AsyncDaytona() as daytona:
             config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
+            compose = config.compose.resolve() if config.compose is not None else None
             if config.limits is not None and config.limits.run_timeout_s is not None:
                 raise ValueError("DaytonaRuntime does not support runtime_config.run_timeout_s")
 
@@ -777,26 +951,29 @@ class DaytonaRuntime:
                     daytona_resources = Resources(**resource_kwargs)
 
             if config.image is not None:
-                kwargs: dict[str, Any] = {
-                    "image": Image.base(config.image),
-                    "ephemeral": True,
-                    "auto_stop_interval": 0,
-                }
-                if daytona_resources is not None:
-                    kwargs["resources"] = daytona_resources
-                sandbox_params = CreateSandboxFromImageParams(**kwargs)
+                sandbox_params = CreateSandboxFromImageParams(
+                    image=Image.base(config.image),
+                    ephemeral=True,
+                    auto_stop_interval=0,
+                    resources=daytona_resources,
+                )
             else:
-                if self.snapshot_name is None:
+                snapshot_name = (
+                    "hud-compose-dind-vm-v1" if compose is not None else self.snapshot_name
+                )
+                snapshot_image = "docker:28.3.3-dind" if compose is not None else self._image
+                snapshot_class = SandboxClass.LINUX_VM if compose is not None else None
+                if snapshot_name is None:
                     raise ValueError(
-                        "DaytonaRuntime requires snapshot_name or runtime_config.image"
+                        "DaytonaRuntime requires snapshot_name, runtime_config.image, "
+                        "or runtime_config.compose"
                     )
-                if daytona_resources is not None and self._image is None:
+                if daytona_resources is not None and snapshot_image is None:
                     raise ValueError(
                         "DaytonaRuntime cannot resize an already-built snapshot: resources "
                         "are fixed when it is built, so pass image= to build one"
                     )
-                snapshot_name = self.snapshot_name
-                if self._image is not None:
+                if snapshot_image is not None:
                     if daytona_resources is not None:
                         # Sizing is baked in at build time, so each sizing is its
                         # own snapshot under a readable suffix (env-4cpu-8gb).
@@ -819,7 +996,7 @@ class DaytonaRuntime:
                             except DaytonaNotFoundError:
                                 existing = None
                             if existing is not None and not await _snapshot_is_current(
-                                existing, self._image
+                                existing, snapshot_image
                             ):
                                 logger.info(
                                     "Daytona snapshot %s is stale; rebuilding", snapshot_name
@@ -840,8 +1017,9 @@ class DaytonaRuntime:
                                 await daytona.snapshot.create(
                                     CreateSnapshotParams(
                                         name=snapshot_name,
-                                        image=self._image,
+                                        image=snapshot_image,
                                         resources=daytona_resources,
+                                        sandbox_class=snapshot_class,
                                     )
                                 )
                             self._resolved.add(snapshot_name)
@@ -860,16 +1038,70 @@ class DaytonaRuntime:
                 sandbox_params,
                 timeout=create_timeout,
             )
+            session_command: Any = None
             try:
-                # Start the env server in a background session (the snapshot's CMD is
-                # not the sandbox's main process). connect() retries the handshake,
-                # so we don't poll for readiness here.
-                session: str = "hud-serve"
-                await sandbox.process.create_session(session)
-                cmd = f"cd {self.workdir} && {self.command}" if self.workdir else self.command
-                started = await sandbox.process.execute_session_command(
-                    session, SessionExecuteRequest(command=cmd, run_async=True)
-                )
+                if compose is None:
+                    # Start the env server in a background session (the snapshot's CMD is
+                    # not the sandbox's main process). connect() retries the handshake,
+                    # so we don't poll for readiness here.
+                    session: str = "hud-serve"
+                    await sandbox.process.create_session(session)
+                    cmd = f"cd {self.workdir} && {self.command}" if self.workdir else self.command
+                    session_command = await sandbox.process.execute_session_command(
+                        session, SessionExecuteRequest(command=cmd, run_async=True)
+                    )
+                else:
+                    main: dict[str, Any] = {
+                        "ports": [f"127.0.0.1:{self.port}:{self.port}"],
+                        "security_opt": [
+                            "seccomp=/hud/docker-seccomp.json",
+                            "systempaths=unconfined",
+                        ],
+                    }
+                    resources = config.resources
+                    if resources is not None:
+                        main.update(
+                            {
+                                key: value
+                                for key, value in (
+                                    ("cpus", resources.cpu),
+                                    (
+                                        "mem_limit",
+                                        f"{resources.memory_mb}m"
+                                        if resources.memory_mb is not None
+                                        else None,
+                                    ),
+                                    (
+                                        "gpus",
+                                        resources.gpu.count if resources.gpu is not None else None,
+                                    ),
+                                )
+                                if value is not None
+                            }
+                        )
+                    with _compose_payload(compose, {"services": {"main": main}}) as (
+                        archive,
+                        override,
+                    ):
+                        await sandbox.fs.upload_file(str(archive), "/hud/project.tar.gz")
+                        await sandbox.fs.upload_file(str(override), "/hud/override.json")
+                        await sandbox.fs.upload_file(
+                            str(_DOCKER_SECCOMP_PROFILE), "/hud/docker-seccomp.json"
+                        )
+                    command = (
+                        "dockerd-entrypoint.sh dockerd >/var/log/dockerd.log 2>&1 & "
+                        "until docker info >/dev/null 2>&1; do sleep 1; done && "
+                        "mkdir -p /hud/project && "
+                        "tar -xzf /hud/project.tar.gz -C /hud/project && "
+                        "docker compose --project-directory /hud/project "
+                        f"--file {shlex.quote(f'/hud/project/{compose.name}')} "
+                        "--file /hud/override.json up --detach --build --remove-orphans"
+                    )
+                    started = await sandbox.process.exec(command, timeout=create_timeout)
+                    if started.exit_code != 0:
+                        raise RuntimeError(
+                            f"Daytona Compose startup failed: {started.result.strip()}"
+                        )
                 ssh = await sandbox.create_ssh_access(expires_in_minutes=self.ssh_expires_minutes)
                 async with asyncssh.connect(
                     self.ssh_host, username=ssh.token, known_hosts=None
@@ -885,13 +1117,22 @@ class DaytonaRuntime:
                         # Why it died only exists inside the sandbox, and the
                         # sandbox may already be gone.
                         try:
-                            logs = await sandbox.process.get_session_command_logs(
-                                session, started.cmd_id
-                            )
+                            if compose is None:
+                                logs = await sandbox.process.get_session_command_logs(
+                                    session, session_command.cmd_id
+                                )
+                                output = (logs.stderr or logs.output or logs.stdout or "").strip()
+                            else:
+                                logs = await sandbox.process.exec(
+                                    "docker compose --project-directory /hud/project "
+                                    f"--file {shlex.quote(f'/hud/project/{compose.name}')} "
+                                    "--file /hud/override.json logs --tail 40 main",
+                                    timeout=30,
+                                )
+                                output = logs.result.strip()
                         except Exception as log_exc:
                             exc.add_note(f"env output unavailable: {log_exc}")
                         else:
-                            output = (logs.stderr or logs.output or logs.stdout or "").strip()
                             exc.add_note(
                                 f"env output in sandbox {sandbox.id}:\n{output}"
                                 if output
@@ -899,6 +1140,14 @@ class DaytonaRuntime:
                             )
                         raise
             finally:
+                if compose is not None:
+                    with contextlib.suppress(Exception):
+                        await sandbox.process.exec(
+                            "docker compose --project-directory /hud/project "
+                            f"--file {shlex.quote(f'/hud/project/{compose.name}')} "
+                            "--file /hud/override.json down --volumes --remove-orphans",
+                            timeout=30,
+                        )
                 try:
                     await daytona.delete(sandbox)
                 except Exception:
@@ -1047,7 +1296,9 @@ class HUDRuntime:
                     "HUDRuntime cannot honor this task's declared GPU/limits on an "
                     "already-deployed env; run it on a placement that provisions them"
                 )
-            softly_ignored = task.runtime_config.model_dump(exclude_none=True, exclude={"image"})
+            softly_ignored = task.runtime_config.model_dump(
+                exclude_none=True, exclude={"image", "compose"}
+            )
             if softly_ignored and not self._warned_unsupported_config:
                 self._warned_unsupported_config = True
                 logger.warning(

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import logging
 import shlex
@@ -917,15 +918,22 @@ class DaytonaRuntime:
             GpuType,
             Image,
             Resources,
-            SandboxClass,
             SessionExecuteRequest,
         )
 
         async with AsyncDaytona() as daytona:
             config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
             compose = config.compose.resolve() if config.compose is not None else None
+            project = json.loads(compose.read_text("utf-8")) if compose is not None else None
+            services = project["services"] if project is not None else None
             if config.limits is not None and config.limits.run_timeout_s is not None:
                 raise ValueError("DaytonaRuntime does not support runtime_config.run_timeout_s")
+            if (
+                services is not None
+                and config.resources is not None
+                and config.resources.gpu is not None
+            ):
+                raise ValueError("Daytona linked sandboxes do not support GPU resources")
 
             daytona_resources = None
             if config.resources is not None:
@@ -950,19 +958,31 @@ class DaytonaRuntime:
                 if resource_kwargs:
                     daytona_resources = Resources(**resource_kwargs)
 
-            if config.image is not None:
+            if config.image is not None or services is not None:
+                main_service = None
+                if services is not None:
+                    main_service = {
+                        "environment": {},
+                        "entrypoint": [],
+                        "command": [],
+                        "working_dir": None,
+                    } | services["main"]
+                main_image = config.image
+                if main_image is None:
+                    assert main_service is not None
+                    main_image = main_service["image"]
                 sandbox_params = CreateSandboxFromImageParams(
-                    image=Image.base(config.image),
+                    image=Image.base(main_image),
                     ephemeral=True,
                     auto_stop_interval=0,
                     resources=daytona_resources,
+                    env_vars=(main_service["environment"] or None)
+                    if main_service is not None
+                    else None,
                 )
             else:
-                snapshot_name = (
-                    "hud-compose-dind-vm-v1" if compose is not None else self.snapshot_name
-                )
-                snapshot_image = "docker:28.3.3-dind" if compose is not None else self._image
-                snapshot_class = SandboxClass.LINUX_VM if compose is not None else None
+                snapshot_name = self.snapshot_name
+                snapshot_image = self._image
                 if snapshot_name is None:
                     raise ValueError(
                         "DaytonaRuntime requires snapshot_name, runtime_config.image, "
@@ -1019,7 +1039,6 @@ class DaytonaRuntime:
                                         name=snapshot_name,
                                         image=snapshot_image,
                                         resources=daytona_resources,
-                                        sandbox_class=snapshot_class,
                                     )
                                 )
                             self._resolved.add(snapshot_name)
@@ -1039,6 +1058,7 @@ class DaytonaRuntime:
                 timeout=create_timeout,
             )
             session_command: Any = None
+            linked_sandboxes: list[Any] = []
             try:
                 if compose is None:
                     # Start the env server in a background session (the snapshot's CMD is
@@ -1051,57 +1071,100 @@ class DaytonaRuntime:
                         session, SessionExecuteRequest(command=cmd, run_async=True)
                     )
                 else:
-                    main: dict[str, Any] = {
-                        "ports": [f"127.0.0.1:{self.port}:{self.port}"],
-                        "security_opt": [
-                            "seccomp=/hud/docker-seccomp.json",
-                            "systempaths=unconfined",
-                        ],
-                    }
-                    resources = config.resources
-                    if resources is not None:
-                        main.update(
-                            {
-                                key: value
-                                for key, value in (
-                                    ("cpus", resources.cpu),
-                                    (
-                                        "mem_limit",
-                                        f"{resources.memory_mb}m"
-                                        if resources.memory_mb is not None
-                                        else None,
-                                    ),
-                                    (
-                                        "gpus",
-                                        resources.gpu.count if resources.gpu is not None else None,
-                                    ),
+                    assert services is not None and main_service is not None
+                    for service_name, raw_service in services.items():
+                        if service_name == "main":
+                            continue
+                        service = {
+                            "environment": {},
+                            "entrypoint": [],
+                            "command": [],
+                            "working_dir": None,
+                            "healthcheck": None,
+                        } | raw_service
+                        image_name = service["image"]
+                        snapshot_name = (
+                            "hud-compose-" + hashlib.sha256(image_name.encode()).hexdigest()[:20]
+                        )
+                        async with self._snapshot_lock:
+                            if snapshot_name not in self._resolved:
+                                try:
+                                    await daytona.snapshot.get(snapshot_name)
+                                except DaytonaNotFoundError:
+                                    await daytona.snapshot.create(
+                                        CreateSnapshotParams(
+                                            name=snapshot_name,
+                                            image=image_name,
+                                        )
+                                    )
+                                self._resolved.add(snapshot_name)
+                        child = await daytona.create(
+                            CreateSandboxFromSnapshotParams(
+                                name=f"hud-{service_name}-{uuid.uuid4().hex[:12]}",
+                                snapshot=snapshot_name,
+                                ephemeral=True,
+                                auto_stop_interval=0,
+                                env_vars=service["environment"],
+                                linked_sandbox=sandbox.id,
+                            ),
+                            timeout=create_timeout,
+                        )
+                        linked_sandboxes.append(child)
+                        session = f"hud-{service_name}"
+                        await child.process.create_session(session)
+                        service_argv = [*service["entrypoint"], *service["command"]]
+                        if not service_argv:
+                            raise ValueError(f"Compose service {service_name!r} has no command")
+                        service_command = shlex.join(service_argv)
+                        if service["working_dir"]:
+                            service_command = (
+                                f"cd {shlex.quote(service['working_dir'])} && {service_command}"
+                            )
+                        await child.process.execute_session_command(
+                            session,
+                            SessionExecuteRequest(command=service_command, run_async=True),
+                        )
+                        alias = shlex.quote(child.id)
+                        hostname = shlex.quote(service_name)
+                        mapped = await sandbox.process.exec(
+                            f"ip=$(getent ahostsv4 {alias} | awk 'NR == 1 {{print $1}}') && "
+                            f'test -n "$ip" && printf \'%s %s\\n\' "$ip" {hostname} '
+                            ">> /etc/hosts",
+                            timeout=30,
+                        )
+                        if mapped.exit_code != 0:
+                            raise RuntimeError(
+                                f"Daytona could not resolve linked service {service_name!r}: "
+                                f"{mapped.result.strip()}"
+                            )
+                        if service["healthcheck"] is not None:
+                            test = ({"test": None} | service["healthcheck"])["test"]
+                            if test and test[0] != "NONE":
+                                health_command = (
+                                    shlex.join(test[1:]) if test[0] == "CMD" else test[1]
                                 )
-                                if value is not None
-                            }
-                        )
-                    with _compose_payload(compose, {"services": {"main": main}}) as (
-                        archive,
-                        override,
-                    ):
-                        await sandbox.fs.upload_file(str(archive), "/hud/project.tar.gz")
-                        await sandbox.fs.upload_file(str(override), "/hud/override.json")
-                        await sandbox.fs.upload_file(
-                            str(_DOCKER_SECCOMP_PROFILE), "/hud/docker-seccomp.json"
-                        )
-                    command = (
-                        "dockerd-entrypoint.sh dockerd >/var/log/dockerd.log 2>&1 & "
-                        "until docker info >/dev/null 2>&1; do sleep 1; done && "
-                        "mkdir -p /hud/project && "
-                        "tar -xzf /hud/project.tar.gz -C /hud/project && "
-                        "docker compose --project-directory /hud/project "
-                        f"--file {shlex.quote(f'/hud/project/{compose.name}')} "
-                        "--file /hud/override.json up --detach --build --remove-orphans"
+                                async with asyncio.timeout(create_timeout):
+                                    while True:
+                                        health = await child.process.exec(
+                                            health_command,
+                                            timeout=30,
+                                        )
+                                        if health.exit_code == 0:
+                                            break
+                                        await asyncio.sleep(1)
+
+                    session = "hud-serve"
+                    await sandbox.process.create_session(session)
+                    main_argv = [*main_service["entrypoint"], *main_service["command"]]
+                    if not main_argv:
+                        raise ValueError("Compose main service has no command")
+                    command = shlex.join(main_argv)
+                    if main_service["working_dir"]:
+                        command = f"cd {shlex.quote(main_service['working_dir'])} && {command}"
+                    session_command = await sandbox.process.execute_session_command(
+                        session,
+                        SessionExecuteRequest(command=command, run_async=True),
                     )
-                    started = await sandbox.process.exec(command, timeout=create_timeout)
-                    if started.exit_code != 0:
-                        raise RuntimeError(
-                            f"Daytona Compose startup failed: {started.result.strip()}"
-                        )
                 ssh = await sandbox.create_ssh_access(expires_in_minutes=self.ssh_expires_minutes)
                 async with asyncssh.connect(
                     self.ssh_host, username=ssh.token, known_hosts=None
@@ -1117,19 +1180,10 @@ class DaytonaRuntime:
                         # Why it died only exists inside the sandbox, and the
                         # sandbox may already be gone.
                         try:
-                            if compose is None:
-                                logs = await sandbox.process.get_session_command_logs(
-                                    session, session_command.cmd_id
-                                )
-                                output = (logs.stderr or logs.output or logs.stdout or "").strip()
-                            else:
-                                logs = await sandbox.process.exec(
-                                    "docker compose --project-directory /hud/project "
-                                    f"--file {shlex.quote(f'/hud/project/{compose.name}')} "
-                                    "--file /hud/override.json logs --tail 40 main",
-                                    timeout=30,
-                                )
-                                output = logs.result.strip()
+                            logs = await sandbox.process.get_session_command_logs(
+                                session, session_command.cmd_id
+                            )
+                            output = (logs.stderr or logs.output or logs.stdout or "").strip()
                         except Exception as log_exc:
                             exc.add_note(f"env output unavailable: {log_exc}")
                         else:
@@ -1140,13 +1194,14 @@ class DaytonaRuntime:
                             )
                         raise
             finally:
-                if compose is not None:
-                    with contextlib.suppress(Exception):
-                        await sandbox.process.exec(
-                            "docker compose --project-directory /hud/project "
-                            f"--file {shlex.quote(f'/hud/project/{compose.name}')} "
-                            "--file /hud/override.json down --volumes --remove-orphans",
-                            timeout=30,
+                for child in reversed(linked_sandboxes):
+                    try:
+                        await daytona.delete(child)
+                    except Exception:
+                        logger.warning(
+                            "failed to delete linked Daytona sandbox %s; it may still be running",
+                            child.id,
+                            exc_info=True,
                         )
                 try:
                     await daytona.delete(sandbox)

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -230,6 +230,9 @@ class _CreateSandboxFromSnapshotParams:
     snapshot: str
     ephemeral: bool
     auto_stop_interval: int
+    name: str | None = None
+    env_vars: dict[str, str] | None = None
+    linked_sandbox: str | None = None
 
 
 @dataclass(frozen=True)
@@ -237,7 +240,6 @@ class _CreateSnapshotParams:
     name: str
     image: object
     resources: object | None = None
-    sandbox_class: object | None = None
 
 
 @dataclass(frozen=True)
@@ -246,6 +248,9 @@ class _CreateSandboxFromImageParams:
     ephemeral: bool
     auto_stop_interval: int
     resources: object | None = None
+    name: str | None = None
+    env_vars: dict[str, str] | None = None
+    linked_sandbox: str | None = None
 
 
 @dataclass(frozen=True)
@@ -273,8 +278,9 @@ class _SessionExecuteRequest:
 
 
 class _FakeDaytonaProcess:
-    def __init__(self, calls: dict[str, object]) -> None:
+    def __init__(self, calls: dict[str, object], sandbox_id: str) -> None:
         self._calls = calls
+        self._sandbox_id = sandbox_id
         self.logs = SimpleNamespace(
             stderr="ImportError: no module named bugs", output="", stdout=""
         )
@@ -284,6 +290,9 @@ class _FakeDaytonaProcess:
 
     async def execute_session_command(self, session: str, request: object) -> SimpleNamespace:
         self._calls["execute"] = (session, request)
+        commands = self._calls.setdefault("session_commands", [])
+        assert isinstance(commands, list)
+        commands.append((self._sandbox_id, session, request))
         return SimpleNamespace(cmd_id="cmd-1")
 
     async def get_session_command_logs(self, session: str, cmd_id: str) -> SimpleNamespace:
@@ -298,11 +307,10 @@ class _FakeDaytonaProcess:
 
 
 class _FakeDaytonaSandbox:
-    id = "sandbox-1"
-
-    def __init__(self, calls: dict[str, object]) -> None:
+    def __init__(self, calls: dict[str, object], sandbox_id: str) -> None:
+        self.id = sandbox_id
         self._calls = calls
-        self.process = _FakeDaytonaProcess(calls)
+        self.process = _FakeDaytonaProcess(calls, sandbox_id)
         self.fs = SimpleNamespace(upload_file=self._upload_file)
 
     async def _upload_file(self, source: str, target: str) -> None:
@@ -374,7 +382,6 @@ class _FakeSnapshotApi:
                     ],
                 ),
             )
-        record.sandbox_class = params.sandbox_class
         self.snapshots[params.name] = record
         self.builds.append(params.name)
 
@@ -386,7 +393,7 @@ class _FakeSnapshotApi:
 class _FakeDaytonaClient:
     def __init__(self, calls: dict[str, object]) -> None:
         self.calls = calls
-        self.sandbox = _FakeDaytonaSandbox(calls)
+        self.sandbox = _FakeDaytonaSandbox(calls, "sandbox-1")
         self.snapshot = _FakeSnapshotApi()
         #: sandbox-create params in order; the last entry is the booted sandbox.
         self.created: list[Any] = []
@@ -395,12 +402,20 @@ class _FakeDaytonaClient:
     async def create(self, params: object, **kwargs: object) -> _FakeDaytonaSandbox:
         self.calls["create"] = (params, kwargs["timeout"])
         self.created.append(params)
-        return self.sandbox
+        sandbox = (
+            self.sandbox
+            if len(self.created) == 1
+            else _FakeDaytonaSandbox(self.calls, f"sandbox-{len(self.created)}")
+        )
+        return sandbox
 
     async def delete(self, sandbox: _FakeDaytonaSandbox) -> None:
         if self.delete_fails:
             raise RuntimeError("daytona API unreachable")
         self.calls["delete"] = sandbox.id
+        deleted = self.calls.setdefault("deleted", [])
+        assert isinstance(deleted, list)
+        deleted.append(sandbox.id)
 
 
 class _FakeSSHConnection:
@@ -463,7 +478,6 @@ def _install_fake_daytona(monkeypatch: pytest.MonkeyPatch) -> _FakeDaytonaClient
     setattr(daytona, "Image", SimpleNamespace(base=lambda name: _DaytonaImage(name)))
     setattr(daytona, "Resources", _DaytonaResources)
     setattr(daytona, "GpuType", _DaytonaGpuType)
-    setattr(daytona, "SandboxClass", SimpleNamespace(LINUX_VM="linux-vm"))
     setattr(daytona, "SessionExecuteRequest", _SessionExecuteRequest)
     setattr(daytona, "_async", daytona_async)
     setattr(daytona_async, "object_storage", object_storage)
@@ -910,38 +924,74 @@ async def test_daytona_runtime_config_flows_into_daytona_sdk(
     assert calls["delete"] == "sandbox-1"
 
 
-async def test_daytona_runtime_runs_compose_inside_a_linux_vm(
+async def test_daytona_runtime_maps_compose_services_to_linked_sandboxes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _install_fake_daytona(monkeypatch)
     compose = tmp_path / "compose.yaml"
-    compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
+    compose.write_text(
+        json.dumps(
+            {
+                "services": {
+                    "main": {
+                        "image": "hud-env:one",
+                        "command": ["hud", "serve", "/env.py"],
+                        "entrypoint": [],
+                        "working_dir": "/app",
+                    },
+                    "redis": {
+                        "image": "redis:7",
+                        "entrypoint": ["docker-entrypoint.sh"],
+                        "command": ["redis-server"],
+                        "working_dir": "/data",
+                        "environment": {"REDIS_ARGS": "--save ''"},
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
 
     async with DaytonaRuntime(runtime_config=RuntimeConfig(compose=compose))(_row()) as runtime:
         assert runtime.url == "tcp://127.0.0.1:54321"
 
-    created = client.calls["create"]
-    assert isinstance(created, tuple)
-    create_params, _ = created
-    assert create_params == _CreateSandboxFromSnapshotParams(
-        snapshot="hud-compose-dind-vm-v1",
+    assert client.created[0] == _CreateSandboxFromImageParams(
+        image=_DaytonaImage("hud-env:one"),
         ephemeral=True,
         auto_stop_interval=0,
+        resources=None,
     )
-    snapshot = client.snapshot.snapshots["hud-compose-dind-vm-v1"]
-    assert snapshot.image_name == "docker:28.3.3-dind"
-    assert snapshot.sandbox_class == "linux-vm"
-    assert client.calls["uploads"] == [
-        ("project.tar.gz", "/hud/project.tar.gz"),
-        ("override.json", "/hud/override.json"),
-        ("docker-seccomp.json", "/hud/docker-seccomp.json"),
+    child = client.created[1]
+    assert isinstance(child, _CreateSandboxFromSnapshotParams)
+    assert child.linked_sandbox == "sandbox-1"
+    assert child.env_vars == {"REDIS_ARGS": "--save ''"}
+    assert child.name is not None and child.name.startswith("hud-redis-")
+    assert client.snapshot.builds == [child.snapshot]
+    assert client.snapshot.snapshots[child.snapshot].image_name == "redis:7"
+    assert client.calls["session_commands"] == [
+        (
+            "sandbox-2",
+            "hud-redis",
+            _SessionExecuteRequest(
+                command="cd /data && docker-entrypoint.sh redis-server",
+                run_async=True,
+            ),
+        ),
+        (
+            "sandbox-1",
+            "hud-serve",
+            _SessionExecuteRequest(
+                command="cd /app && hud serve /env.py",
+                run_async=True,
+            ),
+        ),
     ]
     commands = client.calls["process_execs"]
     assert isinstance(commands, list)
-    assert "dockerd-entrypoint.sh" in commands[0][0]
-    assert "up --detach --build --remove-orphans" in commands[0][0]
-    assert "down --volumes --remove-orphans" in commands[1][0]
+    assert "getent ahostsv4 sandbox-2" in commands[0][0]
+    assert "redis" in commands[0][0]
+    assert client.calls["deleted"] == ["sandbox-2", "sandbox-1"]
     assert client.calls["client_closed"] is True
 
 

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -148,6 +148,10 @@ class _FakeModalSandbox:
         self.wait_until_ready = SimpleNamespace(aio=self._wait_until_ready)
         self.tunnels = SimpleNamespace(aio=self._tunnels)
         self.terminate = SimpleNamespace(aio=self._terminate)
+        self.filesystem = SimpleNamespace(
+            copy_from_local=SimpleNamespace(aio=self._copy_from_local)
+        )
+        self.exec = SimpleNamespace(aio=self._exec)
 
     async def _wait_until_ready(self, **kwargs: object) -> None:
         self._calls["ready_timeout"] = kwargs["timeout"]
@@ -157,6 +161,27 @@ class _FakeModalSandbox:
 
     async def _terminate(self) -> None:
         self._calls["terminated"] = True
+
+    async def _copy_from_local(self, source: Path, target: str) -> None:
+        uploads = self._calls.setdefault("uploads", [])
+        assert isinstance(uploads, list)
+        uploads.append((source.name, target))
+
+    async def _exec(self, *args: str, **kwargs: object) -> SimpleNamespace:
+        commands = self._calls.setdefault("execs", [])
+        assert isinstance(commands, list)
+        commands.append((args, kwargs))
+
+        async def wait() -> int:
+            return 0
+
+        async def read() -> str:
+            return ""
+
+        return SimpleNamespace(
+            wait=SimpleNamespace(aio=wait),
+            stderr=SimpleNamespace(read=SimpleNamespace(aio=read)),
+        )
 
 
 def _install_fake_modal(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
@@ -212,6 +237,7 @@ class _CreateSnapshotParams:
     name: str
     image: object
     resources: object | None = None
+    sandbox_class: object | None = None
 
 
 @dataclass(frozen=True)
@@ -264,6 +290,12 @@ class _FakeDaytonaProcess:
         self._calls["logs"] = (session, cmd_id)
         return self.logs
 
+    async def exec(self, command: str, **kwargs: object) -> SimpleNamespace:
+        commands = self._calls.setdefault("process_execs", [])
+        assert isinstance(commands, list)
+        commands.append((command, kwargs))
+        return SimpleNamespace(exit_code=0, result="")
+
 
 class _FakeDaytonaSandbox:
     id = "sandbox-1"
@@ -271,6 +303,12 @@ class _FakeDaytonaSandbox:
     def __init__(self, calls: dict[str, object]) -> None:
         self._calls = calls
         self.process = _FakeDaytonaProcess(calls)
+        self.fs = SimpleNamespace(upload_file=self._upload_file)
+
+    async def _upload_file(self, source: str, target: str) -> None:
+        uploads = self._calls.setdefault("uploads", [])
+        assert isinstance(uploads, list)
+        uploads.append((Path(source).name, target))
 
     async def create_ssh_access(self, *, expires_in_minutes: int) -> SimpleNamespace:
         self._calls["ssh_expires"] = expires_in_minutes
@@ -336,6 +374,7 @@ class _FakeSnapshotApi:
                     ],
                 ),
             )
+        record.sandbox_class = params.sandbox_class
         self.snapshots[params.name] = record
         self.builds.append(params.name)
 
@@ -424,6 +463,7 @@ def _install_fake_daytona(monkeypatch: pytest.MonkeyPatch) -> _FakeDaytonaClient
     setattr(daytona, "Image", SimpleNamespace(base=lambda name: _DaytonaImage(name)))
     setattr(daytona, "Resources", _DaytonaResources)
     setattr(daytona, "GpuType", _DaytonaGpuType)
+    setattr(daytona, "SandboxClass", SimpleNamespace(LINUX_VM="linux-vm"))
     setattr(daytona, "SessionExecuteRequest", _SessionExecuteRequest)
     setattr(daytona, "_async", daytona_async)
     setattr(daytona_async, "object_storage", object_storage)
@@ -530,6 +570,17 @@ def test_runtime_config_overrides_only_explicit_top_level_fields() -> None:
     assert default.with_overrides(RuntimeConfig(resources=None)).resources is None
 
 
+def test_runtime_config_source_override_is_mutually_exclusive(tmp_path: Path) -> None:
+    compose = tmp_path / "compose.yaml"
+
+    assert RuntimeConfig(image="img:default").with_overrides(
+        RuntimeConfig(compose=compose)
+    ) == RuntimeConfig(compose=compose)
+    assert RuntimeConfig(compose=compose).with_overrides(
+        RuntimeConfig(image="img:task")
+    ) == RuntimeConfig(image="img:task")
+
+
 async def test_runtime_config_rejects_unsupported_docker_fields() -> None:
     with pytest.raises(ValueError, match="GPU"):
         async with DockerRuntime()(
@@ -556,6 +607,63 @@ async def test_runtime_config_rejects_unsupported_docker_fields() -> None:
             )
         ):
             pass
+
+
+async def test_docker_runtime_starts_compose_with_a_main_service_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+    rendered: dict[str, Any] = {}
+    compose = tmp_path / "compose.yaml"
+    compose.write_text(
+        "services:\n  main:\n    image: hud-env:one\n  db:\n    image: postgres:17\n",
+        encoding="utf-8",
+    )
+
+    async def fake_docker(*args: str, **_kwargs: Any) -> tuple[str, str]:
+        calls.append(args)
+        if args[-4:] == ("up", "--detach", "--build", "--remove-orphans"):
+            override = Path(args[args.index("--file", args.index("--file") + 1) + 1])
+            rendered.update(json.loads(override.read_text("utf-8")))
+        if args[-3:] == ("port", "main", "8765"):
+            return "127.0.0.1:43210\n", ""
+        return "", ""
+
+    monkeypatch.setattr(runtime_module, "_docker", fake_docker)
+    task = Task(
+        env="any-env",
+        id="t",
+        runtime_config=RuntimeConfig(
+            compose=compose,
+            resources=RuntimeResources(cpu=2, memory_mb=4096),
+        ),
+    )
+
+    async with DockerRuntime()(task) as runtime:
+        assert runtime.url == "tcp://127.0.0.1:43210"
+        assert runtime.config == task.runtime_config
+
+    assert rendered["services"]["main"] == {
+        "ports": ["127.0.0.1::8765"],
+        "security_opt": [
+            f"seccomp={runtime_module._DOCKER_SECCOMP_PROFILE}",
+            "systempaths=unconfined",
+        ],
+        "cpus": 2.0,
+        "mem_limit": "4096m",
+    }
+    up = next(
+        call for call in calls if call[-4:] == ("up", "--detach", "--build", "--remove-orphans")
+    )
+    assert str(compose.resolve()) in up
+    assert all("/var/run/docker.sock" not in " ".join(call) for call in calls)
+    assert calls[-1][-3:] == ("down", "--volumes", "--remove-orphans")
+
+
+def test_docker_runtime_accepts_only_one_environment_definition(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="either image or compose"):
+        RuntimeConfig(image="img:tag", compose=tmp_path / "compose.yaml")
 
 
 def test_docker_runtime_accepts_runtime_config_defaults() -> None:
@@ -620,6 +728,34 @@ async def test_modal_runtime_config_flows_into_modal_sdk(
     }
     assert calls["ready_timeout"] == 30
     assert calls["terminated"] is True
+
+
+async def test_modal_runtime_runs_compose_inside_a_dind_vm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
+
+    async with ModalRuntime(runtime_config=RuntimeConfig(compose=compose))(_row()) as runtime:
+        assert runtime.url == "tcp://modal.host:4567"
+
+    assert calls["registry_image"] == "docker:28.3.3-dind"
+    kwargs = calls["sandbox_kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["experimental_options"] == {"vm_runtime": True}
+    assert kwargs["readiness_probe"] is None
+    assert calls["uploads"] == [
+        ("project.tar.gz", "/hud/project.tar.gz"),
+        ("override.json", "/hud/override.json"),
+        ("docker-seccomp.json", "/hud/docker-seccomp.json"),
+    ]
+    execs = calls["execs"]
+    assert isinstance(execs, list)
+    assert "docker compose" in execs[0][0][-1]
+    assert "up --detach --build --remove-orphans" in execs[0][0][-1]
+    assert "down" in execs[1][0]
 
 
 async def test_modal_runtime_accepts_modal_image_uri(
@@ -772,7 +908,41 @@ async def test_daytona_runtime_config_flows_into_daytona_sdk(
     )
     assert calls["forward"] == ("127.0.0.1", 0, "127.0.0.1", 8765)
     assert calls["delete"] == "sandbox-1"
-    assert calls["client_closed"] is True
+
+
+async def test_daytona_runtime_runs_compose_inside_a_linux_vm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _install_fake_daytona(monkeypatch)
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
+
+    async with DaytonaRuntime(runtime_config=RuntimeConfig(compose=compose))(_row()) as runtime:
+        assert runtime.url == "tcp://127.0.0.1:54321"
+
+    created = client.calls["create"]
+    assert isinstance(created, tuple)
+    create_params, _ = created
+    assert create_params == _CreateSandboxFromSnapshotParams(
+        snapshot="hud-compose-dind-vm-v1",
+        ephemeral=True,
+        auto_stop_interval=0,
+    )
+    snapshot = client.snapshot.snapshots["hud-compose-dind-vm-v1"]
+    assert snapshot.image_name == "docker:28.3.3-dind"
+    assert snapshot.sandbox_class == "linux-vm"
+    assert client.calls["uploads"] == [
+        ("project.tar.gz", "/hud/project.tar.gz"),
+        ("override.json", "/hud/override.json"),
+        ("docker-seccomp.json", "/hud/docker-seccomp.json"),
+    ]
+    commands = client.calls["process_execs"]
+    assert isinstance(commands, list)
+    assert "dockerd-entrypoint.sh" in commands[0][0]
+    assert "up --detach --build --remove-orphans" in commands[0][0]
+    assert "down --volumes --remove-orphans" in commands[1][0]
+    assert client.calls["client_closed"] is True
 
 
 async def test_daytona_task_runtime_config_overlays_provider_defaults(

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -26,6 +26,8 @@ from hud.eval import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from hud.agents.base import Agent
 
 
@@ -140,6 +142,17 @@ def test_runtime_config_roundtrips_as_part_of_task_row() -> None:
 def test_runtime_config_rejects_unknown_fields() -> None:
     with pytest.raises(ValueError, match="Extra inputs"):
         RuntimeConfig.model_validate({"image": "img:tag", "provider_config": {}})
+
+
+def test_compose_runtime_config_serializes_as_task_data(tmp_path: Path) -> None:
+    compose = tmp_path / "compose.yaml"
+    config = RuntimeConfig(compose=compose)
+    task = Task(env="database", id="cutover", runtime_config=config)
+
+    rebuilt = Task.model_validate(task.model_dump())
+
+    assert rebuilt.runtime_config == config
+    assert config.request_payload() == {"compose": str(compose)}
 
 
 def test_row_validation_rejects_malformed_entries() -> None:

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -340,6 +340,34 @@ async def adapt(
                     raise ValueError(
                         f"Compose service {service_name!r} has neither image nor build"
                     )
+                output, _ = await docker(
+                    "image", "inspect", "--format", "{{json .Config}}", source_image
+                )
+                image_runtime = {
+                    "Entrypoint": None,
+                    "Cmd": None,
+                    "WorkingDir": None,
+                } | json.loads(output)
+                compose_runtime = {
+                    "entrypoint": None,
+                    "command": None,
+                    "working_dir": None,
+                } | service
+                service["entrypoint"] = (
+                    image_runtime["Entrypoint"] or []
+                    if compose_runtime["entrypoint"] is None
+                    else compose_runtime["entrypoint"]
+                )
+                service["command"] = (
+                    image_runtime["Cmd"] or []
+                    if compose_runtime["command"] is None
+                    else compose_runtime["command"]
+                )
+                service["working_dir"] = (
+                    image_runtime["WorkingDir"] or "/"
+                    if compose_runtime["working_dir"] is None
+                    else compose_runtime["working_dir"]
+                )
                 image_id, _ = await docker("image", "inspect", "--format", "{{.Id}}", source_image)
                 fingerprint = image_id.strip().removeprefix("sha256:")[:16]
                 component = normalize_environment_name(f"{name}-{service_name}", default="sidecar")
@@ -464,6 +492,15 @@ async def adapt(
             main["image"] = image
             for field in ("build", "command", "entrypoint"):
                 main.pop(field, None)
+            output, _ = await docker("image", "inspect", "--format", "{{json .Config}}", image)
+            image_runtime = {
+                "Entrypoint": None,
+                "Cmd": None,
+                "WorkingDir": None,
+            } | json.loads(output)
+            main["entrypoint"] = image_runtime["Entrypoint"] or []
+            main["command"] = image_runtime["Cmd"] or []
+            main["working_dir"] = image_runtime["WorkingDir"] or "/"
             (context / "compose.json").write_text(
                 json.dumps(compose, indent=2, sort_keys=True) + "\n",
                 encoding="utf-8",

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
 import os
 import shutil
+import tempfile
 import tomllib
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from hud.capabilities import Capability
 from hud.eval import Task, Taskset
 from hud.eval.runtime import RuntimeConfig, RuntimeGPU, RuntimeResources
 from hud.utils.docker import docker
@@ -32,6 +36,13 @@ IGNORED = shutil.ignore_patterns(
     ".pytest_cache",
 )
 NetworkMode = Literal["public", "no-network", "allowlist"]
+MCPTransport = Literal["sse", "streamable-http", "stdio"]
+COMPOSE_FILENAMES = (
+    "compose.yaml",
+    "compose.yml",
+    "docker-compose.yaml",
+    "docker-compose.yml",
+)
 
 
 class Phase(BaseModel):
@@ -55,6 +66,16 @@ class HealthcheckConfig(BaseModel):
     retries: int = 3
 
 
+class MCPServerConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    transport: MCPTransport
+    url: str | None = None
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+
+
 class EnvironmentConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -72,7 +93,7 @@ class EnvironmentConfig(BaseModel):
     workdir: str | None = None
     env: dict[str, str] = Field(default_factory=dict)
     healthcheck: HealthcheckConfig | None = None
-    mcp_servers: list[dict[str, Any]] = Field(default_factory=list)
+    mcp_servers: list[MCPServerConfig] = Field(default_factory=list)
     skills_dir: str | None = None
 
 
@@ -101,7 +122,7 @@ class HarborTask:
     path: Path
     config: TaskConfig
     environment_hash: str
-    runtime: dict[str, Any]
+    compose: dict[str, Any] | None
 
 
 async def adapt(
@@ -144,70 +165,115 @@ async def adapt(
             unsupported.append("multiple GPU types")
         elif config.environment.gpu_types and not config.environment.gpus:
             unsupported.append("GPU types without GPUs")
-        if config.environment.mcp_servers:
-            unsupported.append("MCP servers")
+        if any(server.transport == "stdio" for server in config.environment.mcp_servers):
+            unsupported.append("stdio MCP servers")
         if config.environment.skills_dir:
             unsupported.append("skills_dir")
         if config.verifier.environment_mode == "separate" or config.verifier.environment:
             unsupported.append("a separate verifier environment")
         if config.steps:
             unsupported.append("multi-step tasks")
-        if any(
-            (task_dir / "environment" / filename).is_file()
-            for filename in (
-                "compose.yaml",
-                "compose.yml",
-                "docker-compose.yaml",
-                "docker-compose.yml",
-            )
-        ):
-            unsupported.append("Docker Compose")
         if unsupported:
             raise NotImplementedError(
                 f"Harbor task {task_dir.name!r} uses unsupported features: "
                 + ", ".join(unsupported)
             )
 
-        environment = config.environment
+        server_names = [server.name for server in config.environment.mcp_servers]
+        if len(server_names) != len(set(server_names)):
+            raise ValueError("MCP server names must be unique")
+        for server in config.environment.mcp_servers:
+            if server.url is None:
+                raise ValueError(f"MCP server {server.name!r} requires a URL")
+
+        environment_dir = task_dir / "environment"
+        authored_compose = next(
+            (
+                environment_dir / filename
+                for filename in COMPOSE_FILENAMES
+                if (environment_dir / filename).is_file()
+            ),
+            None,
+        )
+        compose = None
+        if authored_compose is not None:
+            with tempfile.TemporaryDirectory(prefix="hud-harbor-compose-") as directory:
+                base_compose = Path(directory) / "base.json"
+                base_compose.write_text(json.dumps({"services": {"main": {"image": "hud-main"}}}))
+                output, _ = await docker(
+                    "compose",
+                    "--project-name",
+                    "hud",
+                    "--project-directory",
+                    str(environment_dir),
+                    "--file",
+                    str(base_compose),
+                    "--file",
+                    str(authored_compose),
+                    "config",
+                    "--format",
+                    "json",
+                )
+            try:
+                compose = json.loads(output)
+                compose["services"]["main"]
+            except (json.JSONDecodeError, KeyError, TypeError) as error:
+                raise ValueError(f"{task_dir.name} did not resolve to a Compose project") from error
+            if "name" in compose:
+                del compose["name"]
+            if (
+                "networks" in compose
+                and "default" in compose["networks"]
+                and compose["networks"]["default"] == {"name": "hud_default"}
+            ):
+                compose["networks"]["default"] = {}
+
+        environment_digest = hashlib.sha256()
+        if environment_dir.exists():
+            for entry in sorted(environment_dir.rglob("*")):
+                relative_path = entry.relative_to(environment_dir).as_posix().encode()
+                if entry.is_symlink():
+                    environment_digest.update(
+                        relative_path + b"\0symlink\0" + os.readlink(entry).encode()
+                    )
+                elif entry.is_file():
+                    environment_digest.update(relative_path + b"\0" + entry.read_bytes())
+            environment_hash = environment_digest.hexdigest()[:16]
+        else:
+            environment_hash = "missing"
+
         tasks.append(
             HarborTask(
                 path=task_dir,
                 config=config,
-                environment_hash=_tree_hash(task_dir / "environment"),
-                runtime={
-                    "image": environment.docker_image,
-                    "workdir": environment.workdir,
-                    "environment_env": environment.env,
-                    "environment_network": environment.network_mode,
-                    "environment_hosts": environment.allowed_hosts,
-                    "healthcheck": (
-                        environment.healthcheck.model_dump()
-                        if environment.healthcheck is not None
-                        else None
-                    ),
-                    "agent": config.agent.model_dump(
-                        include={"user", "network_mode", "allowed_hosts", "env"}
-                    ),
-                    "verifier": config.verifier.model_dump(
-                        include={"user", "network_mode", "allowed_hosts", "env"}
-                    ),
-                },
+                environment_hash=environment_hash,
+                compose=compose,
             )
         )
 
     grouped: dict[tuple[str, str], list[HarborTask]] = {}
     for task in tasks:
-        runtime_json = json.dumps(task.runtime, sort_keys=True)
-        grouped.setdefault((task.environment_hash, runtime_json), []).append(task)
+        config_json = json.dumps(
+            task.config.model_dump(mode="json", exclude={"task", "metadata", "steps"}),
+            sort_keys=True,
+        )
+        grouped.setdefault((task.environment_hash, config_json), []).append(task)
 
     rows = []
     base_name = normalize_environment_name(dataset.name, default="harbor")
-    for (environment_hash, runtime_json), group in sorted(grouped.items()):
-        digest = hashlib.sha256((environment_hash + "\0" + runtime_json).encode()).hexdigest()[:12]
+    for (environment_hash, config_json), group in sorted(grouped.items()):
+        digest = hashlib.sha256((environment_hash + "\0" + config_json).encode()).hexdigest()[:12]
         name = f"{base_name}-{digest}"
         source = group[0]
+        environment = source.config.environment
+        compose_main = {"image": None, "environment": {}} | (
+            source.compose["services"]["main"] if source.compose is not None else {}
+        )
         dockerfile = source.path / "environment" / "Dockerfile"
-        base_image = source.runtime["image"]
+        compose_image = compose_main["image"]
+        base_image = environment.docker_image or (
+            compose_image if compose_image != "hud-main" else None
+        )
         if base_image and not dockerfile.is_file():
             await docker("pull", base_image)
         elif dockerfile.is_file():
@@ -229,7 +295,65 @@ async def adapt(
             "{{json .Config}}",
             base_image,
         )
-        image_config = json.loads(output)
+        image_config = {"User": None, "WorkingDir": None, "Entrypoint": None} | json.loads(output)
+        compose = copy.deepcopy(source.compose)
+        peers = []
+        if compose is not None:
+            for service_name, service in compose["services"].items():
+                if service_name == "main":
+                    continue
+                service_config = {"expose": (), "ports": (), "image": None} | service
+                exposed_ports = service_config["expose"]
+                published_ports = service_config["ports"]
+                ports = {
+                    int(value)
+                    for exposed in exposed_ports
+                    if (value := str(exposed).partition("/")[0]).isdigit()
+                }
+                ports.update(
+                    published["target"]
+                    for published in published_ports
+                    if isinstance(published, dict)
+                    and ("protocol" not in published or published["protocol"] == "tcp")
+                    and "target" in published
+                    and isinstance(published["target"], int)
+                )
+                if len(ports) > 1:
+                    raise NotImplementedError(
+                        f"Compose service {service_name!r} exposes multiple ports; "
+                        "Peer names one endpoint"
+                    )
+                if ports:
+                    peers.append({"name": service_name, "port": next(iter(ports))})
+
+                source_image = service_config["image"]
+                if "build" in service:
+                    source_image = f"hud-harbor-sidecar-build:{uuid.uuid4().hex}"
+                    service["image"] = source_image
+                    with tempfile.TemporaryDirectory(prefix="hud-harbor-sidecar-") as directory:
+                        compose_file = Path(directory) / "compose.json"
+                        compose_file.write_text(json.dumps(compose), encoding="utf-8")
+                        await docker("compose", "--file", str(compose_file), "build", service_name)
+                elif source_image:
+                    await docker("pull", source_image)
+                else:
+                    raise ValueError(
+                        f"Compose service {service_name!r} has neither image nor build"
+                    )
+                image_id, _ = await docker("image", "inspect", "--format", "{{.Id}}", source_image)
+                fingerprint = image_id.strip().removeprefix("sha256:")[:16]
+                component = normalize_environment_name(f"{name}-{service_name}", default="sidecar")
+                sidecar_image = (
+                    f"{push}/{component}:{fingerprint}"
+                    if push
+                    else f"hud-harbor-sidecar:{component}-{fingerprint}"
+                )
+                await docker("tag", source_image, sidecar_image)
+                if push:
+                    await docker("push", sidecar_image)
+                service["image"] = sidecar_image
+                if "build" in service:
+                    del service["build"]
         context = dataset / ".hud-adapt" / name
         if context.exists():
             shutil.rmtree(context)
@@ -250,22 +374,42 @@ async def adapt(
             newline="\n",
         )
 
-        workdir = source.runtime["workdir"] or image_config.get("WorkingDir") or "/"
+        workdir = environment.workdir or image_config["WorkingDir"] or "/"
         if Path(workdir).is_relative_to(HUD_ROOT):
             raise ValueError(f"Harbor workdir {workdir!r} is inside reserved path {HUD_ROOT}")
         manifest = {
             "name": name,
             "workdir": workdir,
-            "image_user": image_config.get("User") or None,
-            "entrypoint": image_config.get("Entrypoint") or [],
+            "image_user": image_config["User"] or None,
+            "entrypoint": image_config["Entrypoint"] or [],
             "environment": {
-                "env": source.runtime["environment_env"],
-                "network_mode": source.runtime["environment_network"],
-                "allowed_hosts": source.runtime["environment_hosts"],
-                "healthcheck": source.runtime["healthcheck"],
+                "env": {
+                    **compose_main["environment"],
+                    **environment.env,
+                },
+                "network_mode": environment.network_mode,
+                "allowed_hosts": environment.allowed_hosts,
+                "healthcheck": (
+                    environment.healthcheck.model_dump()
+                    if environment.healthcheck is not None
+                    else None
+                ),
             },
-            "agent": source.runtime["agent"],
-            "verifier": source.runtime["verifier"],
+            "agent": source.config.agent.model_dump(
+                include={"user", "network_mode", "allowed_hosts", "env"}
+            ),
+            "verifier": source.config.verifier.model_dump(
+                include={"user", "network_mode", "allowed_hosts", "env"}
+            ),
+            "capabilities": [
+                Capability.mcp(
+                    name=server.name,
+                    url=cast("str", server.url),
+                    transport=cast('Literal["sse", "streamable-http"]', server.transport),
+                ).to_manifest()
+                for server in environment.mcp_servers
+            ],
+            "peers": peers,
             "tasks": [],
         }
         for task in group:
@@ -293,7 +437,14 @@ async def adapt(
             shutil.copy2(wheel, context / "packages" / wheel.name)
             requirement = f"{HUD_ROOT}/packages/{wheel.name}"
 
-        tag = _tree_hash(context)
+        context_digest = hashlib.sha256()
+        for entry in sorted(context.rglob("*")):
+            relative_path = entry.relative_to(context).as_posix().encode()
+            if entry.is_symlink():
+                context_digest.update(relative_path + b"\0symlink\0" + os.readlink(entry).encode())
+            elif entry.is_file():
+                context_digest.update(relative_path + b"\0" + entry.read_bytes())
+        tag = context_digest.hexdigest()[:16]
         image = f"{push}/{name}:{tag}" if push else f"hud-harbor:{name}-{tag}"
         await docker(
             "build",
@@ -307,6 +458,16 @@ async def adapt(
         )
         if push:
             await docker("push", image)
+
+        if compose is not None:
+            main = compose["services"]["main"]
+            main["image"] = image
+            for field in ("build", "command", "entrypoint"):
+                main.pop(field, None)
+            (context / "compose.json").write_text(
+                json.dumps(compose, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
 
         for task in group:
             config = task.config
@@ -336,7 +497,8 @@ async def adapt(
                     ),
                     columns=columns or None,
                     runtime_config=RuntimeConfig(
-                        image=image,
+                        image=image if compose is None else None,
+                        compose=context / "compose.json" if compose is not None else None,
                         resources=resources if resources.model_dump(exclude_none=True) else None,
                     ),
                 )
@@ -344,16 +506,3 @@ async def adapt(
 
     LOGGER.info("adapted %d Harbor image(s)", len({task.env for task in rows}))
     return Taskset(dataset.name, rows, origin=f"harbor:{dataset}")
-
-
-def _tree_hash(path: Path) -> str:
-    digest = hashlib.sha256()
-    if not path.exists():
-        return "missing"
-    for entry in sorted(path.rglob("*")):
-        name = entry.relative_to(path).as_posix().encode()
-        if entry.is_symlink():
-            digest.update(name + b"\0symlink\0" + os.readlink(entry).encode())
-        elif entry.is_file():
-            digest.update(name + b"\0" + entry.read_bytes())
-    return digest.hexdigest()[:16]

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -15,7 +15,8 @@ from collections.abc import AsyncGenerator  # noqa: TC003
 from pathlib import Path
 from typing import Any
 
-from hud.environment import Environment, Mount
+from hud.capabilities import Capability
+from hud.environment import Environment, Mount, Peer
 from hud.environment.egress import ANY_HOST
 from hud.graders import EvaluationResult
 
@@ -30,10 +31,13 @@ WORKDIR = Path(CONFIG["workdir"])
 os.chdir(WORKDIR)
 
 
-def network(phase: dict[str, Any]) -> tuple[bool, frozenset[str]]:
+def network(phase: dict[str, Any] | None) -> tuple[bool, frozenset[str]]:
     baseline = CONFIG["environment"]
-    mode = phase.get("network_mode") or baseline["network_mode"]
-    hosts = phase.get("allowed_hosts") if phase.get("network_mode") else baseline["allowed_hosts"]
+    mode = phase["network_mode"] if phase is not None else baseline["network_mode"]
+    hosts = phase["allowed_hosts"] if phase is not None else baseline["allowed_hosts"]
+    if mode is None:
+        mode = baseline["network_mode"]
+        hosts = baseline["allowed_hosts"]
     if mode == "no-network":
         return False, frozenset()
     if mode == "allowlist":
@@ -41,9 +45,9 @@ def network(phase: dict[str, Any]) -> tuple[bool, frozenset[str]]:
     return True, frozenset({ANY_HOST})
 
 
-def identity(phase: dict[str, Any]) -> tuple[int, int] | None:
-    declared = phase.get("user")
-    user = str(declared if declared is not None else CONFIG.get("image_user") or "")
+def identity(phase: dict[str, Any] | None) -> tuple[int, int] | None:
+    declared = phase["user"] if phase is not None else None
+    user = str(declared if declared is not None else CONFIG["image_user"] or "")
     if not user:
         return None
     user_name, separator, group_name = user.partition(":")
@@ -85,11 +89,11 @@ def home(user_id: int | None) -> str | None:
 
 
 agent = CONFIG["agent"]
-image_identity = identity({})
+image_identity = identity(None)
 agent_identity = identity(agent)
 agent_uid = agent_identity[0] if agent_identity is not None else None
 agent_network, agent_hosts = network(agent)
-environment_hosts = network({})[1]
+environment_hosts = network(None)[1]
 rooted_at_filesystem = len(WORKDIR.parts) == 1
 harness_parent = ROOT.parent
 harness_mounts = (
@@ -107,6 +111,8 @@ agent_mounts = (
 )
 
 env = Environment(CONFIG["name"])
+for capability in CONFIG["capabilities"]:
+    env.add_capability(Capability.from_manifest(capability))
 workspace = env.workspace(
     WORKDIR,
     guest_path=WORKDIR.as_posix(),
@@ -128,6 +134,10 @@ workspace = env.workspace(
     },
     network=agent_network,
     allowed_hosts=agent_hosts,
+    peers=[
+        Peer(peer["name"], peer["port"], target=(peer["name"], peer["port"]))
+        for peer in CONFIG["peers"]
+    ],
     require_isolation=True,
 )
 

--- a/integrations/harbor/install.sh
+++ b/integrations/harbor/install.sh
@@ -13,10 +13,10 @@ export PATH="$root/bin:$PATH"
 
 if command -v apt-get >/dev/null 2>&1; then
   apt-get update -qq
-  apt-get install -y -qq bubblewrap python3 python3-venv python3-pip git curl ca-certificates
+  apt-get install -y -qq bubblewrap util-linux python3 python3-venv python3-pip git curl ca-certificates
   rm -rf /var/lib/apt/lists/*
 elif command -v apk >/dev/null 2>&1; then
-  apk add --no-cache bubblewrap python3 py3-pip git curl ca-certificates
+  apk add --no-cache bubblewrap util-linux python3 py3-pip git curl ca-certificates
 else
   echo "hud: Harbor environments require an apt- or apk-based image" >&2
   exit 1

--- a/integrations/harbor/tests/tasks/hello-mcp/environment/Dockerfile
+++ b/integrations/harbor/tests/tasks/hello-mcp/environment/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    python3 \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app

--- a/integrations/harbor/tests/tasks/hello-mcp/environment/compose.yaml
+++ b/integrations/harbor/tests/tasks/hello-mcp/environment/compose.yaml
@@ -1,0 +1,17 @@
+services:
+  main:
+    depends_on:
+      mcp-server:
+        condition: service_healthy
+
+  mcp-server:
+    build:
+      context: ./mcp-server
+    expose:
+      - "8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s=socket.create_connection(('localhost',8000),timeout=2); s.close()"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+      start_period: 5s

--- a/integrations/harbor/tests/tasks/hello-mcp/environment/mcp-server/Dockerfile
+++ b/integrations/harbor/tests/tasks/hello-mcp/environment/mcp-server/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+RUN pip install --no-cache-dir fastmcp==3.2.0
+COPY server.py .
+EXPOSE 8000
+CMD ["python", "server.py"]

--- a/integrations/harbor/tests/tasks/hello-mcp/environment/mcp-server/server.py
+++ b/integrations/harbor/tests/tasks/hello-mcp/environment/mcp-server/server.py
@@ -1,0 +1,13 @@
+from fastmcp import FastMCP
+
+mcp = FastMCP("hello-mcp")
+
+
+@mcp.tool()
+def get_secret() -> str:
+    """Return the value expected by the task."""
+    return "harbor-mcp-secret-12345"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http", host="0.0.0.0", port=8000)

--- a/integrations/harbor/tests/tasks/hello-mcp/instruction.md
+++ b/integrations/harbor/tests/tasks/hello-mcp/instruction.md
@@ -1,0 +1,1 @@
+Call the `get_secret` tool from the configured MCP server and write its result to `/app/secret.txt`.

--- a/integrations/harbor/tests/tasks/hello-mcp/solution/solve.sh
+++ b/integrations/harbor/tests/tasks/hello-mcp/solution/solve.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+printf '%s' 'harbor-mcp-secret-12345' > /app/secret.txt

--- a/integrations/harbor/tests/tasks/hello-mcp/task.toml
+++ b/integrations/harbor/tests/tasks/hello-mcp/task.toml
@@ -1,0 +1,10 @@
+[task]
+name = "hello-mcp"
+
+[verifier]
+timeout_sec = 30
+
+[[environment.mcp_servers]]
+name = "mcp-server"
+transport = "streamable-http"
+url = "http://mcp-server:8000/mcp"

--- a/integrations/harbor/tests/tasks/hello-mcp/tests/test.sh
+++ b/integrations/harbor/tests/tasks/hello-mcp/tests/test.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -u
+mkdir -p /logs/verifier
+
+if [ "$(cat /app/secret.txt 2>/dev/null)" = "harbor-mcp-secret-12345" ]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/integrations/harbor/tests/tasks/sidecar-reachability/environment/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/environment/Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app

--- a/integrations/harbor/tests/tasks/sidecar-reachability/environment/compose.yaml
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/environment/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  main: {}
+  web:
+    image: python:3.11-alpine
+    command: ["python", "-m", "http.server", "5678"]
+    expose: ["5678"]

--- a/integrations/harbor/tests/tasks/sidecar-reachability/instruction.md
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/instruction.md
@@ -1,0 +1,1 @@
+Fetch the web service at http://web:5678 and save its response to /app/sidecar.html.

--- a/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+curl -fsS --max-time 10 http://web:5678/ > /app/sidecar.html

--- a/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
@@ -1,0 +1,5 @@
+[task]
+name = "sidecar-reachability"
+
+[verifier]
+timeout_sec = 30

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -u
+mkdir -p /logs/verifier
+
+if grep -q "Directory listing" /app/sidecar.html 2>/dev/null; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo "the agent could not reach the declared web sidecar"
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -22,7 +22,23 @@ def fake_docker(monkeypatch):
     async def run(*args: str, **_kwargs):
         calls.append(args)
         if args[:4] == ("image", "inspect", "--format", "{{json .Config}}"):
-            return json.dumps({"User": "", "WorkingDir": "/workspace", "Entrypoint": None}), ""
+            if args[-1].startswith("hud-harbor:"):
+                return json.dumps(
+                    {
+                        "User": "",
+                        "WorkingDir": "/workspace",
+                        "Entrypoint": [],
+                        "Cmd": ["/media/hud/venv/bin/hud", "serve", "/media/hud/env.py"],
+                    }
+                ), ""
+            return json.dumps(
+                {
+                    "User": "",
+                    "WorkingDir": "/workspace",
+                    "Entrypoint": None,
+                    "Cmd": None,
+                }
+            ), ""
         if args[:4] == ("image", "inspect", "--format", "{{.Id}}"):
             return "sha256:0123456789abcdef0123456789abcdef\n", ""
         if args[0] == "compose" and args[-3:] == ("config", "--format", "json"):
@@ -43,6 +59,7 @@ def fake_docker(monkeypatch):
                         },
                         "redis": {
                             "image": "redis:7-alpine",
+                            "entrypoint": None,
                             "command": ["redis-server", "--save", ""],
                             "environment": {"SIDE": "car"},
                             "expose": ["6379/tcp"],
@@ -122,11 +139,18 @@ async def test_adapt_emits_compose_with_pinned_sidecars_and_peers(
     assert redis["command"] == ["redis-server", "--save", ""]
     assert redis["expose"] == ["6379/tcp"]
     assert redis["healthcheck"]["test"] == ["CMD", "redis-cli", "ping"]
+    assert redis["entrypoint"] == []
+    assert redis["working_dir"] == "/workspace"
     assert "build" not in redis
     manifest = json.loads((context / "tasks.json").read_text("utf-8"))
     assert manifest["environment"]["env"] == {"FROM_COMPOSE": "yes"}
     assert manifest["capabilities"] == []
     assert manifest["peers"] == [{"name": "redis", "port": 6379}]
+    assert compose["services"]["main"]["command"] == [
+        "/media/hud/venv/bin/hud",
+        "serve",
+        "/media/hud/env.py",
+    ]
     assert ("pull", "redis:7-alpine") in fake_docker
     assert any(call[:2] == ("tag", "redis:7-alpine") for call in fake_docker)
 

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -21,8 +21,44 @@ def fake_docker(monkeypatch):
 
     async def run(*args: str, **_kwargs):
         calls.append(args)
-        if args[:3] == ("image", "inspect", "--format"):
-            return json.dumps({"User": "", "WorkingDir": "/workspace"}), ""
+        if args[:4] == ("image", "inspect", "--format", "{{json .Config}}"):
+            return json.dumps({"User": "", "WorkingDir": "/workspace", "Entrypoint": None}), ""
+        if args[:4] == ("image", "inspect", "--format", "{{.Id}}"):
+            return "sha256:0123456789abcdef0123456789abcdef\n", ""
+        if args[0] == "compose" and args[-3:] == ("config", "--format", "json"):
+            return json.dumps(
+                {
+                    "name": "task",
+                    "services": {
+                        "main": {
+                            "image": "hud-main",
+                            "environment": {"FROM_COMPOSE": "yes"},
+                            "depends_on": {
+                                "redis": {
+                                    "condition": "service_healthy",
+                                    "required": True,
+                                }
+                            },
+                            "networks": {"default": None},
+                        },
+                        "redis": {
+                            "image": "redis:7-alpine",
+                            "command": ["redis-server", "--save", ""],
+                            "environment": {"SIDE": "car"},
+                            "expose": ["6379/tcp"],
+                            "healthcheck": {
+                                "test": ["CMD", "redis-cli", "ping"],
+                                "interval": "2s",
+                                "timeout": "3s",
+                                "retries": 5,
+                                "start_period": "1s",
+                            },
+                            "networks": {"default": None},
+                        },
+                    },
+                    "networks": {"default": {"name": "task_default"}},
+                }
+            ), ""
         return "", ""
 
     module = importlib.import_module("integrations.harbor.adapt")
@@ -59,6 +95,74 @@ async def test_adapt_builds_the_source_then_an_authored_hud_environment(
     assert 'Environment(CONFIG["name"])' not in served
     assert (context / "tasks" / "task-a" / "instruction.md").is_file()
     assert (context / "tasks" / "task-a" / "tests" / "test.sh").is_file()
+    assert not (context / "compose.json").exists()
+
+
+async def test_adapt_emits_compose_with_pinned_sidecars_and_peers(
+    tmp_path: Path,
+    fake_docker,
+) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "environment" / "compose.yaml").write_text(
+        "services:\n  main: {}\n  redis:\n    image: redis:7-alpine\n    expose: [6379]\n",
+        encoding="utf-8",
+    )
+
+    (row,) = list(await harbor.adapt(tmp_path))
+
+    assert row.runtime_config is not None
+    assert row.runtime_config.image is None
+    (context,) = (tmp_path / ".hud-adapt").iterdir()
+    assert row.runtime_config.compose == context / "compose.json"
+    compose = json.loads((context / "compose.json").read_text("utf-8"))
+    redis = compose["services"]["redis"]
+    assert redis["image"].startswith("hud-harbor-sidecar:")
+    assert redis["image"].endswith("-0123456789abcdef")
+    assert redis["environment"] == {"SIDE": "car"}
+    assert redis["command"] == ["redis-server", "--save", ""]
+    assert redis["expose"] == ["6379/tcp"]
+    assert redis["healthcheck"]["test"] == ["CMD", "redis-cli", "ping"]
+    assert "build" not in redis
+    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    assert manifest["environment"]["env"] == {"FROM_COMPOSE": "yes"}
+    assert manifest["capabilities"] == []
+    assert manifest["peers"] == [{"name": "redis", "port": 6379}]
+    assert ("pull", "redis:7-alpine") in fake_docker
+    assert any(call[:2] == ("tag", "redis:7-alpine") for call in fake_docker)
+
+
+async def test_network_mcp_servers_become_named_capabilities(
+    tmp_path: Path,
+    fake_docker,
+) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "environment" / "compose.yaml").write_text(
+        "services:\n  main: {}\n  redis:\n    image: redis:7-alpine\n    expose: [6379]\n",
+        encoding="utf-8",
+    )
+    (task / "task.toml").write_text(
+        """
+[[environment.mcp_servers]]
+name = "redis-tools"
+transport = "streamable-http"
+url = "http://redis:6379/mcp"
+args = []
+""",
+        encoding="utf-8",
+    )
+
+    await harbor.adapt(tmp_path)
+
+    (context,) = (tmp_path / ".hud-adapt").iterdir()
+    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    assert manifest["capabilities"] == [
+        {
+            "name": "redis-tools",
+            "params": {"transport": "streamable-http"},
+            "protocol": "mcp/2025-11-25",
+            "url": "http://redis:6379/mcp",
+        }
+    ]
 
 
 async def test_adapt_groups_identical_images_and_keeps_row_metadata(
@@ -259,7 +363,10 @@ async def test_image_entrypoint_is_preserved_as_runtime_data(
             "multiple GPU types",
         ),
         ('[environment]\ngpu_types = ["H100"]\n', "GPU types without GPUs"),
-        ('[[environment.mcp_servers]]\nname = "db"\n', "MCP servers"),
+        (
+            '[[environment.mcp_servers]]\nname = "db"\ntransport = "stdio"\ncommand = "db-mcp"\n',
+            "stdio MCP servers",
+        ),
         ('[verifier]\nenvironment_mode = "separate"\n', "separate verifier"),
     ],
 )

--- a/integrations/harbor/tests/test_integration.py
+++ b/integrations/harbor/tests/test_integration.py
@@ -21,7 +21,7 @@ from hud.eval import DockerRuntime
 from integrations import harbor
 
 if TYPE_CHECKING:
-    from hud.capabilities import SSHClient
+    from hud.capabilities import MCPClient, SSHClient
     from hud.eval.run import Run
 
 TASKS = Path(__file__).parent / "tasks"
@@ -53,6 +53,62 @@ class Oracle(Agent):
 
     async def __call__(self, run: Run) -> None:
         ssh = cast("SSHClient", await run.client.open("ssh/2"))
+        if run.task_id == "hello-mcp":
+            mcp = cast("MCPClient", await run.client.open("mcp-server"))
+            assert {tool.name for tool in await mcp.list_tools()} == {"get_secret"}
+            assert run.client.manifest is not None
+            capability = next(
+                cap for cap in run.client.manifest.bindings if cap.name == "mcp-server"
+            )
+            script = f"""
+import json
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+url = {capability.url!r}
+session_id = None
+
+def post(payload):
+    global session_id
+    headers = {{
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }}
+    if session_id is not None:
+        headers["Mcp-Session-Id"] = session_id
+    request = Request(url, data=json.dumps(payload).encode(), headers=headers)
+    with urlopen(request) as response:
+        body = response.read().decode()
+        returned_session = response.headers.get("Mcp-Session-Id")
+        if returned_session:
+            session_id = returned_session
+    data = [line[6:] for line in body.splitlines() if line.startswith("data: ")]
+    return json.loads(data[-1] if data else body) if body else None
+
+post({{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {{
+        "protocolVersion": "2025-06-18",
+        "capabilities": {{}},
+        "clientInfo": {{"name": "hud-test", "version": "1"}},
+    }},
+}})
+post({{"jsonrpc": "2.0", "method": "notifications/initialized"}})
+result = post({{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {{"name": "get_secret", "arguments": {{}}}},
+}})
+Path("/app/secret.txt").write_text(result["result"]["content"][0]["text"])
+"""
+            result = await ssh.conn.run("python3 -", input=script, check=True)
+            if result.exit_status is None:
+                raise RuntimeError("workspace MCP client closed without an exit status")
+            run.trace.content = "called get_secret from inside the workspace"
+            return
         result = await ssh.conn.run(self.solutions[run.task_id], check=True)
         if result.exit_status is None:
             raise RuntimeError("solution SSH channel closed without an exit status")
@@ -66,7 +122,11 @@ async def _grade_every_task(dataset: Path, wheel: Path) -> dict[str, Run]:
         if (task / "task.toml").is_file()
     }
     taskset = await harbor.adapt(dataset, hud_requirement=str(wheel))
-    job = await taskset.run(Oracle(solutions), runtime=DockerRuntime(), max_concurrent=1)
+    job = await taskset.run(
+        Oracle(solutions),
+        runtime=DockerRuntime(),
+        max_concurrent=1,
+    )
     return {run.task_id: run for run in job.runs}
 
 
@@ -89,7 +149,13 @@ def graded(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Run]:
 
 @pytest.mark.parametrize(
     "task_id",
-    ["phase-boundary", "agent-lifecycle", "verifier-lifecycle"],
+    [
+        "phase-boundary",
+        "agent-lifecycle",
+        "verifier-lifecycle",
+        "sidecar-reachability",
+        "hello-mcp",
+    ],
 )
 def test_harbor_phase_behavior(graded: dict[str, Run], task_id: str) -> None:
     run = graded[task_id]
@@ -97,6 +163,15 @@ def test_harbor_phase_behavior(graded: dict[str, Run], task_id: str) -> None:
     detail = evaluation.get("content") or ""
     info = evaluation.get("info") or {}
     detail = "\n".join(
-        filter(None, (run.trace.content, detail, info.get("stdout"), info.get("stderr")))
+        filter(
+            None,
+            (
+                run.trace.content,
+                run.trace.error,
+                detail,
+                info.get("stdout"),
+                info.get("stderr"),
+            ),
+        )
     )
     assert run.reward == 1.0, f"{task_id} scored {run.reward}; the verifier reported:\n{detail}"


### PR DESCRIPTION
## Summary

- make Docker Compose the canonical Harbor environment description and preserve it through `RuntimeConfig`
- register Harbor MCP servers as ordinary MCP capabilities
- adapt Compose services into pinned images while materializing their image runtime defaults
- run Daytona Compose services as linked standard-container sandboxes instead of nested Docker or privileged Linux VMs
- add a staged bubblewrap launch mode for container substrates where bubblewrap cannot create the PID/proc namespace itself

## Boundary

Harbor owns conversion into canonical Compose plus the HUD manifest. Runtime providers consume `RuntimeConfig`: Docker and Modal use Compose directly, while Daytona maps the same Compose services onto its linked-sandbox primitive. There is no separate provider-specific service model.

## Validation

- `uv run --with='.[dev]' pytest -q hud/environment/tests/test_workspace.py hud/eval/tests/test_docker_provider.py integrations/harbor/tests/test_contract.py` — 109 passed
- `uv run --with='.[dev]' pytest -q -m 'not integration'` — 851 passed, 5 deselected
- `uv run --with='.[dev]' ruff format . --check`
- `uv run --with='.[dev]' ruff check .`
- `uv run --with='.[dev]' pyright` — 0 errors
- live Daytona hello-MCP rollout completed with reward 1.0: the agent called the registered MCP capability, wrote the returned secret through SSH, and the verifier passed

## Notes

Daytona's API requires linked children to be created from snapshots, so sidecar image references resolve to deterministic reusable standard-container snapshots. No privileged Daytona account or Linux-VM runner is required for this path.
