### PR TITLE
docs: add Internals section and drop the single-entry version dropdown

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -595,3 +595,17 @@ div:has(> ul.sidebar-group > li[data-group-tag]) > .sidebar-group-header {
   font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
   font-size: 0.92em;
 }
+
+/* Mintlify renders each markdown paragraph as `<span data-as="p">` and only
+   blockifies it via a shallow `.prose` rule. Nested two levels deep inside
+   `.guide-main` / `.guide-aside`, that rule doesn't reach, so a second
+   paragraph stays inline and runs directly onto the first with no gap. */
+#content .guide-main span[data-as="p"],
+#content .guide-aside span[data-as="p"] {
+  display: block;
+  margin-bottom: 1rem;
+}
+#content .guide-main span[data-as="p"]:last-child,
+#content .guide-aside span[data-as="p"]:last-child {
+  margin-bottom: 0;
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,23 +61,20 @@
       {
         "tab": "SDK",
         "icon": "code",
-        "versions": [
-          {
-            "version": "v6",
-            "default": true,
-            "groups": [
-              { "group": "Start here", "pages": ["v6/start/index", "v6/start/quickstart", "v6/start/overview"] },
-              { "group": "Guides", "pages": ["v6/guides/creating-an-environment", "v6/guides/running-an-eval", "v6/guides/training-agents"] },
-              { "group": "Reference", "pages": ["v6/reference/environment", "v6/reference/tasks", "v6/reference/capabilities", "v6/reference/agents", "v6/reference/runtime", "v6/reference/graders", "v6/reference/training", "v6/reference/types", "v6/reference/cli"] },
-              { "group": "Advanced", "pages": [
-                { "group": "Advanced", "expanded": false, "pages": ["v6/advanced/protocol", "v6/advanced/extending", "v6/reference/advice", "v6/advanced/robots", "v6/advanced/harbor-convert"] }
-              ] },
-              { "group": "Cookbooks", "pages": [
-                { "group": "Cookbooks", "expanded": false, "pages": ["v6/cookbooks/index", "v6/cookbooks/coding-agent", "v6/cookbooks/ops-diagnostics", "v6/cookbooks/a2a-chat", "v6/cookbooks/robot-benchmark"] }
-              ] },
-              { "group": "More", "pages": ["v6/more/faq", "v6/more/migrate-v6", "v6/more/contributing"] }
-            ]
-          }
+        "groups": [
+          { "group": "Start here", "pages": ["v6/start/index", "v6/start/quickstart", "v6/start/overview"] },
+          { "group": "Guides", "pages": ["v6/guides/creating-an-environment", "v6/guides/running-an-eval", "v6/guides/training-agents"] },
+          { "group": "Reference", "pages": ["v6/reference/environment", "v6/reference/tasks", "v6/reference/capabilities", "v6/reference/agents", "v6/reference/runtime", "v6/reference/graders", "v6/reference/training", "v6/reference/types", "v6/reference/cli"] },
+          { "group": "Advanced", "pages": [
+            { "group": "Advanced", "expanded": false, "pages": ["v6/advanced/protocol", "v6/advanced/extending", "v6/reference/advice", "v6/advanced/robots", "v6/advanced/harbor-convert"] }
+          ] },
+          { "group": "Cookbooks", "pages": [
+            { "group": "Cookbooks", "expanded": false, "pages": ["v6/cookbooks/index", "v6/cookbooks/coding-agent", "v6/cookbooks/ops-diagnostics", "v6/cookbooks/a2a-chat", "v6/cookbooks/robot-benchmark"] }
+          ] },
+          { "group": "Internals", "pages": [
+            { "group": "Internals", "expanded": false, "pages": ["v6/internals/index", "v6/internals/walkthrough", "v6/internals/placement", "v6/internals/control-channel"] }
+          ] },
+          { "group": "More", "pages": ["v6/more/faq", "v6/more/migrate-v6", "v6/more/contributing"] }
         ]
       }
     ]

--- a/docs/v6/advanced/protocol.mdx
+++ b/docs/v6/advanced/protocol.mdx
@@ -5,7 +5,7 @@ icon: "route"
 mode: "wide"
 ---
 
-HUD is **protocol-first**. An agent and an environment never integrate directly - they sit on two sides of a thin envelope and exchange a handful of small messages. HUD owns only that envelope; everything inside it - the model, the harness, the work the agent does - stays swappable.
+HUD is **protocol-first**. An agent and an environment never integrate directly - they sit on two sides of a thin envelope and exchange a handful of small messages. HUD owns only that envelope; everything inside it - the model, the harness, the work the agent does - stays swappable. This page is the contract; how the server carries it over one TCP port is the [control channel](/v6/internals/control-channel) internals page.
 
 Three things take part in every run:
 

--- a/docs/v6/internals/control-channel.mdx
+++ b/docs/v6/internals/control-channel.mdx
@@ -1,0 +1,207 @@
+---
+title: "Control channel"
+description: "How a served environment carries both its JSON-RPC control session and raw capability tunnels over one TCP port - the connection grammar, the suspended task, and tunnel.open."
+icon: "network-wired"
+mode: "wide"
+---
+
+A served environment exposes exactly one address: a single TCP port. Everything a client does to
+it - starting a task, grading it, and driving a real shell or browser inside it - travels through
+that one port. The [walkthrough](/v6/internals/walkthrough#bringing-up-the-server) reaches this port when `bind`
+puts an environment on the wire; this page is the port itself: the two kinds of traffic it carries,
+and how one frame tells them apart. The [protocol](/v6/advanced/protocol) page covers the message
+semantics riding on top; this page covers how the server carries them.
+
+| Concept | What it is |
+| --- | --- |
+| **Control channel** | The single TCP server a served env exposes (`hud/environment/server.py`). Every connection to the substrate goes through it. |
+| **Control session** | A JSON-RPC dialogue over one connection: `hello`, `tasks.start`, `tasks.grade`, and friends. |
+| **Capability stream** | A raw byte tunnel over one connection, splicing the client to a **backing daemon** - the real `ssh` / `cdp` / `mcp` server a capability points at. |
+| **Preface frame** | The first frame a connection sends; it decides which of the two that connection becomes. |
+
+## One port, two kinds of connection
+
+A raw TCP connection is one byte pipe with no notion of what it carries. The control port itself
+is an ordinary listening socket, so it accepts as many connections as clients dial - a container
+publishes one port, a hosted sandbox hands back one address, but neither limits how many
+connections reach it. What is scarce is the *address*, not the connection count: an env could
+publish a separate port for its control session and one more per backing daemon, but the
+substrate often cannot expose them. So the env exposes a single control port and every connection
+declares its purpose in its **preface frame** - the first line it sends. That frame is
+transport-level routing, the JSON-RPC analog of an HTTP `CONNECT`, not a session method.
+
+The accept handler reads that one frame and forks on it. A `tunnel.open` frame opens a capability
+stream; anything else begins a control session.
+
+```python hud/environment/server.py · bind
+async def accept(reader, writer):
+    first = await read_frame(reader)                  # the preface frame
+    if first.get("method") == "tunnel.open":
+        await _stream(env, first, reader, writer)     # raw capability tunnel
+    else:
+        await channel.session(first, reader, writer)  # JSON-RPC control session
+```
+
+Everything after the preface is decided by that fork: a control session parses each subsequent
+frame as JSON-RPC, a capability stream stops parsing and moves raw bytes. Because only the preface
+is transport-specific, the same session methods would ride any transport - a WebSocket build would
+tunnel through its native upgrade instead of a `tunnel.open` frame, and the methods below would not
+change.
+
+## The control session
+
+A control session is a JSON-RPC dialogue that lasts the connection's lifetime. Its methods are the
+wire protocol an agent and env speak:
+
+| Method | Does |
+| --- | --- |
+| `hello` | Returns the session id, the env identity, and the capability **bindings** (the manifest). Takes an optional `session_id` to resume a parked session instead of opening a fresh one. |
+| `tasks.list` | Lists task metadata, for introspection and validation. |
+| `tasks.start` | Runs the task to its first yield and returns the prompt. |
+| `tasks.grade` | Resumes the task with the agent's answer and returns the score. |
+| `tasks.cancel` | Drops the held task. |
+| `bye` | Ends the session and tears the held task down. |
+
+The [walkthrough](/v6/internals/walkthrough#starting-the-task) follows the `tasks.start` / `tasks.grade` flow
+end to end. What matters here is where the task's state lives between those two calls.
+
+## The suspended task
+
+Between `tasks.start` and `tasks.grade` the task's generator is paused at its first yield, holding
+the whole world it set up. That paused generator lives on the **control channel** itself, not in
+any one connection: `bind` creates one `_ControlChannel` per served env and every control session
+shares it. The channel holds one suspended task per session, keyed by session id, so concurrent
+sessions each own their own - a session's `start` replaces its task, `grade` consumes it, `cancel`
+clears it. It also tracks which session ids currently have a live connection.
+
+```python hud/environment/server.py · _ControlChannel
+async def start(self, session_id, task_id, args):
+    await self.cancel(session_id)                  # replace this session's task
+    self._runners[session_id] = TaskRunner(self.env.tasks[task_id], args)
+    return await self._runners[session_id].start()
+
+async def grade(self, session_id, payload):
+    runner = self._runners.pop(session_id, None)   # this session's task ...
+    if runner is None:
+        runner = self._adopt_parked()              # ... or the lone parked one
+    return await runner.grade(payload)
+
+def _adopt_parked(self):                           # claim iff exactly one is parked
+    parked = [s for s in self._runners if s not in self._live]
+    if len(parked) != 1:                           # 0: none; >1: resume by id
+        raise _NoTaskInProgress(...)
+    return self._runners.pop(parked[0])
+```
+
+Because the task is held on the channel and not the connection, a dropped connection leaves it in
+place: the session's id leaves the live set and its runner is **parked**, still in `_runners` but
+with no live connection, awaiting a later one to grade it. A client can `tasks.start`, disconnect,
+and reconnect to `tasks.grade` the same suspended task - the split start/grade flow behind
+`hud task start` / `hud task grade` and a reconnecting verifier.
+
+A later connection reaches a parked session by one of two grade paths. Sending `hello` with its
+`session_id` resumes that exact session, so the connection's next `tasks.grade` lands on the right
+task - the path to use whenever more than one session could be parked. A plain `tasks.grade` with no
+prior resume auto-adopts a parked session only when exactly one is parked; with none it reports no
+task in progress, and with several it refuses and names them, telling the caller to resume one by
+`session_id`.
+
+## Capability streams and `tunnel.open`
+
+A capability is not data the env sends over the control session; it is a live daemon the agent
+connects to and drives - a real `sshd`, a browser's `cdp` endpoint. That daemon listens somewhere
+inside the substrate, and the substrate may expose only the control port, so the agent cannot dial
+it directly.
+
+The agent reaches it by opening a **second, separate connection** to the control port - not by
+somehow converting its existing control-session connection. That new connection's preface is a
+`tunnel.open` frame naming the capability, which is enough to send it down the raw-splice branch of
+the fork [above](#one-port-two-kinds-of-connection) instead of starting a session. The control
+session that ran `tasks.start` is a different connection entirely, and keeps speaking JSON-RPC the
+whole time; `tasks.grade` later just uses that same connection normally, with nothing to "recover" -
+it was never touched. Because the port accepts unlimited connections, any number of these can be
+open at once: several capability streams alongside one control session, or streams and sessions
+from several clients, all independent of each other and of which session (if any) opened which
+stream.
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Ctl as Control port
+    participant Sshd as sshd (the "shell" capability)
+    Agent->>Ctl: connection A: hello, tasks.start (JSON-RPC)
+    Note over Agent,Ctl: connection A stays open, still speaking JSON-RPC
+    Agent->>Ctl: connection B: tunnel.open {capability: "shell"}
+    Ctl->>Sshd: dial the backing daemon
+    Ctl-->>Agent: connection B: one reply frame
+    Note over Agent,Sshd: connection B now splices raw bytes, both ways
+    Agent->>Ctl: connection A: tasks.grade (same connection as before, untouched)
+```
+
+On connection B's `tunnel.open` frame, the server resolves the named capability to its backing
+daemon, dials it, replies once, and only then stops speaking JSON-RPC *on that connection*: it
+splices raw bytes between the client and the daemon until either side hangs up.
+
+```python hud/environment/server.py · _stream
+async def _stream(env, msg, reader, writer):    # this connection's own reader/writer
+    name = msg["params"]["capability"]
+    cap = env.capability(name)                  # the declared capability
+    parts = urlsplit(cap.url)                    # its backing daemon's host:port
+    backend = await asyncio.open_connection(parts.hostname, parts.port)
+    await send_frame(writer, reply(msg_id, {"capability": name}))  # the one reply frame
+    await splice((reader, writer), backend)      # then raw bytes, both ways, until EOF
+```
+
+The splice is the whole point: after that one reply frame, connection B becomes a transparent
+pipe to the daemon, so the substrate needs no second published port - just one more connection to
+the port it already has. One `tunnel.open` connection carries exactly one capability stream, so an
+agent needing a shell and a `cdp` tunnel at once simply opens two.
+
+## Reaching a loopback capability
+
+The manifest a client gets from `hello` carries each capability's url, but a loopback url in it
+(`127.0.0.1`, `localhost`, `::1`) is the *substrate's* loopback, not the client's - the daemon
+lives in the substrate's network namespace, which is not ours when the substrate is a container or
+a hosted sandbox. A non-loopback url is globally reachable and passes through unchanged.
+
+For the loopback case the client runs an `ssh -L` style **forwarder**: a local listener whose every
+accepted connection opens one `tunnel.open` connection to the control port and splices to it. It
+then rewrites the binding's url to point at the forwarder's local port, so the address handed to
+the agent always works from here.
+
+```python hud/clients/client.py · HudClient._reachable
+parts = urlsplit(cap.url)
+if self._endpoint is None or parts.hostname not in ("127.0.0.1", "localhost", "::1"):
+    return cap                                  # globally reachable: pass through
+host, port = self._endpoint                     # the control port
+
+async def forward(reader, writer):              # one accepted local connection
+    up_reader, up_writer = await asyncio.open_connection(host, port)
+    await send_frame(up_writer, {"method": "tunnel.open",
+                                 "params": {"capability": cap.name}, ...})
+    await read_frame(up_reader)                  # the one-line reply
+    await splice((reader, writer), (up_reader, up_writer))
+
+forwarder = await asyncio.start_server(forward, "127.0.0.1", 0)
+return replace(cap, url=...forwarder's local port...)   # rewritten binding
+```
+
+So `run.client.open("shell")` connects to a local port that tunnels, frame then raw bytes, all the
+way to the `sshd` inside the substrate:
+
+```mermaid
+sequenceDiagram
+    participant Agent as Agent · open("shell")
+    participant Fwd as Local forwarder
+    participant Ctl as Control port
+    participant Daemon as sshd (substrate)
+    Agent->>Fwd: connect 127.0.0.1:local
+    Fwd->>Ctl: connect + tunnel.open {capability: "shell"}
+    Ctl->>Daemon: open_connection(host, port)
+    Ctl-->>Fwd: reply {capability: "shell"}
+    Note over Fwd,Daemon: splice raw bytes both ways until EOF
+```
+
+The [walkthrough](/v6/internals/walkthrough#connecting) shows where the client runs `hello` and builds these
+forwarders on the pointer's path, and [placement](/v6/internals/placement) covers how the substrate behind this
+port is chosen and brought up.

--- a/docs/v6/internals/index.mdx
+++ b/docs/v6/internals/index.mdx
@@ -1,0 +1,43 @@
+---
+title: "Internals"
+description: "How the SDK code actually runs - the module map and the deep dives, for the people changing it."
+icon: "compass"
+mode: "wide"
+---
+
+These pages explain how the SDK is implemented, for people changing it. The rest of the docs
+teach the API from the outside; this section teaches the code from the inside. Nothing here is
+needed to build environments or run evals.
+
+The mental model is small: an **environment** declares what exists (capabilities and tasks), a
+**provider** brings that environment up somewhere as a **server**, and a **client** in your
+process drives one **agent** through it over a thin wire protocol. Everything else is a variation
+on that single loop.
+
+## Pages
+
+| Page | What it covers |
+| --- | --- |
+| [**Walkthrough**](/v6/internals/walkthrough) | The pointer's path through one full run - from declaring an environment to a graded reward - following the real code, file by file, plus the protocol and the assumptions baked in. |
+| [**Placement**](/v6/internals/placement) | How a task row finds a server: the `Provider` contract, `Runtime` addresses, scheduler resolution, and the routing patterns they compose into. |
+| [**Control channel**](/v6/internals/control-channel) | How one TCP port carries both the JSON-RPC control session and raw capability tunnels: the connection grammar, the suspended task, and `tunnel.open`. |
+
+## The code, at a glance
+
+The SDK splits into two halves that meet at the wire protocol. One half **declares and serves** an
+environment; the other **places and drives** it. A `Task` row is the only thing that crosses
+between them at rest, and a TCP control channel is the only thing that connects them at run time.
+
+| Module | Role |
+| --- | --- |
+| `hud/environment/env.py` | The `Environment` declaration - capabilities, task templates, lifecycle hooks. Pure data, no runtime state. |
+| `hud/environment/server.py` | Puts one declaration on the wire: the JSON-RPC control channel and the per-task suspended generator. |
+| `hud/eval/task.py` | The `Task` row - an env name, a task id, bound args. Plain pydantic. |
+| `hud/eval/runtime.py` | Placement: the `Provider` contract and every built-in (`LocalRuntime`, `DockerRuntime`, hosted, ...). |
+| `hud/eval/run.py` | The `rollout` atom and the `Run` handle - one task driven to a graded result. |
+| `hud/eval/taskset.py` | The scheduler: expand tasks, pick placement once, gather rollouts into a `Job`. |
+| `hud/clients/client.py` | `connect` and `HudClient` - the client side of the protocol, plus capability tunneling. |
+| `hud/agents/base.py` | The `Agent` contract: `async __call__(run)`. |
+
+Start with the [walkthrough](/v6/internals/walkthrough) and read it top to bottom - it visits these
+files in the order the code visits them.

--- a/docs/v6/internals/placement.mdx
+++ b/docs/v6/internals/placement.mdx
@@ -1,0 +1,161 @@
+---
+title: "Placement"
+description: "How a task row finds a server - the Provider contract, Runtime addresses, and the routing patterns they compose into."
+icon: "map-pin"
+mode: "wide"
+---
+
+Every rollout needs a live server to drive, and **placement** is the layer that produces one: given
+a task row, bring up (or find) the environment that row names and hand back a connectable address.
+The [walkthrough](/v6/internals/walkthrough#bringing-up-the-server) visits placement as one step on the
+pointer's path; this page isolates the layer itself - the two abstractions it is made of, how the
+scheduler resolves it, and the routing patterns that fall out of the contract being a plain
+callable.
+
+| Concept | What it is |
+| --- | --- |
+| **Task row** | A `Task` (`hud/eval/task.py`): an env *name*, a task id, bound args. The name is a join key, never a live object - see [what we start with](/v6/internals/walkthrough#what-we-start-with). |
+| **Provider** | Anything callable as `(task) -> async context manager yielding a Runtime` (`hud/eval/runtime.py`). Entering the context provisions; exiting tears down. |
+| **Runtime** | Pure data: the connectable address of one substrate (`url`, connection `params`, optional `config`). |
+| **Substrate** | The provisioned instance behind a url - a local env, a subprocess, a container, a cloud sandbox. |
+
+## The contract
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">1 · A provider is a callable, a Runtime is an address</div>
+
+The whole layer is two definitions. A `Provider` is a structural protocol - no base class, no
+registry - so any function of the right shape is a valid placement strategy. A `Runtime` is the
+value it yields: where to connect, nothing more.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">runtime.py · the contract</p>
+
+```python
+class Provider(Protocol):
+    def __call__(
+        self, task: Task, /
+    ) -> AbstractAsyncContextManager[Runtime]: ...
+
+@dataclass(frozen=True)
+class Runtime:
+    url: str            # tcp://127.0.0.1:7000
+    params: dict = ...  # auth token, sandbox id
+    config: RuntimeConfig | None = None
+
+    def __call__(self, task):     # a Runtime is
+        return nullcontext(self)  # itself a provider
+```
+
+</div>
+</div>
+
+Two consequences do most of the work:
+
+<div className="step-list">
+
+- **The task flows into placement.** A provider receives the row it is placing, so per-row
+  decisions (this env from that file, this row on a bigger GPU) live in the provider, and the
+  engine never branches on them.
+- **A `Runtime` is itself a provider - the borrowed case.** Calling it returns `nullcontext(self)`:
+  entering provisions nothing and yields the address as-is, exiting tears down nothing, because
+  whoever launched that server owns it. This is the degenerate provider every routing pattern below
+  bottoms out in.
+
+</div>
+
+The built-ins (`LocalRuntime`, `SubprocessRuntime`, `DockerRuntime`, `ModalRuntime`,
+`DaytonaRuntime`, `HUDRuntime`) are all providers of this shape. They differ only in *where* the
+substrate runs and how its url is reached; all of them serve the same module and speak the same
+channel.
+
+## Resolution
+
+Placement is chosen **once per batch**. The scheduler, `Taskset.run(agent, runtime=...)`
+(`hud/eval/taskset.py`), resolves a single provider for all rows and threads it into every rollout;
+per-row behavior happens inside the provider, never in the scheduler.
+
+When `runtime=` is omitted, `_resolve_placement` uses what the process already knows:
+
+<div className="step-list">
+
+- A taskset loaded from `.py` source serves that source fresh per rollout (a `LocalRuntime` on the
+  file), provided the source actually declares the rows' envs.
+- A platform taskset runs against the platform (`HUDRuntime`).
+- Rows naming envs declared in already-imported modules serve each env fresh from its declaring
+  file.
+- Anything else raises, naming the forms to pass.
+
+</div>
+
+One placement decision is also *local-drive vs delegated*: every provider yields a channel that
+this process drives through the [rollout atom](/v6/internals/walkthrough#into-the-rollout-atom), except
+`HostedRuntime`, which submits the whole rollout to the platform and folds the result back into a
+`Run`. The scheduler picks between the two, so the atom never branches on placement.
+
+## Routing patterns
+
+Because the contract is a callable that receives the row, routing is composition, not
+configuration. Four patterns cover what exists today.
+
+### Fresh substrate per rollout
+
+The default, and what every built-in does: one acquisition brings up one new substrate and tears it
+down on exit. Isolation is structural - two rollouts never share state because they never share a
+substrate.
+
+```python
+job = await taskset.run(agent, runtime=DockerRuntime("my-env-image"))
+```
+
+### Build the environment from the row
+
+The `LocalRuntime` constructor form takes a `(task) -> Environment` callable, invoked per
+acquisition with the placed row. This is the pattern for benchmarks where one process holds one
+scene (an Isaac sim, where the scene is fixed at build time): one declaration file, many rows, and
+the constructor reads the row to build the right scene.
+
+```python
+def build(task) -> Environment:
+    return make_env(scene=task.args["task"])   # one scene per acquisition
+
+job = await taskset.run(agent, runtime=LocalRuntime(build))
+```
+
+### Route rows across providers
+
+A lambda that reads the row and picks a provider routes a heterogeneous batch: mixed-env tasksets,
+per-row images, per-row resources. The scheduler still resolves one "provider" - the lambda - and
+all branching stays inside it.
+
+```python
+providers = {"web": DockerRuntime("web-env"), "sim": DockerRuntime("sim-env")}
+runtime = lambda task: providers[task.env](task)
+```
+
+### Borrow warm substrates
+
+When provisioning is expensive (a sim that takes a minute to boot), serve long-lived processes once
+and map rows onto them as bare `Runtime` addresses. Entering the context is a no-op, so episodes
+against one task reuse its warm substrate, and per-episode variation travels through task args
+instead of fresh builds.
+
+```python
+servers = {"peg_insert": Runtime("tcp://127.0.0.1:8765"),
+           "gear_mesh":  Runtime("tcp://127.0.0.1:8766")}
+runtime = lambda task: servers[task.args["task"]](task)
+```
+
+<Note>
+A control channel now supports concurrent sessions, one suspended task each (see the
+[control channel](/v6/internals/control-channel#the-suspended-task)), so a shared warm server no longer
+serializes its rows. Its substrate is still one resource, so rows that drive a single shared world
+(one sim) must cap concurrency or run sequentially.
+</Note>
+
+The [server step of the walkthrough](/v6/internals/walkthrough#bringing-up-the-server) shows where these calls
+sit on the pointer's path through one rollout.

--- a/docs/v6/internals/walkthrough.mdx
+++ b/docs/v6/internals/walkthrough.mdx
@@ -1,0 +1,748 @@
+---
+title: "Walkthrough"
+description: "A step-through of one HUD run, following the pointer through the real code from Taskset.run to a graded reward."
+icon: "route"
+mode: "wide"
+---
+
+This is a step-through of one run, following the pointer through the real code. It starts with what
+is defined at rest, then enters `Taskset.run` and follows every step - into `rollout`, out to the
+env server, through `tasks.start`, into the agent, and back through `tasks.grade` - showing the key
+lines at each stop and where the pointer goes next. Irrelevant branches are trimmed with `# ...`.
+
+On this page: [What we start with](#what-we-start-with) · [Start point: the scheduler](#start-point-the-scheduler) · [Into the rollout atom](#into-the-rollout-atom) · [Bringing up the server](#bringing-up-the-server) · [Connecting](#connecting) · [Starting the task](#starting-the-task) · [Checkpoint](#checkpoint) · [Driving the agent](#driving-the-agent) · [Grading and teardown](#grading-and-teardown) · [The whole chain](#the-whole-chain) · [Assumptions](#assumptions)
+
+## What we start with
+
+Before anything runs, we start with an `env.py` file with the **environment** declaration and **task
+templates** registered on it. 
+
+An `@env.template()` decorator turns an async generator into a `_TaskFactory` and stores it in
+`env.tasks`. The generator body *is* the task: advancing the generator to first `yield` returns (yields) 
+the prompt, the value sent back is
+the answer, second `yield` is the score.
+
+```python hud/environment/env.py
+env = Environment("robolab", capabilities=[Capability.ssh(name="shell", url=...)])
+
+@env.template()
+async def fix_bug(difficulty: int):
+    answer = yield f"Fix the bug (difficulty {difficulty})"   # 1st yield -> prompt
+    yield 1.0 if check(answer) else 0.0                       # 2nd yield -> score
+```
+
+<Accordion title="Advancing fix_bug by hand">
+```python
+gen = fix_bug(difficulty=3)
+
+prompt = await gen.__anext__()      # advance to the 1st yield; nothing to send in yet
+print(prompt)                       # "Fix the bug (difficulty 3)"
+
+score = await gen.asend("patched")  # resumes the paused yield with "patched" as its result
+print(score)                        # 1.0, once `check("patched")` returns True
+```
+Calling `asend(value)` resumes the suspended `yield` expression with `value` - that's the moment
+`answer = yield ...` gets populated - then runs the generator forward to the next `yield`, whose
+argument becomes `asend`'s return value. The [`TaskRunner.start`](#starting-the-task) call later in
+this walkthrough is exactly the `__anext__()` call above; [`TaskRunner.grade`](#grading-and-teardown)
+is exactly the `asend(...)` call.
+</Accordion>
+
+```python hud/environment/env.py · Environment.template
+def decorate(func):
+    if not inspect.isasyncgenfunction(func):
+        raise TypeError(...)                 # must be `async def ... yield`
+    task = _TaskFactory(self, id or func.__name__, description, func, ...)
+    self.tasks[task_id] = task               # registered on the env
+    return task
+```
+
+Calling the factory runs nothing. It binds the args and returns a `Task` row - the row's `env` is
+the environment's *name* (a string), not a live object.
+
+```python hud/environment/env.py · _TaskFactory.__call__
+def __call__(self, *args, **kwargs) -> EvalTask:
+    from hud.eval.task import Task
+    bound = self.sig.bind(*args, **kwargs)
+    return Task(env=self.env.name, id=self.id, args=dict(bound.arguments))
+```
+
+A `Taskset` is just a named collection of those rows, indexed by slug:
+
+```python
+taskset = Taskset("bugs", [fix_bug(1), fix_bug(2)])
+job = await taskset.run(agent, runtime=LocalRuntime("env.py"))   # <- the pointer starts here
+```
+
+## Start point: the scheduler
+
+The pointer enters `Taskset.run`. It expands the rows, registers one `Job`, resolves placement
+once, then fans out one `rollout` per (task, group) pair with `asyncio.gather`.
+
+<Accordion title="Full code">
+```python hud/eval/taskset.py · Taskset.run
+async def run(self, agent, *, runtime=None, group=None, max_concurrent=None, ...):
+    group = group or 1
+
+    # expand: task x group; the `group` repeats of one task share a group_id (the GRPO group)
+    expanded = []
+    for task in list(self):
+        group_id = uuid.uuid4().hex
+        expanded += [(task, group_id) for _ in range(group)]
+
+    if job is None:                                  # register one platform Job as the receipt
+        job = Job(id=uuid.uuid4().hex, name=..., group=group, ...)
+        await job_enter(job.id, ...)
+
+    # placement chosen once for the whole batch (the runtime= you passed, or inferred)
+    placement = runtime if runtime is not None else self._resolve_placement()
+    sem = asyncio.Semaphore(max_concurrent) if max_concurrent else None
+
+    async def _run(task, group_id):
+        return [await rollout(task, agent, runtime=placement,       # <- next hop
+                              job_id=job.id, group_id=group_id, rollout_timeout=...)]
+
+    async def _one(task, group_id):
+        if sem is None:
+            return await _run(task, group_id)
+        async with sem:                              # cap parallelism
+            return await _run(task, group_id)
+
+    waves = await asyncio.gather(*(_one(t, gid) for t, gid in expanded))
+    job.runs.extend(run for wave in waves for run in wave)
+    return job
+```
+</Accordion>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">1 · Expand rows into (task, group) pairs</div>
+
+Each row in the taskset becomes `group` entries (default `1`), and the repeats of one task share a
+`group_id` - the tag that later ties their rewards together into one GRPO group.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">taskset.py · Taskset.run</p>
+
+```python
+async def run(self, agent, *, runtime=None,
+               group=None, max_concurrent=None, ...):
+    group = group or 1
+    expanded = []
+    for task in list(self):
+        group_id = uuid.uuid4().hex
+        expanded += [(task, group_id)
+                     for _ in range(group)]
+```
+
+</div>
+</div>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">2 · Register the Job receipt</div>
+
+A `Job` is the accumulator this call fills in and returns - every run below lands in `job.runs`.
+`job_enter` registers it with the platform so a running batch shows up before any rollout finishes.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">taskset.py · Taskset.run</p>
+
+```python
+    if job is None:
+        job = Job(id=uuid.uuid4().hex, name=...,
+                   group=group, ...)
+        await job_enter(job.id, ...)
+```
+
+</div>
+</div>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">3 · Resolve placement once, cap concurrency</div>
+
+`placement` is resolved once into a single callable, not once per row - though that callable can
+itself branch on the task (see [routing patterns](/v6/internals/placement#routing-patterns)). `max_concurrent`
+becomes the semaphore's capacity, capping how many rollouts run at once.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">taskset.py · Taskset.run</p>
+
+```python
+    placement = (runtime if runtime is not None
+                 else self._resolve_placement())
+    sem = (asyncio.Semaphore(max_concurrent)
+           if max_concurrent else None)
+```
+
+</div>
+</div>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">4 · Fan out one rollout per pair, collect into the job</div>
+
+`_one` is the unit `gather` schedules: acquire the semaphore (if there is one), then call
+`rollout` - the next hop. `gather` starts every `_one` at once, but `async with sem:` blocks all
+but `max_concurrent` of them until a running rollout exits and frees a slot.
+
+Each `_one` returns a one-`Run` list, so the nested `waves` gets flattened into individual runs
+before `job.runs.extend` appends them.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">taskset.py · Taskset.run</p>
+
+```python
+    async def _run(task, group_id):
+        return [await rollout(
+            task, agent, runtime=placement,       # <- next hop
+            job_id=job.id, group_id=group_id,
+            rollout_timeout=...)]
+
+    async def _one(task, group_id):
+        if sem is None:
+            return await _run(task, group_id)
+        async with sem:
+            return await _run(task, group_id)
+
+    waves = await asyncio.gather(
+        *(_one(t, gid) for t, gid in expanded))
+    job.runs.extend(run for wave in waves for run in wave)
+    return job
+```
+
+</div>
+</div>
+
+Everything below happens inside one `rollout(task, agent, runtime=placement, ...)`.
+
+## Into the rollout atom
+
+`rollout` is the whole lifecycle for one task. The key structure is one `AsyncExitStack` that
+stacks three context managers - the **provider**, the **client connection**, and the **`Run`** -
+and unwinds them in reverse on the way out.
+
+<Accordion title="Full code">
+```python hud/eval/run.py · rollout
+async def rollout(task, agent, *, runtime, job_id=None, group_id=None, ...):
+    if job_id is None:                       # a lone rollout is a job of one
+        job_id = uuid.uuid4().hex
+        await job_enter(job_id, name=task.id, group=1)
+    trace_id = trace_id or uuid.uuid4().hex
+
+    with set_trace_context(trace_id):
+        await trace_enter(trace_id, job_id=job_id, group_id=group_id, ...)
+
+        async def _drive():
+            nonlocal run, _phase
+            async with contextlib.AsyncExitStack() as stack:
+                addr   = await stack.enter_async_context(runtime(task))    # 1. provider -> Runtime
+                client = await stack.enter_async_context(connect(addr))    # 2. connect -> HudClient
+                live = Run(client, task.id, task.args)
+                live._runtime = addr.url
+                async with live:              # 3. Run.__aenter__ = tasks.start
+                    run = live
+                    _phase = "agent loop"
+                    await agent(run)          #    agent fills run.trace
+                                              #    Run.__aexit__ = tasks.grade
+                _phase = "grading"
+
+        await _drive()
+        # ... failure isolation sets run = Run.failed(...) or marks the trace errored ...
+        await trace_exit(run)
+    return run
+```
+</Accordion>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">1 · Give the rollout a job and a trace</div>
+
+A `rollout` called on its own (not through `Taskset.run`) still needs a `Job` and a trace id to
+report against, so it mints its own `job_id` and `trace_id` when neither arrives from the caller.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">run.py · rollout</p>
+
+```python
+async def rollout(task, agent, *, runtime,
+                   job_id=None, group_id=None, ...):
+    if job_id is None:
+        job_id = uuid.uuid4().hex
+        await job_enter(job_id, name=task.id, group=1)
+    trace_id = trace_id or uuid.uuid4().hex
+```
+
+</div>
+</div>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">2 · Open the AsyncExitStack: provider, then connect</div>
+
+Two of the stack's three context managers enter here. The provider yields a `Runtime` address;
+`connect` turns that address into a live `HudClient`. Exiting `stack` later tears both down, in
+reverse order.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">run.py · rollout · _drive</p>
+
+```python
+async with contextlib.AsyncExitStack() as stack:
+    addr = await stack.enter_async_context(
+        runtime(task))          # 1. provider -> Runtime
+    client = await stack.enter_async_context(
+        connect(addr))          # 2. connect -> HudClient
+```
+
+</div>
+</div>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">3 · Enter the Run, drive the agent</div>
+
+The stack's third context manager is the `Run` itself: entering it sends `tasks.start`, exiting it
+sends `tasks.grade` (messages to the environment server). Everything the agent does happens between those two lines, inside
+`await agent(run)`.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">run.py · rollout · _drive</p>
+
+```python
+live = Run(client, task.id, task.args)
+live._runtime = addr.url
+async with live:          # 3. Run.__aenter__ = tasks.start
+    run = live
+    _phase = "agent loop"
+    await agent(run)      #    fills run.trace
+                           #    __aexit__ = tasks.grade
+_phase = "grading"
+```
+
+</div>
+</div>
+
+<div className="guide-row">
+<div className="guide-main">
+
+<div className="part-label">4 · Unwind and report</div>
+
+`_drive` runs the whole nested block above; if it raises, failure isolation still produces a `run`
+(failed, or with an errored trace) before `trace_exit` closes the trace and the graded - or
+failed - `Run` returns.
+
+</div>
+<div className="guide-aside">
+
+<p className="aside-label">run.py · rollout</p>
+
+```python
+await _drive()
+# ... failure isolation sets run = Run.failed(...)
+# or marks the trace errored ...
+await trace_exit(run)
+return run
+```
+
+</div>
+</div>
+
+The pointer follows `stack.enter_async_context` in order. First stop: `runtime(task)`.
+
+## Bringing up the server
+
+`runtime(task)` calls whichever provider placement resolved - any callable of the shape
+`(task) -> async context manager yielding a Runtime` (see [placement](/v6/internals/placement)). This whole
+step is the **env side** of the protocol, the provider and the environment together, which the
+[agent side](#connecting) then connects to. Two pieces make it up: the environment's serving code,
+which runs identically inside whatever substrate holds it, and the provider, which brings that
+substrate up and hands back a `tcp://` url reaching its control port.
+
+### The serving code
+
+Every substrate runs one entry point, `serve()` - the `python -m hud.environment.server` a
+`SubprocessRuntime` child runs, and the `hud serve` a container CMD runs both land here. It starts the
+env, binds the control channel, prints the bound port, and serves until torn down.
+
+```python hud/environment/server.py · serve
+async def serve(env, host="127.0.0.1", port=0):
+    await env.start()                              # run @env.initialize hooks
+    server = await bind(env, host, port)          # bind the control channel
+    print(f"HUD_SERVE_PORT={server.sockets[0].getsockname()[1]}", flush=True)  # announce it
+    try:
+        async with server:
+            await server.serve_forever()
+    finally:
+        await env.stop()                          # @env.shutdown hooks
+```
+
+The initialize hooks run *before* serving, so every capability is concrete by the time a client
+connects.
+
+```python hud/environment/env.py · Environment.start
+async def start(self):
+    if self._started:
+        return
+    self._started = True
+    for hook in self._on_start:                     # @env.initialize
+        await hook()                                # daemons up, add_capability(...) called here
+    self._hooks_done = True
+```
+
+Then `bind` puts the env on one TCP port that carries both the control session and raw capability
+tunnels - the [control channel](/v6/internals/control-channel). The bound port is the only thing the provider
+needs back: child and container substrates announce it on stdout; the in-process provider reads it
+straight off the socket.
+
+### The provider
+
+The default, `LocalRuntime`, is the smallest provider: it rebuilds the env fresh from its source
+and serves it in *this* process, through the `_local` helper - `env.start()`, `bind` on an
+ephemeral loopback port, and a `Runtime` pointing at it. Exiting cancels the server and runs
+`env.stop()`.
+
+```python hud/eval/runtime.py · _local (entered by LocalRuntime per acquisition)
+started = env.start()
+await asyncio.wait_for(started, ready_timeout)     # @env.initialize, bounded
+server = await bind(env, "127.0.0.1", 0)           # in-process control channel
+host, port = server.sockets[0].getsockname()[:2]
+serve_task = asyncio.create_task(server.serve_forever())
+try:
+    yield Runtime(f"tcp://{host}:{port}")          # <- this is `addr` back in rollout
+finally:
+    serve_task.cancel()
+    # ...
+    await env.stop()                               # @env.shutdown
+```
+
+In-process means the initialize hooks share the caller's event loop, so blocking env code stalls
+concurrent rollouts. `SubprocessRuntime` is the isolation step: it spawns the serve entry point
+above as a child (`python -m hud.environment.server <path> --env name`), reads the announced
+`HUD_SERVE_PORT=` from its stdout, and terminates the child on exit.
+
+Every other provider runs that same serve entry point inside a different substrate and reaches its
+port a different way:
+
+| Provider | Substrate | Reaches the control port by |
+| --- | --- | --- |
+| `LocalRuntime` | this process | reading the bound socket directly (`_local`) |
+| `SubprocessRuntime` | a child process on this host | reading `HUD_SERVE_PORT=` from its stdout |
+| `DockerRuntime` | a `docker run` container | publishing the port, reading the `docker port` mapping |
+| `ModalRuntime` | a Modal sandbox | a raw-TCP tunnel (`unencrypted_ports`) |
+| `DaytonaRuntime` | a Daytona sandbox | an SSH local-forward to a local port |
+| `HUDRuntime` | a HUD-hosted env | a WebSocket tunnel behind a local TCP listener |
+| `Runtime(url)` | one already served elsewhere | nothing - the url passes straight through |
+
+Whichever provider ran, a `Runtime(url)` now exists and the server is listening. The pointer
+returns to `rollout` and enters the second context manager: `connect(addr)`.
+
+## Connecting
+
+`connect` retries the connect-and-`hello` handshake until the env answers (a freshly bound port can
+accept before the env behind it is serving), then yields a `HudClient` with its `manifest` ready.
+
+```python hud/clients/client.py · connect
+@asynccontextmanager
+async def connect(runtime, *, ready_timeout=240.0):
+    parts = urlsplit(runtime.url)
+    client = await _connect_ready(parts.hostname, parts.port, ready_timeout=...)
+    try:
+        yield client
+    finally:
+        await client.close()
+```
+
+```python hud/clients/client.py · _connect_ready
+while True:
+    try:
+        reader, writer = await asyncio.open_connection(host, port)
+    except OSError:
+        ...; continue                               # not accepting yet, retry
+    client = HudClient(reader, writer, endpoint=(host, port))
+    try:
+        await client.hello()                        # handshake
+    except (EOFError, OSError):
+        await client.close(); ...                   # accepted but no env behind it, retry
+    else:
+        return client
+```
+
+`hello()` sends the frame and parses the reply into a `Manifest`. Loopback bindings get rewritten
+to local forwarders here (`_reachable`), so every capability url works from this process. An
+optional `session_id` resumes a parked session instead of minting a fresh one - not needed on
+this first connection, but see [the suspended task](/v6/internals/control-channel#the-suspended-task) for
+when it is.
+
+```python hud/clients/client.py · HudClient.hello
+async def hello(self, session_id=None):
+    params = {} if session_id is None else {"session_id": session_id}
+    result = await self._call("hello", params)      # -> server session
+    bindings = [await self._reachable(Capability.from_manifest(b))
+                for b in (result.get("bindings") or [])]
+    self.manifest = Manifest(session_id=result["session_id"], bindings=bindings, ...)
+    return self.manifest
+```
+
+On the server, the `hello` branch answers with the env identity and its capabilities (the branch
+that resumes a requested `session_id` is elided here; see the link above):
+
+```python hud/environment/server.py · _ControlChannel.session (hello)
+if method == "hello":
+    # ... a requested session_id resumes that parked session instead ...
+    bindings = [c.to_manifest() for c in env.capabilities]
+    await reply_to(msg_id, {"session_id": session_id,
+                            "env": {"name": env.name, "version": env.version},
+                            "bindings": bindings})
+```
+
+The client now holds the manifest. Back in `rollout`, the pointer builds the `Run` and enters it.
+
+## Starting the task
+
+`Run.__aenter__` is the third context manager. It sends `tasks.start` and stores the prompt the
+env returns.
+
+```python hud/eval/run.py · Run.__aenter__
+async def __aenter__(self):
+    started = await self.client.start_task(self._task_id, self._args)   # tasks.start
+    self.prompt = started.get("prompt")
+    self.record(Step(source="task", task_call=TaskCall(phase="setup", ...)))
+    if self.prompt is not None:
+        self.record(Step(source="user", messages=self.prompt_messages))
+    return self
+```
+
+```python hud/clients/client.py · HudClient.start_task
+async def start_task(self, task_id, args=None):
+    return await self._call("tasks.start", {"id": task_id, "args": args or {}})
+```
+
+The frame reaches the server's `tasks.start` branch, which creates a `TaskRunner` and starts it,
+holding it on the channel under this connection's session id:
+
+```python hud/environment/server.py · session (tasks.start) + _ControlChannel.start
+elif method == "tasks.start":
+    prompt = await self.start(session_id, task_id, args)   # _ControlChannel.start
+    await reply_to(msg_id, prompt)
+
+async def start(self, session_id, task_id, args):   # _ControlChannel.start
+    await self.cancel(session_id)                    # replace this session's own task, if any
+    self._runners[session_id] = TaskRunner(self.env.tasks[task_id], args)
+    return await self._runners[session_id].start()
+```
+
+`TaskRunner.start` instantiates the async generator and runs it to the **first yield** - the
+prompt:
+
+```python hud/environment/server.py · TaskRunner.start
+async def start(self):
+    self._gen = self.task.func(**_coerce_args(self.task.sig, self._args))   # make the generator
+    prompt = await self._gen.__anext__()            # run task fn to 1st yield
+    frame = prompt if isinstance(prompt, dict) and "prompt" in prompt else {"prompt": prompt}
+    return _jsonable(frame)                          # -> back over the wire
+```
+
+The prompt travels back: `TaskRunner.start` -> server reply -> `client.start_task` ->
+`Run.prompt`.
+
+## Checkpoint
+
+The pointer is now back inside `async with live:`, just before `await agent(run)`. At this moment
+`run` is a `Run` that holds:
+
+<div className="step-list">
+
+- an attached `client` (`run.client`), which already has the `manifest` and whose server has a
+  `TaskRunner` suspended at the task's first yield,
+- the `prompt` the env returned, on `run.prompt`,
+- an empty `run.trace` (a `Trace()`) waiting to be filled.
+
+</div>
+
+## Driving the agent
+
+`rollout` hands the run to the agent. The agent contract is one method: `async __call__(run)`.
+
+```python hud/eval/run.py · rollout (agent loop)
+run = live
+async with file_tracking_observer(client):
+    await agent(run)                    # Agent.__call__(run)
+```
+
+```python hud/agents/base.py · Agent
+class Agent(ABC):
+    @abstractmethod
+    async def __call__(self, run: Run) -> None:
+        """Drive run to completion, filling run.trace (answer is trace.content)."""
+```
+
+Inside, the agent reads the manifest through the run's client and opens the capabilities it needs,
+then loops - acting, observing, recording steps - until it has an answer. Everything it does lands
+on `run.trace`; the final answer is `run.trace.content`.
+
+```python
+shell = await run.client.open("shell")   # live CapabilityClient (ssh/cdp/mcp/...)
+cdp   = run.client.binding("cdp")        # or raw wire data for something else to dial
+# ... agent loop: append steps to run.trace; final answer -> run.trace.content ...
+```
+
+When `__call__` returns, the pointer leaves the `async with live:` block, which triggers
+`Run.__aexit__`.
+
+## Grading and teardown
+
+`Run.__aexit__` sends `tasks.grade` with the answer taken from `trace.content`, and parses the
+reply into a `Grade` (the env's `score` becomes `reward`). On a Ctrl-C it cancels instead of
+grading.
+
+```python hud/eval/run.py · Run.__aexit__
+async def __aexit__(self, exc_type, exc, tb):
+    if exc_type in (asyncio.CancelledError, KeyboardInterrupt):
+        await self.client.cancel(); return False
+    answer = {"answer": self.trace.content}
+    evaluation = await self.client.grade(answer)    # tasks.grade
+    self.grade = Grade.from_dict(evaluation)        # score -> run.grade.reward
+    self.record(Step(source="task", task_call=TaskCall(phase="evaluate", ...)))
+    return False
+```
+
+The server's `tasks.grade` branch pops this session's held runner and resumes it (or, with no
+runner of its own, adopts the lone parked one - see
+[the suspended task](/v6/internals/control-channel#the-suspended-task)):
+
+```python hud/environment/server.py · session (tasks.grade) + _ControlChannel.grade
+elif method == "tasks.grade":
+    evaluation = await self.grade(session_id, params)   # _ControlChannel.grade
+    await reply_to(msg_id, evaluation)
+
+async def grade(self, session_id, payload):          # _ControlChannel.grade
+    runner = self._runners.pop(session_id, None)      # this session's own task ...
+    if runner is None:
+        runner = self._adopt_parked()                 # ... or the lone parked one
+    return await runner.grade(payload)
+```
+
+`TaskRunner.grade` sends the answer into the paused generator (optionally wrapped as `Answer[T]`
+when `returns=` was declared), which advances past the first yield, evaluates, and yields the
+**score**:
+
+```python hud/environment/server.py · TaskRunner.grade
+async def grade(self, payload):
+    evaluation = await self._gen.asend(_build_answer(self.task.return_type, payload))  # 2nd yield
+    # ... normalize dict / EvaluationResult ...
+    return {"score": _score_value(evaluation)}
+```
+
+The score travels back: `TaskRunner.grade` -> server reply -> `client.grade` -> `Grade.from_dict`
+-> `run.grade.reward`.
+
+Now the `AsyncExitStack` unwinds in reverse: `connect` closes the client (forwarders and socket),
+then the provider context exits and tears the substrate down - for `LocalRuntime` it cancels the
+in-process server and runs `env.stop()` (`@env.shutdown`); for `SubprocessRuntime` it terminates
+the child, whose `serve` does the same on the way out. Back in `rollout`,
+`trace_exit(run)` reports the trace and the graded `Run` returns to `Taskset.run`, which collects it
+into `job.runs`.
+
+## The whole chain
+
+Every hop above, in order:
+
+<div className="step-list">
+
+1. `Taskset.run` - expand rows, register a `Job`, resolve placement, `gather` one `rollout` per (task, group).
+2. `rollout` - open an `AsyncExitStack`: provider, then connect, then `Run`.
+3. `runtime(task)` - bring the env up in its substrate: `LocalRuntime` serves it in-process via `_local`; `SubprocessRuntime` spawns the serve entry point and reads its announced port.
+4. `serve` (in the substrate) - `env.start()` (initialize hooks), `bind()` a TCP server, `serve_forever()`; the provider yields a `Runtime(url)`.
+5. `connect(addr)` - retry until ready, `HudClient.hello()` -> server returns the `manifest`.
+6. `Run.__aenter__` - `client.start_task` -> `tasks.start` -> `TaskRunner.start` runs the generator to the first yield -> `prompt` back on `run.prompt`.
+7. **Checkpoint** - `run` holds a live client (manifest + suspended runner) and the prompt.
+8. `await agent(run)` - agent opens capabilities via `run.client`, loops, fills `run.trace` (answer on `trace.content`).
+9. `Run.__aexit__` - `client.grade` -> `tasks.grade` -> `TaskRunner.grade` resumes the generator to the second yield -> `score` -> `run.grade.reward`.
+10. Unwind - close client, the provider stops the substrate (`serve` runs `env.stop()`), `trace_exit`, return the graded `Run` to `Taskset.run`.
+
+</div>
+
+```mermaid
+sequenceDiagram
+    participant Sched as Taskset.run
+    participant Roll as rollout / Run
+    participant Cli as HudClient
+    participant Prov as Provider
+    participant Env as Env server
+    Sched->>Roll: rollout(task, agent, runtime)
+    Roll->>Prov: runtime(task)
+    Prov->>Env: serve: env.start() + bind()
+    Prov-->>Roll: Runtime(url)
+    Roll->>Cli: connect(url)
+    Cli->>Env: hello (retry until ready)
+    Env-->>Cli: manifest (bindings)
+    Roll->>Env: tasks.start (Run.__aenter__)
+    Env->>Env: TaskRunner.start -> 1st yield
+    Env-->>Roll: prompt
+    rect rgb(238,238,238)
+    Note over Roll,Env: await agent(run) fills run.trace
+    Roll->>Env: tunnel.open + drive capabilities
+    Env-->>Roll: observations
+    end
+    Roll->>Env: tasks.grade (Run.__aexit__)
+    Env->>Env: TaskRunner.grade -> 2nd yield
+    Env-->>Roll: score becomes Grade.reward
+    Prov->>Env: provider stops the substrate + env.stop()
+    Roll-->>Sched: graded Run
+```
+
+## Assumptions
+
+This is one specific shape, and a few assumptions are baked into it. They hold today; they are the
+first things to revisit when the shape needs to grow.
+
+<div className="step-list">
+
+- **One rollout requests one runtime, and that runtime is one container.** `rollout` acquires a
+  single substrate (`await stack.enter_async_context(runtime(task))`) with a single control-channel
+  `url`, and drives one connection to it. A task needing several coordinated containers has no
+  first-class representation - it would be one env bringing the others up behind its own
+  capabilities, or a future provider yielding more than one address.
+- **A control channel holds one suspended task per session.** A `_ControlChannel` keys its
+  suspended `TaskRunner`s by session id, so concurrent sessions each own their own, and a dropped
+  connection parks its session's task for a later one to grade (see the
+  [control channel](/v6/internals/control-channel#the-suspended-task)). Vectorized robot sims reuse that
+  shape: N sessions on one control port, each claiming a bridge slot by token.
+- **The agent loop runs in the caller's process.** Every provider except `HostedRuntime` is
+  *client-here*: the substrate can be anywhere, but `agent(run)` executes locally. With the
+  default `LocalRuntime` the env serves in this same process too, so its hooks share the caller's
+  event loop and blocking env code stalls concurrent rollouts; `SubprocessRuntime` and
+  `DockerRuntime` move the env to its own substrate, where hooks run isolated from the caller.
+- **Every capability is concrete by `hello` time.** `env.start()` runs all initialize hooks before
+  serving, and the manifest is negotiated once. A capability published later will not appear in an
+  already-connected client.
+- **A template generator is single-use per start.** `grade` closes it after the second yield, so
+  one `TaskRunner` grades exactly once; re-running the task means a fresh `tasks.start`.
+- **Placement is chosen once per batch.** `Taskset.run` resolves one provider for all rows. Per-row
+  heterogeneity is possible only because the `Provider` contract takes the `task` and can branch on
+  it - the engine never does.
+
+</div>

--- a/docs/v6/more/contributing.mdx
+++ b/docs/v6/more/contributing.mdx
@@ -24,6 +24,11 @@ We welcome contributions to the HUD SDK!
    uv tool install --force --from "." hud --refresh
    ```
 
+## Learn the codebase
+
+The [Internals](/v6/internals/index) section explains how the SDK is implemented - start with the
+[walkthrough](/v6/internals/walkthrough), which follows one full run through the real code.
+
 ## Development Workflows
 
 <Steps>


### PR DESCRIPTION
- New **Internals** group in the sidebar: `v6/internals/{index,walkthrough,placement,control-channel}` — how the code runs, for people changing it. The index carries the module map; the contributing page links in.
- `advanced/protocol` and `internals/control-channel` cross-link with a clear split: protocol owns the message semantics, control-channel owns how the server carries them.
- The `v6` versions wrapper in `docs.json` is gone — groups sit directly on the SDK tab. Page URLs keep their `v6/...` paths, so nothing breaks and existing redirects stay valid.
- `custom.css` gains a paragraph-display fix for nested `guide-main`/`guide-aside` blocks.

## Outcome / Verification

Rendered in `mint dev`; nav shows the Internals group collapsed, no version dropdown; all internal links resolve. Content ported verbatim from hud-dev-docs (platform half of that repo lands in the monorepo via hud-monorepo PR 986; hud-dev-docs then retires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Mintlify nav/CSS only; no runtime or API changes.
> 
> **Overview**
> Adds a collapsible **Internals** sidebar group with four new pages (`index`, `walkthrough`, `placement`, `control-channel`) that document how the SDK runs end-to-end for contributors—ported from the internal hud-dev-docs repo into the public docs tree.
> 
> **Navigation:** Removes the `versions` wrapper that only listed `v6`; SDK nav groups sit directly on the tab (URLs stay `v6/...`, redirects unchanged). **Cross-links:** `advanced/protocol` points readers at control-channel for transport; contributing gains a **Learn the codebase** section into the walkthrough.
> 
> **Layout:** `custom.css` block-displays nested `span[data-as="p"]` in `guide-main` / `guide-aside` so multi-paragraph margin columns don’t run together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299baf05a14b58fb9f34c83170e6ba818ed640f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->