### PR TITLE
ci: retire the docs deploy job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   release:
     types: [published]
 
@@ -25,50 +24,3 @@ jobs:
         run: |
           uv build
           uv publish
-
-  deploy-docs:
-    if: ${{ always() && (github.event_name == 'workflow_dispatch' || (needs.deploy.result == 'success' && !github.event.release.prerelease)) }}
-    needs: deploy
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    env:
-      MINTLIFY_API_KEY: ${{ secrets.MINTLIFY_API_KEY }}
-      MINTLIFY_PROJECT_ID: ${{ vars.MINTLIFY_PROJECT_ID }}
-    steps:
-      - name: Deploy docs to Mintlify
-        run: |
-          : "${MINTLIFY_API_KEY:?MINTLIFY_API_KEY is not configured}"
-          : "${MINTLIFY_PROJECT_ID:?MINTLIFY_PROJECT_ID is not configured}"
-
-          response=$(curl --silent --show-error --fail-with-body \
-            --request POST \
-            --url "https://api.mintlify.com/v1/project/update/${MINTLIFY_PROJECT_ID}" \
-            --header "Authorization: Bearer ${MINTLIFY_API_KEY}")
-          status_id=$(jq -er '.statusId' <<< "$response")
-
-          for _ in {1..60}; do
-            response=$(curl --silent --show-error --fail-with-body \
-              --url "https://api.mintlify.com/v1/project/update-status/${status_id}" \
-              --header "Authorization: Bearer ${MINTLIFY_API_KEY}")
-            status=$(jq -er '.status' <<< "$response")
-
-            case "$status" in
-              success)
-                exit 0
-                ;;
-              failure)
-                jq -r '.summary, (.logs[]? // empty)' <<< "$response"
-                exit 1
-                ;;
-              queued|in_progress)
-                sleep 10
-                ;;
-              *)
-                echo "Unknown Mintlify deployment status: $status"
-                exit 1
-                ;;
-            esac
-          done
-
-          echo "Timed out waiting for Mintlify deployment $status_id."
-          exit 1


### PR DESCRIPTION
## Issue

docs.hud.ai now deploys from the hud-monorepo docs pipeline (assembled site pushed to a mirror repo that Mintlify auto-deploys; the Mintlify project was repointed at the mirror). This repo's `deploy-docs` job only asks Mintlify to re-pull a mirror it never writes — a no-op on every release.

## Solution

Remove the job. `MINTLIFY_API_KEY` / `MINTLIFY_PROJECT_ID` repo config gets deleted once this merges (deleting it first would fail the job on any release in between).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change; PyPI release path is untouched and docs were already deployed elsewhere.
> 
> **Overview**
> **Removes the `deploy-docs` job** from `.github/workflows/release.yml` and tightens the release trigger so the workflow runs only on `release` events (drops `workflow_dispatch`).
> 
> The deleted job polled Mintlify’s API to redeploy docs after PyPI publish. Docs now ship from the hud-monorepo pipeline into a mirror repo Mintlify watches, so this job was a no-op. The **`deploy` PyPI job is unchanged.**
> 
> Repo secrets/vars `MINTLIFY_API_KEY` and `MINTLIFY_PROJECT_ID` are intended to be removed after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84a2ab3ec2cba4adb43f127ab726b9df5cfe7188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->