### PR TITLE
feat(harbor): support separate verifier environments

### DIFF
--- a/docs/v6/advanced/harbor-convert.mdx
+++ b/docs/v6/advanced/harbor-convert.mdx
@@ -40,12 +40,12 @@ as `runtime_config`. The image's `tasks.json` carries workdir, environment,
 network, and phase-user declarations into the authored HUD environment.
 
 Tasks whose declared behaviour cannot be reproduced faithfully are refused
-rather than silently downgraded. Adaptation replaces the container's own boot
-process with the HUD server, so `healthcheck` and `mcp_servers` declarations are
-refused when they depend on that process. Compose environments, separate
-verifier environments, non-Linux tasks, TPUs, skills directories, and
-multi-step tasks are also refused. Prebuilt images, allowlists, and distinct
-agent/verifier users are supported.
+rather than silently downgraded. Compose environments, network MCP servers,
+healthchecks, and separate verifier Dockerfiles are translated into the HUD
+runtime contract; Docker and Modal can run the resulting Compose environments,
+while Daytona rejects Compose runtime configuration. Stdio MCP servers,
+non-Linux tasks, TPUs, skills directories, and multi-step tasks are refused.
+Prebuilt images, allowlists, and distinct agent/verifier users are supported.
 
 ## Export HUD tasks to Harbor
 

--- a/hud/environment/egress.py
+++ b/hud/environment/egress.py
@@ -115,7 +115,7 @@ BRIDGE_PORT = 3128
 VISITOR_PORT = 3129
 
 #: Run inside the workspace's network namespace, one listener per route out.
-#: Its argument is ``[[host, port, socket], ...]``; every listener is bound
+#: Its stdin is ``[[host, port, socket], ...]``; every listener is bound
 #: before it says it is ready, since a session that starts in between finds
 #: the port refused.
 _BRIDGE = """
@@ -147,7 +147,7 @@ def bridged(path):
 async def main():
     servers = [
         await asyncio.start_server(bridged(path), host, port)
-        for host, port, path in json.loads(sys.argv[1])
+        for host, port, path in json.loads(sys.stdin.readline())
     ]
     print("ready", flush=True)
     await asyncio.gather(*(server.serve_forever() for server in servers))
@@ -203,7 +203,12 @@ def bind_addresses(peers: Sequence[Peer]) -> dict[str, str]:
     return addresses
 
 
-def hosts_text(peers: Sequence[Peer], base: str) -> str:
+def hosts_text(
+    peers: Sequence[Peer],
+    base: str,
+    *,
+    local_aliases: Collection[str] = (),
+) -> str:
     """*base* — the substrate's ``/etc/hosts`` — plus a line per peer.
 
     Names resolve for what runs in the workspace's *mount* namespace, which
@@ -212,7 +217,12 @@ def hosts_text(peers: Sequence[Peer], base: str) -> str:
     at its address, but not by its name.
     """
     addresses = bind_addresses(peers)
-    lines = "".join(f"{addresses[peer.name]}\t{peer.name}\n" for peer in peers)
+    lines = "".join(
+        [
+            *(f"127.0.0.1\t{name}\n" for name in local_aliases),
+            *(f"{addresses[peer.name]}\t{peer.name}\n" for peer in peers),
+        ]
+    )
     return f"{base.rstrip(chr(10))}\n{lines}" if base.strip() else lines
 
 
@@ -220,6 +230,7 @@ def proxy_environment(
     port: int,
     peers: Sequence[Peer] = (),
     *,
+    local_aliases: Collection[str] = (),
     token: str | None = None,
 ) -> dict[str, str]:
     """Proxy variables for a process on a workspace's loopback.
@@ -234,7 +245,9 @@ def proxy_environment(
     credentials = f"hud:{urllib.parse.quote(token, safe='')}@" if token else ""
     url = f"http://{credentials}127.0.0.1:{port}"
     addresses = bind_addresses(peers)
-    bypass = ",".join(dict.fromkeys(["127.0.0.1", "localhost", *addresses, *addresses.values()]))
+    bypass = ",".join(
+        dict.fromkeys(["127.0.0.1", "localhost", *local_aliases, *addresses, *addresses.values()])
+    )
     return {
         "http_proxy": url,
         "https_proxy": url,
@@ -514,11 +527,13 @@ class Egress:
         allowed: Collection[str],
         peers: Sequence[Peer] = (),
         *,
+        local_aliases: Collection[str] = (),
         token: str | None = None,
     ) -> None:
         self.socket_dir = Path(socket_dir)
         self.allowed = frozenset(allowed)
         self.peers = tuple(peers)
+        self.local_aliases = tuple(local_aliases)
         self.token = token
         self._servers: list[tuple[_UnixServer, Path]] = []
 
@@ -571,9 +586,18 @@ class Egress:
             ),
         ]
 
-    def bridge_argv(self, port: int = BRIDGE_PORT) -> list[str]:
-        """Command which serves this policy inside a workspace network namespace."""
-        return [sys.executable, "-c", _BRIDGE, json.dumps(self._bridge_spec(port))]
+    def bridge_command(
+        self,
+        port: int = BRIDGE_PORT,
+        *,
+        visitor_socket: Path | None = None,
+    ) -> tuple[list[str], bytes]:
+        """Command and private input serving this policy in the workspace network."""
+        routes = self._bridge_spec(port)
+        if visitor_socket is not None:
+            routes.append(("127.0.0.1", VISITOR_PORT, str(visitor_socket)))
+        config = json.dumps(routes).encode() + b"\n"
+        return [sys.executable, "-c", _BRIDGE], config
 
     def environment(self, port: int = BRIDGE_PORT) -> dict[str, str]:
         """Proxy variables for what this serves.
@@ -582,7 +606,16 @@ class Egress:
         is not there turns "this task has no network" into a connection error
         on the first hop, which reads as a broken one instead.
         """
-        return proxy_environment(port, self.peers, token=self.token) if self.allowed else {}
+        return (
+            proxy_environment(
+                port,
+                self.peers,
+                local_aliases=self.local_aliases,
+                token=self.token,
+            )
+            if self.allowed
+            else {}
+        )
 
     def stop(self) -> None:
         """Take the routes away."""

--- a/hud/environment/egress.py
+++ b/hud/environment/egress.py
@@ -179,7 +179,11 @@ class Peer:
         return self.target or ("127.0.0.1", self.port)
 
 
-def bind_addresses(peers: Sequence[Peer]) -> dict[str, str]:
+def bind_addresses(
+    peers: Sequence[Peer],
+    *,
+    reserved_ports: Collection[int] = (),
+) -> dict[str, str]:
     """Which loopback address each peer answers on inside the workspace.
 
     ``127.0.0.1`` wherever the port is free, because a task that says
@@ -187,7 +191,11 @@ def bind_addresses(peers: Sequence[Peer]) -> dict[str, str]:
     there, so the second moves down 127.0.0.0/8 and is reached by its name —
     which is how a task naming several services addresses them anyway.
     """
-    taken = {("127.0.0.1", BRIDGE_PORT), ("127.0.0.1", VISITOR_PORT)}
+    taken = {
+        ("127.0.0.1", BRIDGE_PORT),
+        ("127.0.0.1", VISITOR_PORT),
+        *(("127.0.0.1", port) for port in reserved_ports),
+    }
     addresses: dict[str, str] = {}
     for peer in peers:
         if peer.name in addresses:
@@ -208,6 +216,7 @@ def hosts_text(
     base: str,
     *,
     local_aliases: Collection[str] = (),
+    reserved_ports: Collection[int] = (),
 ) -> str:
     """*base* — the substrate's ``/etc/hosts`` — plus a line per peer.
 
@@ -216,7 +225,7 @@ def hosts_text(
     verifier does, to reach a service the agent started) still reaches a peer
     at its address, but not by its name.
     """
-    addresses = bind_addresses(peers)
+    addresses = bind_addresses(peers, reserved_ports=reserved_ports)
     lines = "".join(
         [
             *(f"127.0.0.1\t{name}\n" for name in local_aliases),
@@ -231,6 +240,7 @@ def proxy_environment(
     peers: Sequence[Peer] = (),
     *,
     local_aliases: Collection[str] = (),
+    reserved_ports: Collection[int] = (),
     token: str | None = None,
 ) -> dict[str, str]:
     """Proxy variables for a process on a workspace's loopback.
@@ -244,7 +254,7 @@ def proxy_environment(
     """
     credentials = f"hud:{urllib.parse.quote(token, safe='')}@" if token else ""
     url = f"http://{credentials}127.0.0.1:{port}"
-    addresses = bind_addresses(peers)
+    addresses = bind_addresses(peers, reserved_ports=reserved_ports)
     bypass = ",".join(
         dict.fromkeys(["127.0.0.1", "localhost", *local_aliases, *addresses, *addresses.values()])
     )
@@ -528,12 +538,14 @@ class Egress:
         peers: Sequence[Peer] = (),
         *,
         local_aliases: Collection[str] = (),
+        reserved_ports: Collection[int] = (),
         token: str | None = None,
     ) -> None:
         self.socket_dir = Path(socket_dir)
         self.allowed = frozenset(allowed)
         self.peers = tuple(peers)
         self.local_aliases = tuple(local_aliases)
+        self.reserved_ports = frozenset(reserved_ports)
         self.token = token
         self._servers: list[tuple[_UnixServer, Path]] = []
 
@@ -577,7 +589,7 @@ class Egress:
 
     def _bridge_spec(self, port: int) -> list[tuple[str, int, str]]:
         """Where each route out is offered inside the workspace."""
-        addresses = bind_addresses(self.peers)
+        addresses = bind_addresses(self.peers, reserved_ports=self.reserved_ports)
         return [
             *([("127.0.0.1", port, str(self.socket_path))] if self.allowed else []),
             *(
@@ -611,6 +623,7 @@ class Egress:
                 port,
                 self.peers,
                 local_aliases=self.local_aliases,
+                reserved_ports=self.reserved_ports,
                 token=self.token,
             )
             if self.allowed

--- a/hud/environment/namespace.py
+++ b/hud/environment/namespace.py
@@ -192,6 +192,7 @@ class NamespaceHost:
         tty: bool = False,
         terminal_size: tuple[int, int, int, int] = (80, 24, 0, 0),
         persistent: bool = False,
+        scope: Literal["session", "environment"] = "session",
     ) -> NamespaceProcess:
         connection = self._require_connection()
         request = json.dumps(
@@ -202,6 +203,7 @@ class NamespaceHost:
                 "mount_view": mount_view,
                 "identity": identity,
                 "persistent": persistent,
+                "scope": scope,
             }
         )
         if tty:
@@ -215,6 +217,19 @@ class NamespaceHost:
         else:
             process = await connection.create_process(request, encoding=None)
         return NamespaceProcess(process)
+
+    async def terminate_sessions(self) -> None:
+        connection = self._require_connection()
+        result = await connection.run(
+            json.dumps({"operation": "terminate_sessions"}),
+            check=False,
+            encoding=None,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr or b""
+            assert isinstance(stderr, bytes)
+            detail = stderr.decode("utf-8", "replace").strip()
+            raise RuntimeError(detail or "failed to terminate workspace sessions")
 
     def _require_connection(self) -> asyncssh.SSHClientConnection:
         if self._connection is None:
@@ -278,8 +293,7 @@ class _NamespaceHost:
         self.launcher_depth = launcher_depth
         self.map_identities = map_identities
         self.ports = ports
-        self.holder: ProcessGroup | None = None
-        self.holder_pid: int | None = None
+        self.holders: dict[Literal["session", "environment"], tuple[ProcessGroup, int]] = {}
         self.forwarders: list[asyncio.AbstractServer] = []
 
     async def serve(self) -> None:
@@ -287,7 +301,8 @@ class _NamespaceHost:
         try:
             if self.setup_loopback:
                 self._enable_loopback()
-            self.holder_pid = await self._start_holder()
+            self.holders["session"] = await self._start_holder()
+            self.holders["environment"] = await self._start_holder()
             with contextlib.suppress(FileNotFoundError):
                 self.socket_path.unlink()
             listener = socket.socket(socket.AF_UNIX)
@@ -317,7 +332,7 @@ class _NamespaceHost:
                 process_factory=self._handle,
                 encoding=None,
             )
-            sys.stdout.write(json.dumps({"holder_pid": self.holder_pid}) + "\n")
+            sys.stdout.write(json.dumps({"holder_pid": self.holders["session"][1]}) + "\n")
             sys.stdout.flush()
             await asyncio.Event().wait()
         finally:
@@ -335,10 +350,9 @@ class _NamespaceHost:
         for port in self.ports:
             with contextlib.suppress(FileNotFoundError):
                 _port_socket(self.socket_path, port).unlink()
-        if self.holder is not None:
-            await self.holder.terminate()
-            self.holder = None
-            self.holder_pid = None
+        holders = tuple(self.holders.values())
+        self.holders.clear()
+        await asyncio.gather(*(holder.terminate() for holder, _ in holders))
         with contextlib.suppress(FileNotFoundError):
             self.socket_path.unlink()
 
@@ -347,15 +361,20 @@ class _NamespaceHost:
             if process.command is None:
                 raise ValueError("spawn request required")
             request: dict[str, Any] = json.loads(process.command)
-            process.exit(await self._spawn(request, process))
+            if request.get("operation") == "terminate_sessions":
+                await self._terminate_sessions()
+                process.exit(0)
+            else:
+                process.exit(await self._spawn(request, process))
         except Exception as exc:
             process.stderr.write(str(exc).encode())
             process.exit(1)
         await process.wait_closed()
 
-    async def _start_holder(self) -> int:
+    async def _start_holder(self) -> tuple[ProcessGroup, int]:
         read_fd, write_fd = os.pipe()
         block_read = block_write = -1
+        holder: ProcessGroup | None = None
         try:
             os.set_inheritable(write_fd, True)
             argv = list(self.holder_argv)
@@ -370,7 +389,7 @@ class _NamespaceHost:
                     "--userns-block-fd",
                     str(block_read),
                 ]
-            self.holder = await create_process_group_exec(
+            holder = await create_process_group_exec(
                 *argv,
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
@@ -385,19 +404,18 @@ class _NamespaceHost:
                 pid = await install_identity_map(
                     read_fd,
                     block_write,
-                    launcher_pid=self.holder.process.pid,
+                    launcher_pid=holder.process.pid,
                     launcher_depth=self.launcher_depth,
                 )
                 os.close(block_write)
                 block_write = -1
             else:
                 pid = await read_bwrap_pid(read_fd)
-            assert self.holder.stdout is not None
-            if await asyncio.wait_for(self.holder.stdout.readline(), 30.0) != b"ready\n":
-                raise RuntimeError(await self._holder_error())
-            return pid
+            assert holder.stdout is not None
+            if await asyncio.wait_for(holder.stdout.readline(), 30.0) != b"ready\n":
+                raise RuntimeError(await self._holder_error(holder))
+            return holder, pid
         except BaseException as exc:
-            holder, self.holder = self.holder, None
             if holder is not None:
                 with contextlib.suppress(Exception):
                     await holder.terminate()
@@ -417,22 +435,31 @@ class _NamespaceHost:
                 if descriptor != -1:
                     os.close(descriptor)
 
-    async def _holder_error(self) -> str:
-        if self.holder is None or self.holder.stderr is None:
+    async def _holder_error(self, holder: ProcessGroup) -> str:
+        if holder.stderr is None:
             return "sandbox holder did not become ready"
-        detail = await self.holder.stderr.read(2048)
+        detail = await holder.stderr.read(2048)
         return detail.decode(errors="replace").strip() or "sandbox holder did not become ready"
+
+    async def _terminate_sessions(self) -> None:
+        held = self.holders.pop("session", None)
+        if held is not None:
+            holder, _ = held
+            await holder.terminate()
 
     async def _spawn(
         self,
         request: dict[str, Any],
         channel: asyncssh.SSHServerProcess[bytes],
     ) -> int:
-        if self.holder_pid is None:
-            raise RuntimeError("workspace holder is not running")
         mount_view = request["mount_view"]
         if mount_view not in ("workspace", "host"):
             raise ValueError(f"unknown mount view {mount_view!r}")
+        scope = request["scope"]
+        if scope not in ("session", "environment"):
+            raise ValueError(f"unknown process scope {scope!r}")
+        if scope == "environment" and mount_view != "host":
+            raise ValueError("environment processes require the host mount view")
         identity = request["identity"]
         if isinstance(identity, int):
             uid = gid = identity
@@ -452,10 +479,14 @@ class _NamespaceHost:
                 *(() if identity is None else ("--setgid", str(gid), "--setuid", str(uid))),
                 "--",
             ]
+        held = self.holders.get(scope)
+        if held is None:
+            raise RuntimeError(f"workspace {scope} holder is not running")
+        _, holder_pid = held
         argv = [
             shutil.which("nsenter") or "/usr/bin/nsenter",
             "--target",
-            str(self.holder_pid),
+            str(holder_pid),
             *(("--mount",) if mount_view == "workspace" else ()),
             "--pid",
             "--uts",

--- a/hud/environment/namespace.py
+++ b/hud/environment/namespace.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import contextlib
 import json
+import logging
 import os
 import pty
 import shutil
@@ -17,10 +18,12 @@ from typing import Any, Literal
 
 import asyncssh
 
+from hud.environment.utils import splice
 from hud.utils.process import ProcessGroup, ProcessResult, create_process_group_exec
 
 _AF_NETLINK = getattr(socket, "AF_NETLINK", 16)
 _NETLINK_ROUTE = getattr(socket, "NETLINK_ROUTE", 0)
+LOGGER = logging.getLogger("hud.environment.namespace")
 
 
 async def read_bwrap_pid(info_read: int) -> int:
@@ -36,6 +39,48 @@ async def read_bwrap_pid(info_read: int) -> int:
     if document is None:
         raise RuntimeError("bubblewrap did not report its child pid")
     return int(document["child-pid"])
+
+
+async def install_identity_map(
+    info_read: int,
+    block_write: int,
+    *,
+    launcher_pid: int | None = None,
+    launcher_depth: int = 0,
+) -> int:
+    """Map every available host identity into a blocked bwrap user namespace."""
+    pid = await read_bwrap_pid(info_read)
+    if launcher_pid is not None:
+        pid = launcher_pid
+        for _ in range(launcher_depth):
+            children = Path(f"/proc/{pid}/task/{pid}/children").read_text().split()
+            if len(children) != 1:
+                raise RuntimeError(f"sandbox launcher {pid} has {len(children)} children")
+            pid = int(children[0])
+    _map_identities(pid)
+    os.write(block_write, b"\n")
+    return pid
+
+
+def _map_identities(pid: int) -> None:
+    proc = Path(f"/proc/{pid}")
+    with contextlib.suppress(OSError):
+        (proc / "setgroups").write_text("allow")
+    for name, own in (("uid_map", os.geteuid()), ("gid_map", os.getegid())):
+        identity_map = ""
+        for line in (Path("/proc/self") / name).read_text().splitlines():
+            start, _, length = line.split()
+            identity_map += f"{start} {start} {length}\n"
+        try:
+            (proc / name).write_text(identity_map)
+        except OSError:
+            if name == "gid_map":
+                with contextlib.suppress(OSError):
+                    (proc / "setgroups").write_text("deny")
+            try:
+                (proc / name).write_text(f"{own} {own} 1")
+            except OSError:
+                LOGGER.warning("could not map ids into the sandbox (%s)", name)
 
 
 class NamespaceProcess:
@@ -82,6 +127,8 @@ class NamespaceHost:
     def __init__(self, socket_path: Path) -> None:
         self.socket_path = socket_path
         self._connection: asyncssh.SSHClientConnection | None = None
+        self._listeners: list[asyncio.AbstractServer] = []
+        self._handlers: set[asyncio.Task[None]] = set()
 
     async def connect(self) -> None:
         if self._connection is not None:
@@ -101,10 +148,38 @@ class NamespaceHost:
             raise
 
     async def close(self) -> None:
+        for listener in self._listeners:
+            listener.close()
+        for handler in self._handlers:
+            handler.cancel()
+        await asyncio.gather(*self._handlers, return_exceptions=True)
+        self._handlers.clear()
+        for listener in self._listeners:
+            await listener.wait_closed()
+        self._listeners.clear()
         connection, self._connection = self._connection, None
         if connection is not None:
             connection.close()
             await connection.wait_closed()
+
+    async def forward(self, port: int) -> None:
+        async def accept(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            task = asyncio.current_task()
+            if task is not None:
+                self._handlers.add(task)
+            try:
+                await _to_unix(reader, writer, _port_socket(self.socket_path, port))
+            finally:
+                if task is not None:
+                    self._handlers.discard(task)
+
+        self._listeners.append(
+            await asyncio.start_server(
+                accept,
+                "0.0.0.0",  # noqa: S104 - publish into the substrate network
+                port,
+            )
+        )
 
     async def spawn(
         self,
@@ -150,6 +225,38 @@ class _NoAuth(asyncssh.SSHServer):
         return False
 
 
+def _port_socket(control_socket: Path, port: int) -> Path:
+    return control_socket.with_name(f"port-{port}.sock")
+
+
+async def _to_unix(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    path: Path,
+) -> None:
+    try:
+        peer_reader, peer_writer = await asyncio.open_unix_connection(path)
+    except OSError:
+        writer.close()
+        await writer.wait_closed()
+        return
+    await splice((reader, writer), (peer_reader, peer_writer))
+
+
+async def _to_port(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    port: int,
+) -> None:
+    try:
+        peer_reader, peer_writer = await asyncio.open_connection("127.0.0.1", port)
+    except OSError:
+        writer.close()
+        await writer.wait_closed()
+        return
+    await splice((reader, writer), (peer_reader, peer_writer))
+
+
 class _NamespaceHost:
     def __init__(
         self,
@@ -159,14 +266,19 @@ class _NamespaceHost:
         holder_argv: list[str],
         bwrap: str,
         launcher_depth: int,
+        map_identities: bool,
+        ports: frozenset[int],
     ) -> None:
         self.socket_path = socket_path
         self.setup_loopback = setup_loopback
         self.holder_argv = holder_argv
         self.bwrap = bwrap
         self.launcher_depth = launcher_depth
+        self.map_identities = map_identities
+        self.ports = ports
         self.holder: ProcessGroup | None = None
         self.holder_pid: int | None = None
+        self.forwarders: list[asyncio.AbstractServer] = []
 
     async def serve(self) -> None:
         server: asyncssh.SSHAcceptor | None = None
@@ -181,6 +293,21 @@ class _NamespaceHost:
             listener.listen()
             listener.setblocking(False)
             self.socket_path.chmod(0o600)
+            for port in sorted(self.ports):
+                path = _port_socket(self.socket_path, port)
+                with contextlib.suppress(FileNotFoundError):
+                    path.unlink()
+                self.forwarders.append(
+                    await asyncio.start_unix_server(
+                        lambda reader, writer, port=port: _to_port(
+                            reader,
+                            writer,
+                            port,
+                        ),
+                        path,
+                    )
+                )
+                path.chmod(0o600)
             server = await asyncssh.listen(
                 sock=listener,
                 server_host_keys=[asyncssh.generate_private_key("ssh-ed25519")],
@@ -198,6 +325,14 @@ class _NamespaceHost:
             await self.stop()
 
     async def stop(self) -> None:
+        for server in self.forwarders:
+            server.close()
+        for server in self.forwarders:
+            await server.wait_closed()
+        self.forwarders.clear()
+        for port in self.ports:
+            with contextlib.suppress(FileNotFoundError):
+                _port_socket(self.socket_path, port).unlink()
         if self.holder is not None:
             await self.holder.terminate()
             self.holder = None
@@ -218,41 +353,67 @@ class _NamespaceHost:
 
     async def _start_holder(self) -> int:
         read_fd, write_fd = os.pipe()
+        block_read = block_write = -1
         try:
             os.set_inheritable(write_fd, True)
             argv = list(self.holder_argv)
             index = argv.index(self.bwrap) + 1
             argv[index:index] = ["--info-fd", str(write_fd)]
+            if self.map_identities:
+                block_read, block_write = os.pipe()
+                os.set_inheritable(block_read, True)
+                user_index = argv.index("--unshare-user-try")
+                argv[user_index] = "--unshare-user"
+                argv[user_index + 1 : user_index + 1] = [
+                    "--userns-block-fd",
+                    str(block_read),
+                ]
             self.holder = await create_process_group_exec(
                 *argv,
                 stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                pass_fds=(write_fd,),
+                pass_fds=(write_fd, *((block_read,) if self.map_identities else ())),
             )
             os.close(write_fd)
             write_fd = -1
-            pid = await read_bwrap_pid(read_fd)
-            if self.launcher_depth:
-                pid = self.holder.process.pid
-            for _ in range(self.launcher_depth):
-                children = Path(f"/proc/{pid}/task/{pid}/children").read_text().split()
-                if len(children) != 1:
-                    raise RuntimeError(f"sandbox launcher {pid} has {len(children)} children")
-                pid = int(children[0])
+            if self.map_identities:
+                os.close(block_read)
+                block_read = -1
+                pid = await install_identity_map(
+                    read_fd,
+                    block_write,
+                    launcher_pid=self.holder.process.pid,
+                    launcher_depth=self.launcher_depth,
+                )
+                os.close(block_write)
+                block_write = -1
+            else:
+                pid = await read_bwrap_pid(read_fd)
             assert self.holder.stdout is not None
             if await asyncio.wait_for(self.holder.stdout.readline(), 30.0) != b"ready\n":
                 raise RuntimeError(await self._holder_error())
             return pid
-        except BaseException:
-            if self.holder is not None:
-                await self.holder.terminate()
-                self.holder = None
+        except BaseException as exc:
+            holder, self.holder = self.holder, None
+            if holder is not None:
+                with contextlib.suppress(Exception):
+                    await holder.terminate()
+                if holder.stderr is not None:
+                    with contextlib.suppress(Exception):
+                        detail = (
+                            (await asyncio.wait_for(holder.stderr.read(2048), 1.0))
+                            .decode(errors="replace")
+                            .strip()
+                        )
+                        if detail:
+                            exc.add_note(f"sandbox holder stderr: {detail}")
             raise
         finally:
             os.close(read_fd)
-            if write_fd != -1:
-                os.close(write_fd)
+            for descriptor in (write_fd, block_read, block_write):
+                if descriptor != -1:
+                    os.close(descriptor)
 
     async def _holder_error(self) -> str:
         if self.holder is None or self.holder.stderr is None:
@@ -378,6 +539,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("socket", type=Path)
     parser.add_argument("--setup-loopback", action="store_true")
+    parser.add_argument("--port", action="append", type=int, default=[])
     args = parser.parse_args()
     config = json.loads(sys.stdin.buffer.readline())
     asyncio.run(
@@ -387,6 +549,8 @@ def main() -> None:
             holder_argv=config["holder_argv"],
             bwrap=config["bwrap"],
             launcher_depth=config["launcher_depth"],
+            map_identities=config["map_identities"],
+            ports=frozenset(args.port),
         ).serve()
     )
 

--- a/hud/environment/namespace.py
+++ b/hud/environment/namespace.py
@@ -449,11 +449,7 @@ class _NamespaceHost:
                 "--propagation",
                 "private",
                 "--mount-proc",
-                *(
-                    ()
-                    if identity is None
-                    else ("--setgid", str(gid), "--setuid", str(uid))
-                ),
+                *(() if identity is None else ("--setgid", str(gid), "--setuid", str(uid))),
                 "--",
             ]
         argv = [

--- a/hud/environment/namespace.py
+++ b/hud/environment/namespace.py
@@ -188,6 +188,7 @@ class NamespaceHost:
         cwd: Path,
         env: dict[str, str],
         mount_view: Literal["workspace", "host"] = "workspace",
+        identity: int | tuple[int, int] | None = None,
         tty: bool = False,
         terminal_size: tuple[int, int, int, int] = (80, 24, 0, 0),
         persistent: bool = False,
@@ -199,6 +200,7 @@ class NamespaceHost:
                 "cwd": str(cwd),
                 "env": env,
                 "mount_view": mount_view,
+                "identity": identity,
                 "persistent": persistent,
             }
         )
@@ -431,6 +433,11 @@ class _NamespaceHost:
         mount_view = request["mount_view"]
         if mount_view not in ("workspace", "host"):
             raise ValueError(f"unknown mount view {mount_view!r}")
+        identity = request["identity"]
+        if isinstance(identity, int):
+            uid = gid = identity
+        elif identity is not None:
+            uid, gid = map(int, identity)
         command_prefix: list[str] = []
         if mount_view == "host":
             unshare = shutil.which("unshare")
@@ -442,6 +449,11 @@ class _NamespaceHost:
                 "--propagation",
                 "private",
                 "--mount-proc",
+                *(
+                    ()
+                    if identity is None
+                    else ("--setgid", str(gid), "--setuid", str(uid))
+                ),
                 "--",
             ]
         argv = [
@@ -452,7 +464,11 @@ class _NamespaceHost:
             "--pid",
             "--uts",
             "--ipc",
-            "--preserve-credentials",
+            *(
+                ("--preserve-credentials",)
+                if identity is None or mount_view == "host"
+                else ("--setgid", str(gid), "--setuid", str(uid))
+            ),
             "--",
             *command_prefix,
             *request["argv"],

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -519,6 +519,7 @@ async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
 
     process = await ws.launch(
         ["start-environment", "sleep", "infinity"],
+        cwd="/app",
         identity=(1000, 2000),
         no_new_privs=False,
         persistent=True,
@@ -533,6 +534,7 @@ async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
     assert "--unshare-user-try" in argv
     assert "--dev-bind" in argv
     assert "--reuid" not in argv
+    assert argv[argv.index("--chdir") + 1] == "/app"
     assert kwargs["mount_view"] == "host"
     assert kwargs["identity"] == (1000, 2000)
     assert kwargs["persistent"] is True

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -25,7 +25,7 @@ import pytest
 from hud.capabilities import SSHClient
 from hud.environment import namespace as namespace_mod
 from hud.environment import workspace as workspace_mod
-from hud.environment.egress import _field, _Unrelayable
+from hud.environment.egress import Peer, _field, _Unrelayable
 from hud.environment.workspace import Bubblewrap, Mount, Workspace
 from hud.utils.process import ProcessResult
 
@@ -468,11 +468,18 @@ async def test_visiting_uses_the_reserved_workspace_bridge(
 ) -> None:
     credentials = Path(tempfile.mkdtemp(prefix="hud-visitor-", dir="/tmp"))
     try:
-        ws = Workspace(tmp_path / "root", credentials_dir=credentials)
+        ws = Workspace(
+            tmp_path / "root",
+            peers=[Peer("db", 5432)],
+            ports=[5432],
+            credentials_dir=credentials,
+        )
         monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=7))
 
         async with ws.visiting({"pypi.org"}) as environment:
             assert environment["HTTPS_PROXY"].endswith("127.0.0.1:3129")
+            assert "db" in environment["NO_PROXY"]
+            assert "127.0.0.2" in environment["NO_PROXY"]
             assert (credentials / "visitor" / "egress.sock").is_socket()
 
         assert not (credentials / "visitor" / "egress.sock").exists()

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import itertools
+import json
 import os
 import shutil
 import socket
@@ -22,6 +23,7 @@ import asyncssh
 import pytest
 
 from hud.capabilities import SSHClient
+from hud.environment import namespace as namespace_mod
 from hud.environment import workspace as workspace_mod
 from hud.environment.egress import _field, _Unrelayable
 from hud.environment.workspace import Bubblewrap, Mount, Workspace
@@ -444,6 +446,39 @@ async def test_run_uses_fresh_mounts_and_shared_network_with_visitor_egress(
 
 
 @pytest.mark.asyncio
+async def test_visiting_none_uses_the_workspace_egress(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ws = Workspace(tmp_path / "root")
+    monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=7))
+    ws._egress = cast(
+        "Any",
+        SimpleNamespace(environment=Mock(return_value={"HTTPS_PROXY": "http://workspace"})),
+    )
+
+    async with ws.visiting(None) as environment:
+        assert environment == {"HTTPS_PROXY": "http://workspace"}
+
+
+@pytest.mark.asyncio
+async def test_visiting_uses_the_reserved_workspace_bridge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    credentials = Path(tempfile.mkdtemp(prefix="hud-visitor-", dir="/tmp"))
+    try:
+        ws = Workspace(tmp_path / "root", credentials_dir=credentials)
+        monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=7))
+
+        async with ws.visiting({"pypi.org"}) as environment:
+            assert environment["HTTPS_PROXY"].endswith("127.0.0.1:3129")
+            assert (credentials / "visitor" / "egress.sock").is_socket()
+
+        assert not (credentials / "visitor" / "egress.sock").exists()
+    finally:
+        shutil.rmtree(credentials)
+
+
+@pytest.mark.asyncio
 async def test_staged_verifier_is_launched_by_the_namespace_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -606,6 +641,55 @@ async def test_failed_sandbox_start_discards_the_holder(
     failed_holder.kill.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_staged_sandbox_hosts_the_namespace_server_outside_bwrap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ws = Workspace(tmp_path / "root", network=False)
+    monkeypatch.setattr(
+        ws,
+        "_bwrap",
+        Bubblewrap("/usr/bin/bwrap", pid_unshare="/usr/bin/unshare"),
+    )
+    stdin = SimpleNamespace(write=Mock(), drain=AsyncMock(), close=Mock())
+    sandbox = SimpleNamespace(
+        returncode=None,
+        stdin=stdin,
+        stdout=SimpleNamespace(readline=AsyncMock(return_value=b'{"holder_pid": 121}\n')),
+        stderr=SimpleNamespace(read=AsyncMock(return_value=b"")),
+    )
+    spawn = AsyncMock(return_value=sandbox)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
+    bridge = SimpleNamespace(
+        stdin=SimpleNamespace(write=Mock(), drain=AsyncMock()),
+        stdout=SimpleNamespace(readline=AsyncMock(return_value=b"ready\n")),
+        stderr=SimpleNamespace(read=AsyncMock(return_value=b"")),
+    )
+    namespace = SimpleNamespace(
+        connect=AsyncMock(),
+        forward=AsyncMock(),
+        spawn=AsyncMock(return_value=bridge),
+    )
+    monkeypatch.setattr(workspace_mod, "NamespaceHost", Mock(return_value=namespace))
+
+    assert await ws.sandbox_pid() == 121
+
+    assert spawn.await_args is not None
+    argv, _ = spawn.await_args
+    assert argv[:2] == ("/usr/bin/unshare", "--net")
+    assert "/usr/bin/bwrap" not in argv
+    config = json.loads(stdin.write.call_args.args[0])
+    assert config["holder_argv"][:5] == [
+        "/usr/bin/unshare",
+        "--kill-child=KILL",
+        "--pid",
+        "--mount-proc",
+        "/usr/bin/bwrap",
+    ]
+    assert config["map_identities"] is True
+    assert config["launcher_depth"] == 2
+
+
 def test_a_peer_answers_at_the_address_the_task_expects() -> None:
     """A task that names a service says where it expects to find it. Placed
     anywhere else, the task's own client configuration points at nothing."""
@@ -628,14 +712,19 @@ def test_a_peer_answers_at_the_address_the_task_expects() -> None:
         bind_addresses([Peer("db", 5432), Peer("db", 6379)])
 
 
-def test_a_peers_name_is_added_to_the_substrates_hosts_rather_than_replacing_it() -> None:
+def test_workspace_names_are_added_to_the_substrates_hosts_rather_than_replacing_it() -> None:
     """Dropping the substrate's entries would cost the workspace localhost."""
     from hud.environment.egress import Peer, hosts_text
 
-    text = hosts_text([Peer("db", 5432)], "127.0.0.1\tlocalhost\n::1\tip6-localhost\n")
+    text = hosts_text(
+        [Peer("db", 5432)],
+        "127.0.0.1\tlocalhost\n::1\tip6-localhost\n",
+        local_aliases=["main"],
+    )
 
     assert "127.0.0.1\tlocalhost" in text
     assert "::1\tip6-localhost" in text
+    assert "127.0.0.1\tmain" in text
     assert text.endswith("127.0.0.1\tdb\n")
 
 
@@ -648,13 +737,22 @@ async def test_a_declared_peer_is_a_name_sessions_resolve(
     of its own, since otherwise the service is already at its real address."""
     from hud.environment.egress import Peer
 
-    ws = Workspace(tmp_path / "root", peers=[Peer("db", 5432)], allowed_hosts={"pypi.org"})
+    ws = Workspace(
+        tmp_path / "root",
+        peers=[Peer("db", 5432)],
+        local_aliases=["main"],
+        allowed_hosts={"pypi.org"},
+        credentials_dir=tmp_path / "protected" / "session-keys",
+        hosts_path=tmp_path / "runtime" / "hosts",
+    )
     monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
     ws._prepare_runtime()
 
     argv = ws.bwrap_argv(["true"])
     hosts = Path(argv[argv.index("/etc/hosts") - 1])
+    assert hosts == tmp_path / "runtime" / "hosts"
     assert argv[argv.index("/etc/hosts") - 2] == "--ro-bind"
+    assert "127.0.0.1\tmain\n" in hosts.read_text()
     assert "127.0.0.1\tdb\n" in hosts.read_text()
     # Bound over /etc/hosts, so every session reads it whatever its identity.
     assert hosts.stat().st_mode & 0o044
@@ -673,11 +771,34 @@ def test_a_peer_is_reached_directly_rather_than_through_the_proxy() -> None:
     means nothing and its address is something else entirely."""
     from hud.environment.egress import Egress, Peer
 
-    egress = Egress("/tmp/unused", {"pypi.org"}, [Peer("db", 5432), Peer("replica", 5432)])
+    egress = Egress(
+        "/tmp/unused",
+        {"pypi.org"},
+        [Peer("db", 5432), Peer("replica", 5432)],
+        local_aliases=["main"],
+    )
     bypass = egress.environment()["no_proxy"].split(",")
 
+    assert "main" in bypass
     assert "db" in bypass and "replica" in bypass
     assert "127.0.0.1" in bypass and "127.0.0.2" in bypass
+
+
+def test_bridge_socket_paths_are_configuration_not_process_arguments() -> None:
+    from hud.environment.egress import Egress, Peer
+
+    egress = Egress(
+        "/media/hud/session-keys",
+        {"pypi.org"},
+        [Peer("db", 5432)],
+    )
+
+    visitor = Path("/media/hud/session-keys/visitor/egress.sock")
+    argv, config = egress.bridge_command(visitor_socket=visitor)
+
+    assert "/media/hud/session-keys" not in " ".join(argv)
+    assert "/media/hud/session-keys" in config.decode()
+    assert ["127.0.0.1", 3129, str(visitor)] in json.loads(config)
 
 
 def test_the_proxy_normalizes_http_framing_in_both_directions(
@@ -1094,13 +1215,14 @@ def test_staged_bwrap_keeps_user_isolation_and_uses_the_staged_proc(
     ]
     assert "--unshare-user-try" in argv
     assert "--unshare-pid" not in argv
-    assert "--proc" not in argv
-    assert "/proc" not in argv
+    assert "--proc" in argv
 
     joined = ws.bwrap_argv(["true"], isolate_processes=False, isolate_users=False)
     assert joined[0] == "/usr/bin/bwrap"
     assert "/usr/bin/unshare" not in joined
-    assert "--proc" not in joined
+    assert "--proc" in joined
+    dev = joined.index("--dev-bind")
+    assert joined[dev : dev + 3] == ["--dev-bind", "/dev", "/dev"]
 
 
 def test_required_isolation_refuses_when_unavailable(monkeypatch, tmp_path) -> None:
@@ -1130,8 +1252,8 @@ async def test_identity_map_reads_a_chunked_info_document() -> None:
     writer = threading.Thread(target=write_in_chunks)
     writer.start()
     try:
-        with mock.patch.object(workspace_mod, "_map_identities") as mapped:
-            pid = await workspace_mod.install_identity_map(info_read, block_write)
+        with mock.patch.object(namespace_mod, "_map_identities") as mapped:
+            pid = await namespace_mod.install_identity_map(info_read, block_write)
         assert pid == 4242
         mapped.assert_called_once_with(4242)
         assert os.read(block_read, 1) == b"\n"  # the sandbox was released
@@ -1160,11 +1282,12 @@ async def test_identity_map_resolves_a_staged_sandbox_to_its_parent_pid(
 
     monkeypatch.setattr(Path, "read_text", read_text)
     try:
-        with mock.patch.object(workspace_mod, "_map_identities") as mapped:
-            pid = await workspace_mod.install_identity_map(
+        with mock.patch.object(namespace_mod, "_map_identities") as mapped:
+            pid = await namespace_mod.install_identity_map(
                 info_read,
                 block_write,
                 launcher_pid=100,
+                launcher_depth=2,
             )
         assert pid == 121
         mapped.assert_called_once_with(121)
@@ -1194,7 +1317,7 @@ def test_identity_map_preserves_every_id_available_to_the_container(
     monkeypatch.setattr(Path, "read_text", read_text)
     monkeypatch.setattr(Path, "write_text", write_text)
 
-    workspace_mod._map_identities(42)
+    namespace_mod._map_identities(42)
 
     assert writes["/proc/42/uid_map"] == "0 0 131072\n"
     assert writes["/proc/42/gid_map"] == "0 0 65536\n70000 70000 1000\n"

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -531,8 +531,10 @@ async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
     assert argv[argv.index("--uid") + 1] == "1000"
     assert argv[argv.index("--gid") + 1] == "2000"
     assert "--unshare-user-try" in argv
+    assert "--dev-bind" in argv
     assert "--reuid" not in argv
     assert kwargs["mount_view"] == "host"
+    assert kwargs["identity"] == (1000, 2000)
     assert kwargs["persistent"] is True
 
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -520,6 +520,7 @@ async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
     process = await ws.launch(
         ["start-environment", "sleep", "infinity"],
         identity=(1000, 2000),
+        no_new_privs=False,
         persistent=True,
     )
 
@@ -527,8 +528,10 @@ async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
     assert spawn.await_args is not None
     (argv,), kwargs = spawn.await_args
     assert argv[0] == "/usr/bin/bwrap"
-    assert argv[argv.index("--reuid") + 1] == "1000"
-    assert argv[argv.index("--regid") + 1] == "2000"
+    assert argv[argv.index("--uid") + 1] == "1000"
+    assert argv[argv.index("--gid") + 1] == "2000"
+    assert "--unshare-user-try" in argv
+    assert "--reuid" not in argv
     assert kwargs["mount_view"] == "host"
     assert kwargs["persistent"] is True
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -547,7 +547,11 @@ async def test_run_can_use_a_fresh_no_network_sandbox(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     ws = Workspace(tmp_path / "root")
-    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
+    monkeypatch.setattr(
+        ws,
+        "_bwrap",
+        Bubblewrap("/usr/bin/bwrap", pid_unshare="/usr/bin/unshare"),
+    )
     install_identity_map = AsyncMock(return_value=9)
     complete = AsyncMock(return_value=ProcessResult(0, b"isolated", b""))
     spawn = AsyncMock(return_value=SimpleNamespace(complete=complete))
@@ -567,6 +571,8 @@ async def test_run_can_use_a_fresh_no_network_sandbox(
     install_identity_map.assert_awaited_once()
     assert spawn.await_args is not None
     argv, kwargs = spawn.await_args
+    assert argv[0] == "/usr/bin/bwrap"
+    assert "/usr/bin/unshare" not in argv
     assert "--unshare-net" in argv
     assert len(kwargs["pass_fds"]) == 2
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -726,6 +726,9 @@ def test_a_peer_answers_at_the_address_the_task_expects() -> None:
     both = bind_addresses([Peer("primary", 5432), Peer("replica", 5432)])
     assert both == {"primary": "127.0.0.1", "replica": "127.0.0.2"}
 
+    reserved = bind_addresses([Peer("api", 8080)], reserved_ports={8080})
+    assert reserved == {"api": "127.0.0.2"}
+
     proxies = bind_addresses([Peer("agent", 3128), Peer("verifier", 3129)])
     assert proxies == {"agent": "127.0.0.2", "verifier": "127.0.0.2"}
 
@@ -762,6 +765,7 @@ async def test_a_declared_peer_is_a_name_sessions_resolve(
         tmp_path / "root",
         peers=[Peer("db", 5432)],
         local_aliases=["main"],
+        ports=[5432],
         allowed_hosts={"pypi.org"},
         credentials_dir=tmp_path / "protected" / "session-keys",
         hosts_path=tmp_path / "runtime" / "hosts",
@@ -774,7 +778,7 @@ async def test_a_declared_peer_is_a_name_sessions_resolve(
     assert hosts == tmp_path / "runtime" / "hosts"
     assert argv[argv.index("/etc/hosts") - 2] == "--ro-bind"
     assert "127.0.0.1\tmain\n" in hosts.read_text()
-    assert "127.0.0.1\tdb\n" in hosts.read_text()
+    assert "127.0.0.2\tdb\n" in hosts.read_text()
     # Bound over /etc/hosts, so every session reads it whatever its identity.
     assert hosts.stat().st_mode & 0o044
 
@@ -812,6 +816,7 @@ def test_bridge_socket_paths_are_configuration_not_process_arguments() -> None:
         "/media/hud/session-keys",
         {"pypi.org"},
         [Peer("db", 5432)],
+        reserved_ports={5432},
     )
 
     visitor = Path("/media/hud/session-keys/visitor/egress.sock")
@@ -819,7 +824,9 @@ def test_bridge_socket_paths_are_configuration_not_process_arguments() -> None:
 
     assert "/media/hud/session-keys" not in " ".join(argv)
     assert "/media/hud/session-keys" in config.decode()
-    assert ["127.0.0.1", 3129, str(visitor)] in json.loads(config)
+    routes = json.loads(config)
+    assert ["127.0.0.1", 3129, str(visitor)] in routes
+    assert ["127.0.0.2", 5432, "/media/hud/session-keys/peer-0.sock"] in routes
 
 
 def test_the_proxy_normalizes_http_framing_in_both_directions(

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -339,6 +339,8 @@ def test_hosted_sessions_do_not_create_new_namespaces(
         assert "--unshare-pid" not in argv
         assert "--unshare-net" not in argv
         assert "--die-with-parent" not in argv
+        dev = argv.index("--dev-bind")
+        assert argv[dev : dev + 3] == ["--dev-bind", "/dev", "/dev"]
         assert argv.count("--cap-drop") == 3
         assert argv[argv.index("--chdir") + 1] == "/app"
 
@@ -692,6 +694,12 @@ async def test_staged_sandbox_hosts_the_namespace_server_outside_bwrap(
         "--pid",
         "--mount-proc",
         "/usr/bin/bwrap",
+    ]
+    holder_dev = config["holder_argv"].index("--dev-bind")
+    assert config["holder_argv"][holder_dev : holder_dev + 3] == [
+        "--dev-bind",
+        "/dev",
+        "/dev",
     ]
     assert config["map_identities"] is True
     assert config["launcher_depth"] == 2

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -513,7 +513,7 @@ async def test_staged_verifier_is_launched_by_the_namespace_host(
 
 
 @pytest.mark.asyncio
-async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
+async def test_launch_keeps_an_environment_entrypoint_outside_agent_sessions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     ws = Workspace(tmp_path / "root")
@@ -532,6 +532,7 @@ async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
         identity=(1000, 2000),
         no_new_privs=False,
         persistent=True,
+        scope="environment",
     )
 
     assert process is launched
@@ -547,6 +548,19 @@ async def test_launch_keeps_an_environment_entrypoint_in_the_sandbox(
     assert kwargs["mount_view"] == "host"
     assert kwargs["identity"] == (1000, 2000)
     assert kwargs["persistent"] is True
+    assert kwargs["scope"] == "environment"
+
+
+@pytest.mark.asyncio
+async def test_terminate_sessions_preserves_the_namespace_host(tmp_path: Path) -> None:
+    ws = Workspace(tmp_path / "root")
+    terminate_sessions = AsyncMock()
+    ws._namespace = cast("Any", SimpleNamespace(terminate_sessions=terminate_sessions))
+
+    await ws.terminate_sessions()
+
+    terminate_sessions.assert_awaited_once_with()
+    assert ws._namespace is not None
 
 
 @pytest.mark.asyncio

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -714,6 +714,7 @@ class Workspace:
         isolated: bool = False,
         mounts: Sequence[Mount] | None = None,
         env: Mapping[str, str] | None = None,
+        cwd: str | None = None,
         identity: int | tuple[int, int] | None | Literal["workspace"] = "workspace",
         inherit_workspace_env: bool = True,
         allowed_hosts: Collection[str] | None = (),
@@ -742,6 +743,7 @@ class Workspace:
                     command,
                     mounts=mounts,
                     env=process_env,
+                    cwd=cwd,
                     identity=identity,
                     inherit_workspace_env=inherit_workspace_env,
                     no_new_privs=no_new_privs,
@@ -768,6 +770,7 @@ class Workspace:
             process = await create_process_group_exec(
                 *self.bwrap_argv(
                     payload,
+                    cwd=cwd,
                     env=process_env,
                     # Same environment the joined branch gives a command (the
                     # serving process's, less HUD's own): a command must not
@@ -813,6 +816,7 @@ class Workspace:
         *,
         mounts: Sequence[Mount] | None = None,
         env: Mapping[str, str] | None = None,
+        cwd: str | None = None,
         identity: int | tuple[int, int] | None | Literal["workspace"] = "workspace",
         inherit_workspace_env: bool = True,
         no_new_privs: bool = True,
@@ -834,6 +838,7 @@ class Workspace:
         return await self._namespace.spawn(
             self.bwrap_argv(
                 payload,
+                cwd=cwd,
                 env=process_env,
                 inherit_host_env=True,
                 inherit_workspace_env=inherit_workspace_env,

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -1074,6 +1074,7 @@ class Workspace:
                 _SANDBOX_HOLDER,
                 network=True,
                 isolate_users=staged,
+                bind_devices=True,
             )
             socket_path = self._credentials_dir() / "namespace.sock"
             host_argv = [
@@ -1111,7 +1112,8 @@ class Workspace:
                     "--bind",
                     "/",
                     "/",
-                    "--dev",
+                    "--dev-bind",
+                    "/dev",
                     "/dev",
                     "--",
                 ]
@@ -1292,6 +1294,9 @@ class Workspace:
             "--bind",
             "/",
             "/",
+            "--dev-bind",
+            "/dev",
+            "/dev",
             "--chdir",
             target_cwd,
             "--",

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -466,6 +466,7 @@ class Workspace:
                 VISITOR_PORT,
                 self.peers,
                 local_aliases=self.local_aliases,
+                reserved_ports=self.ports,
                 token=token,
             )
         finally:

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -721,6 +721,7 @@ class Workspace:
         allowed_hosts: Collection[str] | None = (),
         no_new_privs: bool = True,
         max_wait: float | None = None,
+        scope: Literal["session", "environment"] = "session",
     ) -> ProcessResult:
         """Run a captured command against this workspace.
 
@@ -748,6 +749,7 @@ class Workspace:
                     identity=identity,
                     inherit_workspace_env=inherit_workspace_env,
                     no_new_privs=no_new_privs,
+                    scope=scope,
                 )
                 return await process.complete(max_wait=max_wait)
 
@@ -822,8 +824,9 @@ class Workspace:
         inherit_workspace_env: bool = True,
         no_new_privs: bool = True,
         persistent: bool = False,
+        scope: Literal["session", "environment"] = "session",
     ) -> NamespaceProcess:
-        """Launch a process in the persistent workspace sandbox."""
+        """Launch a process in the workspace network and selected process scope."""
         if await self.sandbox_pid() is None:
             raise RuntimeError("workspace commands require a live sandbox")
         assert self._namespace is not None
@@ -855,6 +858,7 @@ class Workspace:
             mount_view="host",
             identity=bwrap_identity,
             persistent=persistent,
+            scope=scope,
         )
 
     # ─── argv builders (public — useful if you want your own subprocess) ──
@@ -1176,6 +1180,7 @@ class Workspace:
                     cwd=self.root,
                     env=dict(os.environ),
                     mount_view="host",
+                    scope="environment",
                 )
                 self._bridge.stdin.write(config)
                 await self._bridge.stdin.drain()
@@ -1223,6 +1228,11 @@ class Workspace:
         sandbox.kill()
         with contextlib.suppress(Exception):
             await asyncio.wait_for(sandbox.wait(), 10.0)
+
+    async def terminate_sessions(self) -> None:
+        """Kill the agent-visible PID namespace while preserving its environment."""
+        if self._namespace is not None:
+            await self._namespace.terminate_sessions()
 
     def shell_argv(
         self,

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -841,11 +841,13 @@ class Workspace:
                 isolate_processes=False,
                 isolate_users=bwrap_identity is not None,
                 identity=bwrap_identity,
+                bind_devices=True,
                 mounts=mounts,
             ),
             cwd=self.root,
             env={**os.environ, **process_env},
             mount_view="host",
+            identity=bwrap_identity,
             persistent=persistent,
         )
 
@@ -870,6 +872,7 @@ class Workspace:
         isolate_processes: bool = True,
         isolate_users: bool = True,
         identity: int | tuple[int, int] | None = None,
+        bind_devices: bool | None = None,
         mounts: Sequence[Mount] | None = None,
         tty: bool = False,
     ) -> list[str]:
@@ -929,11 +932,12 @@ class Workspace:
             argv.extend(["--info-fd", str(info_fd)])
         if userns_block_fd is not None:
             argv.extend(["--userns-block-fd", str(userns_block_fd)])
+        bind_host_devices = not isolate_users if bind_devices is None else bind_devices
         for mount in self._system_mounts:
-            argv.extend(mount.to_bwrap_args(bind_devices=not isolate_users))
+            argv.extend(mount.to_bwrap_args(bind_devices=bind_host_devices))
         argv.extend(["--bind", str(self.root), self._guest_path])
         for m in self.mounts if mounts is None else mounts:
-            argv.extend(m.to_bwrap_args(bind_devices=not isolate_users))
+            argv.extend(m.to_bwrap_args(bind_devices=bind_host_devices))
         if mount_hosts and self._hosts_path is not None:
             # Last, so it survives whatever the caller mounted over /etc: a
             # peer the task can address by port but not by name is not at the

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal
 import asyncssh
 
 from hud.environment.egress import VISITOR_PORT, Egress, Peer, hosts_text, proxy_environment
-from hud.environment.namespace import NamespaceHost, NamespaceProcess, read_bwrap_pid
+from hud.environment.namespace import NamespaceHost, NamespaceProcess, install_identity_map
 from hud.utils.process import ProcessGroup, ProcessResult, create_process_group_exec
 
 if sys.platform != "win32":  # the pty a session runs on has no Windows analogue
@@ -162,7 +162,9 @@ class Mount:
     dst: str = ""
     optional: bool = False
 
-    def to_bwrap_args(self) -> list[str]:
+    def to_bwrap_args(self, *, bind_devices: bool = False) -> list[str]:
+        if self.kind == "dev" and bind_devices:
+            return ["--dev-bind", "/dev", self.dst]
         normal, optional_flag, takes_src = _MOUNT_FLAGS[self.kind]
         flag = optional_flag if (self.optional and optional_flag) else normal
         return [flag, self.src, self.dst] if takes_src else [flag, self.dst]
@@ -223,68 +225,6 @@ def _env_argv(env: Mapping[str, str]) -> list[str]:
     """
     env_bin = shutil.which("env") or "/usr/bin/env"
     return [env_bin, "-i", *(f"{k}={v}" for k, v in env.items())]
-
-
-async def install_identity_map(
-    info_read: int,
-    block_write: int,
-    *,
-    launcher_pid: int | None = None,
-) -> int:
-    """Map ids into a bwrap held at ``--userns-block-fd``, and release it.
-
-    The counterpart to spawning with ``--info-fd``/``--userns-block-fd``:
-    bwrap reports the pid of the namespace it made and waits, this side says
-    who its ids are, and only then does anything run in it. Returns that pid.
-    """
-    pid = await read_bwrap_pid(info_read)
-    if pid and launcher_pid is not None:
-        pid = launcher_pid
-        for _ in range(2):
-            children = Path(f"/proc/{pid}/task/{pid}/children").read_text().split()
-            if len(children) != 1:
-                raise RuntimeError(
-                    f"sandbox launcher {pid} has {len(children)} children; expected one"
-                )
-            pid = int(children[0])
-    if pid:
-        _map_identities(pid)
-    os.write(block_write, b"\n")
-    return pid
-
-
-def _map_identities(pid: int) -> None:
-    """Give the sandbox every id available to the container that created it.
-
-    Left to itself bwrap maps one id, so every file owned by anyone else is
-    ``nobody`` inside — unreadable, unwritable, not even chownable by the
-    sandbox's own root. That is most of an image whose task runs as a non-root
-    user: the agent cannot write its own working directory, and no session can
-    drop to an id the map does not contain. Writing the map from out here
-    needs CAP_SETUID/CAP_SETGID in *this* namespace, which a container's root
-    holds by default. Where the kernel refuses, fall back to the single id
-    bwrap would have mapped: a narrow map is workable, an absent one is not.
-    """
-    proc = Path(f"/proc/{pid}")
-    with contextlib.suppress(OSError):
-        (proc / "setgroups").write_text("allow")
-    for name, own in (("uid_map", os.geteuid()), ("gid_map", os.getegid())):
-        identity_map = ""
-        for line in (Path("/proc/self") / name).read_text().splitlines():
-            start, _, length = line.split()
-            identity_map += f"{start} {start} {length}\n"
-        try:
-            (proc / name).write_text(identity_map)
-        except OSError:
-            if name == "gid_map":
-                # Giving up supplementary groups is the kernel's price for
-                # writing gid_map without the capability.
-                with contextlib.suppress(OSError):
-                    (proc / "setgroups").write_text("deny")
-            try:
-                (proc / name).write_text(f"{own} {own} 1")
-            except OSError:
-                LOGGER.warning("could not map ids into the sandbox (%s)", name)
 
 
 def _open_pty(process: asyncssh.SSHServerProcess[bytes]) -> tuple[int, int]:
@@ -381,6 +321,8 @@ class Workspace:
         network: bool = False,
         allowed_hosts: Collection[str] | None = None,
         peers: Sequence[Peer] = (),
+        local_aliases: Collection[str] = (),
+        ports: Collection[int] = (),
         env: Mapping[str, str] | None = None,
         system_mounts: Sequence[Mount] | None = None,
         guest_path: str = "/workspace",
@@ -395,12 +337,14 @@ class Workspace:
         shell_gid: int | None = None,
         require_isolation: bool = False,
         credentials_dir: Path | str | None = None,
+        hosts_path: Path | str | None = None,
         hand_over_root: bool = True,
     ) -> None:
         self.root: Path = Path(root).resolve()
         # Per-instance credential dir, materialized lazily (see _credentials_dir).
         self._cred_dir: Path | None = None
         self._configured_cred_dir = Path(credentials_dir) if credentials_dir else None
+        self._configured_hosts_path = Path(hosts_path) if hosts_path else None
 
         # Path the root is mounted at inside the sandbox (and the default cwd).
         # Defaults to /workspace; set to the root's real path for callers that
@@ -425,6 +369,8 @@ class Workspace:
         #: named here to exist for it. Nothing to do where sessions share the
         #: substrate's network: the services are already at those addresses.
         self.peers: tuple[Peer, ...] = tuple(peers)
+        self.local_aliases = frozenset(local_aliases)
+        self.ports = frozenset(ports)
         self._egress: Egress | None = None
         # The workspace's own /etc/hosts (the substrate's, plus its peers),
         # materialized alongside the session keys when there is one to write.
@@ -486,7 +432,7 @@ class Workspace:
         self._sandbox_lock = asyncio.Lock()
 
     @contextlib.asynccontextmanager
-    async def visiting(self, allowed: Collection[str]) -> AsyncIterator[dict[str, str]]:
+    async def visiting(self, allowed: Collection[str] | None) -> AsyncIterator[dict[str, str]]:
         """A way out for a process joining this network without being a session.
 
         Yields the proxy variables it should run under. A visitor is behind the
@@ -501,31 +447,28 @@ class Workspace:
         The agent's sessions share this network, so a second and more permissive
         way out that stood open would be one the agent could simply take.
         """
-        if await self.sandbox_pid() is None or not self.owns_netns or not allowed:
+        if await self.sandbox_pid() is None or not self.owns_netns:
             yield {}
             return
-        assert self._namespace is not None
-        namespace = self._namespace
+        if allowed is None:
+            yield self._egress.environment() if self._egress is not None else {}
+            return
+        if not allowed:
+            yield {}
+            return
         token = secrets.token_urlsafe(32)
-        egress = Egress(self._credentials_dir() / "visit", allowed, token=token)
+        egress = Egress(self._credentials_dir() / "visitor", allowed, token=token)
         egress.start()
-        bridge: NamespaceProcess | None = None
         try:
-            bridge = await namespace.spawn(
-                egress.bridge_argv(VISITOR_PORT),
-                cwd=self.root,
-                env=dict(os.environ),
-                mount_view="host",
-            )
-            if await asyncio.wait_for(bridge.stdout.readline(), 30.0) != b"ready\n":
-                detail = (await bridge.stderr.read(2048)).decode(errors="replace").strip()
-                raise RuntimeError(detail or "visitor bridge did not become ready")
             # The peers are the workspace's, bound by its own bridge: a visitor
             # reaches them at those addresses, so they stay out of its proxy.
-            yield proxy_environment(VISITOR_PORT, self.peers, token=token)
+            yield proxy_environment(
+                VISITOR_PORT,
+                self.peers,
+                local_aliases=self.local_aliases,
+                token=token,
+            )
         finally:
-            if bridge is not None:
-                await bridge.terminate()
             egress.stop()
 
     @property
@@ -602,7 +545,7 @@ class Workspace:
                 os.lchown(self.root, self._shell_uid, gid)
         self._host_key, self._host_pubkey_str = self._load_or_generate_host_key()
         self._authorized_keys_path = self._ensure_authorized_keys_file()
-        if self.peers and self.owns_netns and self._bwrap is not None:
+        if (self.peers or self.local_aliases) and self.owns_netns and self._bwrap is not None:
             self._hosts_path = self._write_hosts()
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -690,6 +633,10 @@ class Workspace:
         self._sock = None
         self._bound_host = None
         self._bound_port = None
+        if self._hosts_path is not None:
+            with contextlib.suppress(FileNotFoundError):
+                self._hosts_path.unlink()
+            self._hosts_path = None
         if self._cred_dir is not None:
             shutil.rmtree(self._cred_dir, ignore_errors=True)
             self._cred_dir = None
@@ -769,7 +716,7 @@ class Workspace:
         env: Mapping[str, str] | None = None,
         identity: int | tuple[int, int] | None | Literal["workspace"] = "workspace",
         inherit_workspace_env: bool = True,
-        allowed_hosts: Collection[str] = (),
+        allowed_hosts: Collection[str] | None = (),
         no_new_privs: bool = True,
         max_wait: float | None = None,
     ) -> ProcessResult:
@@ -837,11 +784,7 @@ class Workspace:
             os.close(info_write)
             os.close(block_read)
             info_write = block_read = -1
-            await install_identity_map(
-                info_read,
-                block_write,
-                launcher_pid=(process.process.pid if bwrap.pid_unshare is not None else None),
-            )
+            await install_identity_map(info_read, block_write)
         except BaseException:
             if process is not None:
                 await process.terminate()
@@ -963,12 +906,10 @@ class Workspace:
         if userns_block_fd is not None:
             argv.extend(["--userns-block-fd", str(userns_block_fd)])
         for mount in self._system_mounts:
-            if self._bwrap.pid_unshare is not None and mount.kind == "proc":
-                continue
-            argv.extend(mount.to_bwrap_args())
+            argv.extend(mount.to_bwrap_args(bind_devices=not isolate_users))
         argv.extend(["--bind", str(self.root), self._guest_path])
         for m in self.mounts if mounts is None else mounts:
-            argv.extend(m.to_bwrap_args())
+            argv.extend(m.to_bwrap_args(bind_devices=not isolate_users))
         if mount_hosts and self._hosts_path is not None:
             # Last, so it survives whatever the caller mounted over /etc: a
             # peer the task can address by port but not by name is not at the
@@ -1087,20 +1028,42 @@ class Workspace:
         bwrap = self._bwrap
         assert bwrap is not None
         try:
-            if self.owns_netns and (self.allowed_hosts or self.peers):
-                self._egress = Egress(self._credentials_dir(), self.allowed_hosts or (), self.peers)
+            if self.owns_netns:
+                self._egress = Egress(
+                    self._credentials_dir(),
+                    self.allowed_hosts or (),
+                    self.peers,
+                    local_aliases=self.local_aliases,
+                )
                 self._egress.start()
+            staged = bwrap.pid_unshare is not None
             holder_argv = self.bwrap_argv(
                 _SANDBOX_HOLDER,
                 network=True,
-                isolate_users=False,
+                isolate_users=staged,
             )
-            read_fd, write_fd = os.pipe()
-            block_read, block_write = os.pipe()
-            try:
-                os.set_inheritable(write_fd, True)
-                os.set_inheritable(block_read, True)
-                socket_path = self._credentials_dir() / "namespace.sock"
+            socket_path = self._credentials_dir() / "namespace.sock"
+            host_argv = [
+                sys.executable,
+                str(Path(__file__).with_name("namespace.py")),
+                str(socket_path),
+                *(("--setup-loopback",) if self.owns_netns else ()),
+                *(value for port in sorted(self.ports) for value in ("--port", str(port))),
+            ]
+            if staged:
+                argv = [
+                    *((bwrap.pid_unshare, "--net") if self.owns_netns else ()),
+                    *host_argv,
+                ]
+                self._sandbox = await asyncio.create_subprocess_exec(
+                    *argv,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            else:
+                read_fd, write_fd = os.pipe()
+                block_read, block_write = os.pipe()
                 argv = [
                     bwrap.path,
                     "--die-with-parent",
@@ -1115,6 +1078,8 @@ class Workspace:
                     "--bind",
                     "/",
                     "/",
+                    "--dev",
+                    "/dev",
                     "--",
                 ]
                 if self.owns_netns:
@@ -1122,38 +1087,35 @@ class Workspace:
                     if unshare is None:
                         raise RuntimeError("workspace network isolation requires unshare")
                     argv.extend([unshare, "--net"])
-                argv.extend(
-                    [
-                        sys.executable,
-                        str(Path(__file__).with_name("namespace.py")),
-                        str(socket_path),
-                        *(("--setup-loopback",) if self.owns_netns else ()),
-                    ]
-                )
-                self._sandbox = await asyncio.create_subprocess_exec(
-                    *argv,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    pass_fds=(write_fd, block_read),
-                )
-                os.close(write_fd)
-                os.close(block_read)
-                write_fd = block_read = -1
-                await install_identity_map(read_fd, block_write)
-            finally:
-                os.close(read_fd)
-                os.close(block_write)
-                for stray in (write_fd, block_read):
-                    if stray != -1:
-                        os.close(stray)
+                argv.extend(host_argv)
+                try:
+                    os.set_inheritable(write_fd, True)
+                    os.set_inheritable(block_read, True)
+                    self._sandbox = await asyncio.create_subprocess_exec(
+                        *argv,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        pass_fds=(write_fd, block_read),
+                    )
+                    os.close(write_fd)
+                    os.close(block_read)
+                    write_fd = block_read = -1
+                    await install_identity_map(read_fd, block_write)
+                finally:
+                    os.close(read_fd)
+                    os.close(block_write)
+                    for stray in (write_fd, block_read):
+                        if stray != -1:
+                            os.close(stray)
             assert self._sandbox.stdin is not None and self._sandbox.stdout is not None
             self._sandbox.stdin.write(
                 json.dumps(
                     {
                         "holder_argv": holder_argv,
                         "bwrap": bwrap.path,
-                        "launcher_depth": 2 if bwrap.pid_unshare is not None else 0,
+                        "launcher_depth": 2 if staged else 0,
+                        "map_identities": staged,
                     }
                 ).encode()
                 + b"\n"
@@ -1166,13 +1128,20 @@ class Workspace:
             pid = int(json.loads(ready)["holder_pid"])
             self._namespace = NamespaceHost(socket_path)
             await self._namespace.connect()
+            for port in sorted(self.ports):
+                await self._namespace.forward(port)
             if self._egress is not None:
+                argv, config = self._egress.bridge_command(
+                    visitor_socket=self._credentials_dir() / "visitor" / "egress.sock"
+                )
                 self._bridge = await self._namespace.spawn(
-                    self._egress.bridge_argv(),
+                    argv,
                     cwd=self.root,
                     env=dict(os.environ),
                     mount_view="host",
                 )
+                self._bridge.stdin.write(config)
+                await self._bridge.stdin.drain()
                 if await asyncio.wait_for(self._bridge.stdout.readline(), 30.0) != b"ready\n":
                     detail = (await self._bridge.stderr.read(2048)).decode(errors="replace").strip()
                     raise RuntimeError(detail or "workspace bridge did not become ready")
@@ -1323,14 +1292,20 @@ class Workspace:
     def _write_hosts(self) -> Path:
         """The workspace's own ``/etc/hosts``: the substrate's, plus its peers.
 
-        World-readable, unlike the rest of the credentials directory: it is
-        bound over ``/etc/hosts`` inside the sandbox, where every session —
-        including one dropped to an id of its own — resolves names from it.
+        It is bound read-only over ``/etc/hosts`` inside the sandbox, where
+        every session resolves names from it. Callers which protect credentials
+        at a recognizable path can place this non-secret file separately so
+        process arguments do not disclose that path.
         """
         substrate = Path("/etc/hosts")
-        path = self._credentials_dir() / "hosts"
+        path = self._configured_hosts_path or self._credentials_dir() / "hosts"
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
-            hosts_text(self.peers, substrate.read_text() if substrate.is_file() else ""),
+            hosts_text(
+                self.peers,
+                substrate.read_text() if substrate.is_file() else "",
+                local_aliases=sorted(self.local_aliases),
+            ),
             encoding="utf-8",
         )
         path.chmod(0o644)
@@ -1577,7 +1552,10 @@ class Workspace:
                 pass
             finally:
                 with contextlib.suppress(Exception):
-                    stdin_writer.close()
+                    if isinstance(sub, NamespaceProcess):
+                        stdin_writer.write_eof()
+                    else:
+                        stdin_writer.close()
 
         async def relay_output(
             reader: asyncio.StreamReader | asyncssh.SSHReader[bytes],

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -1067,6 +1067,7 @@ class Workspace:
                     self.allowed_hosts or (),
                     self.peers,
                     local_aliases=self.local_aliases,
+                    reserved_ports=self.ports,
                 )
                 self._egress.start()
             staged = bwrap.pid_unshare is not None
@@ -1343,6 +1344,7 @@ class Workspace:
                 self.peers,
                 substrate.read_text() if substrate.is_file() else "",
                 local_aliases=sorted(self.local_aliases),
+                reserved_ports=self.ports,
             ),
             encoding="utf-8",
         )

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -754,12 +754,20 @@ class Workspace:
         info_read, info_write = os.pipe()
         block_read, block_write = os.pipe()
         process: ProcessGroup | NamespaceProcess | None = None
+        bwrap_identity = (
+            identity if isinstance(identity, int | tuple) and not no_new_privs else None
+        )
+        payload = (
+            command
+            if bwrap_identity is not None
+            else [*self._identity_argv(identity, no_new_privs=no_new_privs), *command]
+        )
         try:
             os.set_inheritable(info_write, True)
             os.set_inheritable(block_read, True)
             process = await create_process_group_exec(
                 *self.bwrap_argv(
-                    [*self._identity_argv(identity, no_new_privs=no_new_privs), *command],
+                    payload,
                     env=process_env,
                     # Same environment the joined branch gives a command (the
                     # serving process's, less HUD's own): a command must not
@@ -773,6 +781,7 @@ class Workspace:
                     network=False,
                     mount_hosts=False,
                     isolate_processes=False,
+                    identity=bwrap_identity,
                     mounts=mounts,
                 ),
                 cwd=self.root,
@@ -814,15 +823,24 @@ class Workspace:
             raise RuntimeError("workspace commands require a live sandbox")
         assert self._namespace is not None
         process_env = dict(env or {})
+        bwrap_identity = (
+            identity if isinstance(identity, int | tuple) and not no_new_privs else None
+        )
+        payload = (
+            command
+            if bwrap_identity is not None
+            else [*self._identity_argv(identity, no_new_privs=no_new_privs), *command]
+        )
         return await self._namespace.spawn(
             self.bwrap_argv(
-                [*self._identity_argv(identity, no_new_privs=no_new_privs), *command],
+                payload,
                 env=process_env,
                 inherit_host_env=True,
                 inherit_workspace_env=inherit_workspace_env,
                 network=True,
                 isolate_processes=False,
-                isolate_users=False,
+                isolate_users=bwrap_identity is not None,
+                identity=bwrap_identity,
                 mounts=mounts,
             ),
             cwd=self.root,
@@ -851,6 +869,7 @@ class Workspace:
         mount_hosts: bool = True,
         isolate_processes: bool = True,
         isolate_users: bool = True,
+        identity: int | tuple[int, int] | None = None,
         mounts: Sequence[Mount] | None = None,
         tty: bool = False,
     ) -> list[str]:
@@ -878,6 +897,11 @@ class Workspace:
             # Blocking means this side installs the map, so the namespace has
             # to be ours to map: --unshare-user, not the best-effort form.
             argv.append("--unshare-user" if userns_block_fd is not None else "--unshare-user-try")
+            if identity is not None:
+                uid, gid = identity if isinstance(identity, tuple) else (identity, identity)
+                argv.extend(["--uid", str(uid), "--gid", str(gid)])
+        elif identity is not None:
+            raise ValueError("a bwrap identity requires a fresh user namespace")
         # A namespace-root session must not be able to inspect or redirect the
         # authenticated verifier route while both briefly share its network.
         argv.extend(

--- a/hud/eval/compose.py
+++ b/hud/eval/compose.py
@@ -85,6 +85,7 @@ class ComposeService(BaseModel):
     healthcheck: ComposeHealthcheck | None = None
     expose: list[str] = Field(default_factory=list)
     ports: list[ComposePort] = Field(default_factory=list)
+    volumes: list[str | dict[str, Any]] = Field(default_factory=list)
 
     def with_image(self, image: str, config: ImageConfig) -> ComposeService:
         entrypoint = (config.entrypoint or []) if self.entrypoint is None else self.entrypoint

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -470,6 +470,10 @@ async def rollout(
                         _phase = "grading"
 
                     verifier = task.verifier
+                    if verifier is not None:
+                        # The verifier is authoritative. Once its phase begins,
+                        # an actor-side grade must not survive a verifier failure.
+                        live.grade = Grade()
                     if (
                         verifier is not None
                         and verifier.env == task.env

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -479,7 +479,7 @@ async def rollout(
                     client = verifier_client
                     _phase = "verifying"
                     await _verify(live, verifier_client, verifier)
-            _phase = "cleanup"
+                    _phase = "cleanup"
 
         driver = asyncio.create_task(_drive())
         try:

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from hud.agents.base import Agent
     from hud.clients.client import HudClient
 
-    from .runtime import Provider, Runtime
+    from .runtime import Provider
     from .task import Task
 
 logger = logging.getLogger("hud.eval.run")
@@ -314,6 +314,42 @@ class Run:
         return run
 
 
+async def _verify(run: Run, client: HudClient, task: Task) -> None:
+    """Run an agent-less verifier task and make its evaluation authoritative."""
+    started_at = now_iso()
+    started = await client.start_task(task.id, task.args)
+    run.record(
+        Step(
+            source="task",
+            task_call=TaskCall(
+                phase="setup",
+                name=task.id,
+                arguments=task.args,
+                result=started,
+            ),
+            started_at=started_at,
+        )
+    )
+
+    answer = {"answer": run.trace.content}
+    started_at = now_iso()
+    evaluation = await client.grade(answer)
+    run.grade = Grade.from_dict(evaluation)
+    run.record(
+        Step(
+            source="task",
+            task_call=TaskCall(
+                phase="evaluate",
+                name=task.id,
+                arguments=answer,
+                result=evaluation,
+            ),
+            started_at=started_at,
+            error=run.grade.content if run.grade.is_error else None,
+        )
+    )
+
+
 async def rollout(
     task: Task,
     agent: Agent,
@@ -383,17 +419,16 @@ async def rollout(
 
         async def _drive() -> None:
             nonlocal client, run, _phase
-            async with contextlib.AsyncExitStack() as stack:
-                addr = cast("Runtime", await stack.enter_async_context(runtime(task)))
+            async with runtime(task) as addr:
                 _phase = "starting task"
-                client = cast("HudClient", await stack.enter_async_context(connect(addr)))
-                live = Run(client, task.id, task.args)
-                live._runtime = addr.url  # the placement record for the receipt
-                try:
-                    async with live:  # start on enter; grade on exit
+                async with connect(addr) as actor_client:
+                    client = actor_client
+                    live = Run(actor_client, task.id, task.args)
+                    live._runtime = addr.url  # the placement record for the receipt
+                    async with live:  # start on enter; complete on exit
                         run = live  # bound only once live: an earlier failure synthesizes
                         _phase = "agent loop"
-                        async with file_tracking_observer(client):
+                        async with file_tracking_observer(actor_client):
                             if agent_timeout is None:
                                 await agent(run)
                             else:
@@ -410,8 +445,33 @@ async def rollout(
                                     run.trace.stop_reason = "timeout"
                                     run.record(Step(source="system", error=detail))
                         _phase = "grading"
-                finally:
-                    _phase = "cleanup"
+
+                    verifier = task.verifier
+                    if (
+                        verifier is not None
+                        and verifier.env == task.env
+                        and verifier.runtime_config is None
+                    ):
+                        _phase = "verifying"
+                        live.grade = Grade()
+                        await _verify(live, actor_client, verifier)
+                        _phase = "cleanup"
+                        return
+
+                _phase = "cleanup"
+
+            verifier = task.verifier
+            if verifier is not None:
+                _phase = "provisioning verifier"
+                live.grade = Grade()
+                async with (
+                    runtime(verifier) as verifier_addr,
+                    connect(verifier_addr) as verifier_client,
+                ):
+                    client = verifier_client
+                    _phase = "verifying"
+                    await _verify(live, verifier_client, verifier)
+            _phase = "cleanup"
 
         driver = asyncio.create_task(_drive())
         try:

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -428,22 +428,30 @@ async def rollout(
                     async with live:  # start on enter; complete on exit
                         run = live  # bound only once live: an earlier failure synthesizes
                         _phase = "agent loop"
-                        async with file_tracking_observer(actor_client):
-                            if agent_timeout is None:
-                                await agent(run)
-                            else:
-                                deadline = asyncio.timeout(agent_timeout)
-                                try:
-                                    async with deadline:
-                                        await agent(run)
-                                except TimeoutError:
-                                    if not deadline.expired():
-                                        raise
-                                    detail = f"agent timed out after {agent_timeout:g}s"
-                                    logger.warning(detail)
-                                    run.trace.status = "error"
-                                    run.trace.stop_reason = "timeout"
-                                    run.record(Step(source="system", error=detail))
+                        try:
+                            async with file_tracking_observer(actor_client):
+                                if agent_timeout is None:
+                                    await agent(run)
+                                else:
+                                    deadline = asyncio.timeout(agent_timeout)
+                                    try:
+                                        async with deadline:
+                                            await agent(run)
+                                    except TimeoutError:
+                                        if not deadline.expired():
+                                            raise
+                                        detail = f"agent timed out after {agent_timeout:g}s"
+                                        logger.warning(detail)
+                                        run.trace.status = "error"
+                                        run.trace.stop_reason = "timeout"
+                                        run.record(Step(source="system", error=detail))
+                        except Exception as exc:
+                            if task.verifier is None:
+                                raise
+                            detail = "".join(traceback.format_exception_only(exc)).strip()
+                            logger.warning("rollout failed mid-run (%s): %s", _phase, detail)
+                            run.trace.status = "error"
+                            run.record(Step(source="system", error=f"[{_phase}] {detail}"))
                         _phase = "grading"
 
                     verifier = task.verifier

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -133,10 +133,18 @@ class Run:
     half-working.
     """
 
-    def __init__(self, client: HudClient | None, task_id: str, args: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        client: HudClient | None,
+        task_id: str,
+        args: dict[str, Any],
+        *,
+        best_effort_grade: bool = False,
+    ) -> None:
         self._client = client
         self._task_id = task_id
         self._args = args
+        self._best_effort_grade = best_effort_grade
         #: The task's opening prompt as ``tasks.start`` returned it: plain
         #: text, or a list of message dicts (``{"role", "content"}``) for
         #: chat-style / multi-turn prompts. Agents consume the normalized
@@ -270,18 +278,19 @@ class Run:
         answer: dict[str, Any] = {"answer": self.trace.content}
         started_at = now_iso()
 
-        # A mid-run error grades best-effort (capture a salvageable reward, keep
-        # status=error), but a grade failure must not mask the original error. A
-        # clean run grades normally — a grader fault propagates.
         if exc_type is not None:
             self.trace.status = "error"
-            try:
-                evaluation = await self.client.grade(answer)
-            except Exception as grade_exc:
-                logger.warning("grade failed after mid-run error: %s", grade_exc)
-                return False
-        else:
+
+        try:
             evaluation = await self.client.grade(answer)
+        except Exception as grade_exc:
+            if exc_type is None and not self._best_effort_grade:
+                raise
+            detail = "".join(traceback.format_exception_only(grade_exc)).strip()
+            logger.warning("best-effort grade failed: %s", detail)
+            self.trace.status = "error"
+            self.record(Step(source="system", error=f"[grading] {detail}"))
+            return False
 
         self.grade = Grade.from_dict(evaluation)
         self.record(
@@ -414,6 +423,7 @@ async def rollout(
         )
         run: Run | None = None
         _phase = "provisioning"
+        rollout_expired = False
 
         client: HudClient | None = None
 
@@ -423,7 +433,12 @@ async def rollout(
                 _phase = "starting task"
                 async with connect(addr) as actor_client:
                     client = actor_client
-                    live = Run(actor_client, task.id, task.args)
+                    live = Run(
+                        actor_client,
+                        task.id,
+                        task.args,
+                        best_effort_grade=task.verifier is not None,
+                    )
                     live._runtime = addr.url  # the placement record for the receipt
                     async with live:  # start on enter; complete on exit
                         run = live  # bound only once live: an earlier failure synthesizes
@@ -461,17 +476,17 @@ async def rollout(
                         and verifier.runtime_config is None
                     ):
                         _phase = "verifying"
-                        live.grade = Grade()
                         await _verify(live, actor_client, verifier)
                         _phase = "cleanup"
                         return
 
-                _phase = "cleanup"
+                _phase = "actor cleanup"
 
+            if rollout_expired:
+                return
             verifier = task.verifier
             if verifier is not None:
                 _phase = "provisioning verifier"
-                live.grade = Grade()
                 async with (
                     runtime(verifier) as verifier_addr,
                     connect(verifier_addr) as verifier_client,
@@ -490,6 +505,7 @@ async def rollout(
                 if done:
                     await driver
                 else:
+                    rollout_expired = True
                     phase = _phase
                     if run is not None:
                         run.trace.stop_reason = "timeout"
@@ -501,7 +517,7 @@ async def rollout(
                         with contextlib.suppress(Exception):
                             await asyncio.wait_for(client.cancel(), timeout=2.0)
                         client.abort()
-                    if phase != "cleanup":
+                    if phase not in {"actor cleanup", "cleanup"}:
                         driver.cancel()
                     driver.add_done_callback(_consume_task_result)
                     detail = f"rollout timed out after {rollout_timeout:g}s during {phase}"

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
 import json
 import logging
 import shlex
@@ -57,7 +56,6 @@ from hud.utils.docker import docker as _docker
 from hud.utils.platform import PlatformClient
 from hud.utils.process import ProcessGroup, create_process_group_exec
 
-from .compose import ComposeConfig
 from .run import Grade, Run, rollout
 
 if TYPE_CHECKING:
@@ -976,23 +974,10 @@ class DaytonaRuntime:
 
         async with AsyncDaytona() as daytona:
             config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
-            compose = config.compose.resolve() if config.compose is not None else None
-            services = None
-            if compose is not None:
-                compose_config = await ComposeConfig.load(
-                    compose,
-                    docker=_docker,
-                    project_directory=compose.parent,
-                )
-                services = (await compose_config.resolve_registry_images(_docker)).services
+            if config.compose is not None:
+                raise ValueError("DaytonaRuntime does not support runtime_config.compose")
             if config.limits is not None and config.limits.run_timeout_s is not None:
                 raise ValueError("DaytonaRuntime does not support runtime_config.run_timeout_s")
-            if (
-                services is not None
-                and config.resources is not None
-                and config.resources.gpu is not None
-            ):
-                raise ValueError("Daytona linked sandboxes do not support GPU resources")
 
             daytona_resources = None
             if config.resources is not None:
@@ -1017,31 +1002,19 @@ class DaytonaRuntime:
                 if resource_kwargs:
                     daytona_resources = Resources(**resource_kwargs)
 
-            if config.image is not None or services is not None:
-                main_service = None
-                if services is not None:
-                    main_service = services["main"]
-                main_image = config.image
-                if main_image is None:
-                    assert main_service is not None
-                    main_image = main_service.image
-                assert main_image is not None
+            if config.image is not None:
                 sandbox_params = CreateSandboxFromImageParams(
-                    image=Image.base(main_image),
+                    image=Image.base(config.image),
                     ephemeral=True,
                     auto_stop_interval=0,
                     resources=daytona_resources,
-                    env_vars=(main_service.environment or None)
-                    if main_service is not None
-                    else None,
                 )
             else:
                 snapshot_name = self.snapshot_name
                 snapshot_image = self._image
                 if snapshot_name is None:
                     raise ValueError(
-                        "DaytonaRuntime requires snapshot_name, runtime_config.image, "
-                        "or runtime_config.compose"
+                        "DaytonaRuntime requires snapshot_name or runtime_config.image"
                     )
                 if daytona_resources is not None and snapshot_image is None:
                     raise ValueError(
@@ -1113,116 +1086,16 @@ class DaytonaRuntime:
                 timeout=create_timeout,
             )
             session_command: Any = None
-            linked_sandboxes: list[Any] = []
             try:
-                if compose is None:
-                    # Start the env server in a background session (the snapshot's CMD is
-                    # not the sandbox's main process). connect() retries the handshake,
-                    # so we don't poll for readiness here.
-                    session: str = "hud-serve"
-                    await sandbox.process.create_session(session)
-                    cmd = f"cd {self.workdir} && {self.command}" if self.workdir else self.command
-                    session_command = await sandbox.process.execute_session_command(
-                        session, SessionExecuteRequest(command=cmd, run_async=True)
-                    )
-                else:
-                    assert services is not None and main_service is not None
-                    service_sandboxes = {"main": sandbox}
-                    for service_name, service in services.items():
-                        if service_name == "main":
-                            continue
-                        image_name = service.image
-                        assert image_name is not None
-                        snapshot_name = (
-                            "hud-compose-" + hashlib.sha256(image_name.encode()).hexdigest()[:20]
-                        )
-                        async with self._snapshot_lock:
-                            if snapshot_name not in self._resolved:
-                                try:
-                                    await daytona.snapshot.get(snapshot_name)
-                                except DaytonaNotFoundError:
-                                    await daytona.snapshot.create(
-                                        CreateSnapshotParams(
-                                            name=snapshot_name,
-                                            image=image_name,
-                                        )
-                                    )
-                                self._resolved.add(snapshot_name)
-                        child = await daytona.create(
-                            CreateSandboxFromSnapshotParams(
-                                name=f"hud-{service_name}-{uuid.uuid4().hex[:12]}",
-                                snapshot=snapshot_name,
-                                ephemeral=True,
-                                auto_stop_interval=0,
-                                env_vars=service.environment,
-                                linked_sandbox=sandbox.id,
-                            ),
-                            timeout=create_timeout,
-                        )
-                        linked_sandboxes.append(child)
-                        service_sandboxes[service_name] = child
-
-                    for destination_name, destination in service_sandboxes.items():
-                        aliases = []
-                        for service_name, service_sandbox in service_sandboxes.items():
-                            if service_name == destination_name:
-                                continue
-                            sandbox_id = shlex.quote(service_sandbox.id)
-                            hostname = shlex.quote(service_name)
-                            aliases.append(
-                                f"ip=$(getent ahostsv4 {sandbox_id} | awk 'NR == 1 {{print $1}}')"
-                                " && "
-                                f'test -n "$ip" && printf \'%s %s\\n\' "$ip" {hostname} '
-                                ">> /etc/hosts"
-                            )
-                        if not aliases:
-                            continue
-                        mapped = await destination.process.exec(
-                            " && ".join(aliases),
-                            timeout=30,
-                        )
-                        if mapped.exit_code != 0:
-                            raise RuntimeError(
-                                f"Daytona could not map Compose services in "
-                                f"{destination_name!r}: {mapped.result.strip()}"
-                            )
-
-                    for service_name, service in services.items():
-                        if service_name == "main":
-                            continue
-                        child = service_sandboxes[service_name]
-                        session = f"hud-{service_name}"
-                        await child.process.create_session(session)
-                        if not service.argv:
-                            raise ValueError(f"Compose service {service_name!r} has no command")
-                        await child.process.execute_session_command(
-                            session,
-                            SessionExecuteRequest(command=service.shell_command(), run_async=True),
-                        )
-                        if service.healthcheck is not None:
-                            test = service.healthcheck.test
-                            if test and test[0] != "NONE":
-                                health_command = (
-                                    shlex.join(test[1:]) if test[0] == "CMD" else test[1]
-                                )
-                                async with asyncio.timeout(create_timeout):
-                                    while True:
-                                        health = await child.process.exec(
-                                            health_command,
-                                            timeout=30,
-                                        )
-                                        if health.exit_code == 0:
-                                            break
-                                        await asyncio.sleep(1)
-
-                    session = "hud-serve"
-                    await sandbox.process.create_session(session)
-                    if not main_service.argv:
-                        raise ValueError("Compose main service has no command")
-                    session_command = await sandbox.process.execute_session_command(
-                        session,
-                        SessionExecuteRequest(command=main_service.shell_command(), run_async=True),
-                    )
+                # Start the env server in a background session (the snapshot's CMD is
+                # not the sandbox's main process). connect() retries the handshake,
+                # so we don't poll for readiness here.
+                session: str = "hud-serve"
+                await sandbox.process.create_session(session)
+                cmd = f"cd {self.workdir} && {self.command}" if self.workdir else self.command
+                session_command = await sandbox.process.execute_session_command(
+                    session, SessionExecuteRequest(command=cmd, run_async=True)
+                )
                 ssh = await sandbox.create_ssh_access(expires_in_minutes=self.ssh_expires_minutes)
                 async with asyncssh.connect(
                     self.ssh_host, username=ssh.token, known_hosts=None
@@ -1252,15 +1125,6 @@ class DaytonaRuntime:
                             )
                         raise
             finally:
-                for child in reversed(linked_sandboxes):
-                    try:
-                        await daytona.delete(child)
-                    except Exception:
-                        logger.warning(
-                            "failed to delete linked Daytona sandbox %s; it may still be running",
-                            child.id,
-                            exc_info=True,
-                        )
                 try:
                     await daytona.delete(sandbox)
                 except Exception:
@@ -1555,6 +1419,11 @@ class HostedRuntime:
         """
         trace_id = trace_id or uuid.uuid4().hex
         try:
+            if task.verifier is not None:
+                raise ValueError(
+                    "HostedRuntime does not support verifier tasks until hosted rollouts "
+                    "can keep both phases in one runtime scope"
+                )
             async with asyncio.timeout(self.run_timeout):
                 state = await self._submit_and_await(
                     task, agent, job_id=job_id, group_id=group_id, trace_id=trace_id

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -111,7 +111,7 @@ class RuntimeConfig(BaseModel):
 
     image: str | None = Field(default=None, min_length=1)
     compose: Path | None = None
-    compose_service_access: bool = False
+    compose_service_access: bool | None = None
     resources: RuntimeResources | None = None
     limits: RuntimeLimits | None = None
 
@@ -130,7 +130,7 @@ class RuntimeConfig(BaseModel):
         changes = override.model_dump(exclude_unset=True)
         if override.image is not None:
             config["compose"] = None
-            config["compose_service_access"] = False
+            config["compose_service_access"] = None
         elif override.compose is not None:
             config["image"] = None
         return RuntimeConfig.model_validate(config | changes)

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -35,6 +35,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import shlex
 import sys
 import tarfile
@@ -67,6 +68,8 @@ if TYPE_CHECKING:
     from .task import Task
 
 logger = logging.getLogger("hud.eval.runtime")
+
+_COMPOSE_SERVICE_SOCKET = "/media/hud/docker.sock"
 
 
 class RuntimeGPU(BaseModel):
@@ -108,6 +111,7 @@ class RuntimeConfig(BaseModel):
 
     image: str | None = Field(default=None, min_length=1)
     compose: Path | None = None
+    compose_service_access: bool = False
     resources: RuntimeResources | None = None
     limits: RuntimeLimits | None = None
 
@@ -115,6 +119,8 @@ class RuntimeConfig(BaseModel):
     def validate_source(self) -> Self:
         if self.image is not None and self.compose is not None:
             raise ValueError("runtime_config accepts either image or compose, not both")
+        if self.compose_service_access and self.compose is None:
+            raise ValueError("compose_service_access requires runtime_config.compose")
         return self
 
     def with_overrides(self, override: RuntimeConfig | None) -> RuntimeConfig:
@@ -124,6 +130,7 @@ class RuntimeConfig(BaseModel):
         changes = override.model_dump(exclude_unset=True)
         if override.image is not None:
             config["compose"] = None
+            config["compose_service_access"] = False
         elif override.compose is not None:
             config["image"] = None
         return RuntimeConfig.model_validate(config | changes)
@@ -252,11 +259,20 @@ def _docker_compose_main(
     resources: RuntimeResources | None,
     *,
     seccomp: str | Path = _DOCKER_SECCOMP_PROFILE,
+    service_socket: str | None = None,
 ) -> dict[str, Any]:
     main: dict[str, Any] = {
         "ports": [published_port],
         "security_opt": [f"seccomp={seccomp}", "systempaths=unconfined"],
     }
+    if service_socket is not None:
+        main["volumes"] = [
+            {
+                "type": "bind",
+                "source": service_socket,
+                "target": _COMPOSE_SERVICE_SOCKET,
+            }
+        ]
     if resources is None:
         return main
     if resources.cpu is not None:
@@ -604,7 +620,29 @@ class DockerRuntime:
                 and resources.gpu.type is not None
             ):
                 raise ValueError("DockerRuntime cannot select Compose GPUs by type")
-            main = _docker_compose_main(f"127.0.0.1::{self.port}", resources)
+            service_socket = None
+            if config.compose_service_access:
+                endpoint = os.environ.get("DOCKER_HOST")
+                if not endpoint:
+                    endpoint, _ = await _docker(
+                        "context",
+                        "inspect",
+                        "--format",
+                        "{{.Endpoints.docker.Host}}",
+                    )
+                    endpoint = endpoint.strip()
+                parsed = urlsplit(endpoint)
+                if parsed.scheme != "unix" or not parsed.path:
+                    raise ValueError(
+                        "DockerRuntime Compose service access requires a local Unix "
+                        f"Docker endpoint, got {endpoint!r}"
+                    )
+                service_socket = parsed.path
+            main = _docker_compose_main(
+                f"127.0.0.1::{self.port}",
+                resources,
+                service_socket=service_socket,
+            )
             project = f"hud-{uuid.uuid4().hex[:12]}"
             with tempfile.TemporaryDirectory(prefix="hud-compose-") as directory:
                 override, ports = _compose_overrides(Path(directory), main)
@@ -818,6 +856,9 @@ class ModalRuntime:
                     f"{self.port}:{self.port}",
                     resources,
                     seccomp="/hud/docker-seccomp.json",
+                    service_socket=(
+                        "/var/run/docker.sock" if config.compose_service_access else None
+                    ),
                 )
                 with _compose_payload(compose, main) as (
                     archive,

--- a/hud/eval/sync.py
+++ b/hud/eval/sync.py
@@ -123,6 +123,7 @@ def _record_to_task(record: dict[str, Any]) -> Task:
             "agent_config": record.get("agent_config"),
             "columns": record.get("columns"),
             "runtime_config": record.get("runtime_config"),
+            "verifier": record.get("verifier"),
         }
     )
 
@@ -164,6 +165,8 @@ def task_upload_payload(task: Task) -> dict[str, Any]:
         payload["columns"] = task.columns
     if task.runtime_config is not None:
         payload["runtime_config"] = task.runtime_config.request_payload()
+    if task.verifier is not None:
+        payload["verifier"] = task.verifier.model_dump(mode="json", exclude_none=True)
     return payload
 
 
@@ -177,6 +180,8 @@ def _task_signature(task: Task) -> str:
         sig_data["columns"] = task.columns
     if task.runtime_config is not None:
         sig_data["runtime_config"] = task.runtime_config.request_payload()
+    if task.verifier is not None:
+        sig_data["verifier"] = task.verifier.model_dump(mode="json", exclude_none=True)
     return f"{task.id}|" + json.dumps(
         sig_data,
         sort_keys=True,

--- a/hud/eval/task.py
+++ b/hud/eval/task.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .runtime import RuntimeConfig
 
@@ -76,6 +76,12 @@ class Task(BaseModel):
     #: with the same answer. Placement may reuse the live substrate when both
     #: tasks name the same environment.
     verifier: Task | None = None
+
+    @model_validator(mode="after")
+    def _reject_nested_verifier(self) -> Self:
+        if self.verifier is not None and self.verifier.verifier is not None:
+            raise ValueError("nested verifier tasks are not supported")
+        return self
 
     # ─── execution ────────────────────────────────────────────────────
 

--- a/hud/eval/task.py
+++ b/hud/eval/task.py
@@ -71,6 +71,11 @@ class Task(BaseModel):
     #: Optional row-level runtime construction input. Runtime adapters apply the
     #: supported subset into their native launch shape or reject it.
     runtime_config: RuntimeConfig | None = None
+    #: Optional agent-less task whose evaluation is the grade of record. The
+    #: rollout completes this task first, then starts and grades the verifier
+    #: with the same answer. Placement may reuse the live substrate when both
+    #: tasks name the same environment.
+    verifier: Task | None = None
 
     # ─── execution ────────────────────────────────────────────────────
 

--- a/hud/eval/task.py
+++ b/hud/eval/task.py
@@ -22,9 +22,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from .runtime import RuntimeConfig
 
@@ -77,11 +77,12 @@ class Task(BaseModel):
     #: tasks name the same environment.
     verifier: Task | None = None
 
-    @model_validator(mode="after")
-    def _reject_nested_verifier(self) -> Self:
-        if self.verifier is not None and self.verifier.verifier is not None:
+    @field_validator("verifier")
+    @classmethod
+    def _reject_nested_verifier(cls, verifier: Task | None) -> Task | None:
+        if verifier is not None and verifier.verifier is not None:
             raise ValueError("nested verifier tasks are not supported")
-        return self
+        return verifier
 
     # ─── execution ────────────────────────────────────────────────────
 

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -143,7 +143,7 @@ class Taskset:
                 tasks.append(value)
             elif isinstance(value, Taskset):
                 tasks.extend(value)
-            elif isinstance(value, (list, tuple)):
+            elif isinstance(value, list | tuple):
                 tasks.extend(item for item in value if isinstance(item, Task))
         return tasks
 
@@ -213,7 +213,9 @@ class Taskset:
 
     def environment_names(self) -> set[str]:
         """Return env names referenced by tasks in this taskset."""
-        return {task.env for task in self}
+        return {task.env for task in self} | {
+            task.verifier.env for task in self if task.verifier is not None
+        }
 
     def _resolve_placement(self) -> Provider | HUDRuntime:
         if self.origin and self.origin.startswith("module:"):

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -167,6 +167,8 @@ class _FakeModalSandbox:
         uploads = self._calls.setdefault("uploads", [])
         assert isinstance(uploads, list)
         uploads.append((source.name, target))
+        if source.name == "override.json":
+            self._calls["compose_override"] = json.loads(source.read_text("utf-8"))
 
     async def _exec(self, *args: str, **kwargs: object) -> SimpleNamespace:
         commands = self._calls.setdefault("execs", [])
@@ -628,6 +630,7 @@ async def test_docker_runtime_starts_compose_with_a_main_service_override(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
     calls: list[tuple[str, ...]] = []
     rendered: dict[str, Any] = {}
     port_override = ""
@@ -640,6 +643,8 @@ async def test_docker_runtime_starts_compose_with_a_main_service_override(
     async def fake_docker(*args: str, **_kwargs: Any) -> tuple[str, str]:
         nonlocal port_override
         calls.append(args)
+        if args[:2] == ("context", "inspect"):
+            return "unix:///Users/test/.docker/run/docker.sock\n", ""
         if args[-4:] == ("up", "--detach", "--build", "--remove-orphans"):
             files = [Path(args[index + 1]) for index, value in enumerate(args) if value == "--file"]
             _, override, ports = files
@@ -655,6 +660,7 @@ async def test_docker_runtime_starts_compose_with_a_main_service_override(
         id="t",
         runtime_config=RuntimeConfig(
             compose=compose,
+            compose_service_access=True,
             resources=RuntimeResources(cpu=2, memory_mb=4096),
         ),
     )
@@ -670,19 +676,49 @@ async def test_docker_runtime_starts_compose_with_a_main_service_override(
         ],
         "cpus": 2.0,
         "mem_limit": "4096m",
+        "volumes": [
+            {
+                "type": "bind",
+                "source": "/Users/test/.docker/run/docker.sock",
+                "target": "/media/hud/docker.sock",
+            }
+        ],
     }
     assert 'ports: !override ["127.0.0.1::8765"]' in port_override
     up = next(
         call for call in calls if call[-4:] == ("up", "--detach", "--build", "--remove-orphans")
     )
     assert str(compose.resolve()) in up
-    assert all("/var/run/docker.sock" not in " ".join(call) for call in calls)
     assert calls[-1][-3:] == ("down", "--volumes", "--remove-orphans")
+
+
+async def test_docker_runtime_rejects_remote_compose_service_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
+    monkeypatch.setenv("DOCKER_HOST", "tcp://docker.example:2376")
+
+    with pytest.raises(ValueError, match="requires a local Unix Docker endpoint"):
+        async with DockerRuntime()(
+            Task(
+                env="any-env",
+                id="t",
+                runtime_config=RuntimeConfig(
+                    compose=compose,
+                    compose_service_access=True,
+                ),
+            )
+        ):
+            pass
 
 
 def test_docker_runtime_accepts_only_one_environment_definition(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="either image or compose"):
         RuntimeConfig(image="img:tag", compose=tmp_path / "compose.yaml")
+    with pytest.raises(ValueError, match="compose_service_access requires"):
+        RuntimeConfig(image="img:tag", compose_service_access=True)
 
 
 def test_docker_runtime_accepts_runtime_config_defaults() -> None:
@@ -757,7 +793,9 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     compose = tmp_path / "compose.yaml"
     compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
 
-    async with ModalRuntime(runtime_config=RuntimeConfig(compose=compose))(_row()) as runtime:
+    async with ModalRuntime(
+        runtime_config=RuntimeConfig(compose=compose, compose_service_access=True)
+    )(_row()) as runtime:
         assert runtime.url == "tcp://modal.host:4567"
 
     assert calls["registry_image"] == "docker:28.3.3-dind"
@@ -770,6 +808,15 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
         ("override.json", "/hud/override.json"),
         ("ports.yaml", "/hud/ports.yaml"),
         ("docker-seccomp.json", "/hud/docker-seccomp.json"),
+    ]
+    override = calls["compose_override"]
+    assert isinstance(override, dict)
+    assert override["services"]["main"]["volumes"] == [
+        {
+            "type": "bind",
+            "source": "/var/run/docker.sock",
+            "target": "/media/hud/docker.sock",
+        }
     ]
     execs = calls["execs"]
     assert isinstance(execs, list)

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -22,7 +22,7 @@ from typing import Any
 import pytest
 
 import hud.eval.runtime as runtime_module
-from hud.eval.compose import ComposeService, ImageConfig
+from hud.eval.compose import ComposeHealthcheck, ComposeService, ImageConfig
 from hud.eval.runtime import (
     DaytonaRuntime,
     DockerRuntime,
@@ -930,153 +930,19 @@ async def test_daytona_runtime_config_flows_into_daytona_sdk(
     assert calls["delete"] == "sandbox-1"
 
 
-async def test_daytona_runtime_maps_compose_services_to_linked_sandboxes(
+async def test_daytona_runtime_rejects_compose(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _install_fake_daytona(monkeypatch)
     compose = tmp_path / "compose.yaml"
-    compose.write_text(
-        """\
-services:
-  main:
-    image: hud-env:one
-    command: hud serve /env.py
-    entrypoint: []
-    working_dir: /app
-  redis:
-    image: redis:7
-    entrypoint: null
-    command: null
-    working_dir: /data
-    environment:
-      REDIS_ARGS: --save ''
-  worker:
-    image: worker:1
-    entrypoint: []
-    command: worker run
-    working_dir: /srv
-""",
-        encoding="utf-8",
-    )
-    docker_calls: list[tuple[str, ...]] = []
+    compose.write_text("services: {}\n", encoding="utf-8")
 
-    async def docker(*args: str, **_: object) -> tuple[str, str]:
-        docker_calls.append(args)
-        if args[0] == "compose":
-            return (
-                json.dumps(
-                    {
-                        "services": {
-                            "main": {
-                                "image": "hud-env:one",
-                                "command": ["hud", "serve", "/env.py"],
-                                "entrypoint": [],
-                                "working_dir": "/app",
-                            },
-                            "redis": {
-                                "image": "redis:7",
-                                "entrypoint": None,
-                                "command": None,
-                                "working_dir": "/data",
-                                "environment": {"REDIS_ARGS": "--save ''"},
-                            },
-                            "worker": {
-                                "image": "worker:1",
-                                "entrypoint": [],
-                                "command": ["worker", "run"],
-                                "working_dir": "/srv",
-                            },
-                        }
-                    }
-                ),
-                "",
-            )
-        if args[:3] == ("buildx", "imagetools", "inspect"):
-            return (
-                json.dumps(
-                    {
-                        "Entrypoint": ["docker-entrypoint.sh"],
-                        "Cmd": ["redis-server"],
-                        "WorkingDir": "/data",
-                    }
-                ),
-                "",
-            )
-        raise AssertionError(args)
+    with pytest.raises(ValueError, match=r"does not support runtime_config\.compose"):
+        async with DaytonaRuntime(runtime_config=RuntimeConfig(compose=compose))(_row()):
+            pass
 
-    monkeypatch.setattr(runtime_module, "_docker", docker)
-
-    async with DaytonaRuntime(runtime_config=RuntimeConfig(compose=compose))(_row()) as runtime:
-        assert runtime.url == "tcp://127.0.0.1:54321"
-
-    assert client.created[0] == _CreateSandboxFromImageParams(
-        image=_DaytonaImage("hud-env:one"),
-        ephemeral=True,
-        auto_stop_interval=0,
-        resources=None,
-    )
-    child = client.created[1]
-    assert isinstance(child, _CreateSandboxFromSnapshotParams)
-    assert child.linked_sandbox == "sandbox-1"
-    assert child.env_vars == {"REDIS_ARGS": "--save ''"}
-    assert child.name is not None and child.name.startswith("hud-redis-")
-    worker = client.created[2]
-    assert isinstance(worker, _CreateSandboxFromSnapshotParams)
-    assert worker.linked_sandbox == "sandbox-1"
-    assert worker.name is not None and worker.name.startswith("hud-worker-")
-    assert client.snapshot.builds == [child.snapshot, worker.snapshot]
-    assert client.snapshot.snapshots[child.snapshot].image_name == "redis:7"
-    assert client.snapshot.snapshots[worker.snapshot].image_name == "worker:1"
-    assert client.calls["session_commands"] == [
-        (
-            "sandbox-2",
-            "hud-redis",
-            _SessionExecuteRequest(
-                command="cd /data && docker-entrypoint.sh redis-server",
-                run_async=True,
-            ),
-        ),
-        (
-            "sandbox-3",
-            "hud-worker",
-            _SessionExecuteRequest(
-                command="cd /srv && worker run",
-                run_async=True,
-            ),
-        ),
-        (
-            "sandbox-1",
-            "hud-serve",
-            _SessionExecuteRequest(
-                command="cd /app && hud serve /env.py",
-                run_async=True,
-            ),
-        ),
-    ]
-    commands = client.calls["process_execs"]
-    assert isinstance(commands, list)
-    aliases = {sandbox_id: command for sandbox_id, command, _ in commands}
-    assert "getent ahostsv4 sandbox-2" in aliases["sandbox-1"]
-    assert "redis" in aliases["sandbox-1"]
-    assert "getent ahostsv4 sandbox-3" in aliases["sandbox-2"]
-    assert "worker" in aliases["sandbox-2"]
-    assert "getent ahostsv4 sandbox-2" in aliases["sandbox-3"]
-    assert "redis" in aliases["sandbox-3"]
-    assert client.calls["deleted"] == ["sandbox-3", "sandbox-2", "sandbox-1"]
-    assert client.calls["client_closed"] is True
-    assert docker_calls[0] == (
-        "compose",
-        "--project-directory",
-        str(tmp_path),
-        "--file",
-        str(compose),
-        "config",
-        "--format",
-        "json",
-    )
-    assert docker_calls[1][:3] == ("buildx", "imagetools", "inspect")
-    assert docker_calls[1][-1] == "redis:7"
+    assert client.created == []
 
 
 def test_compose_service_applies_image_defaults_once() -> None:
@@ -1095,6 +961,16 @@ def test_compose_service_applies_image_defaults_once() -> None:
         entrypoint=["custom-entrypoint"],
     ).with_image("redis:7", image)
     assert overridden.argv == ["custom-entrypoint"]
+
+
+def test_compose_healthcheck_does_not_invent_duration_values() -> None:
+    service = ComposeService(
+        healthcheck=ComposeHealthcheck(test=["CMD", "healthcheck"]),
+    )
+
+    assert service.model_dump(exclude_none=True)["healthcheck"] == {
+        "test": ["CMD", "healthcheck"]
+    }
 
 
 async def test_daytona_task_runtime_config_overlays_provider_defaults(

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -968,9 +968,7 @@ def test_compose_healthcheck_does_not_invent_duration_values() -> None:
         healthcheck=ComposeHealthcheck(test=["CMD", "healthcheck"]),
     )
 
-    assert service.model_dump(exclude_none=True)["healthcheck"] == {
-        "test": ["CMD", "healthcheck"]
-    }
+    assert service.model_dump(exclude_none=True)["healthcheck"] == {"test": ["CMD", "healthcheck"]}
 
 
 async def test_daytona_task_runtime_config_overlays_provider_defaults(

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -162,6 +162,22 @@ async def test_run_rejects_non_gateway_agent() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_rejects_verifier_tasks_until_hosted_supports_both_phases() -> None:
+    run = await HostedRuntime(poll_interval=0.0).run(
+        Task(
+            env="actor",
+            id="solve",
+            verifier=Task(env="judge", id="verify"),
+        ),
+        _agent(),
+        job_id="j",
+    )
+
+    assert run.trace.is_error
+    assert "does not support verifier tasks" in (run.trace.error or "")
+
+
+@pytest.mark.asyncio
 async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     platform = _FakePlatform(
         [

--- a/hud/eval/tests/test_local_runtime.py
+++ b/hud/eval/tests/test_local_runtime.py
@@ -185,6 +185,48 @@ async def test_minted_tasks_resolve_a_declared_env_by_name(imported_env) -> None
     assert all(run.reward == 1.0 for run in job.runs)
 
 
+async def test_inferred_placement_includes_a_verifier_environment(tmp_path, request) -> None:
+    actor_name = f"actor-{request.node.name}"
+    verifier_name = f"verifier-{request.node.name}"
+    module_name = f"_verifier_placement_{request.node.name}"
+    source = tmp_path / f"{module_name}.py"
+    source.write_text(
+        f"""from hud import Environment
+
+actor = Environment("{actor_name}")
+verifier = Environment("{verifier_name}")
+
+@actor.template(id="solve")
+async def solve():
+    answer = yield "answer"
+    yield 0.25
+
+@verifier.template(id="verify")
+async def verify():
+    answer = yield ""
+    yield 1.0 if answer == "secret" else 0.0
+""",
+        encoding="utf-8",
+    )
+    spec = importlib.util.spec_from_file_location(module_name, source)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    try:
+        task = Task(
+            env=actor_name,
+            id="solve",
+            verifier=Task(env=verifier_name, id="verify"),
+        )
+        job = await task.run(_FnAgent(lambda _: "secret"))
+    finally:
+        del sys.modules[module_name]
+
+    assert job.runs[0].reward == 1.0
+
+
 async def test_no_placement_fails_with_the_forms_to_pass() -> None:
     with pytest.raises(ValueError, match="no placement for env"):
         await Task(env="ghost", id="add").run(_FnAgent(_solve_add))

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -304,7 +304,7 @@ async def test_verifier_remains_authoritative_when_actor_grading_fails(
     assert placements == ["actor", "judge"]
 
 
-async def test_actor_grade_survives_a_verifier_provisioning_failure() -> None:
+async def test_verifier_provisioning_failure_leaves_the_run_ungraded() -> None:
     actor_env = Environment("actor")
 
     @actor_env.template()
@@ -324,7 +324,8 @@ async def test_actor_grade_survives_a_verifier_provisioning_failure() -> None:
 
     assert run.trace.is_error
     assert "verifier unavailable" in (run.trace.error or "")
-    assert run.reward == 0.25
+    assert run.grade.raw == {}
+    assert run.reward == 0.0
 
 
 def _bindings_env(published: Any) -> Environment:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -266,6 +266,67 @@ async def test_verifier_remains_authoritative_after_an_agent_error() -> None:
     assert placements == ["actor", "judge"]
 
 
+@pytest.mark.parametrize("agent_fails", [False, True])
+async def test_verifier_remains_authoritative_when_actor_grading_fails(
+    agent_fails: bool,
+) -> None:
+    actor_env = Environment("actor")
+    verifier_env = Environment("judge")
+    placements: list[str] = []
+
+    @actor_env.template()
+    async def solve():
+        yield "answer secret"
+        raise RuntimeError("actor grade exploded")
+
+    @verifier_env.template()
+    async def verify():
+        answer = yield ""
+        yield 1.0 if answer == "secret" else 0.0
+
+    @asynccontextmanager
+    async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
+        placements.append(row.env)
+        async with _local(actor_env if row.env == "actor" else verifier_env) as runtime:
+            yield runtime
+
+    task = Task(env="actor", id="solve", verifier=Task(env="judge", id="verify"))
+    agent = (
+        _AnswerThenBoomAgent(lambda _prompt: "secret")
+        if agent_fails
+        else _FnAgent(lambda _prompt: "secret")
+    )
+    run = await rollout(task, agent, runtime=provider)
+
+    assert run.trace.is_error
+    assert "actor grade exploded" in (run.trace.error or "")
+    assert run.reward == 1.0
+    assert placements == ["actor", "judge"]
+
+
+async def test_actor_grade_survives_a_verifier_provisioning_failure() -> None:
+    actor_env = Environment("actor")
+
+    @actor_env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @asynccontextmanager
+    async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
+        if row.env == "judge":
+            raise RuntimeError("verifier unavailable")
+        async with _local(actor_env) as runtime:
+            yield runtime
+
+    task = Task(env="actor", id="solve", verifier=Task(env="judge", id="verify"))
+    run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=provider)
+
+    assert run.trace.is_error
+    assert "verifier unavailable" in (run.trace.error or "")
+    assert run.reward == 0.25
+
+
 def _bindings_env(published: Any) -> Environment:
     """An env whose task publishes per-episode binding data alongside the prompt."""
     env = Environment("slots")
@@ -637,6 +698,48 @@ async def test_timeout_does_not_wait_for_provider_cleanup() -> None:
 
     release_cleanup.set()
     await asyncio.wait_for(cleanup_finished.wait(), 1.0)
+
+
+async def test_timeout_during_actor_cleanup_does_not_start_the_verifier() -> None:
+    actor_env = Environment("actor")
+    cleanup_started = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    placements: list[str] = []
+
+    @actor_env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @asynccontextmanager
+    async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
+        placements.append(row.env)
+        if row.env == "judge":
+            raise AssertionError("verifier started after the rollout returned")
+        try:
+            async with _local(actor_env) as runtime:
+                yield runtime
+        finally:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            cleanup_finished.set()
+
+    task = Task(env="actor", id="solve", verifier=Task(env="judge", id="verify"))
+    run = await rollout(
+        task,
+        _FnAgent(lambda _prompt: "secret"),
+        runtime=provider,
+        rollout_timeout=0.2,
+    )
+
+    assert run.trace.status == "error"
+    assert run.trace.stop_reason == "timeout"
+    assert placements == ["actor"]
+    release_cleanup.set()
+    await asyncio.wait_for(cleanup_finished.wait(), 1.0)
+    await asyncio.sleep(0)
+    assert placements == ["actor"]
 
 
 async def test_timeout_does_not_cancel_verifier_provider_cleanup() -> None:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -167,6 +167,71 @@ async def test_rollout_returns_graded_run_with_trace_id(env_file: Path) -> None:
     assert run.runtime.startswith("tcp://127.0.0.1:")
 
 
+async def test_verifier_task_replaces_the_actor_grade_in_the_same_runtime() -> None:
+    env = Environment("reviewed")
+    completed: list[str] = []
+
+    @env.template()
+    async def solve():
+        answer = yield "answer secret"
+        completed.append(f"actor:{answer}")
+        yield 0.25
+
+    @env.template()
+    async def verify(expected: str):
+        answer = yield ""
+        completed.append(f"verifier:{answer}")
+        yield 1.0 if answer == expected else 0.0
+
+    task = Task(
+        env="reviewed",
+        id="solve",
+        verifier=Task(env="reviewed", id="verify", args={"expected": "secret"}),
+    )
+    run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=lambda _row: _local(env))
+
+    assert run.reward == 1.0
+    assert completed == ["actor:secret", "verifier:secret"]
+    evaluations = [
+        step.task_call.name
+        for step in run.trace.steps
+        if step.task_call is not None and step.task_call.phase == "evaluate"
+    ]
+    assert evaluations == ["solve", "verify"]
+
+
+async def test_verifier_with_its_own_environment_is_placed_after_the_actor() -> None:
+    actor_env = Environment("actor")
+    verifier_env = Environment("judge")
+    placements: list[str] = []
+
+    @actor_env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @verifier_env.template()
+    async def verify():
+        answer = yield ""
+        yield 1.0 if answer == "secret" else 0.0
+
+    @asynccontextmanager
+    async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
+        placements.append(row.env)
+        async with _local(actor_env if row.env == "actor" else verifier_env) as runtime:
+            yield runtime
+
+    task = Task(
+        env="actor",
+        id="solve",
+        verifier=Task(env="judge", id="verify"),
+    )
+    run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=provider)
+
+    assert run.reward == 1.0
+    assert placements == ["actor", "judge"]
+
+
 def _bindings_env(published: Any) -> Environment:
     """An env whose task publishes per-episode binding data alongside the prompt."""
     env = Environment("slots")

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -232,6 +232,40 @@ async def test_verifier_with_its_own_environment_is_placed_after_the_actor() -> 
     assert placements == ["actor", "judge"]
 
 
+async def test_verifier_remains_authoritative_after_an_agent_error() -> None:
+    actor_env = Environment("actor")
+    verifier_env = Environment("judge")
+    placements: list[str] = []
+
+    @actor_env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @verifier_env.template()
+    async def verify():
+        answer = yield ""
+        yield 1.0 if answer == "secret" else 0.0
+
+    @asynccontextmanager
+    async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
+        placements.append(row.env)
+        async with _local(actor_env if row.env == "actor" else verifier_env) as runtime:
+            yield runtime
+
+    task = Task(
+        env="actor",
+        id="solve",
+        verifier=Task(env="judge", id="verify"),
+    )
+    run = await rollout(task, _AnswerThenBoomAgent(lambda _prompt: "secret"), runtime=provider)
+
+    assert run.trace.is_error
+    assert "agent exploded after answering" in (run.trace.error or "")
+    assert run.reward == 1.0
+    assert placements == ["actor", "judge"]
+
+
 def _bindings_env(published: Any) -> Environment:
     """An env whose task publishes per-episode binding data alongside the prompt."""
     env = Environment("slots")

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -639,6 +639,52 @@ async def test_timeout_does_not_wait_for_provider_cleanup() -> None:
     await asyncio.wait_for(cleanup_finished.wait(), 1.0)
 
 
+async def test_timeout_does_not_cancel_verifier_provider_cleanup() -> None:
+    actor_env = Environment("actor")
+    verifier_env = Environment("judge")
+    cleanup_started = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    @actor_env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @verifier_env.template()
+    async def verify():
+        answer = yield ""
+        yield 1.0 if answer == "secret" else 0.0
+
+    @asynccontextmanager
+    async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
+        try:
+            async with _local(actor_env if row.env == "actor" else verifier_env) as runtime:
+                yield runtime
+        finally:
+            if row.env == "judge":
+                cleanup_started.set()
+                await release_cleanup.wait()
+                cleanup_finished.set()
+
+    task = Task(env="actor", id="solve", verifier=Task(env="judge", id="verify"))
+    run = await rollout(
+        task,
+        _FnAgent(lambda _prompt: "secret"),
+        runtime=provider,
+        rollout_timeout=0.2,
+    )
+
+    assert run.trace.status == "error"
+    assert run.trace.stop_reason == "timeout"
+    assert run.reward == 1.0
+    assert cleanup_started.is_set()
+    assert not cleanup_finished.is_set()
+
+    release_cleanup.set()
+    await asyncio.wait_for(cleanup_finished.wait(), 1.0)
+
+
 async def test_pre_launch_failure_yields_a_synthesized_failed_run() -> None:
     @asynccontextmanager
     async def broken_provider(task: TaskRow) -> AsyncIterator[Runtime]:

--- a/hud/eval/tests/test_sync.py
+++ b/hud/eval/tests/test_sync.py
@@ -160,3 +160,25 @@ def test_task_upload_payload_preserves_runtime_config_null_override() -> None:
     payload = task_upload_payload(task)
 
     assert payload["runtime_config"] == {"resources": None}
+
+
+def test_task_upload_payload_includes_verifier_task() -> None:
+    task = Task(
+        env="actor",
+        id="solve",
+        verifier=Task(
+            env="judge",
+            id="verify",
+            runtime_config=RuntimeConfig(image="judge:latest"),
+        ),
+    )
+
+    payload = task_upload_payload(task)
+
+    assert payload["verifier"] == {
+        "env": "judge",
+        "id": "verify",
+        "args": {},
+        "slug": "verify",
+        "runtime_config": {"image": "judge:latest"},
+    }

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -221,7 +221,13 @@ async def test_platform_taskset_defaults_to_hud_runtime(monkeypatch: pytest.Monk
 
 def test_taskset_is_ordered_and_keyed_by_slug() -> None:
     first = Task(env="e", id="solve", args={"n": 1}, slug="first")
-    second = Task(env="e", id="solve", args={"n": 2}, slug="second")
+    second = Task(
+        env="e",
+        id="solve",
+        args={"n": 2},
+        slug="second",
+        verifier=Task(env="judge", id="verify"),
+    )
 
     tasks = Taskset("demo", [first, second])
 
@@ -230,7 +236,7 @@ def test_taskset_is_ordered_and_keyed_by_slug() -> None:
     assert list(tasks.filter(["second"])) == [second]
     assert list(tasks.exclude(["first"])) == [second]
     assert list(tasks.items()) == [("first", first), ("second", second)]
-    assert tasks.environment_names() == {"e"}
+    assert tasks.environment_names() == {"e", "judge"}
 
 
 def test_taskset_from_file_loads_json_and_jsonl(tmp_path) -> None:

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -175,6 +175,19 @@ def test_verifier_rejects_another_verifier() -> None:
         )
 
 
+def test_verifier_rejects_another_verifier_on_assignment() -> None:
+    task = Task(env="actor", id="solve")
+
+    with pytest.raises(ValueError, match="nested verifier tasks are not supported"):
+        task.verifier = Task(
+            env="judge",
+            id="verify",
+            verifier=Task(env="final-judge", id="verify-final"),
+        )
+
+    assert task.verifier is None
+
+
 def test_runtime_config_rejects_unknown_fields() -> None:
     with pytest.raises(ValueError, match="Extra inputs"):
         RuntimeConfig.model_validate({"image": "img:tag", "provider_config": {}})

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -139,6 +139,29 @@ def test_runtime_config_roundtrips_as_part_of_task_row() -> None:
     assert rebuilt.model_dump(exclude_none=True) == original
 
 
+def test_verifier_roundtrips_as_an_ordinary_nested_task() -> None:
+    original = Task(
+        env="actor",
+        id="solve",
+        verifier=Task(
+            env="judge",
+            id="verify",
+            args={"suite": "hidden"},
+            runtime_config=RuntimeConfig(image="judge:latest"),
+        ),
+    ).model_dump(exclude_none=True)
+
+    rebuilt = Task.model_validate(original)
+
+    assert rebuilt.verifier == Task(
+        env="judge",
+        id="verify",
+        args={"suite": "hidden"},
+        runtime_config=RuntimeConfig(image="judge:latest"),
+    )
+    assert rebuilt.model_dump(exclude_none=True) == original
+
+
 def test_runtime_config_rejects_unknown_fields() -> None:
     with pytest.raises(ValueError, match="Extra inputs"):
         RuntimeConfig.model_validate({"image": "img:tag", "provider_config": {}})

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -162,6 +162,19 @@ def test_verifier_roundtrips_as_an_ordinary_nested_task() -> None:
     assert rebuilt.model_dump(exclude_none=True) == original
 
 
+def test_verifier_rejects_another_verifier() -> None:
+    with pytest.raises(ValueError, match="nested verifier tasks are not supported"):
+        Task(
+            env="actor",
+            id="solve",
+            verifier=Task(
+                env="judge",
+                id="verify",
+                verifier=Task(env="final-judge", id="verify-final"),
+            ),
+        )
+
+
 def test_runtime_config_rejects_unknown_fields() -> None:
     with pytest.raises(ValueError, match="Extra inputs"):
         RuntimeConfig.model_validate({"image": "img:tag", "provider_config": {}})

--- a/hud/utils/process.py
+++ b/hud/utils/process.py
@@ -217,6 +217,8 @@ async def _wait_for_process_group_exit(process_group: int, max_wait: float) -> b
             os.killpg(process_group, 0)
         except ProcessLookupError:
             return True
+        except PermissionError:
+            return False
         if loop.time() >= deadline:
             return False
         await asyncio.sleep(min(_PROCESS_EXIT_POLL_INTERVAL, deadline - loop.time()))

--- a/hud/utils/process.py
+++ b/hud/utils/process.py
@@ -198,7 +198,7 @@ async def _terminate_process_group(
     if await _wait_for_process_group_exit(proc.pid, remaining):
         return
 
-    with contextlib.suppress(ProcessLookupError):
+    with contextlib.suppress(ProcessLookupError, PermissionError):
         os.killpg(proc.pid, signal.SIGKILL)
 
     if proc.returncode is None:

--- a/hud/utils/tests/test_process.py
+++ b/hud/utils/tests/test_process.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import shlex
+import signal
 import sys
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
-from hud.utils.process import ProcessResult, create_process_group_exec
+from hud.utils.process import ProcessGroup, ProcessResult, create_process_group_exec
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -83,3 +87,24 @@ async def test_a_cancelled_call_leaves_nothing_running() -> None:
         await task
 
     assert group.returncode is not None
+
+
+async def test_teardown_survives_a_process_group_becoming_unsignalable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signals: list[int] = []
+
+    def killpg(_process_group: int, sent: int) -> None:
+        signals.append(sent)
+        if sent in (0, signal.SIGKILL):
+            raise PermissionError
+
+    monkeypatch.setattr(os, "killpg", killpg)
+    process = cast(
+        "asyncio.subprocess.Process",
+        SimpleNamespace(pid=1234, returncode=0),
+    )
+
+    await ProcessGroup(process, term_timeout=0).terminate()
+
+    assert signals == [signal.SIGTERM, 0, signal.SIGKILL]

--- a/integrations/harbor/Dockerfile
+++ b/integrations/harbor/Dockerfile
@@ -1,5 +1,9 @@
 ARG BASE_IMAGE
-FROM ${BASE_IMAGE}
+ARG VERIFIER_IMAGE
+
+FROM ${VERIFIER_IMAGE} AS verifier-root
+FROM docker:28.3.3-cli AS docker-cli
+FROM ${BASE_IMAGE} AS runtime
 
 USER root
 ARG HUD_REQUIREMENT=hud
@@ -13,3 +17,9 @@ ENV HUD_SKIP_VERSION_CHECK=1
 EXPOSE 8765
 ENTRYPOINT []
 CMD ["/media/hud/venv/bin/hud", "serve", "/media/hud/env.py", "--host", "0.0.0.0", "--port", "8765"]
+
+FROM runtime AS plain
+
+FROM runtime AS verifier
+COPY --from=docker-cli /usr/local/bin/docker /media/hud/bin/docker
+COPY --from=verifier-root / /media/hud/verifier

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -13,10 +13,10 @@ import tempfile
 import tomllib
 import uuid
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from hud.capabilities import Capability
 from hud.environment.egress import BRIDGE_PORT, VISITOR_PORT
@@ -51,13 +51,21 @@ COMPOSE_FILENAMES = (
 class Artifact(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    source: str = Field(min_length=2, pattern=r"^/")
+    source: str = Field(pattern=r"^/")
     service: str = Field(default="main", min_length=1)
 
     @model_validator(mode="before")
     @classmethod
     def expand_path(cls, value: Any) -> Any:
         return {"source": value} if isinstance(value, str) else value
+
+    @field_validator("source")
+    @classmethod
+    def normalize_source(cls, value: str) -> str:
+        path = PurePosixPath(value)
+        if len(path.parts) == 1 or ".." in path.parts:
+            raise ValueError("artifact source must name a path beneath /")
+        return str(path)
 
 
 class Collect(BaseModel):

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -718,7 +718,9 @@ async def adapt(
                     runtime_config=RuntimeConfig(
                         image=image if compose is None else None,
                         compose=context / "compose.json" if compose is not None else None,
-                        compose_service_access=compose is not None and task_separate,
+                        compose_service_access=(
+                            True if compose is not None and task_separate else None
+                        ),
                         resources=resources if resources.model_dump(exclude_none=True) else None,
                     ),
                     verifier=(

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -538,6 +538,18 @@ async def adapt(
             for entry in verifier_config.environment
             for key, _, value in (entry.partition("="),)
         }
+        verifier_phase = source.config.verifier
+        verifier_policy = verifier_phase.model_dump(
+            include={"user", "network_mode", "allowed_hosts", "env"}
+        )
+        if verifier_phase.environment is not None:
+            if verifier_phase.network_mode is None:
+                verifier_policy["network_mode"] = verifier_environment.network_mode
+                verifier_policy["allowed_hosts"] = verifier_environment.allowed_hosts
+            verifier_policy["env"] = {
+                **verifier_environment.env,
+                **verifier_phase.env,
+            }
         manifest = {
             "name": name,
             "workdir": workdir,
@@ -554,7 +566,7 @@ async def adapt(
             "verifier_root": str(HUD_ROOT / "verifier") if separate else None,
             "verifier_image": {
                 "user": verifier_config.user or None,
-                "workdir": verifier_config.working_dir or "/",
+                "workdir": verifier_environment.workdir or verifier_config.working_dir or "/",
                 "env": verifier_env,
             },
             "environment": {
@@ -569,9 +581,7 @@ async def adapt(
             "agent": source.config.agent.model_dump(
                 include={"user", "network_mode", "allowed_hosts", "env"}
             ),
-            "verifier": source.config.verifier.model_dump(
-                include={"user", "network_mode", "allowed_hosts", "env"}
-            ),
+            "verifier": verifier_policy,
             "capabilities": [
                 Capability.mcp(
                     name=server.name,

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -342,8 +342,9 @@ async def adapt(
 
     rows = []
     base_name = normalize_environment_name(dataset.name, default="harbor")
-    for (environment_hash, config_json, _), group in sorted(grouped.items()):
-        digest = hashlib.sha256((environment_hash + "\0" + config_json).encode()).hexdigest()[:12]
+    for group_key, group in sorted(grouped.items()):
+        environment_hash, config_json, _ = group_key
+        digest = hashlib.sha256("\0".join(group_key).encode()).hexdigest()[:12]
         name = f"{base_name}-{digest}"
         source = group[0]
         environment = source.config.environment

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from hud.capabilities import Capability
 from hud.eval import Task, Taskset
@@ -47,16 +47,24 @@ COMPOSE_FILENAMES = (
 )
 
 
-class Phase(BaseModel):
-    model_config = ConfigDict(extra="allow")
+class Artifact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
 
-    timeout_sec: float | None = Field(default=None, gt=0)
-    user: str | int | None = None
-    network_mode: NetworkMode | None = None
-    allowed_hosts: list[str] = Field(default_factory=list)
-    env: dict[str, str] = Field(default_factory=dict)
-    environment: dict[str, Any] | None = None
-    environment_mode: str | None = None
+    source: str = Field(min_length=2, pattern=r"^/")
+    service: str = Field(default="main", min_length=1)
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_path(cls, value: Any) -> Any:
+        return {"source": value} if isinstance(value, str) else value
+
+
+class Collect(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    service: str = Field(default="main", min_length=1)
+    command: str = Field(min_length=1)
+    timeout_sec: float = Field(default=600.0, gt=0)
 
 
 class HealthcheckConfig(BaseModel):
@@ -138,6 +146,23 @@ class EnvironmentConfig(BaseModel):
     skills_dir: str | None = None
 
 
+class Phase(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    timeout_sec: float | None = Field(default=None, gt=0)
+    user: str | int | None = None
+    network_mode: NetworkMode | None = None
+    allowed_hosts: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    environment: EnvironmentConfig | None = None
+    environment_mode: Literal["separate"] | None = None
+    collect: list[Collect] = Field(default_factory=list)
+
+    @property
+    def separate(self) -> bool:
+        return self.environment_mode == "separate" or self.environment is not None
+
+
 class PackageInfo(BaseModel):
     model_config = ConfigDict(extra="allow")
 
@@ -152,6 +177,7 @@ class TaskConfig(BaseModel):
     schema_version: str | None = None
     task: PackageInfo = Field(default_factory=PackageInfo)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    artifacts: list[Artifact] = Field(default_factory=list)
     environment: EnvironmentConfig = Field(default_factory=EnvironmentConfig)
     agent: Phase = Field(default_factory=Phase)
     verifier: Phase = Field(default_factory=Phase)
@@ -210,8 +236,22 @@ async def adapt(
             unsupported.append("stdio MCP servers")
         if config.environment.skills_dir:
             unsupported.append("skills_dir")
-        if config.verifier.environment_mode == "separate" or config.verifier.environment:
-            unsupported.append("a separate verifier environment")
+        verifier_environment = config.verifier.environment
+        if verifier_environment is not None:
+            if verifier_environment.os != "linux":
+                unsupported.append(f"verifier os={verifier_environment.os!r}")
+            if verifier_environment.tpu:
+                unsupported.append("verifier TPUs")
+            if len(verifier_environment.gpu_types) > 1:
+                unsupported.append("multiple verifier GPU types")
+            elif verifier_environment.gpu_types and not verifier_environment.gpus:
+                unsupported.append("verifier GPU types without GPUs")
+            gpu_types = {
+                *config.environment.gpu_types,
+                *verifier_environment.gpu_types,
+            }
+            if len(gpu_types) > 1:
+                unsupported.append("different agent and verifier GPU types")
         if config.steps:
             unsupported.append("multi-step tasks")
         if unsupported:
@@ -285,17 +325,24 @@ async def adapt(
             )
         )
 
-    grouped: dict[tuple[str, str], list[HarborTask]] = {}
+    grouped: dict[tuple[str, str, str], list[HarborTask]] = {}
     for task in tasks:
         config_json = json.dumps(
             task.config.model_dump(mode="json", exclude={"task", "metadata", "steps"}),
             sort_keys=True,
         )
-        grouped.setdefault((task.environment_hash, config_json), []).append(task)
+        grouped.setdefault(
+            (
+                task.environment_hash,
+                config_json,
+                task.path.name if task.config.verifier.separate else "",
+            ),
+            [],
+        ).append(task)
 
     rows = []
     base_name = normalize_environment_name(dataset.name, default="harbor")
-    for (environment_hash, config_json), group in sorted(grouped.items()):
+    for (environment_hash, config_json, _), group in sorted(grouped.items()):
         digest = hashlib.sha256((environment_hash + "\0" + config_json).encode()).hexdigest()[:12]
         name = f"{base_name}-{digest}"
         source = group[0]
@@ -341,6 +388,35 @@ async def adapt(
             raise FileNotFoundError(f"{source.path.name} has no environment/Dockerfile")
 
         image_config = await ImageConfig.inspect(base_image, docker)
+        separate = source.config.verifier.separate
+        verifier_environment = source.config.verifier.environment or EnvironmentConfig()
+        verifier_image = base_image
+        verifier_config = image_config
+        if separate:
+            verifier_dockerfile = source.path / "tests" / "Dockerfile"
+            if not verifier_dockerfile.is_file():
+                raise FileNotFoundError(
+                    f"{source.path.name} uses a separate verifier but has no tests/Dockerfile"
+                )
+            verifier_digest = hashlib.sha256()
+            for entry in sorted(verifier_dockerfile.parent.rglob("*")):
+                relative_path = entry.relative_to(verifier_dockerfile.parent).as_posix().encode()
+                if entry.is_symlink():
+                    verifier_digest.update(
+                        relative_path + b"\0symlink\0" + os.readlink(entry).encode()
+                    )
+                elif entry.is_file():
+                    verifier_digest.update(relative_path + b"\0" + entry.read_bytes())
+            verifier_image = f"hud-harbor-verifier:{name}-{verifier_digest.hexdigest()[:16]}"
+            await docker(
+                "build",
+                "--tag",
+                verifier_image,
+                str(verifier_dockerfile.parent),
+                deadline=verifier_environment.build_timeout_sec,
+            )
+            verifier_config = await ImageConfig.inspect(verifier_image, docker)
+
         peers = []
         if compose is not None:
             for service_name, service in compose.services.items():
@@ -432,9 +508,24 @@ async def adapt(
         for entry in image_config.environment:
             key, _, value = entry.partition("=")
             image_env[key] = value
+        ports = {
+            int(port)
+            for exposed in (*image_config.exposed_ports, *compose_main.expose)
+            if (port := str(exposed).partition("/")[0]).isdigit()
+        }
+        ports.update(
+            published.target for published in compose_main.ports if published.protocol == "tcp"
+        )
+        if 8765 in ports:
+            raise ValueError("Harbor main service port 8765 conflicts with the HUD control port")
         healthcheck = environment.healthcheck
         if healthcheck is None and compose_main.healthcheck is not None:
             healthcheck = HealthcheckConfig.from_compose(compose_main.healthcheck)
+        verifier_env = {
+            key: value
+            for entry in verifier_config.environment
+            for key, _, value in (entry.partition("="),)
+        }
         manifest = {
             "name": name,
             "workdir": workdir,
@@ -447,6 +538,13 @@ async def adapt(
                 if compose is not None and compose_main.entrypoint is not None
                 else image_config.entrypoint or []
             ),
+            "ports": sorted(ports),
+            "verifier_root": str(HUD_ROOT / "verifier") if separate else None,
+            "verifier_image": {
+                "user": verifier_config.user or None,
+                "workdir": verifier_config.working_dir or "/",
+                "env": verifier_env,
+            },
             "environment": {
                 "env": {
                     **compose_main.environment,
@@ -470,6 +568,7 @@ async def adapt(
                 ).to_manifest()
                 for server in environment.mcp_servers
             ],
+            "local_aliases": ["main"] if compose is not None else [],
             "peers": peers,
             "tasks": [],
         }
@@ -479,12 +578,22 @@ async def adapt(
             target = context / "tasks" / task.path.name
             target.mkdir()
             shutil.copy2(task.path / "instruction.md", target / "instruction.md")
-            shutil.copytree(task.path / "tests", target / "tests", symlinks=True, ignore=IGNORED)
+            task_separate = task.config.verifier.separate
+            if not task_separate:
+                shutil.copytree(
+                    task.path / "tests",
+                    target / "tests",
+                    symlinks=True,
+                    ignore=IGNORED,
+                )
             manifest["tasks"].append(
                 {
                     "id": task.path.name,
                     "description": task.config.task.description,
                     "verifier_timeout": task.config.verifier.timeout_sec or 600.0,
+                    "separate_verifier": task_separate,
+                    "collect": [hook.model_dump() for hook in task.config.verifier.collect],
+                    "artifacts": [artifact.model_dump() for artifact in task.config.artifacts],
                 }
             )
         (context / "tasks.json").write_text(
@@ -509,8 +618,12 @@ async def adapt(
         image = f"{push}/{name}:{tag}" if push else f"hud-harbor:{name}-{tag}"
         await docker(
             "build",
+            "--target",
+            "verifier" if separate else "plain",
             "--build-arg",
             f"BASE_IMAGE={base_image}",
+            "--build-arg",
+            f"VERIFIER_IMAGE={verifier_image}",
             "--build-arg",
             f"HUD_REQUIREMENT={requirement}",
             "--tag",
@@ -521,6 +634,16 @@ async def adapt(
             await docker("push", image)
 
         if compose is not None:
+            volumes = compose.services["main"].volumes
+            if separate:
+                volumes = [
+                    *volumes,
+                    {
+                        "type": "bind",
+                        "source": "/var/run/docker.sock",
+                        "target": str(HUD_ROOT / "docker.sock"),
+                    },
+                ]
             main = compose.services["main"].model_copy(
                 update={
                     "build": None,
@@ -529,6 +652,7 @@ async def adapt(
                     "working_dir": None,
                     "user": None,
                     "healthcheck": None,
+                    "volumes": volumes,
                 }
             )
             compose.services["main"] = main.with_image(
@@ -547,15 +671,23 @@ async def adapt(
 
         for task in group:
             config = task.config
+            task_separate = config.verifier.separate
+            phase_environment = config.verifier.environment or EnvironmentConfig()
+            gpu_count = max(config.environment.gpus or 0, phase_environment.gpus or 0)
+            gpu_types = config.environment.gpu_types or phase_environment.gpu_types
             resources = RuntimeResources(
-                cpu=config.environment.cpus,
-                memory_mb=config.environment.memory_mb,
+                cpu=max(config.environment.cpus or 0, phase_environment.cpus or 0) or None,
+                memory_mb=max(
+                    config.environment.memory_mb or 0,
+                    phase_environment.memory_mb or 0,
+                )
+                or None,
                 gpu=(
                     RuntimeGPU(
-                        count=config.environment.gpus,
-                        type=next(iter(filter(None, config.environment.gpu_types)), None),
+                        count=gpu_count,
+                        type=next(iter(filter(None, gpu_types)), None),
                     )
-                    if config.environment.gpus
+                    if gpu_count
                     else None
                 ),
             )
@@ -576,6 +708,9 @@ async def adapt(
                         image=image if compose is None else None,
                         compose=context / "compose.json" if compose is not None else None,
                         resources=resources if resources.model_dump(exclude_none=True) else None,
+                    ),
+                    verifier=(
+                        Task(env=name, id=f"{task.path.name}:verify") if task_separate else None
                     ),
                 )
             )

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -656,16 +656,6 @@ async def adapt(
             await docker("push", image)
 
         if compose is not None:
-            volumes = compose.services["main"].volumes
-            if separate:
-                volumes = [
-                    *volumes,
-                    {
-                        "type": "bind",
-                        "source": "/var/run/docker.sock",
-                        "target": str(HUD_ROOT / "docker.sock"),
-                    },
-                ]
             main = compose.services["main"].model_copy(
                 update={
                     "build": None,
@@ -674,7 +664,6 @@ async def adapt(
                     "working_dir": None,
                     "user": None,
                     "healthcheck": None,
-                    "volumes": volumes,
                 }
             )
             compose.services["main"] = main.with_image(
@@ -729,6 +718,7 @@ async def adapt(
                     runtime_config=RuntimeConfig(
                         image=image if compose is None else None,
                         compose=context / "compose.json" if compose is not None else None,
+                        compose_service_access=compose is not None and task_separate,
                         resources=resources if resources.model_dump(exclude_none=True) else None,
                     ),
                     verifier=(

--- a/integrations/harbor/adapt.py
+++ b/integrations/harbor/adapt.py
@@ -19,6 +19,7 @@ from typing import Any, Literal, cast
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from hud.capabilities import Capability
+from hud.environment.egress import BRIDGE_PORT, VISITOR_PORT
 from hud.eval import Task, Taskset
 from hud.eval.compose import ComposeConfig, ComposeHealthcheck, ComposeService, ImageConfig
 from hud.eval.runtime import RuntimeConfig, RuntimeGPU, RuntimeResources
@@ -517,8 +518,10 @@ async def adapt(
         ports.update(
             published.target for published in compose_main.ports if published.protocol == "tcp"
         )
-        if 8765 in ports:
-            raise ValueError("Harbor main service port 8765 conflicts with the HUD control port")
+        if conflict := ports & {BRIDGE_PORT, VISITOR_PORT, 8765}:
+            raise ValueError(
+                f"Harbor main service port {min(conflict)} conflicts with a HUD reserved port"
+            )
         healthcheck = environment.healthcheck
         if healthcheck is None and compose_main.healthcheck is not None:
             healthcheck = HealthcheckConfig.from_compose(compose_main.healthcheck)

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -54,27 +54,65 @@ def network(phase: dict[str, Any] | None) -> tuple[bool, frozenset[str]]:
     return True, frozenset({ANY_HOST})
 
 
-def identity(phase: dict[str, Any] | None) -> tuple[int, int] | None:
+def identity(
+    phase: dict[str, Any] | None,
+    *,
+    image_user: str | int | None,
+    root: Path | None = None,
+) -> tuple[int, int] | None:
     declared = phase["user"] if phase is not None else None
-    user = str(declared if declared is not None else CONFIG["image_user"] or "")
+    user = str(declared if declared is not None else image_user or "")
     if not user:
         return None
     user_name, separator, group_name = user.partition(":")
-    account = None
-    if user_name.isdigit():
-        user_id = int(user_name)
-        with contextlib.suppress(KeyError):
-            account = pwd.getpwuid(user_id)
+    if root is None:
+        account = None
+        if user_name.isdigit():
+            user_id = int(user_name)
+            with contextlib.suppress(KeyError):
+                account = pwd.getpwuid(user_id)
+        else:
+            try:
+                account = pwd.getpwnam(user_name)
+            except KeyError as error:
+                raise ValueError(f"Harbor user {user!r} does not exist in this image") from error
+            user_id = account.pw_uid
+        primary_group = account.pw_gid if account is not None else 0
     else:
-        try:
-            account = pwd.getpwnam(user_name)
-        except KeyError as error:
-            raise ValueError(f"Harbor user {user!r} does not exist in this image") from error
-        user_id = account.pw_uid
+        passwd = root / "etc/passwd"
+        accounts = {
+            fields[0]: (int(fields[2]), int(fields[3]))
+            for line in (passwd.read_text("utf-8").splitlines() if passwd.is_file() else ())
+            if len(fields := line.split(":")) >= 4
+        }
+        if user_name.isdigit():
+            user_id = int(user_name)
+            primary_group = next(
+                (group_id for uid, group_id in accounts.values() if uid == user_id),
+                0,
+            )
+        else:
+            try:
+                user_id, primary_group = accounts[user_name]
+            except KeyError as error:
+                raise ValueError(f"Harbor user {user!r} does not exist in this image") from error
 
     if separator:
         if group_name.isdigit():
             group_id = int(group_name)
+        elif root is not None:
+            group = root / "etc/group"
+            groups = {
+                fields[0]: int(fields[2])
+                for line in (group.read_text("utf-8").splitlines() if group.is_file() else ())
+                if len(fields := line.split(":")) >= 3
+            }
+            try:
+                group_id = groups[group_name]
+            except KeyError as error:
+                raise ValueError(
+                    f"Harbor group {group_name!r} does not exist in this image"
+                ) from error
         else:
             try:
                 group_id = grp.getgrnam(group_name).gr_gid
@@ -85,21 +123,31 @@ def identity(phase: dict[str, Any] | None) -> tuple[int, int] | None:
     else:
         # Docker resolves a known account's primary group; a bare numeric uid
         # with no passwd entry keeps the container default group (root).
-        group_id = account.pw_gid if account is not None else 0
+        group_id = primary_group
     return None if (user_id, group_id) == (0, 0) else (user_id, group_id)
 
 
-def home(user_id: int | None) -> str | None:
+def home(user_id: int | None, *, root: Path | None = None) -> str | None:
     if user_id is None:
         return None
+    if root is not None:
+        passwd = root / "etc/passwd"
+        return next(
+            (
+                fields[5]
+                for line in (passwd.read_text("utf-8").splitlines() if passwd.is_file() else ())
+                if len(fields := line.split(":")) >= 6 and int(fields[2]) == user_id
+            ),
+            None,
+        )
     with contextlib.suppress(KeyError):
         return pwd.getpwuid(user_id).pw_dir
     return None
 
 
 agent = CONFIG["agent"]
-image_identity = identity(None)
-agent_identity = identity(agent)
+image_identity = identity(None, image_user=CONFIG["image_user"])
+agent_identity = identity(agent, image_user=CONFIG["image_user"])
 agent_uid = agent_identity[0] if agent_identity is not None else None
 agent_network, agent_hosts = network(agent)
 environment_hosts = network(None)[1]
@@ -423,7 +471,7 @@ async def grade(task_dir: Path, timeout_sec: float, answer: Any) -> EvaluationRe
     AGENT_ANSWER.write_text("" if answer is None else str(answer), encoding="utf-8")
 
     verifier = CONFIG["verifier"]
-    verifier_identity = identity(verifier)
+    verifier_identity = identity(verifier, image_user=CONFIG["image_user"])
     verifier_uid = verifier_identity[0] if verifier_identity is not None else None
     verifier_env = {**CONFIG["environment"]["env"], **verifier["env"]}
     if verifier_uid is not None:
@@ -486,11 +534,15 @@ async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
     verifier = CONFIG["verifier"]
     verifier_network, verifier_hosts = network(verifier)
     image = CONFIG["verifier_image"]
+    verifier_identity = identity(verifier, image_user=image["user"], root=verifier_root)
+    verifier_uid = verifier_identity[0] if verifier_identity is not None else None
     verifier_env = {
         **image["env"],
         **CONFIG["environment"]["env"],
         **verifier["env"],
     }
+    if verifier_home := home(verifier_uid, root=verifier_root):
+        verifier_env["HOME"] = verifier_home
     isolated = Workspace(
         verifier_root,
         guest_path="/",
@@ -508,7 +560,7 @@ async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
         execution = await isolated.run(
             ["/tests/test.sh"],
             env=verifier_env,
-            identity=None,
+            identity=verifier_identity,
             inherit_workspace_env=False,
             allowed_hosts=verifier_hosts,
             no_new_privs=False,

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -499,6 +499,8 @@ async def grade(task_dir: Path, timeout_sec: float, answer: Any) -> EvaluationRe
 
 async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
     verifier_root = Path(CONFIG["verifier_root"])
+    test_script = verifier_root / "tests/test.sh"
+    test_script.chmod(test_script.stat().st_mode | 0o555)
     clear(VERIFIER_LOGS)
     VERIFIER_LOGS.chmod(0o777)
     LOGS.mkdir(parents=True, exist_ok=True)

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -560,50 +560,60 @@ def artifact_mounts(task: dict[str, Any], verifier_root: Path) -> Iterator[list[
 async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
     async with verifier_lock:
         verifier_root = Path(CONFIG["verifier_root"])
+        test_script = verifier_root / "tests/test.sh"
+        test_mode = test_script.stat().st_mode
+        test_script.chmod(test_mode | 0o111)
         clear(VERIFIER_LOGS)
         VERIFIER_LOGS.chmod(0o777)
         LOGS.mkdir(parents=True, exist_ok=True)
         AGENT_ANSWER.write_text("" if answer is None else str(answer), encoding="utf-8")
 
-        with artifact_mounts(task, verifier_root) as mounts:
-            verifier = CONFIG["verifier"]
-            verifier_network, verifier_hosts = network(verifier)
-            image = CONFIG["verifier_image"]
-            verifier_identity = identity(verifier, image_user=image["user"], root=verifier_root)
-            verifier_uid = verifier_identity[0] if verifier_identity is not None else None
-            verifier_env = {
-                **CONFIG["environment"]["env"],
-                **image["env"],
-                **verifier["env"],
-            }
-            if verifier_home := home(verifier_uid, root=verifier_root):
-                verifier_env["HOME"] = verifier_home
-            isolated = Workspace(
-                verifier_root,
-                guest_path="/",
-                system_mounts=(),
-                mounts=mounts,
-                env=verifier_env,
-                network=verifier_network,
-                allowed_hosts=verifier_hosts,
-                credentials_dir=ROOT / "verifier-keys",
-                hand_over_root=False,
-                require_isolation=True,
-            )
-            try:
-                await isolated.start()
-                execution = await isolated.run(
-                    ["/bin/sh", "/tests/test.sh"],
-                    env=verifier_env,
-                    cwd=image["workdir"],
-                    identity=verifier_identity,
-                    inherit_workspace_env=False,
-                    allowed_hosts=verifier_hosts,
-                    no_new_privs=False,
-                    max_wait=task["verifier_timeout"],
+        try:
+            with artifact_mounts(task, verifier_root) as mounts:
+                verifier = CONFIG["verifier"]
+                verifier_network, verifier_hosts = network(verifier)
+                image = CONFIG["verifier_image"]
+                verifier_identity = identity(
+                    verifier,
+                    image_user=image["user"],
+                    root=verifier_root,
                 )
-            finally:
-                await isolated.stop()
+                verifier_uid = verifier_identity[0] if verifier_identity is not None else None
+                verifier_env = {
+                    **CONFIG["environment"]["env"],
+                    **image["env"],
+                    **verifier["env"],
+                }
+                if verifier_home := home(verifier_uid, root=verifier_root):
+                    verifier_env["HOME"] = verifier_home
+                isolated = Workspace(
+                    verifier_root,
+                    guest_path="/",
+                    system_mounts=(),
+                    mounts=mounts,
+                    env=verifier_env,
+                    network=verifier_network,
+                    allowed_hosts=verifier_hosts,
+                    credentials_dir=ROOT / "verifier-keys",
+                    hand_over_root=False,
+                    require_isolation=True,
+                )
+                try:
+                    await isolated.start()
+                    execution = await isolated.run(
+                        ["/tests/test.sh"],
+                        env=verifier_env,
+                        cwd=image["workdir"],
+                        identity=verifier_identity,
+                        inherit_workspace_env=False,
+                        allowed_hosts=verifier_hosts,
+                        no_new_privs=False,
+                        max_wait=task["verifier_timeout"],
+                    )
+                finally:
+                    await isolated.stop()
+        finally:
+            test_script.chmod(test_mode)
     return evaluation(execution, task["verifier_timeout"])
 
 

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -560,6 +560,7 @@ async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
         execution = await isolated.run(
             ["/tests/test.sh"],
             env=verifier_env,
+            cwd=image["workdir"],
             identity=verifier_identity,
             inherit_workspace_env=False,
             allowed_hosts=verifier_hosts,

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -10,14 +10,16 @@ import math
 import os
 import pwd
 import shutil
+import socket
 from collections.abc import AsyncGenerator  # noqa: TC003
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hud.capabilities import Capability
-from hud.environment import Environment, Mount, Peer
+from hud.environment import Environment, Mount, Peer, Workspace
 from hud.environment.egress import ANY_HOST
 from hud.graders import EvaluationResult
+from hud.utils.process import ProcessResult, create_process_group_exec
 
 if TYPE_CHECKING:
     from hud.environment.namespace import NamespaceProcess
@@ -27,6 +29,10 @@ TESTS = Path("/tests")
 LOGS = Path("/logs")
 VERIFIER_LOGS = LOGS / "verifier"
 AGENT_ANSWER = LOGS / "agent_answer.txt"
+ARTIFACTS = ROOT / "artifacts"
+DOCKER_SOCKET = ROOT / "docker.sock"
+DOCKER = ROOT / "bin" / "docker"
+NULL_SINK = ROOT / "null"
 CONFIG = json.loads((ROOT / "tasks.json").read_text("utf-8"))
 
 os.environ.update(CONFIG["environment"]["env"])
@@ -99,6 +105,8 @@ agent_network, agent_hosts = network(agent)
 environment_hosts = network(None)[1]
 rooted_at_filesystem = len(WORKDIR.parts) == 1
 harness_parent = ROOT.parent
+NULL_SINK.touch(mode=0o666)
+NULL_SINK.chmod(0o666)
 harness_mounts = (
     Mount("tmpfs", dst=str(harness_parent)),
     *(
@@ -122,11 +130,13 @@ workspace = env.workspace(
     guest_path=WORKDIR.as_posix(),
     system_mounts=(
         Mount("rw", src="/", dst="/"),
-        Mount("proc", dst="/proc"),
         Mount("dev", dst="/dev"),
+        Mount("proc", dst="/proc"),
+        Mount("rw", src=str(NULL_SINK), dst="/dev/null"),
     ),
     mounts=agent_mounts,
     credentials_dir=ROOT / "session-keys",
+    hosts_path=ROOT / "hosts",
     shell_uid=agent_uid,
     shell_gid=agent_identity[1] if agent_identity is not None else None,
     hand_over_root=False,
@@ -143,6 +153,8 @@ workspace = env.workspace(
         Peer(peer["name"], peer["port"], target=(peer["name"], peer["port"]))
         for peer in CONFIG["peers"]
     ],
+    local_aliases=CONFIG["local_aliases"],
+    ports=CONFIG["ports"],
     require_isolation=True,
 )
 
@@ -187,7 +199,7 @@ async def wait_until_healthy(entrypoint: NamespaceProcess | None) -> None:
             env=CONFIG["environment"]["env"],
             identity=image_identity,
             inherit_workspace_env=False,
-            allowed_hosts=environment_hosts,
+            allowed_hosts=None if environment_hosts == agent_hosts else environment_hosts,
             no_new_privs=False,
             max_wait=healthcheck["timeout_sec"],
         )
@@ -208,6 +220,122 @@ async def wait_until_healthy(entrypoint: NamespaceProcess | None) -> None:
         await asyncio.sleep(delay)
 
 
+async def docker(*args: str, max_wait: float = 60.0, check: bool = True) -> ProcessResult:
+    process = await create_process_group_exec(
+        str(DOCKER),
+        "--host",
+        f"unix://{DOCKER_SOCKET}",
+        *args,
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    result = await process.complete(max_wait=max_wait)
+    if result.timed_out:
+        raise TimeoutError(f"docker {' '.join(args)} timed out after {max_wait:g}s")
+    if check and result.returncode != 0:
+        detail = result.stderr.decode("utf-8", "replace").strip()
+        raise RuntimeError(f"docker {' '.join(args)} failed: {detail}")
+    return result
+
+
+def copy_artifact(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir():
+        shutil.copytree(source, target, symlinks=True)
+    elif source.exists() or source.is_symlink():
+        shutil.copy2(source, target, follow_symlinks=False)
+
+
+async def collect(task: dict[str, Any]) -> None:
+    clear(ARTIFACTS)
+    services: dict[str, str] = {}
+
+    async def container(service: str) -> str:
+        service = "main" if service == "workspace" else service
+        if service == "main":
+            return ""
+        if service in services:
+            return services[service]
+        if not DOCKER_SOCKET.exists():
+            raise RuntimeError(
+                f"collecting from Compose service {service!r} requires runtime service access"
+            )
+        if not services:
+            project = await docker(
+                "inspect",
+                "--format",
+                '{{ index .Config.Labels "com.docker.compose.project" }}',
+                socket.gethostname(),
+            )
+            project_name = project.stdout.decode().strip()
+            if not project_name:
+                raise RuntimeError("the Harbor container has no Compose project label")
+            listed = await docker(
+                "ps",
+                "--filter",
+                f"label=com.docker.compose.project={project_name}",
+                "--format",
+                '{{.ID}} {{.Label "com.docker.compose.service"}}',
+            )
+            for line in listed.stdout.decode().splitlines():
+                container_id, service_name = line.split(maxsplit=1)
+                services[service_name] = container_id
+        try:
+            return services[service]
+        except KeyError as error:
+            raise RuntimeError(f"Compose service {service!r} is not running") from error
+
+    for hook in task["collect"]:
+        service = hook["service"]
+        container_id = await container(service)
+        if container_id:
+            await docker(
+                "exec",
+                container_id,
+                "sh",
+                "-c",
+                hook["command"],
+                max_wait=hook["timeout_sec"],
+            )
+        else:
+            execution = await workspace.run(
+                ["sh", "-c", hook["command"]],
+                mounts=harness_mounts,
+                identity=image_identity,
+                inherit_workspace_env=False,
+                allowed_hosts=None,
+                no_new_privs=False,
+                max_wait=hook["timeout_sec"],
+            )
+            if execution.timed_out:
+                raise TimeoutError(
+                    f"collect hook on {service!r} timed out after {hook['timeout_sec']:g}s"
+                )
+            if execution.returncode != 0:
+                detail = execution.stderr.decode("utf-8", "replace").strip()
+                raise RuntimeError(f"collect hook on {service!r} failed: {detail}")
+
+    for artifact in task["artifacts"]:
+        source = artifact["source"]
+        target = ARTIFACTS / source.lstrip("/").rstrip("/")
+        service = artifact["service"]
+        container_id = await container(service)
+        if container_id:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            copied = await docker(
+                "cp",
+                f"{container_id}:{source.rstrip('/') or '/'}",
+                str(target),
+                max_wait=task["verifier_timeout"],
+                check=False,
+            )
+            if copied.returncode != 0:
+                continue
+        else:
+            copy_artifact(Path(source), target)
+
+
 def register(task: dict[str, Any]) -> None:
     task_dir = ROOT / "tasks" / task["id"]
 
@@ -216,6 +344,7 @@ def register(task: dict[str, Any]) -> None:
         description=task["description"] or f"Harbor task {task['id']}",
     )
     async def run() -> AsyncGenerator[Any, Any]:
+        NULL_SINK.write_bytes(b"")
         clear_grading_files()
         AGENT_ANSWER.parent.mkdir(parents=True, exist_ok=True)
         AGENT_ANSWER.touch()
@@ -228,13 +357,32 @@ def register(task: dict[str, Any]) -> None:
                 raise RuntimeError(
                     f"Harbor environment entrypoint exited with status {entrypoint.returncode}"
                 )
-            yield await grade(task_dir, task["verifier_timeout"], answer)
+            if task["separate_verifier"]:
+                await collect(task)
+                yield 0.0
+            else:
+                yield await grade(task_dir, task["verifier_timeout"], answer)
         finally:
             clear_grading_files()
             await workspace.discard_sandbox()
             if entrypoint is not None:
                 with contextlib.suppress(Exception):
                     await asyncio.wait_for(entrypoint.wait(), 10.0)
+
+    if task["separate_verifier"]:
+
+        @env.template(
+            id=f"{task['id']}:verify",
+            description=f"Verify Harbor task {task['id']}",
+        )
+        async def verify() -> AsyncGenerator[Any, Any]:
+            NULL_SINK.write_bytes(b"")
+            answer = yield ""
+            try:
+                yield await grade_separate(task, answer)
+            finally:
+                clear_grading_files()
+                shutil.rmtree(ARTIFACTS, ignore_errors=True)
 
 
 for task_config in CONFIG["tasks"]:
@@ -297,7 +445,81 @@ async def grade(task_dir: Path, timeout_sec: float, answer: Any) -> EvaluationRe
         no_new_privs=False,
         max_wait=timeout_sec,
     )
+    return evaluation(execution, timeout_sec)
 
+
+async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
+    verifier_root = Path(CONFIG["verifier_root"])
+    clear(VERIFIER_LOGS)
+    VERIFIER_LOGS.chmod(0o777)
+    LOGS.mkdir(parents=True, exist_ok=True)
+    AGENT_ANSWER.write_text("" if answer is None else str(answer), encoding="utf-8")
+
+    mounts: list[Mount] = [
+        Mount("dev", dst="/dev"),
+        Mount("proc", dst="/proc"),
+        Mount("rw", src=str(NULL_SINK), dst="/dev/null"),
+        Mount("rw", src=str(LOGS), dst="/logs"),
+    ]
+    (verifier_root / "logs").mkdir(parents=True, exist_ok=True)
+    for artifact in task["artifacts"]:
+        source = artifact["source"].rstrip("/") or "/"
+        staged = ARTIFACTS / source.lstrip("/")
+        target = verifier_root / source.lstrip("/")
+        if not staged.exists() and not staged.is_symlink():
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target)
+            else:
+                target.unlink(missing_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if staged.is_dir():
+            if target.exists() and not target.is_dir():
+                target.unlink()
+            target.mkdir(exist_ok=True)
+        else:
+            if target.is_dir() and not target.is_symlink():
+                shutil.rmtree(target)
+            target.touch(exist_ok=True)
+        mounts.append(Mount("rw", src=str(staged), dst=source))
+
+    verifier = CONFIG["verifier"]
+    verifier_network, verifier_hosts = network(verifier)
+    image = CONFIG["verifier_image"]
+    verifier_env = {
+        **image["env"],
+        **CONFIG["environment"]["env"],
+        **verifier["env"],
+    }
+    isolated = Workspace(
+        verifier_root,
+        guest_path="/",
+        system_mounts=(),
+        mounts=mounts,
+        env=verifier_env,
+        network=verifier_network,
+        allowed_hosts=verifier_hosts,
+        credentials_dir=ROOT / "verifier-keys",
+        hand_over_root=False,
+        require_isolation=True,
+    )
+    await isolated.start()
+    try:
+        execution = await isolated.run(
+            ["/tests/test.sh"],
+            env=verifier_env,
+            identity=None,
+            inherit_workspace_env=False,
+            allowed_hosts=verifier_hosts,
+            no_new_privs=False,
+            max_wait=task["verifier_timeout"],
+        )
+    finally:
+        await isolated.stop()
+    return evaluation(execution, task["verifier_timeout"])
+
+
+def evaluation(execution: ProcessResult, timeout_sec: float) -> EvaluationResult:
     info: dict[str, Any] = {
         "exit_code": execution.returncode,
         "stdout": execution.stdout.decode("utf-8", "replace")[-4000:],

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -32,7 +32,6 @@ AGENT_ANSWER = LOGS / "agent_answer.txt"
 ARTIFACTS = ROOT / "artifacts"
 DOCKER_SOCKET = ROOT / "docker.sock"
 DOCKER = ROOT / "bin" / "docker"
-NULL_SINK = ROOT / "null"
 CONFIG = json.loads((ROOT / "tasks.json").read_text("utf-8"))
 
 os.environ.update(CONFIG["environment"]["env"])
@@ -153,8 +152,6 @@ agent_network, agent_hosts = network(agent)
 environment_hosts = network(None)[1]
 rooted_at_filesystem = len(WORKDIR.parts) == 1
 harness_parent = ROOT.parent
-NULL_SINK.touch(mode=0o666)
-NULL_SINK.chmod(0o666)
 harness_mounts = (
     Mount("tmpfs", dst=str(harness_parent)),
     *(
@@ -180,7 +177,6 @@ workspace = env.workspace(
         Mount("rw", src="/", dst="/"),
         Mount("dev", dst="/dev"),
         Mount("proc", dst="/proc"),
-        Mount("rw", src=str(NULL_SINK), dst="/dev/null"),
     ),
     mounts=agent_mounts,
     credentials_dir=ROOT / "session-keys",
@@ -234,9 +230,12 @@ async def wait_until_healthy(entrypoint: NamespaceProcess | None) -> None:
         return
 
     loop = asyncio.get_running_loop()
-    start_period_end = loop.time() + healthcheck["start_period_sec"]
+    start_period = healthcheck["start_period_sec"]
+    start_period_end = loop.time() + start_period
+    delay = healthcheck["start_interval_sec"] if start_period > 0 else healthcheck["interval_sec"]
     failures = 0
     while True:
+        await asyncio.sleep(delay)
         in_start_period = loop.time() < start_period_end
         if entrypoint is not None and entrypoint.returncode is not None:
             raise RuntimeError(
@@ -265,7 +264,6 @@ async def wait_until_healthy(entrypoint: NamespaceProcess | None) -> None:
                     + (f": {detail}" if detail else "")
                 )
             delay = healthcheck["interval_sec"]
-        await asyncio.sleep(delay)
 
 
 async def docker(*args: str, max_wait: float = 60.0, check: bool = True) -> ProcessResult:
@@ -392,7 +390,6 @@ def register(task: dict[str, Any]) -> None:
         description=task["description"] or f"Harbor task {task['id']}",
     )
     async def run() -> AsyncGenerator[Any, Any]:
-        NULL_SINK.write_bytes(b"")
         clear_grading_files()
         AGENT_ANSWER.parent.mkdir(parents=True, exist_ok=True)
         AGENT_ANSWER.touch()
@@ -424,7 +421,6 @@ def register(task: dict[str, Any]) -> None:
             description=f"Verify Harbor task {task['id']}",
         )
         async def verify() -> AsyncGenerator[Any, Any]:
-            NULL_SINK.write_bytes(b"")
             answer = yield ""
             try:
                 yield await grade_separate(task, answer)
@@ -506,7 +502,6 @@ async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
     mounts: list[Mount] = [
         Mount("dev", dst="/dev"),
         Mount("proc", dst="/proc"),
-        Mount("rw", src=str(NULL_SINK), dst="/dev/null"),
         Mount("rw", src=str(LOGS), dst="/logs"),
     ]
     (verifier_root / "logs").mkdir(parents=True, exist_ok=True)

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -539,8 +539,8 @@ async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
     verifier_identity = identity(verifier, image_user=image["user"], root=verifier_root)
     verifier_uid = verifier_identity[0] if verifier_identity is not None else None
     verifier_env = {
-        **image["env"],
         **CONFIG["environment"]["env"],
+        **image["env"],
         **verifier["env"],
     }
     if verifier_home := home(verifier_uid, root=verifier_root):

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -219,7 +219,6 @@ async def start_entrypoint() -> NamespaceProcess | None:
         inherit_workspace_env=False,
         no_new_privs=False,
         persistent=True,
-        scope="environment",
     )
     await asyncio.sleep(0)
     if process.returncode is not None:

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -286,6 +286,8 @@ async def docker(*args: str, max_wait: float = 60.0, check: bool = True) -> Proc
 
 
 def copy_artifact(source: Path, target: Path) -> None:
+    if source.is_symlink():
+        raise RuntimeError(f"artifact {source} is a symbolic link")
     target.parent.mkdir(parents=True, exist_ok=True)
     if source.is_dir():
         shutil.copytree(source, target, symlinks=True)
@@ -362,6 +364,7 @@ async def collect(task: dict[str, Any]) -> None:
                 detail = execution.stderr.decode("utf-8", "replace").strip()
                 raise RuntimeError(f"collect hook on {service!r} failed: {detail}")
 
+    await workspace.discard_sandbox()
     for artifact in task["artifacts"]:
         source = artifact["source"]
         target = ARTIFACTS / source.lstrip("/").rstrip("/")
@@ -380,6 +383,8 @@ async def collect(task: dict[str, Any]) -> None:
                 continue
         else:
             copy_artifact(Path(source), target)
+        if target.is_symlink() or any(path.is_symlink() for path in target.rglob("*")):
+            raise RuntimeError(f"artifact {source} contains a symbolic link")
 
 
 def register(task: dict[str, Any]) -> None:

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -288,9 +288,16 @@ async def docker(*args: str, max_wait: float = 60.0, check: bool = True) -> Proc
 def copy_artifact(source: Path, target: Path) -> None:
     if source.is_symlink():
         raise RuntimeError(f"artifact {source} is a symbolic link")
+    if source.resolve(strict=False) != source.absolute():
+        raise RuntimeError(f"artifact {source} has a symbolic link in its path")
     target.parent.mkdir(parents=True, exist_ok=True)
     if source.is_dir():
-        shutil.copytree(source, target, symlinks=True)
+        for root, directories, files in os.walk(source, followlinks=False):
+            for name in (*directories, *files):
+                entry = Path(root, name)
+                if entry.is_symlink():
+                    raise RuntimeError(f"artifact {source} contains symbolic link {entry}")
+        shutil.copytree(source, target)
     elif source.exists() or source.is_symlink():
         shutil.copy2(source, target, follow_symlinks=False)
 

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -219,6 +219,7 @@ async def start_entrypoint() -> NamespaceProcess | None:
         inherit_workspace_env=False,
         no_new_privs=False,
         persistent=True,
+        scope="environment",
     )
     await asyncio.sleep(0)
     if process.returncode is not None:
@@ -251,6 +252,7 @@ async def wait_until_healthy(entrypoint: NamespaceProcess | None) -> None:
             allowed_hosts=None if environment_hosts == agent_hosts else environment_hosts,
             no_new_privs=False,
             max_wait=healthcheck["timeout_sec"],
+            scope="environment",
         )
         if result.returncode == 0 and not result.timed_out:
             return
@@ -364,6 +366,7 @@ async def collect(task: dict[str, Any]) -> None:
                 allowed_hosts=None,
                 no_new_privs=False,
                 max_wait=hook["timeout_sec"],
+                scope="environment",
             )
             if execution.timed_out:
                 raise TimeoutError(
@@ -373,7 +376,6 @@ async def collect(task: dict[str, Any]) -> None:
                 detail = execution.stderr.decode("utf-8", "replace").strip()
                 raise RuntimeError(f"collect hook on {service!r} failed: {detail}")
 
-    await workspace.discard_sandbox()
     for artifact in task["artifacts"]:
         source = artifact["source"]
         target = ARTIFACTS / source.lstrip("/").rstrip("/")
@@ -417,6 +419,7 @@ def register(task: dict[str, Any]) -> None:
                     f"Harbor environment entrypoint exited with status {entrypoint.returncode}"
                 )
             if task["separate_verifier"]:
+                await workspace.terminate_sessions()
                 await collect(task)
                 yield 0.0
             else:

--- a/integrations/harbor/env.py
+++ b/integrations/harbor/env.py
@@ -11,7 +11,8 @@ import os
 import pwd
 import shutil
 import socket
-from collections.abc import AsyncGenerator  # noqa: TC003
+import tempfile
+from collections.abc import AsyncGenerator, Iterator  # noqa: TC003
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -168,6 +169,7 @@ agent_mounts = (
 )
 
 env = Environment(CONFIG["name"])
+verifier_lock = asyncio.Lock()
 for capability in CONFIG["capabilities"]:
     env.add_capability(Capability.from_manifest(capability))
 workspace = env.workspace(
@@ -504,80 +506,104 @@ async def grade(task_dir: Path, timeout_sec: float, answer: Any) -> EvaluationRe
     return evaluation(execution, timeout_sec)
 
 
-async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
-    verifier_root = Path(CONFIG["verifier_root"])
-    test_script = verifier_root / "tests/test.sh"
-    test_script.chmod(test_script.stat().st_mode | 0o555)
-    clear(VERIFIER_LOGS)
-    VERIFIER_LOGS.chmod(0o777)
-    LOGS.mkdir(parents=True, exist_ok=True)
-    AGENT_ANSWER.write_text("" if answer is None else str(answer), encoding="utf-8")
-
+@contextlib.contextmanager
+def artifact_mounts(task: dict[str, Any], verifier_root: Path) -> Iterator[list[Mount]]:
     mounts: list[Mount] = [
         Mount("dev", dst="/dev"),
         Mount("proc", dst="/proc"),
-        Mount("rw", src=str(LOGS), dst="/logs"),
     ]
-    (verifier_root / "logs").mkdir(parents=True, exist_ok=True)
+    bindings: list[tuple[Path | None, str]] = [(LOGS, "/logs")]
     for artifact in task["artifacts"]:
         source = artifact["source"].rstrip("/") or "/"
         staged = ARTIFACTS / source.lstrip("/")
-        target = verifier_root / source.lstrip("/")
-        if not staged.exists() and not staged.is_symlink():
-            if target.is_dir() and not target.is_symlink():
-                shutil.rmtree(target)
-            else:
-                target.unlink(missing_ok=True)
-            continue
-        target.parent.mkdir(parents=True, exist_ok=True)
-        if staged.is_dir():
-            if target.exists() and not target.is_dir():
-                target.unlink()
-            target.mkdir(exist_ok=True)
-        else:
-            if target.is_dir() and not target.is_symlink():
-                shutil.rmtree(target)
-            target.touch(exist_ok=True)
-        mounts.append(Mount("rw", src=str(staged), dst=source))
+        bindings.append((staged if staged.exists() or staged.is_symlink() else None, source))
 
-    verifier = CONFIG["verifier"]
-    verifier_network, verifier_hosts = network(verifier)
-    image = CONFIG["verifier_image"]
-    verifier_identity = identity(verifier, image_user=image["user"], root=verifier_root)
-    verifier_uid = verifier_identity[0] if verifier_identity is not None else None
-    verifier_env = {
-        **CONFIG["environment"]["env"],
-        **image["env"],
-        **verifier["env"],
-    }
-    if verifier_home := home(verifier_uid, root=verifier_root):
-        verifier_env["HOME"] = verifier_home
-    isolated = Workspace(
-        verifier_root,
-        guest_path="/",
-        system_mounts=(),
-        mounts=mounts,
-        env=verifier_env,
-        network=verifier_network,
-        allowed_hosts=verifier_hosts,
-        credentials_dir=ROOT / "verifier-keys",
-        hand_over_root=False,
-        require_isolation=True,
-    )
-    await isolated.start()
-    try:
-        execution = await isolated.run(
-            ["/tests/test.sh"],
-            env=verifier_env,
-            cwd=image["workdir"],
-            identity=verifier_identity,
-            inherit_workspace_env=False,
-            allowed_hosts=verifier_hosts,
-            no_new_privs=False,
-            max_wait=task["verifier_timeout"],
-        )
-    finally:
-        await isolated.stop()
+    with tempfile.TemporaryDirectory(prefix="verifier-backup-", dir=ROOT) as directory:
+        backup_root = Path(directory)
+        replacements: list[tuple[Path, Path | None]] = []
+        try:
+            for staged, destination in bindings:
+                target = verifier_root / destination.lstrip("/")
+                compatible = (
+                    staged is not None
+                    and target.exists()
+                    and not target.is_symlink()
+                    and staged.is_dir() == target.is_dir()
+                )
+                if not compatible and (target.exists() or target.is_symlink()):
+                    backup = backup_root / destination.lstrip("/")
+                    backup.parent.mkdir(parents=True, exist_ok=True)
+                    target.rename(backup)
+                    replacements.append((target, backup))
+                elif staged is not None and not compatible:
+                    replacements.append((target, None))
+                if staged is None:
+                    continue
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if staged.is_dir():
+                    target.mkdir(exist_ok=True)
+                else:
+                    target.touch(exist_ok=True)
+                mounts.append(Mount("rw", src=str(staged), dst=destination))
+            yield mounts
+        finally:
+            for target, backup in reversed(replacements):
+                if target.is_dir() and not target.is_symlink():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink(missing_ok=True)
+                if backup is not None:
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    backup.rename(target)
+
+
+async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
+    async with verifier_lock:
+        verifier_root = Path(CONFIG["verifier_root"])
+        clear(VERIFIER_LOGS)
+        VERIFIER_LOGS.chmod(0o777)
+        LOGS.mkdir(parents=True, exist_ok=True)
+        AGENT_ANSWER.write_text("" if answer is None else str(answer), encoding="utf-8")
+
+        with artifact_mounts(task, verifier_root) as mounts:
+            verifier = CONFIG["verifier"]
+            verifier_network, verifier_hosts = network(verifier)
+            image = CONFIG["verifier_image"]
+            verifier_identity = identity(verifier, image_user=image["user"], root=verifier_root)
+            verifier_uid = verifier_identity[0] if verifier_identity is not None else None
+            verifier_env = {
+                **CONFIG["environment"]["env"],
+                **image["env"],
+                **verifier["env"],
+            }
+            if verifier_home := home(verifier_uid, root=verifier_root):
+                verifier_env["HOME"] = verifier_home
+            isolated = Workspace(
+                verifier_root,
+                guest_path="/",
+                system_mounts=(),
+                mounts=mounts,
+                env=verifier_env,
+                network=verifier_network,
+                allowed_hosts=verifier_hosts,
+                credentials_dir=ROOT / "verifier-keys",
+                hand_over_root=False,
+                require_isolation=True,
+            )
+            try:
+                await isolated.start()
+                execution = await isolated.run(
+                    ["/bin/sh", "/tests/test.sh"],
+                    env=verifier_env,
+                    cwd=image["workdir"],
+                    identity=verifier_identity,
+                    inherit_workspace_env=False,
+                    allowed_hosts=verifier_hosts,
+                    no_new_privs=False,
+                    max_wait=task["verifier_timeout"],
+                )
+            finally:
+                await isolated.stop()
     return evaluation(execution, task["verifier_timeout"])
 
 

--- a/integrations/harbor/install.sh
+++ b/integrations/harbor/install.sh
@@ -3,10 +3,7 @@ set -eu
 
 requirement="${1:-hud}"
 root=/media/hud
-python_version=3.12
 
-export UV_PYTHON_INSTALL_DIR="$root/python"
-export UV_PYTHON_BIN_DIR="$root/bin"
 export UV_NO_CACHE=1
 export XDG_CONFIG_HOME="$root/config"
 export PATH="$root/bin:$PATH"
@@ -16,12 +13,11 @@ if command -v apt-get >/dev/null 2>&1; then
   apt-get install -y -qq bubblewrap util-linux python3 python3-venv python3-pip git curl ca-certificates
   rm -rf /var/lib/apt/lists/*
 elif command -v apk >/dev/null 2>&1; then
-  apk add --no-cache bubblewrap util-linux python3 py3-pip git curl ca-certificates
+  apk add --no-cache bash bubblewrap util-linux python3 py3-pip git curl ca-certificates
 else
   echo "hud: Harbor environments require an apt- or apk-based image" >&2
   exit 1
 fi
 
-uv python install "$python_version"
-uv venv "$root/venv" --python "$python_version"
+uv venv "$root/venv" --python "$(command -v python3)"
 uv pip install --python "$root/venv/bin/python" "$requirement"

--- a/integrations/harbor/install.sh
+++ b/integrations/harbor/install.sh
@@ -3,7 +3,10 @@ set -eu
 
 requirement="${1:-hud}"
 root=/media/hud
+python_version=3.12
 
+export UV_PYTHON_INSTALL_DIR="$root/python"
+export UV_PYTHON_BIN_DIR="$root/bin"
 export UV_NO_CACHE=1
 export XDG_CONFIG_HOME="$root/config"
 export PATH="$root/bin:$PATH"
@@ -19,5 +22,11 @@ else
   exit 1
 fi
 
-uv venv "$root/venv" --python "$(command -v python3)"
+python="$(command -v python3)"
+if ! "$python" -c 'import sys; raise SystemExit(not ((3, 11) <= sys.version_info[:2] < (3, 13)))'; then
+  uv python install "$python_version"
+  python="$root/bin/python$python_version"
+fi
+
+uv venv "$root/venv" --python "$python"
 uv pip install --python "$root/venv/bin/python" "$requirement"

--- a/integrations/harbor/tests/tasks/sidecar-reachability/environment/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/environment/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
+FROM python:3.12-alpine
+RUN apk add --no-cache curl
 WORKDIR /app
+EXPOSE 8080
+ENTRYPOINT ["sh", "-c", "python3 -m http.server 8080 --directory /app >/tmp/main-http.log 2>&1 & exec \"$@\"", "--"]

--- a/integrations/harbor/tests/tasks/sidecar-reachability/environment/compose.yaml
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/environment/compose.yaml
@@ -1,5 +1,10 @@
 services:
-  main: {}
+  main:
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8080"]
+      interval: 100ms
+      timeout: 2s
+      retries: 50
   web:
     image: python:3.11-alpine
     command: ["python", "-m", "http.server", "5678"]

--- a/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
@@ -15,3 +15,8 @@ if printf '%s\n' "$processes" | grep -F "$protected"; then
   echo "protected bridge path is visible in the process list" >&2
   exit 1
 fi
+(
+  while :; do
+    [ ! -e /tmp/main.txt ] || echo agent-race > /tmp/main.txt
+  done
+) >/dev/null 2>&1 &

--- a/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
@@ -11,6 +11,10 @@ curl -fsS --max-time 10 http://main:8080/ > /app/main.html
 protected=/media/hud/session-"keys"
 [ ! -e "$protected" ]
 processes=$(ps -ef)
+if ! printf '%s\n' "$processes" | grep -F "python3 -m http.server 8080 --directory /app" >/dev/null; then
+  echo "the main entrypoint process is absent from the agent process namespace" >&2
+  exit 1
+fi
 if printf '%s\n' "$processes" | grep -F "$protected"; then
   echo "protected bridge path is visible in the process list" >&2
   exit 1

--- a/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
@@ -1,3 +1,16 @@
 #!/bin/sh
 set -eu
+: > /dev/null
 curl -fsS --max-time 10 http://web:5678/ > /app/sidecar.html
+case ",${NO_PROXY:-}," in
+  *,main,*) ;;
+  *) echo "main is absent from NO_PROXY" >&2; exit 1 ;;
+esac
+curl -fsS --max-time 10 http://main:8080/ > /app/main.html
+protected=/media/hud/session-"keys"
+[ ! -e "$protected" ]
+processes=$(ps -ef)
+if printf '%s\n' "$processes" | grep -F "$protected"; then
+  echo "protected bridge path is visible in the process list" >&2
+  exit 1
+fi

--- a/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/solution/solve.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
-: > /dev/null
+[ -c /dev/null ]
+printf discarded > /dev/null
 curl -fsS --max-time 10 http://web:5678/ > /app/sidecar.html
 case ",${NO_PROXY:-}," in
   *,main,*) ;;

--- a/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
@@ -17,7 +17,7 @@ timeout_sec = 30
 
 [[verifier.collect]]
 service = "main"
-command = "head -c 1 /dev/urandom >/dev/null && echo collected-from-main > /tmp/main.txt"
+command = "head -c 1 /dev/urandom >/dev/null && echo collected-from-main > /tmp/main.txt && sleep 0.2"
 timeout_sec = 10
 
 [[verifier.collect]]

--- a/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
@@ -8,6 +8,9 @@ artifacts = [
 [task]
 name = "sidecar-reachability"
 
+[environment.env]
+VERIFIER_PRECEDENCE = "actor"
+
 [verifier]
 environment_mode = "separate"
 timeout_sec = 30

--- a/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/task.toml
@@ -1,5 +1,23 @@
+artifacts = [
+  { source = "/app/sidecar.html", service = "main" },
+  { source = "/app/main.html", service = "main" },
+  { source = "/tmp/main.txt", service = "main" },
+  { source = "/tmp/sidecar.txt", service = "web" },
+]
+
 [task]
 name = "sidecar-reachability"
 
 [verifier]
+environment_mode = "separate"
 timeout_sec = 30
+
+[[verifier.collect]]
+service = "main"
+command = "head -c 1 /dev/urandom >/dev/null && echo collected-from-main > /tmp/main.txt"
+timeout_sec = 10
+
+[[verifier.collect]]
+service = "web"
+command = "echo collected-from-sidecar > /tmp/sidecar.txt"
+timeout_sec = 10

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.12-alpine
 
 COPY . /tests
-RUN chmod +x /tests/test.sh && mkdir -p /app /logs/verifier
+RUN addgroup -g 1001 verifier \
+    && adduser -D -u 1001 -G verifier verifier \
+    && chmod +x /tests/test.sh \
+    && mkdir -p /app /logs/verifier
 
+USER verifier
 ENTRYPOINT []
 CMD ["sleep", "infinity"]

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.12-alpine
 
+ENV VERIFIER_PRECEDENCE=verifier-image
 COPY . /tests
 RUN addgroup -g 1001 verifier \
     && adduser -D -u 1001 -G verifier verifier \

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
@@ -3,8 +3,10 @@ FROM python:3.12-alpine
 COPY . /tests
 RUN addgroup -g 1001 verifier \
     && adduser -D -u 1001 -G verifier verifier \
-    && chmod +x /tests/test.sh \
-    && mkdir -p /app /logs/verifier
+    && chmod 755 /tests/test.sh \
+    && mkdir -p /app /logs/verifier \
+    && touch /home/verifier/owned \
+    && chown verifier:verifier /home/verifier/owned
 
 USER verifier
 ENTRYPOINT []

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1001 verifier \
     && touch /home/verifier/owned \
     && chown verifier:verifier /home/verifier/owned
 
+WORKDIR /home/verifier
 USER verifier
 ENTRYPOINT []
 CMD ["sleep", "infinity"]

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.12-alpine
 COPY . /tests
 RUN addgroup -g 1001 verifier \
     && adduser -D -u 1001 -G verifier verifier \
-    && chmod 755 /tests/test.sh \
     && mkdir -p /app /logs/verifier \
     && touch /home/verifier/owned \
     && chown verifier:verifier /home/verifier/owned

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-alpine
+
+COPY . /tests
+RUN chmod +x /tests/test.sh && mkdir -p /app /logs/verifier
+
+ENTRYPOINT []
+CMD ["sleep", "infinity"]

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
@@ -10,7 +10,8 @@ if grep -q "Directory listing" /app/sidecar.html 2>/dev/null \
   && [ "$(id -u)" = "1001" ] \
   && [ "$(stat -c %u /home/verifier/owned)" = "1001" ] \
   && [ "$PWD" = "/home/verifier" ] \
-  && [ "$HOME" = "/home/verifier" ]; then
+  && [ "$HOME" = "/home/verifier" ] \
+  && [ "$VERIFIER_PRECEDENCE" = "verifier-image" ]; then
   echo 1 > /logs/verifier/reward.txt
 else
   echo "the agent output or collected sidecar artifact is missing"

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
@@ -5,7 +5,9 @@ mkdir -p /logs/verifier
 if grep -q "Directory listing" /app/sidecar.html 2>/dev/null \
   && grep -q "Directory listing" /app/main.html 2>/dev/null \
   && [ "$(cat /tmp/main.txt 2>/dev/null)" = "collected-from-main" ] \
-  && [ "$(cat /tmp/sidecar.txt 2>/dev/null)" = "collected-from-sidecar" ]; then
+  && [ "$(cat /tmp/sidecar.txt 2>/dev/null)" = "collected-from-sidecar" ] \
+  && [ "$(id -u)" = "1001" ] \
+  && [ "$HOME" = "/home/verifier" ]; then
   echo 1 > /logs/verifier/reward.txt
 else
   echo "the agent output or collected sidecar artifact is missing"

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
@@ -7,6 +7,7 @@ if grep -q "Directory listing" /app/sidecar.html 2>/dev/null \
   && [ "$(cat /tmp/main.txt 2>/dev/null)" = "collected-from-main" ] \
   && [ "$(cat /tmp/sidecar.txt 2>/dev/null)" = "collected-from-sidecar" ] \
   && [ "$(id -u)" = "1001" ] \
+  && [ "$(stat -c %u /home/verifier/owned)" = "1001" ] \
   && [ "$HOME" = "/home/verifier" ]; then
   echo 1 > /logs/verifier/reward.txt
 else

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
@@ -8,6 +8,7 @@ if grep -q "Directory listing" /app/sidecar.html 2>/dev/null \
   && [ "$(cat /tmp/sidecar.txt 2>/dev/null)" = "collected-from-sidecar" ] \
   && [ "$(id -u)" = "1001" ] \
   && [ "$(stat -c %u /home/verifier/owned)" = "1001" ] \
+  && [ "$PWD" = "/home/verifier" ] \
   && [ "$HOME" = "/home/verifier" ]; then
   echo 1 > /logs/verifier/reward.txt
 else

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
@@ -4,6 +4,7 @@ mkdir -p /logs/verifier
 
 if grep -q "Directory listing" /app/sidecar.html 2>/dev/null \
   && grep -q "Directory listing" /app/main.html 2>/dev/null \
+  && [ -c /dev/null ] \
   && [ "$(cat /tmp/main.txt 2>/dev/null)" = "collected-from-main" ] \
   && [ "$(cat /tmp/sidecar.txt 2>/dev/null)" = "collected-from-sidecar" ] \
   && [ "$(id -u)" = "1001" ] \

--- a/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
+++ b/integrations/harbor/tests/tasks/sidecar-reachability/tests/test.sh
@@ -2,9 +2,12 @@
 set -u
 mkdir -p /logs/verifier
 
-if grep -q "Directory listing" /app/sidecar.html 2>/dev/null; then
+if grep -q "Directory listing" /app/sidecar.html 2>/dev/null \
+  && grep -q "Directory listing" /app/main.html 2>/dev/null \
+  && [ "$(cat /tmp/main.txt 2>/dev/null)" = "collected-from-main" ] \
+  && [ "$(cat /tmp/sidecar.txt 2>/dev/null)" = "collected-from-sidecar" ]; then
   echo 1 > /logs/verifier/reward.txt
 else
-  echo "the agent could not reach the declared web sidecar"
+  echo "the agent output or collected sidecar artifact is missing"
   echo 0 > /logs/verifier/reward.txt
 fi

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from hud.eval import Task
 from integrations import harbor
 
 from .conftest import make_harbor_task, make_multi_step_task
@@ -40,6 +41,15 @@ def fake_docker(monkeypatch):
                         "Cmd": ["/media/hud/venv/bin/hud", "serve", "/media/hud/env.py"],
                     }
                 ), ""
+            if args[-1].startswith("hud-harbor-base:"):
+                return json.dumps(
+                    {
+                        "User": "",
+                        "WorkingDir": "/workspace",
+                        "Entrypoint": None,
+                        "Cmd": None,
+                    }
+                ), ""
             return json.dumps(
                 {
                     "User": "",
@@ -58,6 +68,14 @@ def fake_docker(monkeypatch):
                     "main": {
                         "image": "hud-main",
                         "environment": {"FROM_COMPOSE": "yes"},
+                        "expose": ["8080/tcp"],
+                        "healthcheck": {
+                            "test": ["CMD-SHELL", "curl -f http://localhost:8080/health"],
+                            "interval": "2s",
+                            "timeout": "3s",
+                            "retries": 5,
+                            "start_period": "1s",
+                        },
                         "depends_on": {
                             "redis": {
                                 "condition": "service_healthy",
@@ -226,6 +244,16 @@ async def test_adapt_emits_compose_with_pinned_sidecars_and_peers(
     assert "build" not in redis
     manifest = json.loads((context / "tasks.json").read_text("utf-8"))
     assert manifest["environment"]["env"] == {"FROM_COMPOSE": "yes"}
+    assert manifest["environment"]["healthcheck"] == {
+        "command": "curl -f http://localhost:8080/health",
+        "interval_sec": 2.0,
+        "timeout_sec": 3.0,
+        "start_period_sec": 1.0,
+        "start_interval_sec": 5.0,
+        "retries": 5,
+    }
+    assert manifest["local_aliases"] == ["main"]
+    assert manifest["ports"] == [8080]
     assert manifest["capabilities"] == []
     assert manifest["peers"] == [{"name": "redis", "port": 6379}]
     assert compose["services"]["main"]["command"] == [
@@ -233,6 +261,7 @@ async def test_adapt_emits_compose_with_pinned_sidecars_and_peers(
         "serve",
         "/media/hud/env.py",
     ]
+    assert "healthcheck" not in compose["services"]["main"]
     assert ("pull", "redis:7-alpine") in fake_docker
     assert any(call[:2] == ("tag", "redis:7-alpine") for call in fake_docker)
 
@@ -586,7 +615,6 @@ async def test_image_entrypoint_is_preserved_as_runtime_data(
             '[[environment.mcp_servers]]\nname = "db"\ntransport = "stdio"\ncommand = "db-mcp"\n',
             "stdio MCP servers",
         ),
-        ('[verifier]\nenvironment_mode = "separate"\n', "separate verifier"),
     ],
 )
 async def test_unsupported_harbor_behaviour_fails_before_building(
@@ -602,6 +630,80 @@ async def test_unsupported_harbor_behaviour_fails_before_building(
         await harbor.adapt(tmp_path)
 
     assert fake_docker == []
+
+
+async def test_adapt_builds_a_separate_verifier_and_reuses_the_runtime(
+    tmp_path: Path,
+    fake_docker,
+) -> None:
+    task = make_harbor_task(tmp_path, "separate")
+    (task / "environment" / "compose.yaml").write_text(
+        "services:\n  main: {}\n  redis:\n    image: redis:7-alpine\n    expose: [6379]\n",
+        encoding="utf-8",
+    )
+    (task / "tests" / "Dockerfile").write_text(
+        "FROM python:3.12-alpine\nCOPY . /tests\n",
+        encoding="utf-8",
+    )
+    (task / "task.toml").write_text(
+        """
+artifacts = ["/tmp/agent.patch"]
+
+[environment]
+cpus = 2
+memory_mb = 2048
+
+[verifier]
+environment_mode = "separate"
+timeout_sec = 30
+
+[verifier.environment]
+cpus = 4
+memory_mb = 1024
+
+[[verifier.collect]]
+service = "redis"
+command = "redis-cli save"
+timeout_sec = 10
+""",
+        encoding="utf-8",
+    )
+
+    (row,) = list(await harbor.adapt(tmp_path))
+
+    assert row.verifier == Task(env=row.env, id="separate:verify")
+    assert row.runtime_config is not None
+    assert row.runtime_config.resources is not None
+    assert row.runtime_config.resources.cpu == 4
+    assert row.runtime_config.resources.memory_mb == 2048
+
+    (context,) = (tmp_path / ".hud-adapt").iterdir()
+    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    assert manifest["verifier_root"] == "/media/hud/verifier"
+    assert manifest["tasks"] == [
+        {
+            "artifacts": [{"service": "main", "source": "/tmp/agent.patch"}],
+            "collect": [
+                {"command": "redis-cli save", "service": "redis", "timeout_sec": 10.0}
+            ],
+            "description": "",
+            "id": "separate",
+            "separate_verifier": True,
+            "verifier_timeout": 30.0,
+        }
+    ]
+    assert not (context / "tasks" / "separate" / "tests").exists()
+    compose = json.loads((context / "compose.json").read_text("utf-8"))
+    assert compose["services"]["main"]["volumes"] == [
+        {
+            "source": "/var/run/docker.sock",
+            "target": "/media/hud/docker.sock",
+            "type": "bind",
+        }
+    ]
+    wrapper = [call for call in fake_docker if call[0] == "build"][-1]
+    assert wrapper[1:3] == ("--target", "verifier")
+    assert any(value.startswith("VERIFIER_IMAGE=hud-harbor-verifier:") for value in wrapper)
 
 
 async def test_multi_step_tasks_are_refused_directly(tmp_path: Path, fake_docker) -> None:

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -132,6 +132,10 @@ def fake_docker(monkeypatch):
                     "retries": 5,
                     "start_period": "1s",
                 }
+            elif "healthcheck-defaults" in authored:
+                project["services"]["main"]["healthcheck"] = {
+                    "test": ["CMD", "true"],
+                }
             elif "expose:" not in authored:
                 project["services"]["redis"].pop("expose")
             if "user: 1001:1002" in authored:
@@ -318,6 +322,27 @@ async def test_adapt_moves_compose_main_healthcheck_into_the_workspace(
         "retries": 5,
     }
     assert "healthcheck" not in compose["services"]["main"]
+
+
+async def test_adapt_uses_compose_healthcheck_defaults(tmp_path: Path) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "environment" / "compose.yaml").write_text(
+        "# healthcheck-defaults\nservices:\n  main: {}\n",
+        encoding="utf-8",
+    )
+
+    await harbor.adapt(tmp_path)
+
+    (context,) = (tmp_path / ".hud-adapt").iterdir()
+    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    assert manifest["environment"]["healthcheck"] == {
+        "command": "true",
+        "interval_sec": 30.0,
+        "timeout_sec": 30.0,
+        "start_period_sec": 0.0,
+        "start_interval_sec": 5.0,
+        "retries": 3,
+    }
 
 
 async def test_adapt_derives_implicit_peer_port_from_image(

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -704,6 +704,16 @@ timeout_sec = 30
 [verifier.environment]
 cpus = 4
 memory_mb = 1024
+workdir = "/judge"
+network_mode = "allowlist"
+allowed_hosts = ["verifier.example"]
+
+[verifier.environment.env]
+NESTED_ONLY = "yes"
+SHARED = "nested"
+
+[verifier.env]
+SHARED = "phase"
 
 [[verifier.collect]]
 service = "redis"
@@ -724,6 +734,13 @@ timeout_sec = 10
     (context,) = (tmp_path / ".hud-adapt").iterdir()
     manifest = json.loads((context / "tasks.json").read_text("utf-8"))
     assert manifest["verifier_root"] == "/media/hud/verifier"
+    assert manifest["verifier_image"]["workdir"] == "/judge"
+    assert manifest["verifier"] == {
+        "user": None,
+        "network_mode": "allowlist",
+        "allowed_hosts": ["verifier.example"],
+        "env": {"NESTED_ONLY": "yes", "SHARED": "phase"},
+    }
     assert manifest["tasks"] == [
         {
             "artifacts": [{"service": "main", "source": "/tmp/agent.patch"}],

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -730,6 +730,7 @@ timeout_sec = 10
     assert row.runtime_config.resources is not None
     assert row.runtime_config.resources.cpu == 4
     assert row.runtime_config.resources.memory_mb == 2048
+    assert row.runtime_config.compose_service_access is True
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
     manifest = json.loads((context / "tasks.json").read_text("utf-8"))
@@ -753,13 +754,7 @@ timeout_sec = 10
     ]
     assert not (context / "tasks" / "separate" / "tests").exists()
     compose = json.loads((context / "compose.json").read_text("utf-8"))
-    assert compose["services"]["main"]["volumes"] == [
-        {
-            "source": "/var/run/docker.sock",
-            "target": "/media/hud/docker.sock",
-            "type": "bind",
-        }
-    ]
+    assert compose["services"]["main"].get("volumes", []) == []
     wrapper = [call for call in fake_docker if call[0] == "build"][-1]
     assert wrapper[1:3] == ("--target", "verifier")
     assert any(value.startswith("VERIFIER_IMAGE=hud-harbor-verifier:") for value in wrapper)

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -799,6 +799,21 @@ async def test_invalid_task_config_is_not_silently_defaulted(
     assert fake_docker == []
 
 
+@pytest.mark.parametrize("source", ["/", "//", "/workspace/../secret"])
+async def test_artifacts_must_name_normalized_paths_beneath_root(
+    tmp_path: Path,
+    fake_docker,
+    source: str,
+) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "task.toml").write_text(f'artifacts = ["{source}"]\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="artifact source must name a path beneath /"):
+        await harbor.adapt(tmp_path)
+
+    assert fake_docker == []
+
+
 async def test_agent_timeout_becomes_per_task_agent_policy(
     tmp_path: Path,
     fake_docker,

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -136,7 +136,10 @@ def fake_docker(monkeypatch):
                 project["services"]["main"]["healthcheck"] = {
                     "test": ["CMD", "true"],
                 }
-            elif "expose:" not in authored:
+            for port in (3128, 3129, 8765):
+                if f"expose: [{port}]" in authored:
+                    project["services"]["main"]["expose"] = [f"{port}/tcp"]
+            if "expose:" not in authored and "redis" in project["services"]:
                 project["services"]["redis"].pop("expose")
             if "user: 1001:1002" in authored:
                 project["services"]["main"]["user"] = "1001:1002"
@@ -655,6 +658,22 @@ async def test_unsupported_harbor_behaviour_fails_before_building(
         await harbor.adapt(tmp_path)
 
     assert fake_docker == []
+
+
+@pytest.mark.parametrize("port", [3128, 3129, 8765])
+async def test_adapt_rejects_main_ports_reserved_by_hud(
+    tmp_path: Path,
+    fake_docker,
+    port: int,
+) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "environment" / "compose.yaml").write_text(
+        f"services:\n  main:\n    expose: [{port}]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match=f"port {port} conflicts with a HUD reserved port"):
+        await harbor.adapt(tmp_path)
 
 
 async def test_adapt_builds_a_separate_verifier_and_reuses_the_runtime(

--- a/integrations/harbor/tests/test_contract.py
+++ b/integrations/harbor/tests/test_contract.py
@@ -683,9 +683,7 @@ timeout_sec = 10
     assert manifest["tasks"] == [
         {
             "artifacts": [{"service": "main", "source": "/tmp/agent.patch"}],
-            "collect": [
-                {"command": "redis-cli save", "service": "redis", "timeout_sec": 10.0}
-            ],
+            "collect": [{"command": "redis-cli save", "service": "redis", "timeout_sec": 10.0}],
             "description": "",
             "id": "separate",
             "separate_verifier": True,
@@ -704,6 +702,35 @@ timeout_sec = 10
     wrapper = [call for call in fake_docker if call[0] == "build"][-1]
     assert wrapper[1:3] == ("--target", "verifier")
     assert any(value.startswith("VERIFIER_IMAGE=hud-harbor-verifier:") for value in wrapper)
+
+
+async def test_separate_verifier_groups_have_distinct_environment_names(
+    tmp_path: Path,
+    fake_docker,
+) -> None:
+    declaration = '[verifier]\nenvironment_mode = "separate"\n'
+    compose = "services:\n  main: {}\n  redis:\n    image: redis:7-alpine\n    expose: [6379]\n"
+    verifier = "FROM python:3.12-alpine\nCOPY . /tests\n"
+    for name in ("task-a", "task-b"):
+        task = make_harbor_task(tmp_path, name)
+        (task / "task.toml").write_text(declaration, encoding="utf-8")
+        (task / "environment" / "compose.yaml").write_text(compose, encoding="utf-8")
+        (task / "tests" / "Dockerfile").write_text(verifier, encoding="utf-8")
+
+    rows = list(await harbor.adapt(tmp_path))
+
+    assert len({row.env for row in rows}) == 2
+    compose_paths = {
+        row.runtime_config.compose
+        for row in rows
+        if row.runtime_config is not None and row.runtime_config.compose is not None
+    }
+    assert len(compose_paths) == 2
+    assert all(path.is_file() for path in compose_paths)
+    manifests = [
+        json.loads((path.parent / "tasks.json").read_text("utf-8")) for path in compose_paths
+    ]
+    assert {manifest["tasks"][0]["id"] for manifest in manifests} == {"task-a", "task-b"}
 
 
 async def test_multi_step_tasks_are_refused_directly(tmp_path: Path, fake_docker) -> None:
@@ -777,6 +804,12 @@ async def test_adapt_hashes_links_not_their_targets(
 def test_authored_runtime_assets_are_valid_source() -> None:
     integration = Path(__file__).parents[1]
     compile((integration / "env.py").read_text("utf-8"), "env.py", "exec")
+    installer = (integration / "install.sh").read_text("utf-8")
+    assert "python_version=3.12" in installer
+    assert "sys.version_info[:2] < (3, 13)" in installer
+    assert 'uv python install "$python_version"' in installer
+    assert 'python="$root/bin/python$python_version"' in installer
+    assert 'uv venv "$root/venv" --python "$python"' in installer
     result = subprocess.run(
         ["sh", "-n", integration / "install.sh"],
         check=False,

--- a/integrations/harbor/tests/test_integration.py
+++ b/integrations/harbor/tests/test_integration.py
@@ -301,3 +301,36 @@ timeout_sec = 30
             and step.task_call.name == "sidecar-reachability:verify"
             for step in run.trace.steps
         )
+
+
+def test_separate_verifier_honors_the_test_script_shebang(
+    tmp_path_factory: pytest.TempPathFactory, wheel: Path
+) -> None:
+    dataset = tmp_path_factory.mktemp("harbor-verifier-shebang") / "harbor-harness"
+    task = dataset / "sidecar-reachability"
+    shutil.copytree(TASKS / "sidecar-reachability", task)
+    (task / "task.toml").write_text(
+        """\
+[task]
+name = "sidecar-reachability"
+
+[verifier]
+environment_mode = "separate"
+timeout_sec = 30
+""",
+        encoding="utf-8",
+    )
+    (task / "solution" / "solve.sh").write_text("true\n", encoding="utf-8")
+    (task / "tests" / "test.sh").write_text(
+        """\
+#!/usr/bin/env python3
+from pathlib import Path
+
+Path("/logs/verifier/reward.txt").write_text("1")
+""",
+        encoding="utf-8",
+    )
+
+    run = asyncio.run(_grade_every_task(dataset, wheel))["sidecar-reachability"]
+
+    assert run.reward == 1.0

--- a/integrations/harbor/tests/test_integration.py
+++ b/integrations/harbor/tests/test_integration.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, cast
 import pytest
 
 from hud.agents.base import Agent
-from hud.eval import DockerRuntime
+from hud.eval import DockerRuntime, Shared
 from integrations import harbor
 
 if TYPE_CHECKING:
@@ -258,3 +258,46 @@ timeout_sec = 30
 
     assert run.reward == 0.0
     assert "artifact /app/linked/tests has a symbolic link in its path" in (run.trace.error or "")
+
+
+def test_separate_verifier_restores_image_paths_between_shared_rollouts(
+    tmp_path_factory: pytest.TempPathFactory, wheel: Path
+) -> None:
+    dataset = tmp_path_factory.mktemp("harbor-verifier-restore") / "harbor-harness"
+    task = dataset / "sidecar-reachability"
+    shutil.copytree(TASKS / "sidecar-reachability", task)
+    (task / "task.toml").write_text(
+        """\
+artifacts = [{ source = "/tests/test.sh", service = "main" }]
+
+[task]
+name = "sidecar-reachability"
+
+[verifier]
+environment_mode = "separate"
+timeout_sec = 30
+""",
+        encoding="utf-8",
+    )
+    (task / "solution" / "solve.sh").write_text("true\n", encoding="utf-8")
+
+    async def grade_twice() -> list[Run]:
+        taskset = await harbor.adapt(dataset, hud_requirement=str(wheel))
+        job = await taskset.run(
+            Oracle({"sidecar-reachability": "true"}),
+            runtime=Shared(DockerRuntime(), width=1),
+            group=2,
+            max_concurrent=1,
+        )
+        return job.runs
+
+    runs = asyncio.run(grade_twice())
+
+    assert len(runs) == 2
+    for run in runs:
+        assert any(
+            step.task_call is not None
+            and step.task_call.phase == "evaluate"
+            and step.task_call.name == "sidecar-reachability:verify"
+            for step in run.trace.steps
+        )

--- a/integrations/harbor/tests/test_integration.py
+++ b/integrations/harbor/tests/test_integration.py
@@ -53,6 +53,14 @@ class Oracle(Agent):
 
     async def __call__(self, run: Run) -> None:
         ssh = cast("SSHClient", await run.client.open("ssh/2"))
+        if run.task_id == "agent-lifecycle":
+            for index in range(40):
+                result = await ssh.conn.run(f"printf '%s' {index}", check=False)
+                assert result.exit_status == 0, f"command session {index} failed: {result.stderr!r}"
+                assert result.stdout == str(index), f"command session {index} lost output"
+            await ssh.conn.run("cat > session-input", input="written", check=True)
+            written = await ssh.conn.run("cat session-input", check=True)
+            assert written.stdout == "written"
         if run.task_id == "hello-mcp":
             mcp = cast("MCPClient", await run.client.open("mcp-server"))
             assert {tool.name for tool in await mcp.list_tools()} == {"get_secret"}
@@ -109,9 +117,16 @@ Path("/app/secret.txt").write_text(result["result"]["content"][0]["text"])
                 raise RuntimeError("workspace MCP client closed without an exit status")
             run.trace.content = "called get_secret from inside the workspace"
             return
-        result = await ssh.conn.run(self.solutions[run.task_id], check=True)
+        result = await ssh.conn.run(self.solutions[run.task_id], check=False)
         if result.exit_status is None:
+            run.trace.content = (
+                "solution SSH channel closed without an exit status:\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
             raise RuntimeError("solution SSH channel closed without an exit status")
+        if result.exit_status != 0:
+            run.trace.content = f"solution failed:\n{result.stdout}\n{result.stderr}"
+            raise RuntimeError(f"solution exited with status {result.exit_status}")
         run.trace.content = "solution completed"
 
 
@@ -131,12 +146,8 @@ async def _grade_every_task(dataset: Path, wheel: Path) -> dict[str, Run]:
 
 
 @pytest.fixture(scope="module")
-def graded(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Run]:
-    """Adapt and grade the fixture dataset once for this module."""
+def wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
     workdir = tmp_path_factory.mktemp("harbor")
-    dataset = workdir / "harbor-harness"
-    shutil.copytree(TASKS, dataset)
-
     wheels = workdir / "wheels"
     subprocess.run(
         ["uv", "build", "--wheel", "--out-dir", str(wheels)],
@@ -144,7 +155,24 @@ def graded(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Run]:
         check=True,
         capture_output=True,
     )
-    return asyncio.run(_grade_every_task(dataset, next(iter(wheels.glob("*.whl")))))
+    return next(iter(wheels.glob("*.whl")))
+
+
+@pytest.fixture(scope="module")
+def graded(tmp_path_factory: pytest.TempPathFactory, wheel: Path) -> dict[str, Run]:
+    """Adapt and grade the inline-verifier fixtures once for this module."""
+    dataset = tmp_path_factory.mktemp("harbor-inline") / "harbor-harness"
+    shutil.copytree(TASKS, dataset, ignore=shutil.ignore_patterns("sidecar-reachability"))
+    return asyncio.run(_grade_every_task(dataset, wheel))
+
+
+@pytest.fixture(scope="module")
+def separately_graded(tmp_path_factory: pytest.TempPathFactory, wheel: Path) -> dict[str, Run]:
+    """Adapt and grade the separate-verifier fixture."""
+    dataset = tmp_path_factory.mktemp("harbor-separate") / "harbor-harness"
+    dataset.mkdir()
+    shutil.copytree(TASKS / "sidecar-reachability", dataset / "sidecar-reachability")
+    return asyncio.run(_grade_every_task(dataset, wheel))
 
 
 @pytest.mark.parametrize(
@@ -153,7 +181,6 @@ def graded(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Run]:
         "phase-boundary",
         "agent-lifecycle",
         "verifier-lifecycle",
-        "sidecar-reachability",
         "hello-mcp",
     ],
 )
@@ -175,3 +202,7 @@ def test_harbor_phase_behavior(graded: dict[str, Run], task_id: str) -> None:
         )
     )
     assert run.reward == 1.0, f"{task_id} scored {run.reward}; the verifier reported:\n{detail}"
+
+
+def test_separate_verifier_phase_behavior(separately_graded: dict[str, Run]) -> None:
+    test_harbor_phase_behavior(separately_graded, "sidecar-reachability")

--- a/integrations/harbor/tests/test_integration.py
+++ b/integrations/harbor/tests/test_integration.py
@@ -226,3 +226,35 @@ def test_separate_verifier_rejects_artifact_symlinks(
 
     assert run.reward == 0.0
     assert "artifact /app/main.html is a symbolic link" in (run.trace.error or "")
+
+
+def test_separate_verifier_rejects_artifacts_beneath_symlinks(
+    tmp_path_factory: pytest.TempPathFactory, wheel: Path
+) -> None:
+    dataset = tmp_path_factory.mktemp("harbor-ancestor-symlink") / "harbor-harness"
+    task = dataset / "sidecar-reachability"
+    shutil.copytree(TASKS / "sidecar-reachability", task)
+    config = task / "task.toml"
+    config.write_text(
+        """\
+artifacts = [{ source = "/app/linked/tests", service = "main" }]
+
+[task]
+name = "sidecar-reachability"
+
+[verifier]
+environment_mode = "separate"
+timeout_sec = 30
+""",
+        encoding="utf-8",
+    )
+    solution = task / "solution" / "solve.sh"
+    solution.write_text(
+        "#!/bin/sh\nset -eu\nln -s /media/hud/verifier /app/linked\n",
+        encoding="utf-8",
+    )
+
+    run = asyncio.run(_grade_every_task(dataset, wheel))["sidecar-reachability"]
+
+    assert run.reward == 0.0
+    assert "artifact /app/linked/tests has a symbolic link in its path" in (run.trace.error or "")

--- a/integrations/harbor/tests/test_integration.py
+++ b/integrations/harbor/tests/test_integration.py
@@ -206,3 +206,23 @@ def test_harbor_phase_behavior(graded: dict[str, Run], task_id: str) -> None:
 
 def test_separate_verifier_phase_behavior(separately_graded: dict[str, Run]) -> None:
     test_harbor_phase_behavior(separately_graded, "sidecar-reachability")
+
+
+def test_separate_verifier_rejects_artifact_symlinks(
+    tmp_path_factory: pytest.TempPathFactory, wheel: Path
+) -> None:
+    dataset = tmp_path_factory.mktemp("harbor-symlink") / "harbor-harness"
+    task = dataset / "sidecar-reachability"
+    shutil.copytree(TASKS / "sidecar-reachability", task)
+    solution = task / "solution" / "solve.sh"
+    solution.write_text(
+        solution.read_text("utf-8")
+        + "\nrm -f /app/main.html\n"
+        + "ln -s /media/hud/verifier/tests /app/main.html\n",
+        encoding="utf-8",
+    )
+
+    run = asyncio.run(_grade_every_task(dataset, wheel))["sidecar-reachability"]
+
+    assert run.reward == 0.0
+    assert "artifact /app/main.html is a symbolic link" in (run.trace.error or "")


### PR DESCRIPTION
Stacked on #540.

## Summary
- add an optional nested verifier task and reuse the live runtime when both phases share an environment
- build and embed Harbor verifier Dockerfiles, collect declared artifacts from Compose services, and grade them inside a separate isolated Workspace
- preserve Compose main aliases and exposed ports inside the agent namespace while keeping bridge socket paths out of process arguments
- consolidate agent and verifier egress onto one persistent workspace bridge
- reject Compose in DaytonaRuntime before provisioning while preserving its regular image and snapshot paths

## Validation
- 199 focused SDK, Workspace, runtime, and Harbor contract tests passed
- 5 real Docker Harbor lifecycle tests passed, including separate-verifier sidecar collection
- Ruff passed on every changed Python file
- Pyright completed with 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to sandbox/namespace isolation, egress bridging, and rollout grading semantics, plus removal of Daytona Compose support and new Docker socket exposure for Compose verifier collection.
> 
> **Overview**
> **Verifier rollouts** — Tasks can declare an optional nested `verifier` task whose grade is authoritative. Rollouts run the agent first (with best-effort actor grading when a verifier exists), then verify in the same runtime when env and config match, or after actor cleanup on a second placement. Mid-run agent failures still proceed to verification; hosted rollouts reject verifier tasks for now.
> 
> **Workspace & egress** — The namespace host runs outside bwrap when PID staging is available, with separate session vs environment holders, port forwarding, identity mapping moved into `namespace.py`, and `terminate_sessions()`. Egress gains `local_aliases`, `reserved_ports`, and bridge config via stdin (`bridge_command`) so socket paths stay out of argv; visitor egress uses the workspace bridge on port 3129.
> 
> **Compose runtimes** — `runtime_config.compose_service_access` bind-mounts the local Docker socket into the main service (Docker/Modal). **Daytona** no longer implements linked-sandbox Compose and rejects `runtime_config.compose` up front.
> 
> **Harbor adapt** — Docs and `adapt.py` now translate compose envs, network MCP, healthchecks, and separate verifier Dockerfiles (multi-stage image with embedded verifier root, collect hooks, artifacts, nested verifier `Task` rows) instead of refusing them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab66dadd30a11a0f1d372124a62fe1bc91757db6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->