### PR TITLE
Upgrade uv and Ruff tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run ruff
         run: |
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run pyright
         run: uv run --with=".[dev]" pyright

--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ from hud import Environment
 
 env = Environment(name="letter-count")
 
+
 @env.template()
 async def count_letter(word: str = "strawberry", letter: str = "r"):
     answer = yield f"How many '{letter}'s are in '{word}'? Reply with just the number."
     yield 1.0 if answer and str(word.count(letter)) in answer else 0.0
+
 
 tasks = [count_letter(word=w) for w in ("strawberry", "raspberry", "blueberry")]
 ```

--- a/cookbooks/rl-training/README.md
+++ b/cookbooks/rl-training/README.md
@@ -53,13 +53,13 @@ for the local one. **The training code is identical either way.**
 Both scripts are the same five lines — the only difference is the training call:
 
 ```python
-taskset, runtime = load_taskset_and_runtime()   # deployed+remote, or local
-session = await Job.start("rl", group=8)         # one job spans the session
+taskset, runtime = load_taskset_and_runtime()  # deployed+remote, or local
+session = await Job.start("rl", group=8)  # one job spans the session
 for step in range(steps):
     start = len(session.runs)
-    await taskset.run(agent, runtime=runtime, job=session)   # roll out current weights
-    batch = session.runs[start:]                             # this step's runs
-    await trainer.step(batch, learning_rate=1e-5, group_size=8)   # train + promote
+    await taskset.run(agent, runtime=runtime, job=session)  # roll out current weights
+    batch = session.runs[start:]  # this step's runs
+    await trainer.step(batch, learning_rate=1e-5, group_size=8)  # train + promote
 ```
 
 The loop only ever touches `job.runs`, so where the rollouts executed — a remote

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -41,10 +41,12 @@ from hud import Environment
 
 env = Environment(name="letter-count")
 
+
 @env.template()
 async def count_letter(word: str = "strawberry", letter: str = "r"):
     answer = yield f"How many '{letter}'s are in '{word}'?"
     yield 1.0 if answer and str(word.count(letter)) in answer else 0.0
+
 
 tasks = [count_letter(word=w) for w in ("strawberry", "raspberry", "blueberry")]
 ```
@@ -83,28 +85,36 @@ server = FastMCP(name="my-env")
 env = Environment(name="my-env")
 _task: asyncio.Task | None = None
 
+
 @server.tool
 async def do_thing(x: int) -> str:
     return f"result: {x}"
+
 
 @env.initialize
 async def _start() -> None:
     global _task
     if _task is None:
-        s = socket.socket(); s.bind(("", 0)); port = s.getsockname()[1]; s.close()
+        s = socket.socket()
+        s.bind(("", 0))
+        port = s.getsockname()[1]
+        s.close()
         _task = asyncio.create_task(
             server.run_async(transport="http", host="127.0.0.1", port=port, show_banner=False)
         )
         await asyncio.sleep(0.3)
         env.add_capability(Capability.mcp(name="tools", url=f"http://127.0.0.1:{port}/mcp"))
 
+
 @env.shutdown
 async def _stop() -> None:
     global _task
     if _task is not None:
         _task.cancel()
-        with contextlib.suppress(Exception): await _task
+        with contextlib.suppress(Exception):
+            await _task
         _task = None
+
 
 @env.template()
 async def my_task(param: str = "default"):
@@ -196,7 +206,7 @@ for _ in range(steps):
 ```python
 for c in await trainer.checkpoints():
     print(c.name, c.mean_reward, c.metrics.get("reward_std"))
-head = await trainer.head()           # the active checkpoint
+head = await trainer.head()  # the active checkpoint
 ```
 
 **Pick the loss.** `step`/`forward_backward` take `loss_fn` (default `importance_sampling`; also `ppo`, `cispo`, `dro`, `cross_entropy`). Prefer `ppo` when a single lucky rollout could otherwise blow up the update — it clips the IS ratio. Discover the supported set with `await trainer.available_losses()`; leave `loss_fn_config` at `None` unless a provider documents a key.
@@ -206,7 +216,7 @@ head = await trainer.head()           # the active checkpoint
 ```python
 combined: list[Run | TrajectoryPayload] = []
 for run in batch:
-    combined.append(run)                                              # agent side
+    combined.append(run)  # agent side
     combined.append(TrajectoryPayload(samples=opp, reward=1.0 - run.reward))  # opponent
 await trainer.forward_backward(combined, loss_fn="ppo", group_size=2)
 await trainer.optim_step(learning_rate=1e-5)
@@ -217,7 +227,7 @@ Get the opponent's tokens from the gateway call with `extra_body={"return_token_
 **Reset when the objective changes.** If you edit the reward or the environment mid-run, the current head encodes the *old* objective — continuing from it trains a contaminated policy, and the next steps mostly undo the old shaping. Roll the head back to a checkpoint from before the change (or fork a fresh model):
 
 ```python
-await trainer.set_head(checkpoint_id)   # or: hud models head <slug> --set <id>
+await trainer.set_head(checkpoint_id)  # or: hud models head <slug> --set <id>
 ```
 
 **Custom loss / primitives.** Author the loss yourself (e.g. double-sided IS) with `forward_backward_custom` — the service returns per-token tensors, your torch function makes the gradients (needs `pip install 'hud[train]'`). Drop to `forward_backward` + `optim_step` directly when you want the `forward_backward` metrics or gradient accumulation (`num_substeps`) in between; `step` is just the two chained.

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -771,7 +771,7 @@ async def _run_evaluation(cfg: EvalConfig) -> Any:
     from hud.eval import Taskset
 
     source_path = Path(cfg.source)
-    is_local = source_path.exists()
+    is_local = await asyncio.to_thread(source_path.exists)
     if is_local:
         hud_console.info(f"Loading tasks from: {cfg.source}")
         try:

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -245,6 +245,26 @@ def test_resolve_runtime_local_file_defaults_to_local(tmp_path: Path) -> None:
     assert cfg.runtime == "local"
 
 
+async def test_python_task_source_loads_on_main_thread(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "tasks.py"
+    marker = tmp_path / "main-thread.txt"
+    source.write_text(
+        "import threading\n"
+        "from pathlib import Path\n"
+        f"Path({str(marker)!r}).write_text("
+        "str(threading.current_thread() is threading.main_thread()))\n"
+        "tasks = []\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(typer.Exit):
+        await eval_mod._run_evaluation(EvalConfig(source=str(source), agent_type="openai"))
+
+    assert marker.read_text(encoding="utf-8") == "True"
+
+
 def test_resolve_runtime_slug_defaults_to_remote() -> None:
     cfg = EvalConfig(source="My Tasks").resolve_runtime()
     assert cfg.runtime is None

--- a/hud/environment/namespace.py
+++ b/hud/environment/namespace.py
@@ -53,12 +53,13 @@ async def install_identity_map(
     if launcher_pid is not None:
         pid = launcher_pid
         for _ in range(launcher_depth):
-            children = Path(f"/proc/{pid}/task/{pid}/children").read_text().split()
+            children_file = Path(f"/proc/{pid}/task/{pid}/children")
+            children = (await asyncio.to_thread(children_file.read_text)).split()
             if len(children) != 1:
                 raise RuntimeError(f"sandbox launcher {pid} has {len(children)} children")
             pid = int(children[0])
-    _map_identities(pid)
-    os.write(block_write, b"\n")
+    await asyncio.to_thread(_map_identities, pid)
+    await asyncio.to_thread(os.write, block_write, b"\n")
     return pid
 
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -798,10 +798,11 @@ async def test_a_declared_peer_is_a_name_sessions_resolve(
     hosts = Path(argv[argv.index("/etc/hosts") - 1])
     assert hosts == tmp_path / "runtime" / "hosts"
     assert argv[argv.index("/etc/hosts") - 2] == "--ro-bind"
-    assert "127.0.0.1\tmain\n" in hosts.read_text()
-    assert "127.0.0.2\tdb\n" in hosts.read_text()
+    hosts_content = await asyncio.to_thread(hosts.read_text)
+    assert "127.0.0.1\tmain\n" in hosts_content
+    assert "127.0.0.2\tdb\n" in hosts_content
     # Bound over /etc/hosts, so every session reads it whatever its identity.
-    assert hosts.stat().st_mode & 0o044
+    assert (await asyncio.to_thread(hosts.stat)).st_mode & 0o044
 
     sharing = Workspace(tmp_path / "shared", peers=[Peer("db", 5432)], network=True)
     monkeypatch.setattr(sharing, "_bwrap", Bubblewrap("/usr/bin/bwrap"))

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -716,7 +716,7 @@ class Workspace:
         mounts: Sequence[Mount] | None = None,
         env: Mapping[str, str] | None = None,
         cwd: str | None = None,
-        identity: int | tuple[int, int] | None | Literal["workspace"] = "workspace",
+        identity: int | tuple[int, int] | Literal["workspace"] | None = "workspace",
         inherit_workspace_env: bool = True,
         allowed_hosts: Collection[str] | None = (),
         no_new_privs: bool = True,
@@ -820,7 +820,7 @@ class Workspace:
         mounts: Sequence[Mount] | None = None,
         env: Mapping[str, str] | None = None,
         cwd: str | None = None,
-        identity: int | tuple[int, int] | None | Literal["workspace"] = "workspace",
+        identity: int | tuple[int, int] | Literal["workspace"] | None = "workspace",
         inherit_workspace_env: bool = True,
         no_new_privs: bool = True,
         persistent: bool = False,
@@ -986,7 +986,7 @@ class Workspace:
 
     def _identity_argv(
         self,
-        identity: int | tuple[int, int] | None | Literal["workspace"],
+        identity: int | tuple[int, int] | Literal["workspace"] | None,
         *,
         no_new_privs: bool,
     ) -> list[str]:

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -168,7 +168,8 @@ class _FakeModalSandbox:
         assert isinstance(uploads, list)
         uploads.append((source.name, target))
         if source.name == "override.json":
-            self._calls["compose_override"] = json.loads(source.read_text("utf-8"))
+            content = await asyncio.to_thread(source.read_text, "utf-8")
+            self._calls["compose_override"] = json.loads(content)
 
     async def _exec(self, *args: str, **kwargs: object) -> SimpleNamespace:
         commands = self._calls.setdefault("execs", [])
@@ -326,7 +327,7 @@ class _FakeDaytonaSandbox:
         return SimpleNamespace(token="ssh-token")
 
 
-async def _tree_hash(path_str: str) -> str:
+def _tree_hash_sync(path_str: str) -> str:
     """Deterministic fingerprint of a context tree: same tree, same hash."""
     digest = hashlib.md5(usedforsecurity=False)
     root = Path(path_str)
@@ -334,6 +335,10 @@ async def _tree_hash(path_str: str) -> str:
         digest.update(file.relative_to(root).as_posix().encode())
         digest.update(file.read_bytes())
     return digest.hexdigest()
+
+
+async def _tree_hash(path_str: str) -> str:
+    return await asyncio.to_thread(_tree_hash_sync, path_str)
 
 
 class _FakeObjectStorage:

--- a/hud/integrations/harbor/adapt.py
+++ b/hud/integrations/harbor/adapt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -208,7 +209,7 @@ async def adapt(
     hud_requirement: str = "hud",
 ) -> Taskset:
     """Build a runnable HUD image for each distinct Harbor environment."""
-    root = Path(path).resolve()
+    root = await asyncio.to_thread(Path(path).resolve)
     if (root / "task.toml").is_file():
         task_dirs = [root]
         dataset = root.parent
@@ -625,7 +626,7 @@ async def adapt(
 
         wheel = Path(hud_requirement)
         requirement = hud_requirement
-        if wheel.suffix == ".whl" and wheel.is_file():
+        if wheel.suffix == ".whl" and await asyncio.to_thread(wheel.is_file):
             shutil.copy2(wheel, context / "packages" / wheel.name)
             requirement = f"{HUD_ROOT}/packages/{wheel.name}"
 

--- a/hud/integrations/harbor/env.py
+++ b/hud/integrations/harbor/env.py
@@ -563,12 +563,16 @@ async def grade_separate(task: dict[str, Any], answer: Any) -> EvaluationResult:
     async with verifier_lock:
         verifier_root = Path(CONFIG["verifier_root"])
         test_script = verifier_root / "tests/test.sh"
-        test_mode = test_script.stat().st_mode
-        test_script.chmod(test_mode | 0o111)
-        clear(VERIFIER_LOGS)
-        VERIFIER_LOGS.chmod(0o777)
-        LOGS.mkdir(parents=True, exist_ok=True)
-        AGENT_ANSWER.write_text("" if answer is None else str(answer), encoding="utf-8")
+        test_mode = (await asyncio.to_thread(test_script.stat)).st_mode
+        await asyncio.to_thread(test_script.chmod, test_mode | 0o111)
+        await asyncio.to_thread(clear, VERIFIER_LOGS)
+        await asyncio.to_thread(VERIFIER_LOGS.chmod, 0o777)
+        await asyncio.to_thread(LOGS.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(
+            AGENT_ANSWER.write_text,
+            "" if answer is None else str(answer),
+            encoding="utf-8",
+        )
 
         try:
             with artifact_mounts(task, verifier_root) as mounts:

--- a/hud/integrations/harbor/export.py
+++ b/hud/integrations/harbor/export.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import shlex
 import shutil
@@ -64,10 +65,10 @@ async def export(
     authored environment and Dockerfile. Each task becomes one self-contained
     Harbor task folder.
     """
-    src = Path(source).resolve()
+    src = await asyncio.to_thread(Path(source).resolve)
     source_dir = src.parent if src.is_file() else src
-    out = Path(out_dir).resolve()
-    out.mkdir(parents=True, exist_ok=True)
+    out = await asyncio.to_thread(Path(out_dir).resolve)
+    await asyncio.to_thread(out.mkdir, parents=True, exist_ok=True)
     tasks = list(Taskset.from_file(src))
 
     scan = source_dir if src.suffix in (".json", ".jsonl") else src

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import json
 import os
@@ -103,7 +104,7 @@ def fake_docker(monkeypatch):
                 "networks": {"default": {"name": "task_default"}},
             }
             authored_file = Path(args[-4])
-            authored = authored_file.read_text("utf-8")
+            authored = await asyncio.to_thread(authored_file.read_text, "utf-8")
             if "dockerfile: Containerfile" in authored:
                 project["services"] = {
                     "main": {
@@ -148,7 +149,8 @@ def fake_docker(monkeypatch):
             return json.dumps(project), ""
         if args[0] == "compose" and args[-2] == "build":
             compose_file = Path(args[args.index("--file") + 1])
-            calls.append(("compose-build-config", args[-1], compose_file.read_text("utf-8")))
+            compose = await asyncio.to_thread(compose_file.read_text, "utf-8")
+            calls.append(("compose-build-config", args[-1], compose))
         return "", ""
 
     module = importlib.import_module("hud.integrations.harbor.adapt")

--- a/hud/integrations/harbor/tests/test_harbor.py
+++ b/hud/integrations/harbor/tests/test_harbor.py
@@ -67,6 +67,19 @@ async def test_export_writes_task_folder(tmp_path: Path) -> None:
     assert (task_dir / "environment" / "hud_entrypoint.sh").exists()
 
 
+async def test_export_loads_python_source_on_main_thread(tmp_path: Path) -> None:
+    src = _write_env(tmp_path)
+    source = src.read_text(encoding="utf-8")
+    src.write_text(
+        "import threading\nassert threading.current_thread() is threading.main_thread()\n" + source,
+        encoding="utf-8",
+    )
+
+    created = await export(str(src), tmp_path / "out")
+
+    assert len(created) == 1
+
+
 async def test_requires_dockerfile(tmp_path: Path) -> None:
     _write_env(tmp_path, dockerfile=False)
     with pytest.raises(FileNotFoundError, match="Dockerfile"):

--- a/hud/integrations/harbor/tests/test_integration.py
+++ b/hud/integrations/harbor/tests/test_integration.py
@@ -131,11 +131,14 @@ Path("/app/secret.txt").write_text(result["result"]["content"][0]["text"])
 
 
 async def _grade_every_task(dataset: Path, wheel: Path) -> dict[str, Run]:
-    solutions = {
-        task.name: (task / "solution" / "solve.sh").read_text("utf-8")
-        for task in sorted(dataset.iterdir())
-        if (task / "task.toml").is_file()
-    }
+    def load_solutions() -> dict[str, str]:
+        return {
+            task.name: (task / "solution" / "solve.sh").read_text("utf-8")
+            for task in sorted(dataset.iterdir())
+            if (task / "task.toml").is_file()
+        }
+
+    solutions = await asyncio.to_thread(load_solutions)
     taskset = await harbor.adapt(dataset, hud_requirement=str(wheel))
     job = await taskset.run(
         Oracle(solutions),

--- a/hud/types.py
+++ b/hud/types.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import contextlib
 import json
 import uuid
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeAlias, TypeVar, cast
 
 import mcp.types as types
@@ -58,7 +58,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class AgentType(str, Enum):
+class AgentType(StrEnum):
     CLAUDE = "claude"
     OPENAI = "openai"
     GEMINI = "gemini"

--- a/hud/utils/serialization.py
+++ b/hud/utils/serialization.py
@@ -8,7 +8,7 @@ import pydantic_core
 # JSON-compatible scalar/container values. Nested JSON payloads are intentionally
 # opaque to Pydantic; recursive aliases make schema generation fragile across
 # supported Python/Pydantic versions. (Public home: re-exported by ``hud.types``.)
-JsonValue: TypeAlias = str | int | float | bool | None | list[Any] | dict[str, Any]
+JsonValue: TypeAlias = str | int | float | bool | list[Any] | dict[str, Any] | None
 JsonObject: TypeAlias = dict[str, JsonValue]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ dev = [
     "hud[robot]",  # the robot end-to-end gates (hud/tests/test_robot.py) run the real wire
     "dotenv>=0.9.9",
     # Testing and linting
-    "ruff >=0.11.8, <0.15.0",
+    "ruff==0.16.1",
     "pytest >=8.1.1",
     "pytest-asyncio",
     "pytest-mock",
@@ -167,10 +167,13 @@ train = [
 ]
 
 
+[tool.uv]
+required-version = "==0.12.2"
+
 [tool.ruff]
 target-version = "py311"
 line-length = 100
-lint.extend-select = [
+lint.select = [
     "I",       # isort
     "F",       # pyflakes
     "ANN",     # flake8-annotations


### PR DESCRIPTION
## Summary

- pin the current stable uv 0.12.2 and Ruff 0.16.1 releases
- upgrade the SHA-pinned `astral-sh/setup-uv` action to v9.0.0
- make the Ruff rule set explicit so future default expansions do not silently change policy
- resolve the Ruff 0.16 diagnostics without adding suppressions, including moving blocking filesystem work off async event loops
- apply Ruff's new formatting for fenced Python examples in Markdown

## Impact

Local development and CI now use the same exact uv and Ruff versions. The selected Ruff policy remains intentional instead of inheriting the expanded Ruff 0.16 defaults. Pyright remains unchanged in this slice; migration to ty is a follow-up.

## Validation

- `uv sync --extra dev`
- `uv run ruff check .`
- `uv run ruff format . --check`
- `uv run pyright` (0 errors; 22 existing optional-import warnings)
- `uv run pytest -q` (957 passed, 9 deselected)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly CI, lint pins, and threading refactors for async correctness; behavior should be equivalent with lower event-loop blocking risk.
> 
> **Overview**
> **Tooling:** Pins **uv 0.12.2** (`[tool.uv] required-version`) and **Ruff 0.16.1**, bumps CI’s `astral-sh/setup-uv` to **v9.0.0** (SHA-pinned), and switches Ruff from `lint.extend-select` to an explicit **`lint.select`** list so future Ruff defaults don’t change policy silently.
> 
> **Ruff 0.16 compliance:** Addresses new diagnostics without suppressions—mainly **`ASYNC`** by wrapping blocking `Path`/proc I/O and sandbox identity setup in **`asyncio.to_thread`** across eval, Harbor adapt/export/grade, workspace namespace, and related tests. Smaller type/style fixes: **`AgentType`** → `StrEnum`, `JsonValue` union order, workspace `identity` annotation reorder.
> 
> **Docs:** Ruff format-only tweaks to fenced Python in README, cookbooks, and `docs/skill.md`.
> 
> **Tests:** Adds coverage that Python task sources (eval + Harbor export) load on the **main thread**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0dcc75e16228b28a3316086b0125cb55bfbe8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->