### PR TITLE
refactor: replace type checker workarounds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
           uv run --with=".[dev]" ruff format . --check
           uv run --with=".[dev]" ruff check .
 
-  lint-pyright:
+  lint-ty:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
-      - name: Run pyright
-        run: uv run --with=".[dev]" pyright
+      - name: Run ty
+        run: uv run --extra dev --extra train ty check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ adding local workarounds.
   capabilities, agents, graders, types, cli), run guides, and cookbooks.
 - `CONTRIBUTING.md` for setup, test, lint, and type-check commands.
 - `pyproject.toml` for supported Python versions, dependencies, optional extras,
-  ruff, pyright, pytest, and coverage configuration.
+  ruff, ty, pytest, and coverage configuration.
 - Source files and colocated tests for exact behavior. Trust code and tests over
   stale prose.
 - `cookbooks/` for runnable end-to-end examples (each is its own uv project).
@@ -56,7 +56,7 @@ uv sync --extra dev
 uv run pytest -q
 uv run ruff format . --check
 uv run ruff check .
-uv run pyright
+uv run --extra train ty check
 ```
 
 The shared pre-push hook lives in `.githooks/pre-push`, but agents should not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We welcome contributions to the HUD SDK! This guide covers how to get started.
 
 ### Git Hooks
 
-Enable the shared pre-push hook (runs ruff, pyright, pytest before each push):
+Enable the shared pre-push hook (runs ruff, ty, pytest before each push):
 
 ```bash
 git config core.hooksPath .githooks
@@ -45,7 +45,7 @@ a cold build cache.
 ```bash
 uv run ruff format . --check   # Formatting
 uv run ruff check .            # Linting
-uv run pyright                 # Type checking
+uv run --extra train ty check  # Type checking
 ```
 
 ## Code Style
@@ -59,7 +59,7 @@ uv run pyright                 # Type checking
 
 1. **Branch naming**: `feature/description` or `fix/issue-number`
 2. **Commits**: Use clear, descriptive messages
-3. **Tests**: All CI checks must pass (ruff, pyright, pytest)
+3. **Tests**: All CI checks must pass (ruff, ty, pytest)
 4. **Review**: Address feedback promptly
 
 ## Need Help?

--- a/hud/_legacy.py
+++ b/hud/_legacy.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING, Any
 
 from mcp.types import ContentBlock, ImageContent, TextContent
 from pydantic import BaseModel, Field
+from typing_extensions import override
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
@@ -267,6 +268,7 @@ class _V5CompatFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     no-op) so deployed v5 envs still import without error.
     """
 
+    @override
     def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
         if fullname.startswith(("hud.native", "hud.services")):
             if _alias_target(fullname) is None:
@@ -276,9 +278,11 @@ class _V5CompatFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
             return importlib.util.spec_from_loader(fullname, self)
         return None
 
+    @override
     def create_module(self, spec: Any) -> ModuleType:
         return ModuleType(spec.name)
 
+    @override
     def exec_module(self, module: ModuleType) -> None:
         name = module.__name__
 
@@ -286,13 +290,13 @@ class _V5CompatFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
             target = _alias_target(name)
             assert target is not None  # find_spec already filtered unknowns
             module.__path__ = []  # mark as package so submodule imports route back here
-            module.__getattr__ = _make_alias_getattr(name, target)  # type: ignore[attr-defined]
+            module.__getattr__ = _make_alias_getattr(name, target)
             return
 
         # Removed submodule (types, computer, executors, filesystem, ...):
         # resolve names lazily (redirect / capability marker / no-op).
         module.__path__ = []
-        module.__getattr__ = _make_legacy_getattr(name)  # type: ignore[attr-defined]
+        module.__getattr__ = _make_legacy_getattr(name)
 
 
 def install() -> None:

--- a/hud/_legacy.py
+++ b/hud/_legacy.py
@@ -43,7 +43,8 @@ from pydantic import BaseModel, Field
 from typing_extensions import override
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable, Sequence
+    from importlib.machinery import ModuleSpec
 
     from hud.graders import EvaluationResult, SubScore
 
@@ -240,7 +241,7 @@ def _alias_target(fullname: str) -> str | None:
     return None
 
 
-def _make_alias_getattr(fullname: str, target_name: str) -> Any:
+def _make_alias_getattr(fullname: str, target_name: str) -> Callable[[str], Any]:
     def __getattr__(name: str) -> Any:
         if name == "Grade" and target_name == "hud.graders":
             return Grade
@@ -252,11 +253,26 @@ def _make_alias_getattr(fullname: str, target_name: str) -> Any:
     return __getattr__
 
 
-def _make_legacy_getattr(module_name: str) -> Any:
+def _make_legacy_getattr(module_name: str) -> Callable[[str], Any]:
     def __getattr__(name: str) -> Any:
         return resolve_legacy_name(module_name, name)
 
     return __getattr__
+
+
+class _LegacyModule(ModuleType):
+    """Synthetic package whose lazy attribute contract is explicit."""
+
+    __path__: list[str]
+
+    def __init__(self, name: str, resolve: Callable[[str], Any]) -> None:
+        super().__init__(name)
+        self.__path__ = []
+        self._resolve = resolve
+
+    @override
+    def __getattr__(self, name: str) -> Any:
+        return self._resolve(name)
 
 
 class _V5CompatFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
@@ -269,7 +285,12 @@ class _V5CompatFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     """
 
     @override
-    def find_spec(self, fullname: str, path: Any = None, target: Any = None) -> Any:
+    def find_spec(
+        self,
+        fullname: str,
+        path: Sequence[str] | None = None,
+        target: ModuleType | None = None,
+    ) -> ModuleSpec | None:
         if fullname.startswith(("hud.native", "hud.services")):
             if _alias_target(fullname) is None:
                 return None  # unknown legacy name: fail with ModuleNotFoundError
@@ -279,24 +300,18 @@ class _V5CompatFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
         return None
 
     @override
-    def create_module(self, spec: Any) -> ModuleType:
-        return ModuleType(spec.name)
+    def create_module(self, spec: ModuleSpec) -> ModuleType:
+        name = spec.name
+        target = _alias_target(name)
+        resolve = (
+            _make_alias_getattr(name, target) if target is not None else _make_legacy_getattr(name)
+        )
+        return _LegacyModule(name, resolve)
 
     @override
     def exec_module(self, module: ModuleType) -> None:
-        name = module.__name__
-
-        if name.startswith(("hud.native", "hud.services")):
-            target = _alias_target(name)
-            assert target is not None  # find_spec already filtered unknowns
-            module.__path__ = []  # mark as package so submodule imports route back here
-            module.__getattr__ = _make_alias_getattr(name, target)
-            return
-
-        # Removed submodule (types, computer, executors, filesystem, ...):
-        # resolve names lazily (redirect / capability marker / no-op).
-        module.__path__ = []
-        module.__getattr__ = _make_legacy_getattr(name)
+        if not isinstance(module, _LegacyModule):
+            raise TypeError(f"unexpected module type for {module.__name__}")
 
 
 def install() -> None:

--- a/hud/agents/browser_use/agent.py
+++ b/hud/agents/browser_use/agent.py
@@ -15,14 +15,13 @@ optional dependency
 
 from __future__ import annotations
 
-# browser-use is an optional, untyped dependency (lazy __getattr__ exports), so
-# its symbols and members resolve as Unknown under strict checking. This whole
-# module is the boundary around that SDK; contain the unknowns here.
-# pyright: reportAttributeAccessIssue=false, reportUnknownVariableType=false, reportUnknownMemberType=false
 import contextlib
+import importlib
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
+
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.agents.types import AgentStep, BrowserUseConfig
@@ -45,6 +44,7 @@ class BrowserUseAgent(Agent):
     def __init__(self, config: BrowserUseConfig | None = None) -> None:
         self.config = config or BrowserUseConfig()
 
+    @override
     async def __call__(self, run: Run) -> None:
         """Drive browser-use over the run's CDP capability, filling ``run.trace``.
 
@@ -52,8 +52,7 @@ class BrowserUseAgent(Agent):
         loop, and writes the final answer + trajectory metadata onto ``run.trace``
         (graded on exit).
         """
-        from browser_use import Agent as BrowserUseSdkAgent
-        from browser_use import Browser, ChatAnthropic
+        browser_use: Any = importlib.import_module("browser_use")
 
         trace = run.trace
         cdp_url = _ws_to_http(run.client.binding(CDP_PROTOCOL).url)
@@ -63,9 +62,13 @@ class BrowserUseAgent(Agent):
         if not api_key:
             raise ValueError("BrowserUseAgent needs an Anthropic API key (set ANTHROPIC_API_KEY)")
 
-        llm = ChatAnthropic(model=self.config.model, api_key=api_key, base_url=self.config.base_url)
-        browser: Any = Browser(cdp_url=cdp_url)
-        sdk_agent = cast("Any", BrowserUseSdkAgent(task=run.prompt_text, llm=llm, browser=browser))
+        llm = browser_use.ChatAnthropic(
+            model=self.config.model,
+            api_key=api_key,
+            base_url=self.config.base_url,
+        )
+        browser: Any = browser_use.Browser(cdp_url=cdp_url)
+        sdk_agent = browser_use.Agent(task=run.prompt_text, llm=llm, browser=browser)
 
         try:
             history: Any = await sdk_agent.run(max_steps=self.config.max_steps)

--- a/hud/agents/browser_use/agent.py
+++ b/hud/agents/browser_use/agent.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Protocol, cast
 from urllib.parse import urlsplit, urlunsplit
 
 from typing_extensions import override
@@ -34,6 +34,44 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("hud.agents.browser_use")
 
 CDP_PROTOCOL = "cdp/1.3"
+
+
+class _Browser(Protocol):
+    async def stop(self) -> None: ...
+
+
+class _History(Protocol):
+    def is_successful(self) -> bool | None: ...
+
+    def final_result(self) -> str | None: ...
+
+    def number_of_steps(self) -> int: ...
+
+    def urls(self) -> list[str]: ...
+
+    def is_done(self) -> bool: ...
+
+
+class _BrowserAgent(Protocol):
+    async def run(self, *, max_steps: int) -> _History: ...
+
+
+class _ChatAnthropicFactory(Protocol):
+    def __call__(self, *, model: str, api_key: str, base_url: str | None) -> object: ...
+
+
+class _BrowserFactory(Protocol):
+    def __call__(self, *, cdp_url: str) -> _Browser: ...
+
+
+class _AgentFactory(Protocol):
+    def __call__(self, *, task: str, llm: object, browser: _Browser) -> _BrowserAgent: ...
+
+
+class _BrowserUseModule(Protocol):
+    ChatAnthropic: _ChatAnthropicFactory
+    Browser: _BrowserFactory
+    Agent: _AgentFactory
 
 
 class BrowserUseAgent(Agent):
@@ -52,7 +90,7 @@ class BrowserUseAgent(Agent):
         loop, and writes the final answer + trajectory metadata onto ``run.trace``
         (graded on exit).
         """
-        browser_use: Any = importlib.import_module("browser_use")
+        browser_use = cast("_BrowserUseModule", importlib.import_module("browser_use"))
 
         trace = run.trace
         cdp_url = _ws_to_http(run.client.binding(CDP_PROTOCOL).url)
@@ -67,11 +105,11 @@ class BrowserUseAgent(Agent):
             api_key=api_key,
             base_url=self.config.base_url,
         )
-        browser: Any = browser_use.Browser(cdp_url=cdp_url)
+        browser = browser_use.Browser(cdp_url=cdp_url)
         sdk_agent = browser_use.Agent(task=run.prompt_text, llm=llm, browser=browser)
 
         try:
-            history: Any = await sdk_agent.run(max_steps=self.config.max_steps)
+            history = await sdk_agent.run(max_steps=self.config.max_steps)
         except Exception as exc:
             LOGGER.exception("browser-use run failed")
             trace.status = "error"

--- a/hud/agents/claude/agent.py
+++ b/hud/agents/claude/agent.py
@@ -23,6 +23,7 @@ from anthropic.types.beta import (
     BetaToolResultBlockParam,
     BetaToolUnionParam,
 )
+from typing_extensions import override
 
 from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentStep, Citation, ClaudeConfig, Usage
@@ -35,7 +36,7 @@ from .tools.computer import ClaudeComputerTool
 from .tools.mcp_proxy import ClaudeMCPProxyTool
 
 if TYPE_CHECKING:
-    from anthropic.types.beta import BetaTextBlock, BetaTextCitation
+    from anthropic.types.beta import BetaTextCitation
 
 logger = logging.getLogger(__name__)
 
@@ -70,17 +71,20 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
 
     # ─── ToolAgent hooks ──────────────────────────────────────────────
 
+    @override
     async def _initialize_state(
         self, *, prompt: list[mcp_types.PromptMessage]
     ) -> RunState[BetaMessageParam]:
         return RunState(messages=self._initial_messages(prompt))
 
+    @override
     def _format_message(self, role: str, text: str) -> BetaMessageParam:
         return BetaMessageParam(
             role="assistant" if role == "assistant" else "user",
             content=[BetaTextBlockParam(type="text", text=text)],
         )
 
+    @override
     def _format_result(
         self,
         call: MCPToolCall,
@@ -168,6 +172,7 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
 
     # ─── Anthropic call ───────────────────────────────────────────────
 
+    @override
     async def get_response(
         self,
         state: RunState[BetaMessageParam],
@@ -284,7 +289,7 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
                     )
                     result.done = False
                 case "text":
-                    text_block = cast("BetaTextBlock", block)
+                    text_block = block
                     text_parts.append(text_block.text)
                     citations.extend(self._citation(c) for c in (text_block.citations or []))
                 case "thinking":

--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -16,6 +16,8 @@ import shlex
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from typing_extensions import override
+
 from hud.agents.base import Agent
 from hud.agents.types import AgentStep, ClaudeSDKConfig, Usage
 from hud.settings import settings
@@ -84,6 +86,7 @@ class ClaudeSDKAgent(Agent):
         self._mcp_servers: dict[str, dict[str, Any]] = {}
         self._shell = "bash"
 
+    @override
     async def __call__(self, run: Run) -> None:
         self._mcp_servers = {}
         manifest = run.client.manifest

--- a/hud/agents/claude/sdk/computer_mcp.py
+++ b/hud/agents/claude/sdk/computer_mcp.py
@@ -27,7 +27,7 @@ def create_computer_mcp(rfb: RFBClient) -> fastmcp.FastMCP:
     mcp = fastmcp.FastMCP("computer-use")
 
     @mcp.tool()
-    async def computer(  # pyright: ignore[reportUnusedFunction]
+    async def computer(
         action: str,
         coordinate: str | None = None,
         text: str | None = None,

--- a/hud/agents/claude/tools/coding.py
+++ b/hud/agents/claude/tools/coding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 import mcp.types as mcp_types
+from typing_extensions import override
 
 from hud.agents.tools import SSHTool
 from hud.agents.tools.base import result_text, tool_err
@@ -36,16 +37,19 @@ class ClaudeBashTool(SSHTool):
     name = "bash"
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> ClaudeToolSpec:
         del model
         return CLAUDE_BASH_SPEC
 
+    @override
     def to_params(self) -> BetaToolBash20250124Param:
         return cast(
             "BetaToolBash20250124Param",
             {"type": self.spec.api_type, "name": self.name},
         )
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         if arguments.get("restart"):
             # SSH session lives across calls; "restart" is a no-op for us.
@@ -72,20 +76,24 @@ class ClaudeTextEditorTool(SSHTool):
     name = "str_replace_based_edit_tool"
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> ClaudeToolSpec:
         del model
         return CLAUDE_TEXT_EDITOR_SPEC
 
     @property
+    @override
     def provider_name(self) -> str:
         return self.spec.api_name
 
+    @override
     def to_params(self) -> BetaToolTextEditor20250728Param:
         return cast(
             "BetaToolTextEditor20250728Param",
             {"type": self.spec.api_type, "name": self.provider_name},
         )
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         command = arguments.get("command")
         path = arguments.get("path")

--- a/hud/agents/claude/tools/computer.py
+++ b/hud/agents/claude/tools/computer.py
@@ -13,6 +13,7 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Any, cast
 
 import mcp.types as mcp_types
+from typing_extensions import override
 
 from hud.agents.tools import RFBTool
 from hud.agents.tools.base import tool_err, tool_ok
@@ -119,12 +120,14 @@ class ClaudeComputerTool(RFBTool):
     name = "computer"
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> ClaudeToolSpec | None:
         for candidate in CLAUDE_COMPUTER_SPECS:
             if candidate.supports_model(model):
                 return candidate
         return _DEFAULT_COMPUTER_SPEC
 
+    @override
     def to_params(self) -> BetaToolComputerUse20250124Param | BetaToolComputerUse20251124Param:
         if self.spec.api_type == "computer_20251124":
             return cast(
@@ -149,6 +152,7 @@ class ClaudeComputerTool(RFBTool):
             },
         )
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         action = arguments.get("action")
         try:

--- a/hud/agents/claude/tools/hosted.py
+++ b/hud/agents/claude/tools/hosted.py
@@ -12,6 +12,7 @@ from anthropic.types.beta import (
     BetaWebFetchTool20250910Param,
     BetaWebSearchTool20250305Param,
 )
+from typing_extensions import override
 
 if TYPE_CHECKING:
     BetaUserLocationParam = Any
@@ -33,6 +34,7 @@ class ClaudeWebSearchTool(ClaudeHostedTool):
     blocked_domains: list[str] | None = None
     user_location: BetaUserLocationParam | None = None
 
+    @override
     def to_params(self) -> BetaWebSearchTool20250305Param:
         _validate_domain_filters(self.allowed_domains, self.blocked_domains)
         params = BetaWebSearchTool20250305Param(
@@ -60,6 +62,7 @@ class ClaudeWebFetchTool(ClaudeHostedTool):
     max_content_tokens: int | None = None
     citations_enabled: bool = False
 
+    @override
     def to_params(self) -> BetaWebFetchTool20250910Param:
         _validate_domain_filters(self.allowed_domains, self.blocked_domains)
         params = BetaWebFetchTool20250910Param(
@@ -85,6 +88,7 @@ class ClaudeToolSearchTool(ClaudeHostedTool):
 
     threshold: int = 10
 
+    @override
     def to_params(self) -> BetaToolSearchToolBm25_20251119Param:
         return BetaToolSearchToolBm25_20251119Param(
             type="tool_search_tool_bm25_20251119",

--- a/hud/agents/claude/tools/mcp_proxy.py
+++ b/hud/agents/claude/tools/mcp_proxy.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from inspect import cleandoc
 from typing import TYPE_CHECKING, cast
 
+from typing_extensions import override
+
 from hud.agents.tools import MCPTool
 
 from .base import ClaudeToolSpec
@@ -17,10 +19,12 @@ class ClaudeMCPProxyTool(MCPTool):
     """Expose one discovered MCP tool as a Claude function tool."""
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> ClaudeToolSpec:
         del model
         return ClaudeToolSpec(api_type="function", api_name="function")
 
+    @override
     def to_params(self) -> BetaToolUnionParam:
         if self.mcp_tool.description is None:
             raise ValueError(

--- a/hud/agents/claude/tools/tests/test_computer.py
+++ b/hud/agents/claude/tools/tests/test_computer.py
@@ -1,17 +1,17 @@
 """``ClaudeComputerTool`` — key translation, per-model spec gating, and the
 computer-use action dispatch (translation to RFB primitives), without a live VNC.
 """
-# pyright: reportPrivateUsage=false, reportIncompatibleMethodOverride=false
 
 from __future__ import annotations
 
 from io import BytesIO
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 import mcp.types as mcp_types
 from PIL import Image
+from typing_extensions import override
 
 from hud.agents.claude.tools.computer import (
     CLAUDE_COMPUTER_SPECS,
@@ -21,6 +21,9 @@ from hud.agents.claude.tools.computer import (
     _split_keys,
     _translate_key,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 from hud.agents.tools.base import result_text, tool_ok
 
 
@@ -34,39 +37,77 @@ class RecordingComputer(ClaudeComputerTool):
         self.screenshot_mime_type = "image/webp"
         self.client = SimpleNamespace(width=200, height=100)
 
+    @override
     async def screenshot(self) -> Any:
         self.calls.append(("screenshot",))
         return tool_ok("shot")
 
-    async def click(self, x: Any, y: Any, **kw: Any) -> None:
+    @override
+    async def click(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        *,
+        button: Any = "left",
+        hold_keys: Iterable[str] | None = None,
+        count: int = 1,
+        interval_ms: int = 0,
+    ) -> None:
+        kw: dict[str, Any] = {}
+        if button != "left":
+            kw["button"] = button
+        if hold_keys is not None:
+            kw["hold_keys"] = hold_keys
+        if count != 1:
+            kw["count"] = count
+        if interval_ms:
+            kw["interval_ms"] = interval_ms
         self.calls.append(("click", x, y, kw))
 
+    @override
     async def move(self, x: Any, y: Any) -> None:
         self.calls.append(("move", x, y))
 
-    async def mouse_down(self, button: Any) -> None:
+    @override
+    async def mouse_down(self, button: Any = "left") -> None:
         self.calls.append(("down", button))
 
-    async def mouse_up(self, button: Any) -> None:
+    @override
+    async def mouse_up(self, button: Any = "left") -> None:
         self.calls.append(("up", button))
 
+    @override
     async def type_text(self, text: Any) -> None:
         self.calls.append(("type", text))
 
+    @override
     async def press_keys(self, keys: Any, **kw: Any) -> None:
         self.calls.append(("keys", tuple(keys), kw))
 
+    @override
     async def hold_key(self, key: Any, **kw: Any) -> None:
         self.calls.append(("hold", key, kw))
 
-    async def scroll(self, x: Any, y: Any, **kw: Any) -> None:
+    @override
+    async def scroll(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        *,
+        scroll_x: int = 0,
+        scroll_y: int = 0,
+        hold_keys: Iterable[str] | None = None,
+    ) -> None:
+        kw = {"scroll_x": scroll_x, "scroll_y": scroll_y, "hold_keys": hold_keys}
         self.calls.append(("scroll", x, y, kw))
 
+    @override
     async def drag(self, path: Any, **kw: Any) -> None:
         self.calls.append(("drag", tuple(path), kw))
 
-    async def wait(self, ms: Any) -> None:
-        self.calls.append(("wait", ms))
+    @override
+    async def wait(self, duration_ms: int) -> None:
+        self.calls.append(("wait", duration_ms))
 
 
 # ─── key translation helpers ──────────────────────────────────────────

--- a/hud/agents/gemini/agent.py
+++ b/hud/agents/gemini/agent.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 import mcp.types as mcp_types
 from google import genai
 from google.genai import types as genai_types
+from typing_extensions import override
 
 from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentStep, Citation, GeminiConfig, Usage
@@ -77,11 +78,13 @@ class GeminiAgent(ToolAgent[genai_types.Content, GeminiConfig]):
 
     # ─── ToolAgent hooks ──────────────────────────────────────────────
 
+    @override
     async def _initialize_state(
         self, *, prompt: list[mcp_types.PromptMessage]
     ) -> RunState[genai_types.Content]:
         return RunState(messages=self._initial_messages(prompt))
 
+    @override
     def _format_message(self, role: str, text: str) -> genai_types.Content:
         # Gemini uses "model" for the assistant role.
         return genai_types.Content(
@@ -89,6 +92,7 @@ class GeminiAgent(ToolAgent[genai_types.Content, GeminiConfig]):
             parts=[genai_types.Part(text=text)],
         )
 
+    @override
     def _format_result(
         self,
         call: MCPToolCall,
@@ -129,6 +133,7 @@ class GeminiAgent(ToolAgent[genai_types.Content, GeminiConfig]):
             ],
         )
 
+    @override
     async def get_response(
         self,
         state: RunState[genai_types.Content],

--- a/hud/agents/gemini/tools/coding.py
+++ b/hud/agents/gemini/tools/coding.py
@@ -6,6 +6,7 @@ import shlex
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from google.genai import types as genai_types
+from typing_extensions import override
 
 from hud.agents.tools import SSHTool
 from hud.agents.tools.base import result_text, tool_err
@@ -49,13 +50,16 @@ class GeminiShellTool(SSHTool):
     }
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_SHELL_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return tool_decl(self.name, self.description, self.parameters)
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         command = arguments.get("command")
         if not isinstance(command, str) or not command:
@@ -84,13 +88,16 @@ class GeminiEditTool(SSHTool):
     }
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_EDIT_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return tool_decl(self.name, self.description, self.parameters)
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         file_path = required_str(arguments, "file_path")
         old_string = arguments.get("old_string", "")
@@ -119,13 +126,16 @@ class GeminiWriteTool(SSHTool):
     }
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_WRITE_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return tool_decl(self.name, self.description, self.parameters)
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         return await self.file_write(
             required_str(arguments, "file_path"),

--- a/hud/agents/gemini/tools/computer.py
+++ b/hud/agents/gemini/tools/computer.py
@@ -7,6 +7,7 @@ import platform
 from typing import TYPE_CHECKING, Any
 
 from google.genai import types as genai_types
+from typing_extensions import override
 
 from hud.agents.tools import RFBTool
 from hud.agents.tools.base import tool_err
@@ -53,10 +54,12 @@ class GeminiComputerTool(RFBTool):
         self.excluded_predefined_functions: list[str] = []
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_COMPUTER_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return genai_types.Tool(
             computer_use=genai_types.ComputerUse(
@@ -65,6 +68,7 @@ class GeminiComputerTool(RFBTool):
             ),
         )
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         action = arguments.get("action")
         if not isinstance(action, str):

--- a/hud/agents/gemini/tools/filesystem.py
+++ b/hud/agents/gemini/tools/filesystem.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from typing_extensions import override
+
 from hud.agents.tools import SSHTool
 from hud.types import MCPToolResult
 
@@ -33,13 +35,16 @@ class GeminiReadTool(SSHTool):
     }
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_READ_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return tool_decl(self.name, self.description, self.parameters)
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         path = required_str(arguments, "file_path")
         result = await self.file_read(path)
@@ -76,13 +81,16 @@ class GeminiSearchTool(SSHTool):
     }
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_SEARCH_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return tool_decl(self.name, self.description, self.parameters)
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         pattern = required_str(arguments, "pattern")
         dir_path = arguments.get("dir_path") or "."
@@ -106,13 +114,16 @@ class GeminiGlobTool(SSHTool):
     }
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_GLOB_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return tool_decl(self.name, self.description, self.parameters)
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         pattern = required_str(arguments, "pattern")
         dir_path = arguments.get("dir_path") or "."
@@ -132,13 +143,16 @@ class GeminiListTool(SSHTool):
     }
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GEMINI_LIST_SPEC
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return tool_decl(self.name, self.description, self.parameters)
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         return await self.file_list(required_str(arguments, "dir_path"))
 

--- a/hud/agents/gemini/tools/hosted.py
+++ b/hud/agents/gemini/tools/hosted.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from google.genai import types as genai_types
+from typing_extensions import override
 
 from hud.agents.tools import HostedTool
 
@@ -20,6 +21,7 @@ class GeminiGoogleSearchTool(GeminiHostedTool):
 
     dynamic_threshold: float | None = None
 
+    @override
     def to_params(self) -> genai_types.Tool:
         if self.dynamic_threshold is not None:
             raise ValueError("dynamic_threshold is not supported by Gemini Google Search.")
@@ -30,6 +32,7 @@ class GeminiGoogleSearchTool(GeminiHostedTool):
 class GeminiUrlContextTool(GeminiHostedTool):
     """Gemini URL context."""
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return genai_types.Tool(url_context=genai_types.UrlContext())
 
@@ -38,5 +41,6 @@ class GeminiUrlContextTool(GeminiHostedTool):
 class GeminiCodeExecutionTool(GeminiHostedTool):
     """Gemini code execution."""
 
+    @override
     def to_params(self) -> genai_types.Tool:
         return genai_types.Tool(code_execution=genai_types.ToolCodeExecution())

--- a/hud/agents/gemini/tools/mcp_proxy.py
+++ b/hud/agents/gemini/tools/mcp_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from google.genai import types as genai_types
+from typing_extensions import override
 
 from hud.agents.tools import MCPTool
 
@@ -13,10 +14,12 @@ class GeminiMCPProxyTool(MCPTool):
     """Expose one discovered MCP tool as a Gemini FunctionDeclaration."""
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> GeminiToolSpec:
         del model
         return GeminiToolSpec(api_type="function", api_name="function")
 
+    @override
     def to_params(self) -> genai_types.Tool:
         if self.mcp_tool.description is None:
             raise ValueError(f"MCP tool {self.mcp_tool.name!r} requires a description.")

--- a/hud/agents/gemini/tools/tests/test_computer.py
+++ b/hud/agents/gemini/tools/tests/test_computer.py
@@ -2,15 +2,19 @@
 
 No live VNC: a recording subclass captures the primitive calls.
 """
-# pyright: reportPrivateUsage=false, reportIncompatibleMethodOverride=false
 
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import override
 
 from hud.agents.gemini.tools.computer import GEMINI_COMPUTER_SPEC, GeminiComputerTool
 from hud.agents.tools.base import tool_ok
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class RecordingGemini(GeminiComputerTool):
@@ -21,30 +25,56 @@ class RecordingGemini(GeminiComputerTool):
         self.client = SimpleNamespace(width=400, height=300)
         self.excluded_predefined_functions = []
 
+    @override
     async def screenshot(self) -> Any:
         self.calls.append(("screenshot",))
         return tool_ok("shot")
 
-    async def click(self, x: Any, y: Any, **kw: Any) -> None:
+    @override
+    async def click(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        *,
+        button: Any = "left",
+        hold_keys: Iterable[str] | None = None,
+        count: int = 1,
+        interval_ms: int = 0,
+    ) -> None:
         self.calls.append(("click", x, y))
 
+    @override
     async def move(self, x: Any, y: Any) -> None:
         self.calls.append(("move", x, y))
 
+    @override
     async def type_text(self, text: Any) -> None:
         self.calls.append(("type", text))
 
+    @override
     async def press_keys(self, keys: Any, **kw: Any) -> None:
         self.calls.append(("keys", tuple(keys)))
 
-    async def scroll(self, x: Any, y: Any, **kw: Any) -> None:
+    @override
+    async def scroll(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        *,
+        scroll_x: int = 0,
+        scroll_y: int = 0,
+        hold_keys: Iterable[str] | None = None,
+    ) -> None:
+        kw = {"scroll_x": scroll_x, "scroll_y": scroll_y, "hold_keys": hold_keys}
         self.calls.append(("scroll", x, y, kw))
 
+    @override
     async def drag(self, path: Any, **kw: Any) -> None:
         self.calls.append(("drag", tuple(path)))
 
-    async def wait(self, ms: Any) -> None:
-        self.calls.append(("wait", ms))
+    @override
+    async def wait(self, duration_ms: int) -> None:
+        self.calls.append(("wait", duration_ms))
 
 
 def test_default_spec() -> None:

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -23,6 +23,7 @@ from openai.types.responses.response_input_param import (
     ResponseInputItemParam,
 )
 from openai.types.shared_params.reasoning import Reasoning  # noqa: TC002
+from typing_extensions import override
 
 from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentStep, Citation, OpenAIConfig, Usage
@@ -83,9 +84,11 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
 
     # ─── ToolAgent hooks ──────────────────────────────────────────────
 
+    @override
     async def _initialize_state(self, *, prompt: list[mcp_types.PromptMessage]) -> OpenAIRunState:
         return OpenAIRunState(messages=self._initial_messages(prompt))
 
+    @override
     def _format_message(self, role: str, text: str) -> ResponseInputItemParam:
         return cast(
             "ResponseInputItemParam",
@@ -95,6 +98,7 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
             ),
         )
 
+    @override
     def _format_result(
         self,
         call: MCPToolCall,
@@ -157,6 +161,7 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
 
         return format_openai_result(call, result)
 
+    @override
     async def get_response(
         self,
         state: RunState[ResponseInputItemParam],

--- a/hud/agents/openai/tools/apply_patch.py
+++ b/hud/agents/openai/tools/apply_patch.py
@@ -1,4 +1,3 @@
-# pyright: reportUnusedFunction=false
 """OpenAI apply_patch parser helpers."""
 
 from __future__ import annotations

--- a/hud/agents/openai/tools/coding.py
+++ b/hud/agents/openai/tools/coding.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 import mcp.types as mcp_types
+from typing_extensions import override
 
 from hud.agents.tools import SSHTool
 from hud.types import MCPToolResult
@@ -24,15 +25,18 @@ class OpenAIShellTool(SSHTool):
     name = "shell"
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> OpenAIToolSpec:
         del model
         return OPENAI_SHELL_SPEC
 
+    @override
     def to_params(self) -> Any:
         # openai.types.responses.FunctionShellToolParam, as a plain dict (TypedDicts
         # are dicts at runtime, and the param type isn't present in all SDK versions).
         return {"type": "shell", "environment": {"type": "local"}}
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         requested_limit = arguments.get("max_output_length")
         if requested_limit is None:

--- a/hud/agents/openai/tools/computer.py
+++ b/hud/agents/openai/tools/computer.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, cast
 
 import mcp.types as mcp_types
+from typing_extensions import override
 
 from hud.agents.tools import RFBTool
 from hud.agents.tools.base import tool_err
@@ -81,13 +82,16 @@ class OpenAIComputerTool(RFBTool):
     name = "computer"
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> OpenAIToolSpec:
         del model
         return OPENAI_COMPUTER_SPEC
 
+    @override
     def to_params(self) -> Any:
         return {"type": "computer"}
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         actions = arguments.get("actions")
         if isinstance(actions, list):
@@ -148,14 +152,14 @@ class OpenAIComputerTool(RFBTool):
             if button_raw == "wheel":
                 button = "middle"
             elif isinstance(button_raw, str):
-                button = button_raw  # type: ignore[assignment]
+                button = button_raw
             else:
                 button = "left"
             hold = _hold_keys(args.get("keys"))
             await self.click(
                 args.get("x"),
                 args.get("y"),
-                button=button,  # type: ignore[arg-type]
+                button=button,
                 hold_keys=hold,
             )
 

--- a/hud/agents/openai/tools/hosted.py
+++ b/hud/agents/openai/tools/hosted.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from openai.types.responses import ToolParam
+from typing_extensions import override
 
 from hud.agents.tools import HostedTool
 
@@ -21,6 +22,7 @@ class OpenAICodeInterpreterTool(OpenAIHostedTool):
 
     container: dict[str, Any]
 
+    @override
     def to_params(self) -> ToolParam:
         return cast("ToolParam", {"type": "code_interpreter", "container": self.container})
 
@@ -31,5 +33,6 @@ class OpenAIToolSearchTool(OpenAIHostedTool):
 
     threshold: int = 10
 
+    @override
     def to_params(self) -> ToolParam:
         return cast("ToolParam", {"type": "tool_search"})

--- a/hud/agents/openai/tools/mcp_proxy.py
+++ b/hud/agents/openai/tools/mcp_proxy.py
@@ -6,6 +6,8 @@ import copy
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
+from typing_extensions import override
+
 from hud.agents.tools import MCPTool
 
 from .base import OpenAIToolSpec
@@ -21,10 +23,12 @@ class OpenAIMCPProxyTool(MCPTool):
     """Expose one discovered MCP tool as an OpenAI function tool."""
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> OpenAIToolSpec:
         del model
         return OpenAIToolSpec(api_type="function", api_name="function")
 
+    @override
     def to_params(self) -> Any:
         if self.mcp_tool.description is None:
             raise ValueError(f"MCP tool {self.mcp_tool.name!r} requires a description.")

--- a/hud/agents/openai/tools/tests/test_computer.py
+++ b/hud/agents/openai/tools/tests/test_computer.py
@@ -2,12 +2,13 @@
 
 No live VNC: a recording subclass captures the primitive calls.
 """
-# pyright: reportPrivateUsage=false, reportIncompatibleMethodOverride=false
 
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import override
 
 from hud.agents.openai.tools.computer import (
     OpenAIComputerTool,
@@ -15,6 +16,9 @@ from hud.agents.openai.tools.computer import (
     _map_key,
 )
 from hud.agents.tools.base import result_text, tool_ok
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class RecordingOpenAI(OpenAIComputerTool):
@@ -24,30 +28,61 @@ class RecordingOpenAI(OpenAIComputerTool):
         self.calls: list[tuple[Any, ...]] = []
         self.client = SimpleNamespace(width=200, height=100)
 
+    @override
     async def screenshot(self) -> Any:
         self.calls.append(("screenshot",))
         return tool_ok("shot")
 
-    async def click(self, x: Any, y: Any, **kw: Any) -> None:
+    @override
+    async def click(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        *,
+        button: Any = "left",
+        hold_keys: Iterable[str] | None = None,
+        count: int = 1,
+        interval_ms: int = 0,
+    ) -> None:
+        kw = {"button": button, "hold_keys": hold_keys}
+        if count != 1:
+            kw["count"] = count
+        if interval_ms:
+            kw["interval_ms"] = interval_ms
         self.calls.append(("click", x, y, kw))
 
+    @override
     async def move(self, x: Any, y: Any) -> None:
         self.calls.append(("move", x, y))
 
+    @override
     async def type_text(self, text: Any) -> None:
         self.calls.append(("type", text))
 
+    @override
     async def press_keys(self, keys: Any, **kw: Any) -> None:
         self.calls.append(("keys", tuple(keys)))
 
-    async def scroll(self, x: Any, y: Any, **kw: Any) -> None:
+    @override
+    async def scroll(
+        self,
+        x: int | None = None,
+        y: int | None = None,
+        *,
+        scroll_x: int = 0,
+        scroll_y: int = 0,
+        hold_keys: Iterable[str] | None = None,
+    ) -> None:
+        kw = {"scroll_x": scroll_x, "scroll_y": scroll_y, "hold_keys": hold_keys}
         self.calls.append(("scroll", x, y, kw))
 
+    @override
     async def drag(self, path: Any, **kw: Any) -> None:
         self.calls.append(("drag", tuple(path)))
 
-    async def wait(self, ms: Any) -> None:
-        self.calls.append(("wait", ms))
+    @override
+    async def wait(self, duration_ms: int) -> None:
+        self.calls.append(("wait", duration_ms))
 
 
 def test_key_mapping() -> None:

--- a/hud/agents/openai_compatible/agent.py
+++ b/hud/agents/openai_compatible/agent.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from openai import AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessageParam
+from typing_extensions import override
 
 from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentStep, OpenAIChatConfig, Sample, Usage
@@ -89,11 +90,13 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
 
     # ─── ToolAgent hooks ──────────────────────────────────────────────
 
+    @override
     async def _initialize_state(
         self, *, prompt: list[mcp_types.PromptMessage]
     ) -> OpenAIChatRunState:
         return OpenAIChatRunState(messages=self._initial_messages(prompt))
 
+    @override
     def _format_message(self, role: str, text: str) -> ChatCompletionMessageParam:
         return cast(
             "ChatCompletionMessageParam",
@@ -103,6 +106,7 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
             },
         )
 
+    @override
     def _format_result(
         self,
         call: MCPToolCall,
@@ -111,6 +115,7 @@ class OpenAIChatAgent(ToolAgent[ChatCompletionMessageParam, OpenAIChatConfig]):
     ) -> ChatCompletionMessageParam | list[ChatCompletionMessageParam] | None:
         return format_chat_result(call, result)
 
+    @override
     async def get_response(
         self,
         state: RunState[ChatCompletionMessageParam],

--- a/hud/agents/openai_compatible/tools/filesystem.py
+++ b/hud/agents/openai_compatible/tools/filesystem.py
@@ -8,6 +8,7 @@ import shlex
 from typing import Any, ClassVar
 
 import mcp.types as mcp_types
+from typing_extensions import override
 
 from hud.agents.tools import SSHTool
 from hud.agents.tools.base import AgentToolSpec, result_text, tool_err
@@ -21,10 +22,12 @@ class _FilesystemTool(SSHTool):
     parameters: ClassVar[dict[str, Any]]
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> AgentToolSpec:
         del model
         return AgentToolSpec(api_type="function", api_name=cls.name)
 
+    @override
     def to_params(self) -> dict[str, Any]:
         return {
             "type": "function",
@@ -62,6 +65,7 @@ class ReadTool(_FilesystemTool):
         "required": ["filePath"],
     }
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         path = arguments.get("filePath")
         if not isinstance(path, str) or not path:
@@ -147,6 +151,7 @@ class BashTool(_FilesystemTool):
         "required": ["command"],
     }
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         command = arguments.get("command")
         if not isinstance(command, str) or not command:
@@ -189,6 +194,7 @@ class EditTool(_FilesystemTool):
         "required": ["filePath", "oldString", "newString"],
     }
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         path = arguments.get("filePath")
         if not isinstance(path, str) or not path:
@@ -248,6 +254,7 @@ class WriteTool(_FilesystemTool):
         "required": ["content", "filePath"],
     }
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         path = arguments.get("filePath")
         if not isinstance(path, str) or not path:
@@ -283,6 +290,7 @@ class GrepTool(_FilesystemTool):
         "required": ["pattern"],
     }
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         pattern = arguments.get("pattern")
         if not isinstance(pattern, str):
@@ -307,6 +315,7 @@ class GlobTool(_FilesystemTool):
         "required": ["pattern"],
     }
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         pattern = arguments.get("pattern")
         if not isinstance(pattern, str):

--- a/hud/agents/openai_compatible/tools/mcp_proxy.py
+++ b/hud/agents/openai_compatible/tools/mcp_proxy.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing_extensions import override
+
 from hud.agents.tools import MCPTool
 
 from .base import openai_compatible_tool_name, openai_compatible_tool_param
@@ -13,6 +15,7 @@ class OpenAICompatibleMCPProxyTool(MCPTool):
     """Expose one discovered MCP tool as an OpenAI-compatible function tool."""
 
     @classmethod
+    @override
     def default_spec(cls, model: str) -> Any:
         del model
         from hud.agents.tools.base import AgentToolSpec
@@ -20,9 +23,11 @@ class OpenAICompatibleMCPProxyTool(MCPTool):
         return AgentToolSpec(api_type="function", api_name="function")
 
     @property
+    @override
     def provider_name(self) -> str:
         return openai_compatible_tool_name(super().provider_name)
 
+    @override
     def to_params(self) -> Any:
         return openai_compatible_tool_param(self.mcp_tool, name=self.provider_name)
 

--- a/hud/agents/robot/adapter.py
+++ b/hud/agents/robot/adapter.py
@@ -7,10 +7,12 @@ Use :class:`LeRobotAdapter` for LeRobot models; subclass for custom wiring;
 
 from __future__ import annotations
 
+import importlib
 from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
+from typing_extensions import override
 
 #: A policy-emitted action / chunk array (the robot stack's shared alias).
 ActionArray = NDArray[np.floating[Any]]
@@ -87,10 +89,9 @@ class LeRobotAdapter(Adapter):
     identity (postprocess already returns env-space actions).
     """
 
+    @override
     def adapt_observation(self, obs: dict[str, Any], prompt: str) -> dict[str, Any]:
-        import torch  # pyright: ignore[reportMissingImports]
-
-        torch_mod: Any = torch  # torch ships no stubs; keep strict mode quiet
+        torch_mod: Any = importlib.import_module("torch")
         data = obs["data"]
         state = np.asarray(data[self.state_key], dtype=np.float32)
         batched = state.ndim > 1  # [N, S] vs [S]
@@ -109,6 +110,7 @@ class OpenPIAdapter(Adapter):
     """Unwraps ``obs['data']`` to OpenPI wire keys and attaches the prompt;
     actions are pass-through."""
 
+    @override
     def adapt_observation(self, obs: dict[str, Any], prompt: str) -> dict[str, Any]:
         out = dict(obs["data"])
         out.setdefault("prompt", prompt)

--- a/hud/agents/robot/adapter.py
+++ b/hud/agents/robot/adapter.py
@@ -8,17 +8,32 @@ Use :class:`LeRobotAdapter` for LeRobot models; subclass for custom wiring;
 from __future__ import annotations
 
 import importlib
-from typing import Any
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast
 
 import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    import builtins
 
 #: A policy-emitted action / chunk array (the robot stack's shared alias).
 ActionArray = NDArray[np.floating[Any]]
 
 #: Image types the bundled adapters treat as cameras (vs the state vector).
 IMAGE_TYPES = ("rgb", "bgr", "gray", "depth")
+
+
+class _TorchTensor(Protocol):
+    def permute(self, *dims: int) -> Self: ...
+
+    def float(self) -> Self: ...
+
+    def __truediv__(self, value: builtins.float) -> Self: ...
+
+
+class _TorchModule(Protocol):
+    def from_numpy(self, array: NDArray[Any], /) -> _TorchTensor: ...
 
 
 class Adapter:
@@ -91,7 +106,7 @@ class LeRobotAdapter(Adapter):
 
     @override
     def adapt_observation(self, obs: dict[str, Any], prompt: str) -> dict[str, Any]:
-        torch_mod: Any = importlib.import_module("torch")
+        torch_mod = cast("_TorchModule", importlib.import_module("torch"))
         data = obs["data"]
         state = np.asarray(data[self.state_key], dtype=np.float32)
         batched = state.ndim > 1  # [N, S] vs [S]

--- a/hud/agents/robot/agent.py
+++ b/hud/agents/robot/agent.py
@@ -17,6 +17,7 @@ from collections import deque
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.capabilities.robot import RobotClient
@@ -57,6 +58,7 @@ class RobotAgent(Agent):
         """Return whether to stop before selecting the next action."""
         return bool(np.asarray(obs["terminated"]).reshape(-1)[0])
 
+    @override
     async def __call__(self, run: Run, *, max_steps: int | None = None) -> None:
         """The generic rollout contract: one run, one scalar robot connection.
 

--- a/hud/agents/robot/batching.py
+++ b/hud/agents/robot/batching.py
@@ -11,6 +11,8 @@ import copy
 import importlib
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import override
+
 from hud.agents.base import Agent
 
 from .model import Model
@@ -46,9 +48,11 @@ class BatchedModel(Model):
         self._queue: asyncio.Queue[tuple[Any, asyncio.Future[ActionArray]]] | None = None
         self._worker: asyncio.Task[None] | None = None
 
+    @override
     def infer(self, batch: Any) -> ActionArray:
         return self.inner.infer(batch)
 
+    @override
     async def ainfer(self, batch: Any) -> ActionArray:
         loop = asyncio.get_running_loop()
         if self._worker is None:
@@ -117,6 +121,7 @@ class BatchedAgent(Agent):
         # Every per-run clone shares this batcher by reference.
         agent.model = BatchedModel(agent.model, batch_size=batch_size, max_wait_s=max_wait_s)
 
+    @override
     async def __call__(self, run: Run, **kwargs: Any) -> None:
         worker = copy.copy(self._template)  # fresh __dict__; shares the batched model
         if worker.adapter is not None:  # defensive: a stateful custom adapter must be per-run

--- a/hud/agents/robot/model.py
+++ b/hud/agents/robot/model.py
@@ -16,6 +16,7 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from typing_extensions import override
 
 if TYPE_CHECKING:
     from .adapter import ActionArray
@@ -63,6 +64,7 @@ class LeRobotModel(Model):
         #: CUDA/flow-matching warmup message.
         self._first_inference = True
 
+    @override
     def infer(self, batch: Any) -> ActionArray:
         """run batch dict (N dim) → [N, T, A] chunk"""
         torch: Any = importlib.import_module("torch")
@@ -113,6 +115,7 @@ class RemoteModel(Model):
             )
             self._client = mod.WebsocketClientPolicy(self.host, self.port)
 
+    @override
     def infer(self, batch: Any) -> ActionArray:
         """Ship one request dict → the server's ``[T, A]`` chunk, returned as ``[1, T, A]``."""
         self.connect()  # lazy connect on first call (blocks until the server is up)

--- a/hud/agents/tests/test_apply_patch.py
+++ b/hud/agents/tests/test_apply_patch.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 """The OpenAI V4A apply-patch engine: parse a patch + apply it via callbacks.
 
 ``_text_to_patch`` parses the V4A diff text against the current files; ``_apply_patch``

--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from typing_extensions import override
 
 from hud.agents import OpenAIAgent, OpenAIChatAgent, create_agent
 from hud.agents.base import Agent
@@ -18,6 +19,7 @@ from hud.utils.exceptions import HudAuthenticationError
 
 
 class _FillingAgent(Agent):
+    @override
     async def __call__(self, run: Any) -> None:
         run.trace.content = "done"
 
@@ -27,7 +29,7 @@ class _FillingAgent(Agent):
 
 def test_agent_requires_call_implementation() -> None:
     with pytest.raises(TypeError):
-        Agent()  # type: ignore[abstract]
+        Agent()
 
 
 async def test_agent_call_fills_trace() -> None:

--- a/hud/agents/tests/test_claude_agent.py
+++ b/hud/agents/tests/test_claude_agent.py
@@ -1,7 +1,6 @@
 """``ClaudeAgent`` — ``get_response`` parsing over a fake streaming Messages client,
 plus the pure ``_citation`` / ``_cache_last_user_block`` helpers.
 """
-# pyright: reportPrivateUsage=false
 
 from __future__ import annotations
 

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -6,7 +6,6 @@ command must ride a batch file invoked via ``cmd /c``. Bare ``.hud_run.bat`` is
 rejected by the remote shell (and silently fails under PowerShell), so the
 ``cmd /c`` prefix is a regression guard for local Windows setups.
 """
-# pyright: reportPrivateUsage=false
 
 from __future__ import annotations
 

--- a/hud/agents/tests/test_gemini_agent.py
+++ b/hud/agents/tests/test_gemini_agent.py
@@ -1,7 +1,6 @@
 """``GeminiAgent`` — ``get_response`` parsing over a fake Generate Content client,
 plus ``_make_tool_call`` mapping and ``_grounding_citations``.
 """
-# pyright: reportPrivateUsage=false
 
 from __future__ import annotations
 

--- a/hud/agents/tests/test_openai_agent.py
+++ b/hud/agents/tests/test_openai_agent.py
@@ -1,7 +1,6 @@
 """``OpenAIAgent`` — construction + ``get_response`` parsing of the Responses API,
 with a fake ``AsyncOpenAI`` client (no network).
 """
-# pyright: reportPrivateUsage=false
 
 from __future__ import annotations
 

--- a/hud/agents/tests/test_openai_compatible_agent.py
+++ b/hud/agents/tests/test_openai_compatible_agent.py
@@ -1,5 +1,4 @@
 """``OpenAIChatAgent`` — chat.completions ``get_response`` parsing + error path."""
-# pyright: reportPrivateUsage=false
 
 from __future__ import annotations
 

--- a/hud/agents/tests/test_robot_dataset_writer.py
+++ b/hud/agents/tests/test_robot_dataset_writer.py
@@ -27,9 +27,9 @@ def _contract(
 
 @pytest.fixture(autouse=True)
 def reset_dataset_writer_globals(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
-    DatasetWriter._datasets.clear()  # pyright: ignore[reportPrivateUsage]
-    DatasetWriter._open.clear()  # pyright: ignore[reportPrivateUsage]
-    DatasetWriter._atexit_registered = False  # pyright: ignore[reportPrivateUsage]
+    DatasetWriter._datasets.clear()
+    DatasetWriter._open.clear()
+    DatasetWriter._atexit_registered = False
     monkeypatch.setenv("RECORD_DIR", str(tmp_path))
     monkeypatch.delenv("HF_REPO", raising=False)
 
@@ -63,7 +63,7 @@ def test_matching_writers_share_one_dataset(monkeypatch: pytest.MonkeyPatch) -> 
     DatasetWriter(contract, fps=10).add(obs, act, task="t")
     DatasetWriter(contract, fps=10).add(obs, act, task="t")
     assert len(created) == 1
-    assert len(DatasetWriter._datasets) == 1  # pyright: ignore[reportPrivateUsage]
+    assert len(DatasetWriter._datasets) == 1
 
 
 def test_different_fps_or_features_get_separate_datasets(
@@ -114,7 +114,7 @@ def test_finalize_clears_all_datasets(monkeypatch: pytest.MonkeyPatch) -> None:
     a.end_episode()
     b.end_episode()
     DatasetWriter.finalize()
-    assert DatasetWriter._datasets == {}  # pyright: ignore[reportPrivateUsage]
+    assert DatasetWriter._datasets == {}
     for ds in created:
         ds.finalize.assert_called_once()
 

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -1,4 +1,3 @@
-# pyright: reportPrivateUsage=false
 """``ToolAgent`` plumbing: catalog→clients, message formatting, dispatch + loop.
 
 The provider-specific bits are abstract; this drives a tiny concrete subclass with a
@@ -8,12 +7,13 @@ scripted ``get_response`` so the loop, dispatch, and message formatting run offl
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import fastmcp
 import mcp.types as mcp_types
 import pytest
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+from typing_extensions import override
 
 from hud.agents.openai.tools.coding import OpenAIShellTool
 from hud.agents.openai.tools.mcp_proxy import OpenAIMCPProxyTool
@@ -21,6 +21,9 @@ from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.types import AgentConfig, AgentStep, ToolStep
 from hud.capabilities import Capability, CapabilityClient, MCPClient, RFBClient, SSHClient
 from hud.types import MCPToolCall, MCPToolResult, Step, Trace
+
+if TYPE_CHECKING:
+    from hud.eval.run import Run
 
 _Msg = dict[str, Any]
 
@@ -42,17 +45,21 @@ class DictAgent(ToolAgent[_Msg, AgentConfig]):
         self.config = AgentConfig(model="test-model", **config)
         self._turns = list(turns)
 
+    @override
     async def _initialize_state(self, *, prompt: Any) -> RunState[_Msg]:
         return RunState(messages=self._initial_messages(prompt))
 
+    @override
     async def get_response(
         self, state: RunState[_Msg], *, system_prompt: Any = None, citations_enabled: bool = False
     ) -> AgentStep:
         return self._turns.pop(0)
 
+    @override
     def _format_message(self, role: str, text: str) -> _Msg:
         return {"role": role, "content": text}
 
+    @override
     def _format_result(
         self, call: MCPToolCall, result: MCPToolResult, state: RunState[_Msg]
     ) -> _Msg:
@@ -199,9 +206,11 @@ async def test_multiple_mcp_capabilities_qualify_tool_names() -> None:
             ]
             self.calls: list[str] = []
 
+        @override
         async def list_tools(self) -> list[mcp_types.Tool]:
             return self.tools
 
+        @override
         async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
             self.calls.append(name)
             return MCPToolResult(content=[])
@@ -238,9 +247,11 @@ async def test_multiple_mcp_capabilities_reject_qualified_name_collisions() -> N
                 inputSchema={"type": "object", "properties": {}},
             )
 
+        @override
         async def list_tools(self) -> list[mcp_types.Tool]:
             return [self.tool]
 
+        @override
         async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
             raise AssertionError("colliding tools must not be callable")
 
@@ -260,9 +271,11 @@ async def test_qualified_mcp_names_are_valid_provider_tool_names() -> None:
                 inputSchema={"type": "object", "properties": {}},
             )
 
+        @override
         async def list_tools(self) -> list[mcp_types.Tool]:
             return [self.tool]
 
+        @override
         async def call_tool(self, name: str, arguments: dict[str, Any]) -> MCPToolResult:
             return MCPToolResult(content=[])
 
@@ -319,9 +332,9 @@ async def test_dispatch_unparsed_arguments_returns_error_result() -> None:
 
 async def test_loop_finishes_on_done_response() -> None:
     agent = DictAgent([AgentStep(content="final answer", done=True)])
-    run = _FakeRun()
+    run = cast("Run", _FakeRun())
 
-    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+    await agent._loop(run, RunState(), max_steps=3)
 
     assert run.trace.status == "completed"
     assert run.trace.content == "final answer"
@@ -344,9 +357,9 @@ async def test_loop_dispatches_tool_calls_then_finishes() -> None:
             AgentStep(content="done now", done=True),
         ]
     )
-    run = _FakeRun()
+    run = cast("Run", _FakeRun())
 
-    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+    await agent._loop(run, RunState(), max_steps=3)
 
     assert run.trace.content == "done now"
     assert [step.source for step in run.trace.steps] == ["agent", "tool", "agent"]
@@ -367,9 +380,9 @@ async def test_loop_max_steps_is_normal_termination() -> None:
         AgentStep(content="", done=False, tool_calls=[MCPToolCall(name="ghost")]) for _ in range(5)
     ]
     agent = DictAgent(never_done)
-    run = _FakeRun()
+    run = cast("Run", _FakeRun())
 
-    await agent._loop(run, RunState(), max_steps=2)  # type: ignore[arg-type]
+    await agent._loop(run, RunState(), max_steps=2)
 
     assert run.trace.is_error is False
     assert run.trace.status == "completed"
@@ -385,9 +398,9 @@ async def test_loop_marks_length_finish_as_truncated() -> None:
     # provider's finish-reason vocabulary.
     for finish_reason in ("length", "max_output_tokens", "max_tokens", "MAX_TOKENS"):
         agent = DictAgent([AgentStep(content="partial", done=True, finish_reason=finish_reason)])
-        run = _FakeRun()
+        run = cast("Run", _FakeRun())
 
-        await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+        await agent._loop(run, RunState(), max_steps=3)
 
         assert run.trace.status == "completed"
         assert run.trace.stop_reason == "length"
@@ -406,9 +419,9 @@ async def test_loop_answers_malformed_call_by_default() -> None:
             AgentStep(content="recovered", done=True),
         ]
     )
-    run = _FakeRun()
+    run = cast("Run", _FakeRun())
 
-    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+    await agent._loop(run, RunState(), max_steps=3)
 
     assert run.trace.content == "recovered"
     tool_step = run.trace.steps[1]
@@ -430,9 +443,9 @@ async def test_loop_stops_on_malformed_call_when_configured() -> None:
         ],
         stop_on={"malformed_tool_call"},
     )
-    run = _FakeRun()
+    run = cast("Run", _FakeRun())
 
-    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+    await agent._loop(run, RunState(), max_steps=3)
 
     assert run.trace.status == "completed"
     assert run.trace.stop_reason == "malformed_tool_call"
@@ -453,9 +466,9 @@ async def test_loop_stops_on_length_when_configured() -> None:
         ],
         stop_on={"length", "malformed_tool_call"},
     )
-    run = _FakeRun()
+    run = cast("Run", _FakeRun())
 
-    await agent._loop(run, RunState(), max_steps=3)  # type: ignore[arg-type]
+    await agent._loop(run, RunState(), max_steps=3)
 
     assert run.trace.stop_reason == "length"
     assert run.trace.is_truncated is True

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 import mcp.types as mcp_types
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.agents.misc import auto_respond
@@ -83,7 +84,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
     def __init_subclass__(cls, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
         if "tool_catalog" in cls.__dict__:
-            seen: dict[type, None] = {}
+            seen: dict[type[CapabilityClient], None] = {}
             for t in cls.tool_catalog:
                 seen.setdefault(t.client_type, None)
             cls.clients = tuple(seen.keys())
@@ -113,6 +114,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
         )
         return {"type": agent_type.value, "config": config}
 
+    @override
     async def __call__(self, run: Run) -> None:
         """Drive this (stateless) agent over a live ``Run``, filling ``run.trace``.
 
@@ -252,7 +254,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                     if msg is None:
                         continue
                     if isinstance(msg, list):
-                        state.messages.extend(cast("list[MessageT]", msg))
+                        state.messages.extend(msg)
                     else:
                         state.messages.append(cast("MessageT", msg))
 

--- a/hud/agents/tools/mcp.py
+++ b/hud/agents/tools/mcp.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from typing_extensions import override
+
 from hud.agents.tools.base import AgentTool, AgentToolSpec
 from hud.capabilities import MCPClient
 
@@ -37,9 +39,11 @@ class MCPTool(AgentTool[MCPClient]):
         self._provider_name = mcp_tool.name if provider_name is None else provider_name
 
     @property
+    @override
     def provider_name(self) -> str:
         return self._provider_name
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         return await self.client.call_tool(self.mcp_tool.name, arguments)
 

--- a/hud/agents/tools/rfb.py
+++ b/hud/agents/tools/rfb.py
@@ -174,8 +174,7 @@ class RFBTool(AgentTool[RFBClient]):
 
     # ─── timing ──────────────────────────────────────────────────────
 
-    @staticmethod
-    async def wait(duration_ms: int) -> None:
+    async def wait(self, duration_ms: int) -> None:
         await asyncio.sleep(duration_ms / 1000)
 
     # ─── internal ────────────────────────────────────────────────────

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -335,7 +335,7 @@ class ObservationStep(Step):
     """
 
     schema_tag: ClassVar[str] = ROBOT_STEP_SCHEMA
-    source: RobotStepSource = "observation"  # type: ignore[assignment]
+    source: RobotStepSource = "observation"
 
     tick: int = 0
     # TODO: note - this reuses the MCP-native ImageContent type
@@ -414,7 +414,7 @@ class InferenceStep(Step):
     """
 
     schema_tag: ClassVar[str] = ROBOT_STEP_SCHEMA
-    source: RobotStepSource = "inference"  # type: ignore[assignment]
+    source: RobotStepSource = "inference"
 
     # tick id
     tick: int = 0  # start of inference
@@ -441,7 +441,7 @@ class VideoSegmentStep(Step):
     """
 
     schema_tag: ClassVar[str] = ROBOT_STEP_SCHEMA
-    source: RobotStepSource = "video_segment"  # type: ignore[assignment]
+    source: RobotStepSource = "video_segment"
 
     camera: str = ""
     #: Position in the camera's stream; ``index`` 0 is the init segment.

--- a/hud/capabilities/cdp.py
+++ b/hud/capabilities/cdp.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self
 from urllib.parse import urlsplit
 
 import httpx
+from typing_extensions import override
 from websockets.asyncio.client import connect as ws_connect
 from websockets.exceptions import ConnectionClosed
 
@@ -63,6 +64,7 @@ class CDPClient(CapabilityClient):
         self._reader: asyncio.Task[None] | None = None
 
     @classmethod
+    @override
     async def connect(cls, cap: Capability) -> Self:
         parts = urlsplit(cap.url)
         if parts.hostname is None or parts.port is None:
@@ -136,6 +138,7 @@ class CDPClient(CapabilityClient):
                 if not future.done():
                     future.set_exception(ConnectionError("CDP connection closed"))
 
+    @override
     async def close(self) -> None:
         if self._reader is not None:
             self._reader.cancel()

--- a/hud/capabilities/mcp.py
+++ b/hud/capabilities/mcp.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Self
 import fastmcp
 from fastmcp.client.auth import BearerAuth
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+from typing_extensions import override
 
 from .base import Capability, CapabilityClient
 
@@ -38,6 +39,7 @@ class MCPClient(CapabilityClient):
         self._exit_stack = exit_stack
 
     @classmethod
+    @override
     async def connect(cls, cap: Capability) -> Self:
         token = cap.params.get("auth_token")
         auth = BearerAuth(token) if token else None
@@ -74,6 +76,7 @@ class MCPClient(CapabilityClient):
         data.setdefault("content", [])
         return _Result.model_validate(data)
 
+    @override
     async def close(self) -> None:
         await self._exit_stack.aclose()
 

--- a/hud/capabilities/rfb.py
+++ b/hud/capabilities/rfb.py
@@ -29,6 +29,7 @@ from urllib.parse import urlsplit
 
 import asyncvnc
 from PIL import Image
+from typing_extensions import override
 
 from .base import Capability, CapabilityClient
 
@@ -59,6 +60,7 @@ class RFBClient(CapabilityClient):
         self._password = capability.params.get("password")
 
     @classmethod
+    @override
     async def connect(cls, cap: Capability) -> Self:
         parts = urlsplit(cap.url)
         if parts.hostname is None or parts.port is None:
@@ -138,6 +140,7 @@ class RFBClient(CapabilityClient):
         """Flush any queued mouse/keyboard writes to the server."""
         await self._conn.drain()
 
+    @override
     async def close(self) -> None:
         await self._exit_stack.aclose()
 

--- a/hud/capabilities/robot.py
+++ b/hud/capabilities/robot.py
@@ -21,6 +21,7 @@ import numpy as np
 import websockets
 import websockets.exceptions
 from openpi_client import msgpack_numpy
+from typing_extensions import override
 
 from .base import Capability, CapabilityClient
 
@@ -72,6 +73,7 @@ class RobotClient(CapabilityClient):
         return action, observations
 
     @classmethod
+    @override
     async def connect(cls, cap: Capability, *, token: str | None = None) -> Self:
         """Dial the robot WebSocket; ``token`` claims a sim slot after the metadata frame.
 
@@ -147,6 +149,7 @@ class RobotClient(CapabilityClient):
             msg["delay_used"] = int(delay_used)
         await self._ws.send(_packb(msg))
 
+    @override
     async def close(self) -> None:
         self._mailman.cancel()
         with contextlib.suppress(asyncio.CancelledError):

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -8,6 +8,7 @@ from typing import Any, ClassVar, Self
 from urllib.parse import urlsplit
 
 import asyncssh
+from typing_extensions import override
 
 from .base import Capability, CapabilityClient
 
@@ -28,6 +29,7 @@ class SSHClient(CapabilityClient):
         self._conn = conn
 
     @classmethod
+    @override
     async def connect(cls, cap: Capability) -> Self:
         parts = urlsplit(cap.url)
         if parts.hostname is None or parts.port is None:
@@ -100,6 +102,7 @@ class SSHClient(CapabilityClient):
     def _is_windows(self) -> bool:
         return self.capability.params.get("shell") in ("cmd", "powershell")
 
+    @override
     async def close(self) -> None:
         self._conn.close()
         await self._conn.wait_closed()

--- a/hud/capabilities/tests/test_rfb.py
+++ b/hud/capabilities/tests/test_rfb.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import mcp.types as mcp_types
 from PIL import Image
+from typing_extensions import override
 
 from hud.agents.tools.rfb import RFBTool
 from hud.capabilities.rfb import RFBClient
@@ -21,10 +22,12 @@ class RecordingRFBTool(RFBTool):
             screenshot_png=AsyncMock(return_value=(b"webp", "image/webp")),
         )
 
+    @override
     async def execute(self, arguments: dict[str, Any]) -> Any:
         del arguments
         raise NotImplementedError
 
+    @override
     def to_params(self) -> Any:
         raise NotImplementedError
 

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -57,7 +57,7 @@ app.add_typer(trace_app, name="trace")
 
 @app.command(name="set")
 def set_command(
-    assignments: list[str] = typer.Argument(  # type: ignore[arg-type]  # noqa: B008
+    assignments: list[str] = typer.Argument(  # noqa: B008
         ..., help="One or more KEY=VALUE pairs to persist in ~/.hud/.env"
     ),
 ) -> None:

--- a/hud/cli/cancel.py
+++ b/hud/cli/cancel.py
@@ -79,8 +79,9 @@ def cancel_command(
                     hud_console.info(f"  • {job['job_id']}: {job['cancelled']} tasks cancelled")
 
         elif trace_id:
+            assert job_id is not None
             hud_console.info(f"Cancelling trace {trace_id} in job {job_id}...")
-            result = await cancel_task(job_id, trace_id)  # type: ignore[arg-type]
+            result = await cancel_task(job_id, trace_id)
 
             # Two-phase cancel: "accepted" = marked cancelling; "noop" = nothing
             # to do (already terminal, or not found).
@@ -90,8 +91,9 @@ def cancel_command(
                 hud_console.warning("Task not found or already finished.")
 
         else:
+            assert job_id is not None
             hud_console.info(f"Cancelling job {job_id}...")
-            result = await cancel_job(job_id)  # type: ignore[arg-type]
+            result = await cancel_job(job_id)
 
             cancelled = result.get("cancelled", 0)
             if cancelled == 0:

--- a/hud/cli/tests/test_deploy.py
+++ b/hud/cli/tests/test_deploy.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 import typer
+from typing_extensions import override
 
 from hud.cli.deploy import _resolve_environment_name
 from hud.cli.utils.registry import RegistryEnvironment
@@ -355,6 +356,7 @@ class TestDeployAsync:
         class FakePlatform(PlatformClient):
             payload: dict[str, object] | None = None
 
+            @override
             async def apost(
                 self,
                 path: str,
@@ -396,6 +398,7 @@ class TestDeployAsync:
         class FakePlatform(PlatformClient):
             payload: dict[str, object] | None = None
 
+            @override
             async def apost(
                 self,
                 path: str,

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -2,7 +2,6 @@
 
 Pure config logic; no agent is constructed and no network is touched.
 """
-# pyright: reportArgumentType=false, reportPrivateUsage=false
 
 from __future__ import annotations
 

--- a/hud/cli/utils/tests/test_registry.py
+++ b/hud/cli/utils/tests/test_registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hud.cli.utils.registry import (
     RegistryEnvironment,
@@ -42,7 +42,7 @@ def test_resolve_accepts_uuid_without_lookup() -> None:
 
 
 def test_get_registry_environment_treats_404_as_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_request(method: str, url: str, **kwargs: object) -> dict:
+    def fake_request(method: str, url: str, **kwargs: object) -> dict[str, Any]:
         raise HudRequestError("not found", status_code=404)
 
     monkeypatch.setattr("hud.utils.platform.make_request_sync", fake_request)
@@ -55,7 +55,7 @@ def test_get_registry_environment_treats_404_as_missing(monkeypatch: pytest.Monk
 def test_search_filters_paginated_registry_list(monkeypatch: pytest.MonkeyPatch) -> None:
     requested: dict[str, str] = {}
 
-    def fake_request(method: str, url: str, **kwargs: object) -> dict:
+    def fake_request(method: str, url: str, **kwargs: object) -> dict[str, Any]:
         requested.update(method=method, url=url)
         return {
             "items": [

--- a/hud/cli/utils/tests/test_tasks.py
+++ b/hud/cli/utils/tests/test_tasks.py
@@ -32,7 +32,7 @@ def test_find_tasks_file_single_file(mock_cwd, mock_console):
     """Test that when only one file exists, it's returned without prompting."""
     mock_path = MagicMock(spec=Path)
     mock_file = MagicMock(spec=Path)
-    mock_file.__str__.return_value = "test.json"  # type: ignore
+    mock_file.__str__.return_value = "test.json"
 
     def glob_side_effect(pattern):
         if pattern == "*.json":
@@ -40,7 +40,7 @@ def test_find_tasks_file_single_file(mock_cwd, mock_console):
         return []
 
     mock_path.glob.side_effect = glob_side_effect
-    mock_path.__str__.return_value = str(Path.cwd())  # type: ignore
+    mock_path.__str__.return_value = str(Path.cwd())
     mock_cwd.return_value = mock_path
 
     result = find_tasks_file(None)
@@ -54,9 +54,9 @@ def test_find_tasks_file_multiple_files(mock_cwd, mock_console):
     """Test that when multiple files exist, user is prompted to select one."""
     mock_path = MagicMock(spec=Path)
     mock_file1 = MagicMock(spec=Path)
-    mock_file1.__str__.return_value = "test1.json"  # type: ignore
+    mock_file1.__str__.return_value = "test1.json"
     mock_file2 = MagicMock(spec=Path)
-    mock_file2.__str__.return_value = "test2.jsonl"  # type: ignore
+    mock_file2.__str__.return_value = "test2.jsonl"
 
     def glob_side_effect(pattern):
         if pattern == "*.json":
@@ -66,7 +66,7 @@ def test_find_tasks_file_multiple_files(mock_cwd, mock_console):
         return []
 
     mock_path.glob.side_effect = glob_side_effect
-    mock_path.__str__.return_value = str(Path.cwd())  # type: ignore
+    mock_path.__str__.return_value = str(Path.cwd())
     mock_cwd.return_value = mock_path
     mock_console.select.return_value = "test2.jsonl"
 

--- a/hud/environment/egress.py
+++ b/hud/environment/egress.py
@@ -42,7 +42,9 @@ import urllib.parse
 from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+
+from typing_extensions import override
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
@@ -325,7 +327,8 @@ class _Proxy(BaseHTTPRequestHandler):
     allowed: Collection[str] = ()
     token: str | None = None
 
-    def log_message(self, *_: object) -> None:
+    @override
+    def log_message(self, format: str, *args: Any) -> None:
         """The workspace's traffic is not the substrate's log."""
 
     def _fail(self, status: int, reason: str) -> None:
@@ -499,6 +502,7 @@ class _Forward(socketserver.BaseRequestHandler):
 
     target: tuple[str, int] = ("127.0.0.1", 0)
 
+    @override
     def handle(self) -> None:
         try:
             upstream = socket.create_connection(self.target, timeout=15)
@@ -511,6 +515,7 @@ class _Forward(socketserver.BaseRequestHandler):
 class _UnixServer(socketserver.ThreadingUnixStreamServer):
     daemon_threads = True
 
+    @override
     def get_request(self) -> tuple[socket.socket, tuple[str, int]]:
         # A unix peer has no address; the handler wants one to log.
         request, _ = super().get_request()

--- a/hud/environment/env.py
+++ b/hud/environment/env.py
@@ -14,6 +14,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, create_model
+from typing_extensions import override
 
 from hud.capabilities import Capability
 
@@ -207,7 +208,7 @@ class Environment(LegacyEnvMixin):
                     f"@env.template: {getattr(func, '__qualname__', func)} must be an async "
                     "generator function (`async def ...:` with `yield`)",
                 )
-            task_id = id or func.__name__
+            task_id = id or cast("Any", func).__name__
             if task_id in self.tasks:
                 raise ValueError(
                     f"template {task_id!r} already registered on env {self.name!r}",
@@ -242,6 +243,7 @@ class Environment(LegacyEnvMixin):
 
     # ─── capabilities ─────────────────────────────────────────────────────
 
+    @override
     def add_capability(self, cap: Capability) -> None:
         """Publish concrete wire data, replacing any same-named entry.
 

--- a/hud/environment/env.py
+++ b/hud/environment/env.py
@@ -11,7 +11,7 @@ import contextlib
 import functools
 import inspect
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, ParamSpec, Protocol, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, create_model
 from typing_extensions import override
@@ -32,6 +32,13 @@ T = TypeVar("T")
 
 #: Control-session id for the running accept/cancel task (robot slot claims key on it).
 current_session_id: ContextVar[str | None] = ContextVar("hud_current_session_id", default=None)
+
+
+class _TaskFunction(Protocol[P]):
+    __name__: str
+    __doc__: str | None
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> AsyncGenerator[Any, Any]: ...
 
 
 class Answer(BaseModel, Generic[T]):
@@ -89,7 +96,7 @@ class _TaskFactory(Generic[P]):
         env: Environment,
         id: str,
         description: str,
-        func: Callable[P, AsyncGenerator[Any, Any]],
+        func: _TaskFunction[P],
         *,
         input: Any = None,
         returns: Any = None,
@@ -183,6 +190,7 @@ class Environment(LegacyEnvMixin):
         """The registered ``@env.template`` factories by id (alias of ``tasks``)."""
         return self.tasks
 
+    @override
     def template(
         self,
         *,
@@ -190,7 +198,7 @@ class Environment(LegacyEnvMixin):
         description: str = "",
         input: Any = None,
         returns: Any = None,
-    ) -> Callable[[Callable[P, AsyncGenerator[Any, Any]]], _TaskFactory[P]]:
+    ) -> Callable[[_TaskFunction[P]], _TaskFactory[P]]:
         """Register a **task template** — an async generator that mints tasks.
 
         The generator yields a prompt, then — once the answer is sent back — a
@@ -202,13 +210,13 @@ class Environment(LegacyEnvMixin):
         args returns a concrete :class:`~hud.eval.Task` row.
         """
 
-        def decorate(func: Callable[P, AsyncGenerator[Any, Any]]) -> _TaskFactory[P]:
+        def decorate(func: _TaskFunction[P]) -> _TaskFactory[P]:
             if not inspect.isasyncgenfunction(func):
                 raise TypeError(
                     f"@env.template: {getattr(func, '__qualname__', func)} must be an async "
                     "generator function (`async def ...:` with `yield`)",
                 )
-            task_id = id or cast("Any", func).__name__
+            task_id = id or func.__name__
             if task_id in self.tasks:
                 raise ValueError(
                     f"template {task_id!r} already registered on env {self.name!r}",

--- a/hud/environment/legacy.py
+++ b/hud/environment/legacy.py
@@ -285,7 +285,7 @@ class LegacyEnvMixin:
         )
 
         def decorate(fn: Callable[P, AsyncGenerator[Any, Any]]) -> _TaskFactory[P]:
-            scenario_name = name or fn.__name__
+            scenario_name = name or cast("Any", fn).__name__
             if ":" in scenario_name:
                 raise ValueError(
                     f"scenario name {scenario_name!r} cannot contain ':' (reserved separator)",

--- a/hud/environment/legacy.py
+++ b/hud/environment/legacy.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
     from hud.capabilities import Capability
 
-    from .env import Environment, _TaskFactory
+    from .env import Environment, _TaskFactory, _TaskFunction
 
 LOGGER = logging.getLogger("hud.environment.legacy")
 
@@ -90,6 +90,17 @@ class LegacyEnvMixin:
     add_capability: Callable[[Capability], None]
     _on_start: list[Callable[[], Any]]
     _on_stop: list[Callable[[], Any]]
+
+    if TYPE_CHECKING:
+
+        def template(
+            self,
+            *,
+            id: str | None = None,
+            description: str = "",
+            input: Any = None,
+            returns: Any = None,
+        ) -> Callable[[_TaskFunction[P]], _TaskFactory[P]]: ...
 
     def _init_legacy(self) -> None:
         """Initialize legacy-compat state (called from ``Environment.__init__``)."""
@@ -267,7 +278,7 @@ class LegacyEnvMixin:
         allowed_tools: list[str] | None = None,
         returns: type | None = None,
         enable_citations: bool = False,
-    ) -> Callable[[Callable[P, AsyncGenerator[Any, Any]]], _TaskFactory[P]]:
+    ) -> Callable[[_TaskFunction[P]], _TaskFactory[P]]:
         """[deprecated] Register a scenario as a v6 task. Prefer ``@env.template``.
 
         Accepts the full v5 ``scenario`` signature; the generator (``yield prompt``
@@ -284,8 +295,8 @@ class LegacyEnvMixin:
             stacklevel=2,
         )
 
-        def decorate(fn: Callable[P, AsyncGenerator[Any, Any]]) -> _TaskFactory[P]:
-            scenario_name = name or cast("Any", fn).__name__
+        def decorate(fn: _TaskFunction[P]) -> _TaskFactory[P]:
+            scenario_name = name or fn.__name__
             if ":" in scenario_name:
                 raise ValueError(
                     f"scenario name {scenario_name!r} cannot contain ':' (reserved separator)",
@@ -296,10 +307,7 @@ class LegacyEnvMixin:
                 )
 
             desc = description or (fn.__doc__ or "").strip().split("\n", 1)[0]
-            register = cast("Any", self).template  # provided by Environment
-            task: _TaskFactory[P] = register(id=scenario_name, description=desc, returns=returns)(
-                fn
-            )
+            task = self.template(id=scenario_name, description=desc, returns=returns)(fn)
 
             self._scenario_fns[scenario_name] = fn
             if chat:

--- a/hud/environment/namespace.py
+++ b/hud/environment/namespace.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import asyncssh
+from typing_extensions import override
 
 from hud.environment.utils import splice
 from hud.utils.process import ProcessGroup, ProcessResult, create_process_group_exec
@@ -239,6 +240,7 @@ class NamespaceHost:
 
 
 class _NoAuth(asyncssh.SSHServer):
+    @override
     def begin_auth(self, username: str) -> bool:
         return False
 
@@ -462,10 +464,12 @@ class _NamespaceHost:
         if scope == "environment" and mount_view != "host":
             raise ValueError("environment processes require the host mount view")
         identity = request["identity"]
+        identity_argv: tuple[str, ...] = ()
         if isinstance(identity, int):
-            uid = gid = identity
+            identity_argv = ("--setgid", str(identity), "--setuid", str(identity))
         elif identity is not None:
             uid, gid = map(int, identity)
+            identity_argv = ("--setgid", str(gid), "--setuid", str(uid))
         command_prefix: list[str] = []
         if mount_view == "host":
             unshare = shutil.which("unshare")
@@ -477,7 +481,7 @@ class _NamespaceHost:
                 "--propagation",
                 "private",
                 "--mount-proc",
-                *(() if identity is None else ("--setgid", str(gid), "--setuid", str(uid))),
+                *identity_argv,
                 "--",
             ]
         held = self.holders.get(scope)
@@ -495,7 +499,7 @@ class _NamespaceHost:
             *(
                 ("--preserve-credentials",)
                 if identity is None or mount_view == "host"
-                else ("--setgid", str(gid), "--setuid", str(uid))
+                else identity_argv
             ),
             "--",
             *command_prefix,

--- a/hud/environment/robot/bridge.py
+++ b/hud/environment/robot/bridge.py
@@ -37,6 +37,8 @@ from hud.environment.utils import error, read_frame, reply, send_frame
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from numpy.typing import NDArray
+
 #: Line the sim program prints once its control channel is bound; the spawning
 #: RobotEndpoint reads it from this process's stdout.
 PORT_ANNOUNCEMENT = "HUD_SIM_PORT="
@@ -53,7 +55,7 @@ class _Slot:
     index: int
     token: str | None = None
     ws: Any = None
-    action: np.ndarray | None = None
+    action: NDArray[Any] | None = None
     idle: bool = False  # not a barrier participant (disconnected / terminated)
     # Touched this episode; after release stays unreclaimable until the next global reset.
     used: bool = False
@@ -227,11 +229,11 @@ class RobotBridge(ABC):
         """
 
     @abstractmethod
-    def step(self, action: np.ndarray) -> None:
+    def step(self, action: NDArray[Any]) -> None:
         """Advance the sim by one batched action ``[N, A]``."""
 
     @abstractmethod
-    def get_observation(self) -> tuple[dict[str, np.ndarray], np.ndarray] | None:
+    def get_observation(self) -> tuple[dict[str, NDArray[Any]], NDArray[Any]] | None:
         """Return ``(data[N, ...], terminated[N])``, or ``None`` if not ready."""
 
     def result(self) -> dict[str, Any]:
@@ -256,7 +258,7 @@ class RobotBridge(ABC):
         grade = self.result()
         return [dict(grade) for _ in range(self.num_envs)]
 
-    def hold_action(self) -> np.ndarray:
+    def hold_action(self) -> NDArray[Any]:
         """Action used for idle/stalled slots at a barrier step (zeros)."""
         action = next(
             (f for f in self.contract.get("features", {}).values() if f.get("role") == "action"),
@@ -424,7 +426,7 @@ class RobotBridge(ABC):
     async def _send_slot_observation(
         self,
         slot: _Slot,
-        batch: tuple[dict[str, np.ndarray], np.ndarray] | None,
+        batch: tuple[dict[str, NDArray[Any]], NDArray[Any]] | None,
     ) -> None:
         """Fan one scalar obs frame to a claimed connection from a batched read."""
         if slot.ws is None or batch is None:

--- a/hud/environment/robot/gym.py
+++ b/hud/environment/robot/gym.py
@@ -26,19 +26,24 @@ plots; an existing file is loaded instead, so edits stick.
 from __future__ import annotations
 
 import atexit
+import importlib
 import inspect
 import itertools
 import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 import numpy as np
+from typing_extensions import override
 
 from hud.telemetry.robot import JobRecorder, to_numpy
 
 from .bridge import RobotBridge, serve_bridge
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +110,7 @@ def split_observation(obs: Any, *, batched: bool = False) -> tuple[dict[str, Any
     return state, frames
 
 
-def probe_success(info: Any, *, num_envs: int = 1) -> np.ndarray | None:
+def probe_success(info: Any, *, num_envs: int = 1) -> NDArray[Any] | None:
     """Per-env success bools from conventional info keys; ``None`` when the env reports none."""
     if not isinstance(info, dict):
         return None
@@ -245,10 +250,10 @@ class GymBridge(RobotBridge):
         self._instance: Any = None  # current env-defining args; a mismatch rebuilds
         self._is_torch = False
         # Per-slot episode scoring, sticky until the next reset.
-        self._done: np.ndarray = np.zeros(1, dtype=bool)
-        self._success: np.ndarray = np.zeros(1, dtype=bool)
-        self._acc_reward: np.ndarray = np.zeros(1)
-        self._step_reward: np.ndarray = np.zeros(1)  # last env.step reward (RL wire sibling)
+        self._done: NDArray[Any] = np.zeros(1, dtype=bool)
+        self._success: NDArray[Any] = np.zeros(1, dtype=bool)
+        self._acc_reward: NDArray[Any] = np.zeros(1)
+        self._step_reward: NDArray[Any] = np.zeros(1)  # last env.step reward (RL wire sibling)
         self._seen_success = False  # any env-reported success signal this episode
 
     @property
@@ -283,6 +288,7 @@ class GymBridge(RobotBridge):
         if not existed and self._contract_path is not None:
             print(f"[env] wrote {self._contract_path} (edit names to relabel plots)", flush=True)
 
+    @override
     async def ensure_contract(self) -> dict[str, Any]:
         """Return the wire contract, probing the env when start() did not already.
 
@@ -293,6 +299,7 @@ class GymBridge(RobotBridge):
             await self._run_on_sim(self.reset)
         return self.contract
 
+    @override
     async def start(self) -> None:
         """Bind the wire with a complete contract so ``env.initialize`` can publish it.
 
@@ -320,6 +327,7 @@ class GymBridge(RobotBridge):
             await self._run_on_sim(self.reset)
         await super().start()
 
+    @override
     def reset(self, **task_args: Any) -> str:
         """Build/reset the gym env on the sim thread (base claim hops here)."""
         # Defaults from env.gym(..., num_envs=N) fill in when the task omits them.
@@ -347,6 +355,7 @@ class GymBridge(RobotBridge):
         self._ensure_contract_from_env()  # no-op when start() already probed
         return self._prompt(merged)
 
+    @override
     async def stop(self) -> None:
         await super().stop()
         if self.env is not None:
@@ -386,7 +395,8 @@ class GymBridge(RobotBridge):
 
     # ── bridge protocol ──────────────────────────────────────────────────────────
 
-    def step(self, action: np.ndarray) -> None:
+    @override
+    def step(self, action: NDArray[Any]) -> None:
         act: Any = np.array(action, dtype=np.float32)  # wire buffer is read-only
         if not self.batched:
             act = act[0] if act.ndim > 1 else act  # single plain env: drop the batch dim
@@ -400,8 +410,7 @@ class GymBridge(RobotBridge):
         if dtype is not None and np.issubdtype(dtype, np.integer):
             act = act.astype(dtype)
         if self._is_torch:
-            import torch
-
+            torch: Any = importlib.import_module("torch")
             act = torch.as_tensor(act, device=getattr(self._unwrapped, "device", None))
         obs, reward, terminated, truncated, info = self.env.step(act)
         self._obs = obs
@@ -419,7 +428,7 @@ class GymBridge(RobotBridge):
                 self._success |= success & newly
         self._done |= done
 
-    def _resolve_success(self, info: Any) -> np.ndarray | None:
+    def _resolve_success(self, info: Any) -> NDArray[Any] | None:
         """Env-reported success at a done step: info keys, else Isaac's termination term."""
         found = probe_success(info, num_envs=self.num_envs)
         if found is not None:
@@ -432,7 +441,8 @@ class GymBridge(RobotBridge):
                 return None
         return None
 
-    def get_observation(self) -> tuple[dict[str, np.ndarray], np.ndarray] | None:
+    @override
+    def get_observation(self) -> tuple[dict[str, NDArray[Any]], NDArray[Any]] | None:
         """Always ``[N, ...]`` arrays + ``[N]`` terminated for the barrier fan-out."""
         if self.env is None or self._obs is None:
             return None
@@ -448,6 +458,7 @@ class GymBridge(RobotBridge):
             data["reward"] = np.atleast_1d(reward)
         return data, np.asarray(self._done, dtype=bool).reshape(self.num_envs)
 
+    @override
     def result_slots(self) -> list[dict[str, Any]]:
         """Per-slot grades: env-reported success when available, else accumulated reward."""
         # The env's own success check outranks accumulated shaped reward.

--- a/hud/environment/robot/gym.py
+++ b/hud/environment/robot/gym.py
@@ -33,7 +33,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Self
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast
 
 import numpy as np
 from typing_extensions import override
@@ -49,6 +49,10 @@ logger = logging.getLogger(__name__)
 
 #: Conventional info keys carrying env-reported success, probed in order.
 SUCCESS_KEYS = ("success", "is_success", "task_success")
+
+
+class _TorchModule(Protocol):
+    def as_tensor(self, data: object, *, device: object = None) -> object: ...
 
 
 # ── env introspection (pure; no telemetry, no wrapper state) ──────────────────
@@ -397,7 +401,7 @@ class GymBridge(RobotBridge):
 
     @override
     def step(self, action: NDArray[Any]) -> None:
-        act: Any = np.array(action, dtype=np.float32)  # wire buffer is read-only
+        act = np.array(action, dtype=np.float32)  # wire buffer is read-only
         if not self.batched:
             act = act[0] if act.ndim > 1 else act  # single plain env: drop the batch dim
         elif act.ndim == 1:
@@ -409,10 +413,11 @@ class GymBridge(RobotBridge):
         dtype = getattr(space, "dtype", None)
         if dtype is not None and np.issubdtype(dtype, np.integer):
             act = act.astype(dtype)
+        env_action: object = act
         if self._is_torch:
-            torch: Any = importlib.import_module("torch")
-            act = torch.as_tensor(act, device=getattr(self._unwrapped, "device", None))
-        obs, reward, terminated, truncated, info = self.env.step(act)
+            torch = cast("_TorchModule", importlib.import_module("torch"))
+            env_action = torch.as_tensor(act, device=getattr(self._unwrapped, "device", None))
+        obs, reward, terminated, truncated, info = self.env.step(env_action)
         self._obs = obs
         done = np.atleast_1d(to_numpy(terminated)).astype(bool) | np.atleast_1d(
             to_numpy(truncated)

--- a/hud/environment/server.py
+++ b/hud/environment/server.py
@@ -458,8 +458,9 @@ async def bind(env: Environment, host: str = "127.0.0.1", port: int = 0) -> asyn
                 await writer.wait_closed()
 
     server = await asyncio.start_server(accept, host=host, port=port)
-    server._hud_handlers = active  # type: ignore[attr-defined]
-    server._hud_channel = channel  # type: ignore[attr-defined]
+    server_state = cast("Any", server)
+    server_state._hud_handlers = active
+    server_state._hud_channel = channel
     sock = server.sockets[0].getsockname()
     LOGGER.info("env %r bound on %s:%s", env.name, sock[0], sock[1])
     return server
@@ -471,7 +472,8 @@ async def _shutdown(server: asyncio.Server) -> None:
     for task in handlers:
         task.cancel()
     await asyncio.gather(*handlers, return_exceptions=True)
-    await server._hud_channel.cancel_all()  # type: ignore[attr-defined]
+    channel = cast("_ControlChannel", cast("Any", server)._hud_channel)
+    await channel.cancel_all()
     await server.wait_closed()
 
 

--- a/hud/environment/server.py
+++ b/hud/environment/server.py
@@ -19,8 +19,10 @@ import inspect
 import logging
 import secrets
 import signal
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlsplit
+from weakref import WeakKeyDictionary
 
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
@@ -39,6 +41,15 @@ LOGGER = logging.getLogger("hud.environment.server")
 #: Line a serving process prints once its control channel is bound; the
 #: ``spawn`` provider reads it from the child's stdout.
 PORT_ANNOUNCEMENT = "HUD_SERVE_PORT="
+
+
+@dataclass
+class _ServerState:
+    handlers: set[asyncio.Task[None]]
+    channel: _ControlChannel
+
+
+_SERVER_STATES: WeakKeyDictionary[asyncio.Server, _ServerState] = WeakKeyDictionary()
 
 
 # ─── task execution ──────────────────────────────────────────────────────
@@ -458,9 +469,7 @@ async def bind(env: Environment, host: str = "127.0.0.1", port: int = 0) -> asyn
                 await writer.wait_closed()
 
     server = await asyncio.start_server(accept, host=host, port=port)
-    server_state = cast("Any", server)
-    server_state._hud_handlers = active
-    server_state._hud_channel = channel
+    _SERVER_STATES[server] = _ServerState(handlers=active, channel=channel)
     sock = server.sockets[0].getsockname()
     LOGGER.info("env %r bound on %s:%s", env.name, sock[0], sock[1])
     return server
@@ -468,12 +477,12 @@ async def bind(env: Environment, host: str = "127.0.0.1", port: int = 0) -> asyn
 
 async def _shutdown(server: asyncio.Server) -> None:
     server.close()
-    handlers = list(getattr(server, "_hud_handlers", ()))
+    state = _SERVER_STATES.pop(server)
+    handlers = list(state.handlers)
     for task in handlers:
         task.cancel()
     await asyncio.gather(*handlers, return_exceptions=True)
-    channel = cast("_ControlChannel", cast("Any", server)._hud_channel)
-    await channel.cancel_all()
+    await state.channel.cancel_all()
     await server.wait_closed()
 
 

--- a/hud/environment/tests/test_legacy.py
+++ b/hud/environment/tests/test_legacy.py
@@ -15,6 +15,7 @@ from typing import Any, cast
 
 import pytest
 from pydantic import BaseModel
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.clients import HudProtocolError
@@ -39,6 +40,7 @@ class _FnAgent(Agent):
     def __init__(self, fn: Any) -> None:
         self._fn = fn
 
+    @override
     async def __call__(self, run: Any) -> None:
         run.trace.content = self._fn(run.prompt)
 

--- a/hud/environment/tests/test_loader.py
+++ b/hud/environment/tests/test_loader.py
@@ -41,8 +41,8 @@ def factory_module(request):
 
     name = f"_loader_target_{request.node.name}"
     mod = ModuleType(name)
-    mod.env = Environment("declared")  # type: ignore[attr-defined]
-    mod.make_env = lambda name="built": Environment(name)  # type: ignore[attr-defined]
+    setattr(mod, "env", Environment("declared"))
+    setattr(mod, "make_env", lambda name="built": Environment(name))
     sys.modules[name] = mod
     yield name
     del sys.modules[name]
@@ -63,7 +63,7 @@ def test_module_env_attribute_is_returned_not_called(factory_module) -> None:
 def test_module_factory_returning_non_environment_raises(factory_module) -> None:
     import sys
 
-    sys.modules[factory_module].make_env = lambda: object()  # type: ignore[attr-defined]
+    setattr(sys.modules[factory_module], "make_env", lambda: object())
 
     with pytest.raises(ValueError, match="not an Environment"):
         load_environment(factory_module, name="make_env")

--- a/hud/environment/tests/test_robot_regressions.py
+++ b/hud/environment/tests/test_robot_regressions.py
@@ -5,16 +5,20 @@ from __future__ import annotations
 import asyncio
 import contextlib
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
+from typing_extensions import override
 
 from hud.environment.env import current_session_id
 from hud.environment.robot.bridge import _HUD_STATE, RobotBridge, _apply_declaration_state
 from hud.environment.robot.endpoint import RobotEndpoint, _bridge_init_kwargs
 from hud.environment.robot.gym import GymBridge, action_dim_of
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 # --- spawn state (declaration → child) -------------------------------------------------
 
@@ -26,12 +30,15 @@ class _CustomBridge(RobotBridge):
         super().__init__()
         self.use_delta = use_delta
 
+    @override
     def reset(self, **kwargs: Any) -> str:
         return "p"
 
+    @override
     def step(self, action: Any) -> None:
         return None
 
+    @override
     def get_observation(self) -> tuple[dict[str, Any], Any] | None:
         return None
 
@@ -112,7 +119,7 @@ def test_step_reshapes_float_box_action() -> None:
         def __init__(self) -> None:
             self.last_action: Any = None
 
-        def step(self, action: Any) -> tuple:
+        def step(self, action: Any) -> tuple[Any, ...]:
             self.last_action = action
             return np.zeros(3, dtype=np.float32), 0.0, False, False, {}
 
@@ -135,7 +142,7 @@ def test_step_reshapes_batched_float_box_action() -> None:
         def __init__(self) -> None:
             self.last_action: Any = None
 
-        def step(self, action: Any) -> tuple:
+        def step(self, action: Any) -> tuple[Any, ...]:
             self.last_action = action
             return (
                 np.zeros((2, 3), dtype=np.float32),
@@ -168,7 +175,9 @@ def test_plain_env_observation_always_gets_batch_axis() -> None:
         "state": np.array([1.0], dtype=np.float32),
         "camera": np.zeros((1, 4, 3), dtype=np.uint8),
     }
-    data, terminated = bridge.get_observation()  # type: ignore[misc]
+    observation = bridge.get_observation()
+    assert observation is not None
+    data, terminated = observation
     assert data is not None
     assert data["state"].shape == (1, 1)
     assert data["camera"].shape == (1, 1, 4, 3)
@@ -183,30 +192,32 @@ def test_plain_env_observation_always_gets_batch_axis() -> None:
 @pytest.fixture
 def endpoint() -> RobotEndpoint:
     ep = RobotEndpoint.remote("127.0.0.1", 9)
-    ep._call = AsyncMock()  # type: ignore[method-assign]
+    setattr(ep, "_call", AsyncMock())
     return ep
 
 
 @pytest.mark.asyncio
 async def test_release_claim_frees_current_session_slot(endpoint: RobotEndpoint) -> None:
-    endpoint._call.return_value = {"prompt": "p", "token": "slot-0-abcd"}  # type: ignore[attr-defined]
+    call = cast("AsyncMock", endpoint._call)
+    call.return_value = {"prompt": "p", "token": "slot-0-abcd"}
     token = current_session_id.set("sess-a")
     try:
         await endpoint.reset()
         assert endpoint._claims["sess-a"] == "slot-0-abcd"
-        endpoint._call.return_value = {"score": 0.0}  # type: ignore[attr-defined]
+        call.return_value = {"score": 0.0}
         await endpoint.release_claim()
         assert "sess-a" not in endpoint._claims
-        endpoint._call.assert_called_with("result", {"token": "slot-0-abcd"})  # type: ignore[attr-defined]
+        call.assert_called_with("result", {"token": "slot-0-abcd"})
     finally:
         current_session_id.reset(token)
 
 
 @pytest.mark.asyncio
 async def test_release_claim_on_shutdown_frees_each_session(endpoint: RobotEndpoint) -> None:
+    call = cast("AsyncMock", endpoint._call)
     endpoint._claims["sess-a"] = "tok-a"
     endpoint._claims["sess-b"] = "tok-b"
-    endpoint._call.return_value = {"score": 0.0}  # type: ignore[attr-defined]
+    call.return_value = {"score": 0.0}
 
     for sid in ("sess-a", "sess-b"):
         token = current_session_id.set(sid)
@@ -216,7 +227,7 @@ async def test_release_claim_on_shutdown_frees_each_session(endpoint: RobotEndpo
             current_session_id.reset(token)
 
     assert endpoint._claims == {}
-    tokens = [c.args[1]["token"] for c in endpoint._call.call_args_list]  # type: ignore[attr-defined]
+    tokens = [c.args[1]["token"] for c in call.call_args_list]
     assert sorted(tokens) == ["tok-a", "tok-b"]
 
 
@@ -224,39 +235,42 @@ async def test_release_claim_on_shutdown_frees_each_session(endpoint: RobotEndpo
 async def test_result_marks_claim_freed_so_disconnect_does_not_re_result(
     endpoint: RobotEndpoint,
 ) -> None:
+    call = cast("AsyncMock", endpoint._call)
     token = current_session_id.set("sess-a")
     try:
         endpoint._claims["sess-a"] = "tok-a"
-        endpoint._call.return_value = {"score": 1.0, "success": True, "total_reward": 1.0}  # type: ignore[attr-defined]
+        call.return_value = {"score": 1.0, "success": True, "total_reward": 1.0}
         await endpoint.result(token="tok-a")
         assert endpoint._claims["sess-a"] == ""
-        endpoint._call.reset_mock()  # type: ignore[attr-defined]
+        call.reset_mock()
         await endpoint.release_claim()
-        endpoint._call.assert_not_called()  # type: ignore[attr-defined]
+        call.assert_not_called()
     finally:
         current_session_id.reset(token)
 
 
 @pytest.mark.asyncio
 async def test_failed_release_rpc_retries_then_succeeds(endpoint: RobotEndpoint) -> None:
+    call = cast("AsyncMock", endpoint._call)
     token = current_session_id.set("sess-a")
     try:
         endpoint._claims["sess-a"] = "tok-a"
-        endpoint._call.side_effect = [  # type: ignore[attr-defined]
+        call.side_effect = [
             ConnectionError("sim down"),
             {"score": 0.0},
         ]
         await endpoint.release_claim()
         assert "sess-a" not in endpoint._claims
-        assert endpoint._call.call_count == 2  # type: ignore[attr-defined]
+        assert call.call_count == 2
     finally:
         current_session_id.reset(token)
 
 
 @pytest.mark.asyncio
 async def test_stop_drains_claims_that_cancel_failed_to_free(endpoint: RobotEndpoint) -> None:
+    call = cast("AsyncMock", endpoint._call)
     endpoint._claims["sess-a"] = "tok-a"
-    endpoint._call.side_effect = [  # type: ignore[attr-defined]
+    call.side_effect = [
         ConnectionError("sim down"),
         ConnectionError("sim down"),
         ConnectionError("sim down"),
@@ -268,8 +282,8 @@ async def test_stop_drains_claims_that_cancel_failed_to_free(endpoint: RobotEndp
     finally:
         current_session_id.reset(token)
 
-    endpoint._call.side_effect = None  # type: ignore[attr-defined]
-    endpoint._call.return_value = {"score": 0.0}  # type: ignore[attr-defined]
+    call.side_effect = None
+    call.return_value = {"score": 0.0}
     await endpoint.stop()  # last chance while the control link is up
     assert endpoint._claims == {}
 
@@ -280,16 +294,19 @@ async def test_stop_drains_claims_that_cancel_failed_to_free(endpoint: RobotEndp
 class _StubBridge(RobotBridge):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self.steps: list[np.ndarray] = []
+        self.steps: list[NDArray[Any]] = []
         self.contract = {"features": {"action": {"role": "action", "names": ["a"]}}}
 
+    @override
     def reset(self, **kwargs: Any) -> str:
         return f"prompt:{kwargs!r}"
 
-    def step(self, action: np.ndarray) -> None:
+    @override
+    def step(self, action: NDArray[Any]) -> None:
         self.steps.append(np.asarray(action))
 
-    def get_observation(self) -> tuple[dict[str, np.ndarray], np.ndarray] | None:
+    @override
+    def get_observation(self) -> tuple[dict[str, NDArray[Any]], NDArray[Any]] | None:
         return {"x": np.zeros((self.num_envs, 1), dtype=np.float32)}, np.zeros(
             self.num_envs, dtype=bool
         )
@@ -302,12 +319,14 @@ class _FakeWS:
 
 @pytest.mark.asyncio
 async def test_claim_awaits_legacy_async_reset() -> None:
-    class _AsyncReset(_StubBridge):
-        async def reset(self, **kwargs: Any) -> str:
-            await asyncio.sleep(0)
-            return "async-prompt"
+    bridge = _StubBridge()
 
-    ep = await _AsyncReset()._claim_episode()
+    async def async_reset(**kwargs: Any) -> str:
+        await asyncio.sleep(0)
+        return "async-prompt"
+
+    setattr(bridge, "reset", async_reset)
+    ep = await bridge._claim_episode()
     assert ep["prompt"] == "async-prompt"
 
 
@@ -324,6 +343,7 @@ async def test_claim_rejects_empty_kwargs_after_nonempty_batch() -> None:
 @pytest.mark.asyncio
 async def test_release_uses_overridden_result() -> None:
     class _CustomGrade(_StubBridge):
+        @override
         def result(self) -> dict[str, Any]:
             return {"score": 0.42, "success": True, "total_reward": 3.0, "detail": "custom"}
 
@@ -367,11 +387,13 @@ async def test_tick_loop_stops_after_terminal_obs_while_ws_still_open() -> None:
             super().__init__()
             self.tick = 0
 
-        def step(self, action: np.ndarray) -> None:
+        @override
+        def step(self, action: NDArray[Any]) -> None:
             self.tick += 1
             super().step(action)
 
-        def get_observation(self) -> tuple[dict[str, np.ndarray], np.ndarray] | None:
+        @override
+        def get_observation(self) -> tuple[dict[str, NDArray[Any]], NDArray[Any]] | None:
             data = {"x": np.zeros((self.num_envs, 1), dtype=np.float32)}
             return data, np.array([self.tick >= 3])
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, Mock
 
 import asyncssh
 import pytest
+from typing_extensions import override
 
 from hud.capabilities import SSHClient
 from hud.environment import namespace as namespace_mod
@@ -878,7 +879,8 @@ def test_the_proxy_normalizes_http_framing_in_both_directions(
             self.end_headers()
             self.wfile.write(b"5\r\nhello\r\n0\r\n\r\n")
 
-        def log_message(self, *_: object) -> None:
+        @override
+        def log_message(self, format: str, *args: Any) -> None:
             pass
 
     upstream = HTTPServer(("127.0.0.1", 0), Chunked)

--- a/hud/eval/_runtime_protocols.py
+++ b/hud/eval/_runtime_protocols.py
@@ -1,0 +1,212 @@
+"""Structural contracts for lazily imported runtime provider SDKs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Mapping, Sequence
+    from contextlib import AbstractAsyncContextManager
+    from pathlib import Path
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+class AioMethod(Protocol[T_co]):
+    async def aio(self, *args: object, **kwargs: object) -> T_co: ...
+
+
+class ModalImage(Protocol):
+    build: AioMethod[None]
+
+    def env(self, variables: Mapping[str, str]) -> ModalImage: ...
+
+
+class _ModalImageFactory(Protocol):
+    def from_id(self, image_id: str) -> ModalImage: ...
+
+    def from_registry(self, image: str) -> ModalImage: ...
+
+    def from_name(self, name: str) -> ModalImage: ...
+
+
+class _ModalAppFactory(Protocol):
+    lookup: AioMethod[object]
+
+
+class _ModalStream(Protocol):
+    read: AioMethod[str]
+
+
+class _ModalProcess(Protocol):
+    wait: AioMethod[int]
+    stderr: _ModalStream
+
+
+class _ModalFilesystem(Protocol):
+    copy_from_local: AioMethod[None]
+
+
+class _ModalTunnel(Protocol):
+    tcp_socket: tuple[str, int]
+
+
+class _ModalSandbox(Protocol):
+    object_id: str
+    wait_until_ready: AioMethod[None]
+    filesystem: _ModalFilesystem
+    exec: AioMethod[_ModalProcess]
+    tunnels: AioMethod[dict[int, _ModalTunnel]]
+    terminate: AioMethod[None]
+
+
+class _ModalSandboxFactory(Protocol):
+    create: AioMethod[_ModalSandbox]
+
+
+class _ModalProbeFactory(Protocol):
+    def with_tcp(self, port: int) -> object: ...
+
+
+class ModalModule(Protocol):
+    Image: _ModalImageFactory
+    App: _ModalAppFactory
+    Sandbox: _ModalSandboxFactory
+    Probe: _ModalProbeFactory
+
+
+class DaytonaContextEntry(Protocol):
+    @property
+    def source_path(self) -> str | Path: ...
+
+    @property
+    def archive_path(self) -> str | Path: ...
+
+
+class DaytonaImage(Protocol):
+    @property
+    def _context_list(self) -> Sequence[DaytonaContextEntry]: ...
+
+    def dockerfile(self) -> str: ...
+
+
+class _DaytonaBuildInfo(Protocol):
+    dockerfile_content: str
+    context_hashes: Sequence[str] | None
+
+
+class DaytonaSnapshot(Protocol):
+    image_name: str
+    build_info: _DaytonaBuildInfo | None
+
+
+class ObjectStorage(Protocol):
+    async def _compute_hash_for_path_md5(
+        self,
+        source_path: str | Path,
+        archive_path: str | Path,
+    ) -> str: ...
+
+
+class ObjectStorageModule(Protocol):
+    AsyncObjectStorage: type[ObjectStorage]
+
+
+class _DaytonaResources(Protocol):
+    cpu: int | None
+    memory: int | None
+    gpu: int | None
+    gpu_type: Sequence[object] | None
+
+
+class _DaytonaSessionCommand(Protocol):
+    cmd_id: str
+
+
+class _DaytonaSessionLogs(Protocol):
+    stderr: str | None
+    output: str | None
+    stdout: str | None
+
+
+class _DaytonaProcess(Protocol):
+    async def create_session(self, session: str) -> object: ...
+
+    async def execute_session_command(
+        self,
+        session: str,
+        request: object,
+    ) -> _DaytonaSessionCommand: ...
+
+    async def get_session_command_logs(
+        self,
+        session: str,
+        command_id: str,
+    ) -> _DaytonaSessionLogs: ...
+
+
+class _DaytonaSshAccess(Protocol):
+    token: str
+
+
+class _DaytonaSandbox(Protocol):
+    id: str
+    process: _DaytonaProcess
+
+    async def create_ssh_access(self, *, expires_in_minutes: int) -> _DaytonaSshAccess: ...
+
+
+class _DaytonaSnapshotClient(Protocol):
+    async def get(self, name: str) -> DaytonaSnapshot: ...
+
+    async def delete(self, snapshot: DaytonaSnapshot) -> object: ...
+
+    async def create(self, params: object) -> object: ...
+
+
+class _DaytonaCreate(Protocol):
+    def __call__(
+        self,
+        params: object,
+        *,
+        timeout: int,
+    ) -> Awaitable[_DaytonaSandbox]: ...
+
+
+class _DaytonaClient(Protocol):
+    snapshot: _DaytonaSnapshotClient
+    create: _DaytonaCreate
+
+    async def delete(self, sandbox: _DaytonaSandbox) -> object: ...
+
+
+class _DaytonaFactory(Protocol):
+    def __call__(self) -> AbstractAsyncContextManager[_DaytonaClient]: ...
+
+
+class _ObjectFactory(Protocol):
+    def __call__(self, *args: object, **kwargs: object) -> object: ...
+
+
+class _ResourcesFactory(Protocol):
+    def __call__(self, *args: object, **kwargs: object) -> _DaytonaResources: ...
+
+
+class _GpuTypeFactory(Protocol):
+    def __call__(self, value: str) -> object: ...
+
+
+class _DaytonaImageFactory(Protocol):
+    def base(self, image: str) -> object: ...
+
+
+class DaytonaModule(Protocol):
+    AsyncDaytona: _DaytonaFactory
+    CreateSandboxFromImageParams: _ObjectFactory
+    CreateSandboxFromSnapshotParams: _ObjectFactory
+    CreateSnapshotParams: _ObjectFactory
+    DaytonaNotFoundError: type[Exception]
+    GpuType: _GpuTypeFactory
+    Image: _DaytonaImageFactory
+    Resources: _ResourcesFactory
+    SessionExecuteRequest: _ObjectFactory

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -27,7 +27,7 @@ import logging
 import traceback
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Self, cast
+from typing import TYPE_CHECKING, Any, Literal, Self, cast
 
 import mcp.types as mcp_types
 
@@ -65,9 +65,8 @@ def _prompt_message(item: Any) -> mcp_types.PromptMessage:
         return item
     if not isinstance(item, dict):
         item = {"content": str(item)}
-    role = item.get("role")
-    if role not in ("user", "assistant"):
-        role = "user"
+    raw_role = item.get("role")
+    role: Literal["user", "assistant"] = "assistant" if raw_role == "assistant" else "user"
     content = item.get("content")
     if isinstance(content, str):
         return mcp_types.PromptMessage(

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import importlib
 import json
 import logging
 import os
@@ -45,7 +46,7 @@ from collections import deque
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, Self, cast
+from typing import TYPE_CHECKING, Any, Protocol, Self
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
@@ -691,7 +692,11 @@ class DockerRuntime:
         resources = config.resources
         if resources is not None:
             if resources.cpu is not None:
-                cpu = str(int(resources.cpu)) if resources.cpu.is_integer() else str(resources.cpu)
+                cpu = (
+                    str(int(resources.cpu))
+                    if isinstance(resources.cpu, float) and resources.cpu.is_integer()
+                    else str(resources.cpu)
+                )
                 resource_args.extend(("--cpus", cpu))
             if resources.memory_mb is not None:
                 resource_args.extend(("--memory", f"{resources.memory_mb}m"))
@@ -788,7 +793,7 @@ class ModalRuntime:
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
         compose = config.compose.resolve() if config.compose is not None else None
-        import modal
+        modal: Any = importlib.import_module("modal")
 
         app = None
         if compose is not None:
@@ -929,11 +934,12 @@ async def _snapshot_is_current(snapshot: Any, image: Any) -> bool:
     build = snapshot.build_info
     if build is None:
         return False
-    from daytona._async.object_storage import AsyncObjectStorage
+    object_storage: Any = importlib.import_module("daytona._async.object_storage")
+    AsyncObjectStorage = object_storage.AsyncObjectStorage
 
     # The hasher is an instance method only for code organization; credentials
     # are needed to upload, not to hash, so skip the credentialed __init__.
-    storage = cast("Any", AsyncObjectStorage.__new__(AsyncObjectStorage))
+    storage = AsyncObjectStorage.__new__(AsyncObjectStorage)
     hashes = [
         await storage._compute_hash_for_path_md5(entry.source_path, entry.archive_path)
         for entry in image._context_list
@@ -1001,17 +1007,17 @@ class DaytonaRuntime:
     @asynccontextmanager
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         import asyncssh
-        from daytona import (
-            AsyncDaytona,
-            CreateSandboxFromImageParams,
-            CreateSandboxFromSnapshotParams,
-            CreateSnapshotParams,
-            DaytonaNotFoundError,
-            GpuType,
-            Image,
-            Resources,
-            SessionExecuteRequest,
-        )
+
+        daytona_sdk: Any = importlib.import_module("daytona")
+        AsyncDaytona = daytona_sdk.AsyncDaytona
+        CreateSandboxFromImageParams = daytona_sdk.CreateSandboxFromImageParams
+        CreateSandboxFromSnapshotParams = daytona_sdk.CreateSandboxFromSnapshotParams
+        CreateSnapshotParams = daytona_sdk.CreateSnapshotParams
+        DaytonaNotFoundError = daytona_sdk.DaytonaNotFoundError
+        GpuType = daytona_sdk.GpuType
+        Image = daytona_sdk.Image
+        Resources = daytona_sdk.Resources
+        SessionExecuteRequest = daytona_sdk.SessionExecuteRequest
 
         async with AsyncDaytona() as daytona:
             config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
@@ -1025,7 +1031,10 @@ class DaytonaRuntime:
                 resource_kwargs: dict[str, Any] = {}
                 if config.resources.cpu is not None:
                     # Daytona allocates whole cores; truncating resizes silently.
-                    if not config.resources.cpu.is_integer():
+                    if (
+                        isinstance(config.resources.cpu, float)
+                        and not config.resources.cpu.is_integer()
+                    ):
                         raise ValueError(
                             "DaytonaRuntime needs a whole number of CPUs, got "
                             f"{config.resources.cpu}"

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -46,7 +46,7 @@ from collections import deque
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, Self
+from typing import TYPE_CHECKING, Any, Protocol, Self, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
@@ -66,6 +66,14 @@ if TYPE_CHECKING:
     from hud.agents.base import Agent
     from hud.environment.env import Environment
 
+    from ._runtime_protocols import (
+        DaytonaImage,
+        DaytonaModule,
+        DaytonaSnapshot,
+        ModalImage,
+        ModalModule,
+        ObjectStorageModule,
+    )
     from .task import Task
 
 logger = logging.getLogger("hud.eval.runtime")
@@ -233,7 +241,7 @@ class Shared:
             yield addr
 
 
-def _modal_image_from_uri(modal: Any, image_uri: str) -> Any:
+def _modal_image_from_uri(modal: ModalModule, image_uri: str) -> ModalImage:
     modal_uri_prefix = "modal://"
     if image_uri.startswith(modal_uri_prefix):
         return modal.Image.from_id(image_uri.removeprefix(modal_uri_prefix))
@@ -751,7 +759,7 @@ class ModalRuntime:
         self,
         image_name: str | None = None,
         *,
-        image: Any = None,
+        image: ModalImage | None = None,
         command: Sequence[str] | None = None,
         app_name: str = "hud-envs",
         workdir: str | None = None,
@@ -786,14 +794,14 @@ class ModalRuntime:
         # Resolved (named) or built-once (from Dockerfile) image, behind a lock so
         # concurrent first acquisitions build/look up exactly once.
         self._image = image
-        self._resolved: Any = None
+        self._resolved: ModalImage | None = None
         self._image_lock = asyncio.Lock()
 
     @asynccontextmanager
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
         compose = config.compose.resolve() if config.compose is not None else None
-        modal: Any = importlib.import_module("modal")
+        modal = cast("ModalModule", importlib.import_module("modal"))
 
         app = None
         if compose is not None:
@@ -920,7 +928,10 @@ class ModalRuntime:
                 await sb.terminate.aio()
 
 
-async def _snapshot_is_current(snapshot: Any, image: Any) -> bool:
+async def _snapshot_is_current(
+    snapshot: DaytonaSnapshot,
+    image: str | DaytonaImage,
+) -> bool:
     """Whether *snapshot* was built from *image* as it exists right now.
 
     Daytona records what a snapshot was built from — the registry ref, or for a
@@ -934,7 +945,10 @@ async def _snapshot_is_current(snapshot: Any, image: Any) -> bool:
     build = snapshot.build_info
     if build is None:
         return False
-    object_storage: Any = importlib.import_module("daytona._async.object_storage")
+    object_storage = cast(
+        "ObjectStorageModule",
+        importlib.import_module("daytona._async.object_storage"),
+    )
     AsyncObjectStorage = object_storage.AsyncObjectStorage
 
     # The hasher is an instance method only for code organization; credentials
@@ -976,7 +990,7 @@ class DaytonaRuntime:
         self,
         snapshot_name: str | None = None,
         *,
-        image: Any = None,
+        image: str | DaytonaImage | None = None,
         command: str | None = None,
         workdir: str | None = "/app",
         port: int = 8765,
@@ -1008,7 +1022,7 @@ class DaytonaRuntime:
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         import asyncssh
 
-        daytona_sdk: Any = importlib.import_module("daytona")
+        daytona_sdk = cast("DaytonaModule", importlib.import_module("daytona"))
         AsyncDaytona = daytona_sdk.AsyncDaytona
         CreateSandboxFromImageParams = daytona_sdk.CreateSandboxFromImageParams
         CreateSandboxFromSnapshotParams = daytona_sdk.CreateSandboxFromSnapshotParams
@@ -1083,7 +1097,7 @@ class DaytonaRuntime:
                         if daytona_resources.gpu:
                             sizing.append(f"{daytona_resources.gpu}gpu")
                             sizing.extend(
-                                (t.value if isinstance(t, GpuType) else t).lower()
+                                str(getattr(t, "value", t)).lower()
                                 for t in daytona_resources.gpu_type or []
                             )
                         snapshot_name = "-".join([snapshot_name, *sizing])
@@ -1135,7 +1149,6 @@ class DaytonaRuntime:
                 sandbox_params,
                 timeout=create_timeout,
             )
-            session_command: Any = None
             try:
                 # Start the env server in a background session (the snapshot's CMD is
                 # not the sandbox's main process). connect() retries the handshake,

--- a/hud/eval/tests/test_chat.py
+++ b/hud/eval/tests/test_chat.py
@@ -7,10 +7,11 @@ Turn tests place each turn's rollout with ``runtime=SubprocessRuntime(env_file)`
 from __future__ import annotations
 
 import textwrap
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from mcp.types import TextContent
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.eval import SubprocessRuntime, Task
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
 class _EchoAgent(Agent):
     """Replies with ``echo:<last user message>`` read from the prompt."""
 
+    @override
     async def __call__(self, run: Any) -> None:
         last = run.prompt[-1]["content"]["text"]
         run.trace.content = f"echo:{last}"
@@ -49,7 +51,7 @@ class TestContentHelpers:
 class TestChatConstruction:
     def test_requires_an_agent(self, dummy_task: Any) -> None:
         with pytest.raises(TypeError):
-            Chat(dummy_task)  # type: ignore[call-arg]
+            cast("Any", Chat)(dummy_task)
 
     def test_messages_start_empty_and_are_the_public_history(self, dummy_task: Any) -> None:
         chat = Chat(dummy_task, _EchoAgent())
@@ -122,6 +124,7 @@ class TestSend:
         self, chat_env_file: Path
     ) -> None:
         class _Boom(Agent):
+            @override
             async def __call__(self, run: Any) -> None:
                 raise RuntimeError("agent exploded")
 

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -143,7 +143,7 @@ class _ModalImageRef:
 class _FakeModalSandbox:
     object_id = "sb-1"
 
-    def __init__(self, calls: dict[str, object], port: int) -> None:
+    def __init__(self, calls: dict[str, Any], port: int) -> None:
         self._calls = calls
         self._port = port
         self.wait_until_ready = SimpleNamespace(aio=self._wait_until_ready)
@@ -188,8 +188,8 @@ class _FakeModalSandbox:
         )
 
 
-def _install_fake_modal(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
-    calls: dict[str, object] = {}
+def _install_fake_modal(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    calls: dict[str, Any] = {}
     modal = ModuleType("modal")
 
     class Image:
@@ -282,7 +282,7 @@ class _SessionExecuteRequest:
 
 
 class _FakeDaytonaProcess:
-    def __init__(self, calls: dict[str, object], sandbox_id: str) -> None:
+    def __init__(self, calls: dict[str, Any], sandbox_id: str) -> None:
         self._calls = calls
         self._sandbox_id = sandbox_id
         self.logs = SimpleNamespace(
@@ -311,7 +311,7 @@ class _FakeDaytonaProcess:
 
 
 class _FakeDaytonaSandbox:
-    def __init__(self, calls: dict[str, object], sandbox_id: str) -> None:
+    def __init__(self, calls: dict[str, Any], sandbox_id: str) -> None:
         self.id = sandbox_id
         self._calls = calls
         self.process = _FakeDaytonaProcess(calls, sandbox_id)
@@ -399,7 +399,7 @@ class _FakeSnapshotApi:
 
 
 class _FakeDaytonaClient:
-    def __init__(self, calls: dict[str, object]) -> None:
+    def __init__(self, calls: dict[str, Any]) -> None:
         self.calls = calls
         self.sandbox = _FakeDaytonaSandbox(calls, "sandbox-1")
         self.snapshot = _FakeSnapshotApi()
@@ -427,7 +427,7 @@ class _FakeDaytonaClient:
 
 
 class _FakeSSHConnection:
-    def __init__(self, calls: dict[str, object]) -> None:
+    def __init__(self, calls: dict[str, Any]) -> None:
         self._calls = calls
 
     async def forward_local_port(
@@ -444,7 +444,7 @@ class _FakeSSHConnection:
 class _FakeSSHConnect:
     def __init__(
         self,
-        calls: dict[str, object],
+        calls: dict[str, Any],
         args: tuple[object, ...],
         kwargs: dict[str, object],
     ) -> None:
@@ -461,7 +461,7 @@ class _FakeSSHConnect:
 
 
 def _install_fake_daytona(monkeypatch: pytest.MonkeyPatch) -> _FakeDaytonaClient:
-    calls: dict[str, object] = {}
+    calls: dict[str, Any] = {}
     client = _FakeDaytonaClient(calls)
     daytona = ModuleType("daytona")
     daytona_async = ModuleType("daytona._async")

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -1073,13 +1073,24 @@ async def test_daytona_snapshot_sandboxes_disable_auto_stop(
     assert create_timeout == 120
 
 
-def _build_image(context: Path) -> SimpleNamespace:
+@dataclass(frozen=True)
+class _BuildContextEntry:
+    source_path: str
+    archive_path: str
+
+
+class _BuildImage:
+    def __init__(self, context: Path) -> None:
+        self._context_list = [_BuildContextEntry(source_path=str(context), archive_path=".")]
+
+    def dockerfile(self) -> str:
+        return "FROM python:3.11-slim\nCOPY . .\n"
+
+
+def _build_image(context: Path) -> _BuildImage:
     """A stand-in for ``daytona.Image.from_dockerfile``: the Dockerfile text plus
     the context entries the SDK would archive and upload."""
-    return SimpleNamespace(
-        dockerfile=lambda: "FROM python:3.11-slim\nCOPY . .\n",
-        _context_list=[SimpleNamespace(source_path=str(context), archive_path=".")],
-    )
+    return _BuildImage(context)
 
 
 async def _boot_snapshot(context: Path, daytona: _FakeDaytonaClient) -> str:

--- a/hud/eval/tests/test_file_tracking_observer.py
+++ b/hud/eval/tests/test_file_tracking_observer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from hud.capabilities import Capability
 from hud.environment.file_tracker import FileTracker
@@ -13,6 +13,8 @@ from hud.telemetry.context import set_trace_context
 
 if TYPE_CHECKING:
     import pytest
+
+    from hud.clients.client import HudClient
 
 _CAP = Capability(
     name="filetracking",
@@ -128,7 +130,7 @@ async def test_setup_failure_skips_polling(monkeypatch: pytest.MonkeyPatch) -> N
     ft = _FakeFt(setup_raises=True)
     _connects_to(monkeypatch, ft)
 
-    async with observer.file_tracking_observer(_BoundClient()):  # type: ignore[arg-type]
+    async with observer.file_tracking_observer(cast("HudClient", _BoundClient())):
         await asyncio.sleep(0.05)
 
     assert ft.setup_calls == 1
@@ -151,7 +153,7 @@ async def test_successful_setup_anchors_and_polls(monkeypatch: pytest.MonkeyPatc
     ft = _FakeFt()
     _connects_to(monkeypatch, ft)
 
-    async with observer.file_tracking_observer(_BoundClient()):  # type: ignore[arg-type]
+    async with observer.file_tracking_observer(cast("HudClient", _BoundClient())):
         await asyncio.sleep(0.05)
 
     assert ft.setup_calls == 1
@@ -176,7 +178,7 @@ async def test_legacy_server_advances_without_setup_event(
     ft = _FakeFt()
     _connects_to(monkeypatch, ft, _LEGACY_CAP)
 
-    async with observer.file_tracking_observer(_BoundClient(_LEGACY_CAP)):  # type: ignore[arg-type]
+    async with observer.file_tracking_observer(cast("HudClient", _BoundClient(_LEGACY_CAP))):
         pass
 
     assert ft.advance_calls == 1
@@ -205,7 +207,7 @@ async def test_flush_emits_skipped_capture_metadata(monkeypatch: pytest.MonkeyPa
     ft = _FakeFt(flush_result={"diff": {"files_changed": 0, "patches": []}, "capture": capture})
     _connects_to(monkeypatch, ft)
 
-    async with observer.file_tracking_observer(_BoundClient()):  # type: ignore[arg-type]
+    async with observer.file_tracking_observer(cast("HudClient", _BoundClient())):
         pass
 
     assert ft.flush_calls == 1
@@ -231,7 +233,7 @@ async def test_connect_failure_does_not_break_the_rollout(monkeypatch: pytest.Mo
 
     # A failed connection must degrade to a no-op, not raise into the agent loop.
     ran = False
-    async with observer.file_tracking_observer(_BoundClient()):  # type: ignore[arg-type]
+    async with observer.file_tracking_observer(cast("HudClient", _BoundClient())):
         ran = True
 
     assert ran

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import pytest
+from typing_extensions import override
 
 from hud.agents.openai_compatible import OpenAIChatAgent
 from hud.agents.types import OpenAIChatConfig
@@ -32,6 +33,9 @@ from hud.eval.runtime import (
     _splice_websocket,
 )
 from hud.eval.task import Task
+
+if TYPE_CHECKING:
+    from hud.agents.base import Agent
 from hud.settings import settings
 from hud.telemetry.context import set_trace_context
 
@@ -154,8 +158,8 @@ async def test_run_rejects_non_gateway_agent() -> None:
     """An agent that can't serialize its identity yields a failed Run, not a crash."""
     run = await HostedRuntime(poll_interval=0.0).run(
         Task(env="e", id="x"),
-        object(),  # type: ignore[arg-type]
-        job_id="j",  # type: ignore[arg-type]
+        cast("Agent", object()),
+        job_id="j",
     )
     assert run.trace.is_error
     assert "gateway agent" in (run.trace.error or "")
@@ -277,6 +281,7 @@ async def test_submit_timeout_requests_platform_cancel(monkeypatch: pytest.Monke
     never = asyncio.Event()
 
     class _StuckSubmitPlatform(_FakePlatform):
+        @override
         async def apost(self, path: str, *, json: Any | None = None) -> Any:
             self.posts.append((path, json or {}))
             if path == "/rollouts/submit":
@@ -413,7 +418,8 @@ async def test_scheduler_delegates_hosted(monkeypatch: pytest.MonkeyPatch) -> No
     seen: dict[str, Any] = {}
 
     class _RecordingHostedRuntime(HostedRuntime):
-        async def run(self, task: Task, agent: Any, **kwargs: Any) -> Run:  # type: ignore[override]
+        @override
+        async def run(self, task: Task, agent: Agent, **kwargs: Any) -> Run:
             seen.update(kwargs)
             run = Run(None, task.id, {})
             run.trace.status = "completed"

--- a/hud/eval/tests/test_local_runtime.py
+++ b/hud/eval/tests/test_local_runtime.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncGenerator  # noqa: TC003 - env.template resolve
 from typing import Any, cast
 
 import pytest
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.environment import Environment
@@ -71,6 +72,7 @@ class _FnAgent(Agent):
     def __init__(self, fn: Any) -> None:
         self._fn = fn
 
+    @override
     async def __call__(self, run: Any) -> None:
         run.trace.content = self._fn(run.prompt)
 

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Any
 
 import mcp.types as mcp_types
 import pytest
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.agents.openai_compatible import OpenAIChatAgent
@@ -68,6 +69,7 @@ class _FnAgent(Agent):
     def __init__(self, fn: Any) -> None:
         self._fn = fn
 
+    @override
     async def __call__(self, run: Any) -> None:
         run.trace.content = self._fn(run.prompt)
 
@@ -344,6 +346,7 @@ async def test_episode_bindings_from_the_start_frame_reach_the_agent() -> None:
     seen: dict[str, dict[str, Any]] = {}
 
     class _Claiming(Agent):
+        @override
         async def __call__(self, run: Any) -> None:
             seen.update(run.bindings)
 
@@ -485,6 +488,7 @@ class _AnswerThenBoomAgent(Agent):
     def __init__(self, fn: Any) -> None:
         self._fn = fn
 
+    @override
     async def __call__(self, run: Any) -> None:
         run.trace.content = self._fn(run.prompt)
         raise RuntimeError("agent exploded after answering")
@@ -510,6 +514,7 @@ class _SlowAgent(Agent):
         self._fn = fn
         self.cancelled = asyncio.Event()
 
+    @override
     async def __call__(self, run: Any) -> None:
         run.trace.content = self._fn(run.prompt)
         try:
@@ -579,6 +584,7 @@ async def test_agent_timeout_error_is_not_the_phase_deadline(agent_timeout: floa
         yield 1.0 if answer == str(a + b) else 0.0
 
     class TimeoutAgent(Agent):
+        @override
         async def __call__(self, run: Any) -> None:
             run.trace.content = _solve_add(run.prompt)
             raise TimeoutError("provider timed out")

--- a/hud/eval/tests/test_shared.py
+++ b/hud/eval/tests/test_shared.py
@@ -15,6 +15,7 @@ from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.environment import Environment
@@ -57,6 +58,7 @@ def _echo_env() -> Environment:
 
 
 class _OkAgent(Agent):
+    @override
     async def __call__(self, run: Any) -> None:
         run.trace.content = "ok"
 
@@ -93,6 +95,7 @@ async def test_width_bounds_occupancy_by_waiting_not_erroring() -> None:
     peak = 0
 
     class _SlowAgent(Agent):
+        @override
         async def __call__(self, run: Any) -> None:
             nonlocal live, peak
             live += 1

--- a/hud/eval/tests/test_sync.py
+++ b/hud/eval/tests/test_sync.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hud.eval import Task, Taskset
 from hud.eval.runtime import RuntimeConfig
@@ -60,7 +60,7 @@ def test_fetched_tasks_map_canonical_export_fields(
         ],
     }
 
-    def fake_request(method: str, url: str, **kwargs: object) -> dict:
+    def fake_request(method: str, url: str, **kwargs: object) -> dict[str, Any]:
         requested.update(method=method, url=url)
         return payload
 
@@ -79,7 +79,7 @@ def test_fetched_tasks_map_canonical_export_fields(
 def test_resolve_taskset_id_looks_up_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
     requested: dict[str, str] = {}
 
-    def fake_request(method: str, url: str, **kwargs: object) -> dict:
+    def fake_request(method: str, url: str, **kwargs: object) -> dict[str, Any]:
         requested.update(method=method, url=url)
         return {"taskset_id": "ts-id", "name": "demo", "tasks": []}
 
@@ -104,7 +104,9 @@ def test_upload_taskset_posts_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     upload = Task(env="e", id="solve", args={"n": 1}, slug="solve-one")
     posted: dict[str, object] = {}
 
-    def fake_request(method: str, url: str, json: object = None, **kwargs: object) -> dict:
+    def fake_request(
+        method: str, url: str, json: object = None, **kwargs: object
+    ) -> dict[str, Any]:
         posted.update(method=method, url=url, json=json, api_key=kwargs.get("api_key"))
         return {"ok": True}
 

--- a/hud/graders/bash.py
+++ b/hud/graders/bash.py
@@ -6,6 +6,8 @@ import asyncio
 import logging
 from typing import Any
 
+from typing_extensions import override
+
 from hud.utils.process import create_process_group_exec
 
 from .base import Grader
@@ -22,14 +24,17 @@ class BashGrader(Grader):
     default_timeout: int = 600
 
     @classmethod
+    @override
     async def compute_score(
         cls,
-        command: str,
+        command: str | None = None,
         cwd: str | None = None,
         timeout_seconds: float | None = None,
         **kwargs: Any,
     ) -> SubScore:
         """Run ``command`` via ``bash -lc`` and score by exit code."""
+        if command is None:
+            raise ValueError("BashGrader requires command")
         if timeout_seconds is None:
             timeout_seconds = cls.default_timeout
         del kwargs

--- a/hud/graders/judge.py
+++ b/hud/graders/judge.py
@@ -14,6 +14,8 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
+from typing_extensions import override
+
 from .base import Grader
 from .results import SubScore
 
@@ -72,6 +74,7 @@ class LLMJudgeGrader(Grader):
     name = "LLMJudgeGrader"
 
     @classmethod
+    @override
     async def compute_score(
         cls,
         answer: str | Any = "",

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -63,7 +64,7 @@ def fake_docker(monkeypatch):
         if args[:4] == ("image", "inspect", "--format", "{{.Id}}"):
             return "sha256:0123456789abcdef0123456789abcdef\n", ""
         if args[0] == "compose" and args[-3:] == ("config", "--format", "json"):
-            project = {
+            project: Any = {
                 "name": "task",
                 "services": {
                     "main": {

--- a/hud/integrations/harbor/tests/test_harbor.py
+++ b/hud/integrations/harbor/tests/test_harbor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import textwrap
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -39,7 +39,9 @@ CMD ["hud", "serve", "env:env"]
 """
 
 
-def _write_env(tmp_path: Path, *, dockerfile: bool = True, args: dict | None = None) -> Path:
+def _write_env(
+    tmp_path: Path, *, dockerfile: bool = True, args: dict[str, Any] | None = None
+) -> Path:
     src = tmp_path / "env.py"
     body = textwrap.dedent(_ENV_PY)
     if args is not None:

--- a/hud/integrations/harbor/tests/test_integration.py
+++ b/hud/integrations/harbor/tests/test_integration.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 import pytest
+from typing_extensions import override
 
 from hud.agents.base import Agent
 from hud.eval import DockerRuntime, Shared
@@ -51,6 +52,7 @@ class Oracle(Agent):
     def __init__(self, solutions: dict[str, str]) -> None:
         self.solutions = solutions
 
+    @override
     async def __call__(self, run: Run) -> None:
         ssh = cast("SSHClient", await run.client.open("ssh/2"))
         if run.task_id == "agent-lifecycle":

--- a/hud/patches/mcp_patches.py
+++ b/hud/patches/mcp_patches.py
@@ -290,9 +290,9 @@ def patch_server_output_validation() -> None:
                         tool = await self._get_cached_tool_definition(tool_name)
 
                         if validate_input and tool:
-                            try:
-                                import jsonschema
+                            import jsonschema
 
+                            try:
                                 jsonschema.validate(instance=arguments, schema=tool.inputSchema)
                             except jsonschema.ValidationError as e:
                                 return self._make_error_result(

--- a/hud/settings.py
+++ b/hud/settings.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic_settings.sources import DotEnvSettingsSource, PydanticBaseSettingsSource
+from typing_extensions import override
 
 
 class Settings(BaseSettings):
@@ -18,6 +19,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="allow")
 
     @classmethod
+    @override
     def settings_customise_sources(
         cls,
         settings_cls: type[BaseSettings],

--- a/hud/telemetry/instrument.py
+++ b/hud/telemetry/instrument.py
@@ -240,8 +240,9 @@ def instrument(
                 _emit_span(task_run_id, args, kwargs, start_time, start_perf, result, error)
 
         wrapper = async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
-        wrapper._hud_instrumented = True  # type: ignore[attr-defined]
-        wrapper._hud_original = func  # type: ignore[attr-defined]
+        wrapper_state = cast("Any", wrapper)
+        wrapper_state._hud_instrumented = True
+        wrapper_state._hud_original = func
 
         return wrapper
 

--- a/hud/telemetry/instrument.py
+++ b/hud/telemetry/instrument.py
@@ -18,7 +18,7 @@ import functools
 import inspect
 import logging
 import time
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, overload
 
 from hud.telemetry.context import get_current_trace_id
 from hud.telemetry.exporter import queue_span
@@ -41,6 +41,13 @@ if TYPE_CHECKING:
     R = TypeVar("R")
 
 logger = logging.getLogger(__name__)
+
+
+class _InstrumentedCallable(Protocol):
+    _hud_instrumented: bool
+    _hud_original: Callable[..., Any]
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 def _serialize_value(value: Any, max_items: int = 10) -> JsonValue:
@@ -240,7 +247,7 @@ def instrument(
                 _emit_span(task_run_id, args, kwargs, start_time, start_perf, result, error)
 
         wrapper = async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
-        wrapper_state = cast("Any", wrapper)
+        wrapper_state = cast("_InstrumentedCallable", wrapper)
         wrapper_state._hud_instrumented = True
         wrapper_state._hud_original = func
 

--- a/hud/telemetry/tests/test_instrument.py
+++ b/hud/telemetry/tests/test_instrument.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from typing_extensions import override
 
 from hud.telemetry.context import set_trace_context
 from hud.telemetry.instrument import _serialize_value, instrument
@@ -243,7 +244,7 @@ async def test_instrument_async_complex_result():
     """Test instrument with complex result object."""
 
     @instrument
-    async def test_func() -> dict:
+    async def test_func() -> dict[str, Any]:
         return {"nested": {"data": [1, 2, 3]}, "count": 3}
 
     result = await test_func()
@@ -298,6 +299,7 @@ async def test_instrument_async_serialization_error():
     """Test instrument handles serialization errors gracefully."""
 
     class UnserializableArg:
+        @override
         def __getattribute__(self, name):
             raise Exception("Can't serialize")
 
@@ -430,7 +432,7 @@ def test_instrument_sync_with_kwargs():
     """Test instrument with keyword arguments."""
 
     @instrument
-    def test_func(x: int, **kwargs) -> dict:
+    def test_func(x: int, **kwargs: Any) -> dict[str, Any]:
         return {"x": x, **kwargs}
 
     result = test_func(1, a=2, b=3)

--- a/hud/tests/test_graders.py
+++ b/hud/tests/test_graders.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import warnings
@@ -10,6 +11,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from typing_extensions import override
 
 from hud.graders import (
     BashGrader,
@@ -388,7 +390,7 @@ class TestGradeCompatShim:
     """v5 environments call ``Grade.gather`` / ``Grade.from_subscores`` via ``hud.native``."""
 
     async def test_gather_combines_like_combine(self) -> None:
-        from hud.native import Grade  # pyright: ignore[reportAttributeAccessIssue]
+        Grade = getattr(importlib.import_module("hud.native"), "Grade")
 
         result = await Grade.gather(
             SubScore(name="alpha", value=1.0, weight=1.0),
@@ -398,7 +400,7 @@ class TestGradeCompatShim:
         assert result.reward == pytest.approx(0.5)
 
     def test_from_subscores_is_sync(self) -> None:
-        from hud.native.graders import Grade
+        Grade = getattr(importlib.import_module("hud.native.graders"), "Grade")
 
         result = Grade.from_subscores([SubScore(name="alpha", value=1.0, weight=1.0)])
         assert isinstance(result, EvaluationResult)
@@ -411,6 +413,7 @@ class TestGrader:
             name = "DummyGrader"
 
             @classmethod
+            @override
             async def compute_score(cls, **kwargs: object) -> Any:
                 return 0.75
 
@@ -428,6 +431,7 @@ class TestGrader:
             name = "tuple"
 
             @classmethod
+            @override
             async def compute_score(cls, **kwargs: object) -> Any:
                 return 0.75, {"source": "released-contract"}
 
@@ -444,6 +448,7 @@ class TestGrader:
             name = "rubric"
 
             @classmethod
+            @override
             async def compute_score(cls, **kwargs: object) -> SubScore:
                 return SubScore(name="specific-rubric", value=1.0)
 
@@ -456,6 +461,7 @@ class TestGrader:
             name = "rubric"
 
             @classmethod
+            @override
             async def compute_score(cls, **kwargs: object) -> SubScore:
                 return SubScore(
                     name="ignored",

--- a/hud/tests/test_robot.py
+++ b/hud/tests/test_robot.py
@@ -24,12 +24,16 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
+from typing_extensions import override
 
 from hud.agents.robot import Adapter, Model, RobotAgent
 from hud.environment import Environment
 from hud.environment.robot import RobotBridge, RobotEndpoint
 from hud.eval import LocalRuntime, Shared, Task, Taskset, rollout
 from hud.eval.runtime import _local
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -70,16 +74,19 @@ class _StubSim(RobotBridge):
         self.tick = 0
         self.executed = np.zeros(num_envs)
 
+    @override
     def reset(self, **task_args: Any) -> str:
         self.tick = 0
         self.executed[:] = 0.0
         return f"stub task: {task_args.get('goal', 'none')}"
 
-    def step(self, action: np.ndarray) -> None:
+    @override
+    def step(self, action: NDArray[Any]) -> None:
         self.tick += 1
         self.executed += np.asarray(action)[:, 0]  # one row per slot
 
-    def get_observation(self) -> tuple[dict[str, np.ndarray], np.ndarray]:
+    @override
+    def get_observation(self) -> tuple[dict[str, NDArray[Any]], NDArray[Any]]:
         slots = np.arange(1, self.num_envs + 1, dtype=np.float32)
         data = {
             "observation/image": np.zeros((self.num_envs, 16, 16, 3), dtype=np.uint8),
@@ -89,6 +96,7 @@ class _StubSim(RobotBridge):
         }
         return data, np.full(self.num_envs, self.tick >= EPISODE_TICKS)
 
+    @override
     def result_slots(self) -> list[dict[str, Any]]:
         # Per-slot grades, never one batch-wide scalar: the token has to resolve.
         return [
@@ -150,6 +158,7 @@ class _EchoAdapter(Adapter):
         super().__init__()
         self.wired: list[dict[str, Any]] = []
 
+    @override
     def adapt_observation(self, obs: dict[str, Any], prompt: str) -> dict[str, Any]:
         data = obs["data"]
         batch = {"state": data[self.state_key], "image": data[self.image_keys[0]], "task": prompt}
@@ -163,6 +172,7 @@ class _EchoModel(Model):
     def __init__(self, action_dim: int) -> None:
         self.action_dim = action_dim
 
+    @override
     def infer(self, batch: Any) -> Any:
         slot = float(np.asarray(batch["state"]).reshape(-1)[0])
         return np.full((1, 1, self.action_dim), slot, dtype=np.float32)  # [N, T, A]
@@ -181,6 +191,7 @@ class _EchoAgent(RobotAgent):
 class _EarlyStopAgent(_EchoAgent):
     """Stop after one action through the public rollout hook."""
 
+    @override
     def should_stop(self, obs: dict[str, Any], *, step: int, max_steps: int) -> bool:
         return step >= 1 or super().should_stop(obs, step=step, max_steps=max_steps)
 

--- a/hud/tests/test_tools_shim.py
+++ b/hud/tests/test_tools_shim.py
@@ -7,21 +7,27 @@ fallback, each access emitting a ``DeprecationWarning``.
 
 from __future__ import annotations
 
+import importlib
 import warnings
+from typing import Any
 
 import pytest
 
 from hud.environment import Answer
 
 
+def _legacy_attr(module: str, name: str) -> Any:
+    return getattr(importlib.import_module(module), name)
+
+
 def test_basetool_and_agenttool_resolve_to_noops() -> None:
     # ``BaseTool`` / ``AgentTool`` were removed in v6; importing them must not
     # raise, but resolves to a no-op stand-in with a DeprecationWarning.
-    import hud.tools
+    tools = importlib.import_module("hud.tools")
 
     for name in ("BaseTool", "AgentTool"):
         with pytest.warns(DeprecationWarning):
-            cls = getattr(hud.tools, name)
+            cls = getattr(tools, name)
         assert cls.__module__ == "hud._legacy"
         assert cls() is not None
 
@@ -29,7 +35,10 @@ def test_basetool_and_agenttool_resolve_to_noops() -> None:
 def test_result_types_redirect_to_their_v6_homes() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        from hud.tools.types import AgentAnswer, EvaluationResult, ScenarioResult, TextContent
+        AgentAnswer = _legacy_attr("hud.tools.types", "AgentAnswer")
+        EvaluationResult = _legacy_attr("hud.tools.types", "EvaluationResult")
+        ScenarioResult = _legacy_attr("hud.tools.types", "ScenarioResult")
+        TextContent = _legacy_attr("hud.tools.types", "TextContent")
 
     # The real types (not no-ops): graders for results, mcp.types for blocks.
     assert EvaluationResult.from_float(0.5).reward == 0.5
@@ -43,8 +52,8 @@ def test_quarantined_v5_shapes_still_work() -> None:
     # hud._legacy and keep their v5 behavior for deployed environments.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        from hud.tools.bash import ToolError  # type: ignore[import-not-found]
-        from hud.tools.types import ContentResult
+        ToolError = _legacy_attr("hud.tools.bash", "ToolError")
+        ContentResult = _legacy_attr("hud.tools.types", "ContentResult")
 
     combined = ContentResult(output="a", error="e1") + ContentResult(output="b", error="e2")
     assert combined.output == "ab"
@@ -59,10 +68,10 @@ def test_quarantined_v5_shapes_still_work() -> None:
 
 
 def test_computer_tool_resolves_to_capability_marker() -> None:
-    import hud.tools
+    tools = importlib.import_module("hud.tools")
 
     with pytest.warns(DeprecationWarning):
-        computer_cls = hud.tools.HudComputerTool  # pyright: ignore[reportAttributeAccessIssue]
+        computer_cls = getattr(tools, "HudComputerTool")
 
     instance = computer_cls(width=800, height=600)
     assert getattr(instance, "_legacy_capability_kind", None) == "computer"
@@ -73,8 +82,8 @@ def test_shell_tool_resolves_to_capability_marker() -> None:
     # ``ssh`` capability at serve time via the shell marker.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        from hud.tools import BashTool  # pyright: ignore[reportAttributeAccessIssue]
-        from hud.tools.coding import EditTool  # pyright: ignore[reportAttributeAccessIssue]
+        BashTool = _legacy_attr("hud.tools", "BashTool")
+        EditTool = _legacy_attr("hud.tools.coding", "EditTool")
 
     for tool_cls in (BashTool, EditTool):
         instance = tool_cls(base_path="/tmp")
@@ -85,7 +94,7 @@ def test_removed_name_from_real_module_falls_back_to_noop() -> None:
     # ``BaseHub`` was dropped in v6; importing it must not raise ImportError.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        from hud.tools.base import BaseHub
+        BaseHub = _legacy_attr("hud.tools.base", "BaseHub")
 
         # No-op stand-in: constructs and calls without error.
         assert BaseHub(anything=1)() is not None
@@ -94,7 +103,7 @@ def test_removed_name_from_real_module_falls_back_to_noop() -> None:
 def test_removed_submodule_resolves_names() -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        from hud.tools.filesystem import ReadTool  # pyright: ignore[reportAttributeAccessIssue]
+        ReadTool = _legacy_attr("hud.tools.filesystem", "ReadTool")
 
         assert ReadTool() is not None
 
@@ -103,13 +112,9 @@ def test_jupyter_and_playwright_resolve_to_noops() -> None:
     # Dropped in v6: registering them in a v5 env silently does nothing.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        from hud.tools import (  # pyright: ignore[reportAttributeAccessIssue]
-            JupyterTool,
-            PlaywrightTool,
-        )
-        from hud.tools.playwright import (  # pyright: ignore[reportAttributeAccessIssue]
-            PlaywrightTool as deep_playwright,
-        )
+        JupyterTool = _legacy_attr("hud.tools", "JupyterTool")
+        PlaywrightTool = _legacy_attr("hud.tools", "PlaywrightTool")
+        deep_playwright = _legacy_attr("hud.tools.playwright", "PlaywrightTool")
 
     for tool_cls in (JupyterTool, PlaywrightTool, deep_playwright):
         instance = tool_cls(cdp_url="http://localhost:9222")
@@ -117,26 +122,28 @@ def test_jupyter_and_playwright_resolve_to_noops() -> None:
 
 
 def test_unknown_symbol_is_noop_not_error() -> None:
-    import hud.tools
+    tools = importlib.import_module("hud.tools")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", DeprecationWarning)
-        noop = hud.tools.SomethingThatNeverExisted  # pyright: ignore[reportAttributeAccessIssue]
+        noop = getattr(tools, "SomethingThatNeverExisted")
         assert noop() is not None
 
 
 def test_hud_native_aliases_preserve_module_identity() -> None:
-    import hud.native
-    import hud.native.tools.base as native_base
     from hud.graders import combine
-    from hud.tools.base import BaseTool
 
-    assert native_base.BaseTool is BaseTool
-    assert hud.native.combine is combine  # pyright: ignore[reportAttributeAccessIssue]
+    native = importlib.import_module("hud.native")
+    native_base = importlib.import_module("hud.native.tools.base")
+    BaseTool = _legacy_attr("hud.tools.base", "BaseTool")
+
+    assert getattr(native_base, "BaseTool") is BaseTool
+    assert getattr(native, "combine") is combine
 
 
 def test_hud_services_alias_resolves_chat() -> None:
     from hud.eval.chat import Chat
-    from hud.services import Chat as legacy_chat  # type: ignore[import-not-found]
+
+    legacy_chat = _legacy_attr("hud.services", "Chat")
 
     assert legacy_chat is Chat

--- a/hud/train/client.py
+++ b/hud/train/client.py
@@ -11,9 +11,10 @@ string (the service resolves recorded tokens + reward) or a :class:`hud.Run`
 
 from __future__ import annotations
 
+import importlib
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hud.agents.types import AgentStep
 from hud.train.base import BaseTrainingClient
@@ -234,7 +235,7 @@ class TrainingClient(BaseTrainingClient):
         torch (``pip install 'hud[train]'``).
         """
         try:
-            import torch
+            torch: Any = importlib.import_module("torch")
         except ImportError as exc:
             raise ImportError(
                 "forward_backward_custom requires torch; install 'hud[train]'"

--- a/hud/train/client.py
+++ b/hud/train/client.py
@@ -11,10 +11,9 @@ string (the service resolves recorded tokens + reward) or a :class:`hud.Run`
 
 from __future__ import annotations
 
-import importlib
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from hud.agents.types import AgentStep
 from hud.train.base import BaseTrainingClient
@@ -235,7 +234,7 @@ class TrainingClient(BaseTrainingClient):
         torch (``pip install 'hud[train]'``).
         """
         try:
-            torch: Any = importlib.import_module("torch")
+            import torch
         except ImportError as exc:
             raise ImportError(
                 "forward_backward_custom requires torch; install 'hud[train]'"

--- a/hud/types.py
+++ b/hud/types.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeAlias, TypeVar, ca
 import mcp.types as types
 from mcp.types import CallToolRequestParams, CallToolResult
 from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, model_validator
+from typing_extensions import override
 
 from hud.telemetry.context import get_current_trace_id
 from hud.telemetry.exporter import queue_span
@@ -138,6 +139,7 @@ class MCPToolCall(CallToolRequestParams):
     #: a str is never executed — dispatch answers it with an error result.
     arguments: dict[str, Any] | str | None = None
 
+    @override
     def __str__(self) -> str:
         """Format tool call as plain text."""
         args_str = ""
@@ -196,6 +198,7 @@ class MCPToolResult(CallToolResult):
 
         return content_summary
 
+    @override
     def __str__(self) -> str:
         """Format tool result as plain text for compatibility."""
         content_summary = self._get_content_summary()

--- a/hud/utils/exceptions.py
+++ b/hud/utils/exceptions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from typing_extensions import override
+
 if TYPE_CHECKING:
     from typing import Self
 
@@ -50,6 +52,7 @@ class HudException(Exception):
         # If hints not provided, use defaults defined by subclass
         self.hints: list[Hint] = hints if hints is not None else list(self.default_hints)
 
+    @override
     def __str__(self) -> str:
         if self.response_json:
             prefix = f"{self.message} | " if self.message else ""
@@ -108,6 +111,7 @@ class HudRequestError(HudException):
             return [PRO_PLAN_REQUIRED] if mentions_pro else [HUD_API_KEY_MISSING]
         return None
 
+    @override
     def __str__(self) -> str:
         parts = [self.message]
 

--- a/hud/utils/hints.py
+++ b/hud/utils/hints.py
@@ -165,8 +165,9 @@ def render_hints(hints: Iterable[Hint] | None, *, design: Any | None = None) -> 
     if not hints:
         return
 
+    hud_console = design
     try:
-        if design is None:
+        if hud_console is None:
             from hud.utils.hud_console import hud_console as default_design  # lazy import
 
             hud_console = default_design

--- a/hud/utils/tests/test_platform.py
+++ b/hud/utils/tests/test_platform.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from hud.utils.exceptions import HudAuthenticationError
@@ -23,7 +25,9 @@ def test_url_prefixes_version_segment_and_joins_params() -> None:
 def test_get_and_post_route_through_shared_requests(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[dict[str, object]] = []
 
-    def fake_request(method: str, url: str, json: object = None, **kwargs: object) -> dict:
+    def fake_request(
+        method: str, url: str, json: object = None, **kwargs: object
+    ) -> dict[str, Any]:
         calls.append({"method": method, "url": url, "json": json, "api_key": kwargs.get("api_key")})
         return {"ok": True}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "packaging>=21.0",
     "pydantic>=2.10,<3",
     "pydantic-settings>=2.2,<3",
+    "typing-extensions>=4.12",
     # MCP dependencies
     "mcp>=1.24.0,<2.0",
     "fastmcp==3.2.0",
@@ -132,7 +133,7 @@ dev = [
     "pytest-asyncio",
     "pytest-mock",
     "pytest-cov",
-    "pyright==1.1.407",
+    "ty==0.0.67",
 ]
 
 # Alias for backwards compatibility
@@ -225,18 +226,15 @@ docstring-code-format = true
 [tool.ruff.lint.flake8-type-checking]
 runtime-evaluated-base-classes = ["pydantic.BaseModel"]
 
-[tool.pyright]
+[tool.ty.src]
 include = ["hud"]
-exclude = [
-    "**/node_modules",
-    "**/__pycache__",
-    "**/venv",
-    "**/.venv",
-]
-pythonVersion = "3.11"
-typeCheckingMode = "basic"
-strict = ["hud/agents"]
-reportMissingImports = "warning"
+
+[tool.ty.rules]
+all = "error"
+
+[tool.ty.analysis]
+respect-type-ignore-comments = false
+strict-equality-semantics = true
 
 [tool.coverage.run]
 source = ["hud"]


### PR DESCRIPTION
## Summary

- replace dynamic `Any` module boundaries with structural contracts for browser-use, torch-backed robot adapters, Modal, and Daytona
- give task decorators, server lifecycle state, telemetry wrappers, and synthetic legacy modules explicit owned types
- use native `torch.Tensor` typing for custom training losses and a typed Daytona image test double

## Why

PR #552 makes ty strict across the repository, but several optional integrations and dynamic runtime hooks were initially made checker-compatible with `Any` casts and dynamic attributes. This follow-up keeps every strict rule enabled and models those boundaries directly instead.

Optional dependencies remain lazy, `bind()` still returns its documented `asyncio.Server`, and runtime behavior is unchanged.

## Stack

Depends on #552. Until that PR merges, GitHub will show the parent migration in this PR's comparison against `main`.

## Validation

- `uv run --extra dev --extra train ty check`
- `uv run ruff format . --check`
- `uv run ruff check .`
- `uv run pytest -q` (959 passed, 9 deselected)
