### PR TITLE
Configure computer screenshot encoding

### DIFF
--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -108,7 +108,7 @@ class ClaudeSDKAgent(Agent):
                 from hud.agents.claude.sdk.computer_mcp import serve_computer_mcp
 
                 rfb = cast("RFBClient", await run.client.open("rfb"))
-                port = await serve_computer_mcp(rfb)
+                port = await serve_computer_mcp(rfb, self.config.screenshot_encoding)
                 self._mcp_servers["computer-use"] = {
                     "type": "http",
                     "url": f"http://127.0.0.1:{port}/mcp",

--- a/hud/agents/claude/sdk/computer_mcp.py
+++ b/hud/agents/claude/sdk/computer_mcp.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any
 
 import fastmcp
 
+from hud.capabilities.rfb import ScreenshotEncoding, WebPScreenshotEncoding
+
 if TYPE_CHECKING:
     from hud.capabilities.rfb import RFBClient
 
@@ -19,9 +21,13 @@ logger = logging.getLogger(__name__)
 
 #: Keep references to background server tasks so they aren't garbage-collected.
 _BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
+_DEFAULT_SCREENSHOT_ENCODING = WebPScreenshotEncoding()
 
 
-def create_computer_mcp(rfb: RFBClient) -> fastmcp.FastMCP:
+def create_computer_mcp(
+    rfb: RFBClient,
+    screenshot_encoding: ScreenshotEncoding = _DEFAULT_SCREENSHOT_ENCODING,
+) -> fastmcp.FastMCP:
     """Build a FastMCP server with one ``computer`` tool backed by ``rfb``."""
 
     mcp = fastmcp.FastMCP("computer-use")
@@ -79,7 +85,11 @@ def create_computer_mcp(rfb: RFBClient) -> fastmcp.FastMCP:
                 arguments["region"] = region
 
         spec = AgentToolSpec(api_type="computer", api_name="computer")
-        tool = ClaudeComputerTool(spec=spec, client=rfb)
+        tool = ClaudeComputerTool(
+            spec=spec,
+            client=rfb,
+            screenshot_encoding=screenshot_encoding,
+        )
         result = await tool.execute(arguments)
 
         # Return content blocks directly so the CLI/model sees real images.
@@ -106,6 +116,7 @@ def create_computer_mcp(rfb: RFBClient) -> fastmcp.FastMCP:
 
 async def serve_computer_mcp(
     rfb: RFBClient,
+    screenshot_encoding: ScreenshotEncoding = _DEFAULT_SCREENSHOT_ENCODING,
     host: str = "127.0.0.1",
     port: int = 0,
 ) -> int:
@@ -115,7 +126,7 @@ async def serve_computer_mcp(
         port = srv.sockets[0].getsockname()[1]
         srv.close()
 
-    mcp = create_computer_mcp(rfb)
+    mcp = create_computer_mcp(rfb, screenshot_encoding)
     task = asyncio.create_task(_run(mcp, host, port))
     _BACKGROUND_TASKS.add(task)
     task.add_done_callback(_BACKGROUND_TASKS.discard)

--- a/hud/agents/claude/tools/computer.py
+++ b/hud/agents/claude/tools/computer.py
@@ -16,6 +16,7 @@ import mcp.types as mcp_types
 
 from hud.agents.tools import RFBTool
 from hud.agents.tools.base import tool_err, tool_ok
+from hud.capabilities.rfb import ScreenshotEncoding, WebPScreenshotEncoding
 from hud.types import MCPToolResult
 
 from .base import ClaudeToolSpec
@@ -279,11 +280,7 @@ class ClaudeComputerTool(RFBTool):
         except (TypeError, ValueError):
             return tool_err("region must contain 4 integers")
         screenshot, _ = await self.client.screenshot_png("image/png")
-        cropped, mime_type = _crop_png(
-            screenshot,
-            (x0, y0, x1, y1),
-            self.screenshot_mime_type,
-        )
+        cropped, mime_type = _crop_png(screenshot, (x0, y0, x1, y1), self.screenshot_encoding)
         return MCPToolResult(
             content=[
                 mcp_types.ImageContent(
@@ -356,18 +353,18 @@ def _drag_path(arguments: dict[str, Any]) -> list[tuple[int, int]]:
 def _crop_png(
     png: bytes,
     region: tuple[int, int, int, int],
-    mime_type: str,
+    encoding: ScreenshotEncoding,
 ) -> tuple[bytes, str]:
     from PIL import Image
 
     image = Image.open(BytesIO(png))
     cropped = image.crop(region)
     buf = BytesIO()
-    if mime_type == "image/webp":
-        cropped.save(buf, format="WEBP", quality=85)
+    if isinstance(encoding, WebPScreenshotEncoding):
+        cropped.save(buf, format="WEBP", quality=encoding.quality)
     else:
         cropped.save(buf, format="PNG")
-    return buf.getvalue(), mime_type
+    return buf.getvalue(), encoding.mime_type
 
 
 __all__ = ["CLAUDE_COMPUTER_SPECS", "ClaudeComputerTool"]

--- a/hud/agents/claude/tools/tests/test_computer.py
+++ b/hud/agents/claude/tools/tests/test_computer.py
@@ -22,6 +22,7 @@ from hud.agents.claude.tools.computer import (
     _translate_key,
 )
 from hud.agents.tools.base import result_text, tool_ok
+from hud.capabilities.rfb import WebPScreenshotEncoding
 
 
 class RecordingComputer(ClaudeComputerTool):
@@ -31,7 +32,7 @@ class RecordingComputer(ClaudeComputerTool):
 
     def __init__(self) -> None:
         self.calls: list[tuple[Any, ...]] = []
-        self.screenshot_mime_type = "image/webp"
+        self.screenshot_encoding = WebPScreenshotEncoding(quality=42)
         self.client = SimpleNamespace(width=200, height=100)
 
     async def screenshot(self) -> Any:
@@ -160,7 +161,11 @@ def test_crop_reports_encoded_mime_type() -> None:
     source = BytesIO()
     Image.effect_noise((128, 128), 100).convert("RGB").save(source, format="PNG")
 
-    cropped, mime_type = _crop_png(source.getvalue(), (0, 0, 128, 128), "image/webp")
+    cropped, mime_type = _crop_png(
+        source.getvalue(),
+        (0, 0, 128, 128),
+        WebPScreenshotEncoding(quality=42),
+    )
 
     assert mime_type == "image/webp"
     assert cropped.startswith(b"RIFF")
@@ -177,6 +182,6 @@ async def test_zoom_reports_encoded_mime_type() -> None:
         result = await tool._zoom({"region": [0, 0, 10, 10]})
 
     tool.client.screenshot_png.assert_awaited_once_with("image/png")
-    crop.assert_called_once_with(b"png", (0, 0, 10, 10), "image/webp")
+    crop.assert_called_once_with(b"png", (0, 0, 10, 10), tool.screenshot_encoding)
     image = next(block for block in result.content if isinstance(block, mcp_types.ImageContent))
     assert image.mimeType == "image/webp"

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -18,8 +18,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from hud.agents.claude.sdk import computer_mcp
 from hud.agents.claude.sdk.agent import ClaudeSDKAgent, build_remote_invocation
-from hud.capabilities import Capability, SSHClient
+from hud.agents.types import ClaudeSDKConfig
+from hud.capabilities import Capability, RFBClient, SSHClient
+from hud.capabilities.rfb import WebPScreenshotEncoding
 
 # ─── build_remote_invocation (pure) ───────────────────────────────────
 
@@ -197,3 +200,43 @@ async def test_manifest_mcp_capability_is_written_for_remote_claude(
         "database": {"type": claude_type, "url": "http://database:8000/mcp"}
     }
     execute.assert_awaited_once()
+
+
+async def test_remote_claude_passes_screenshot_encoding_to_computer_mcp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shell = Capability(
+        name="shell",
+        protocol="ssh/2",
+        url="ssh://localhost:22",
+        params={"shell": "bash"},
+    )
+    screen = Capability.rfb(name="screen", url="rfb://localhost:5900", display=0)
+    ssh = SSHClient(shell, cast("Any", object()))
+    rfb = object.__new__(RFBClient)
+
+    class Client:
+        manifest = SimpleNamespace(bindings=[shell, screen])
+
+        async def open(self, ref: str) -> Any:
+            return ssh if ref == "ssh" else rfb
+
+    encoding = WebPScreenshotEncoding(quality=42)
+    agent = ClaudeSDKAgent(ClaudeSDKConfig(screenshot_encoding=encoding))
+    execute = AsyncMock()
+    serve = AsyncMock(return_value=8765)
+    monkeypatch.setattr(agent, "_exec", execute)
+    monkeypatch.setattr(computer_mcp, "serve_computer_mcp", serve)
+
+    await agent(
+        cast(
+            "Any",
+            SimpleNamespace(client=Client(), prompt_text="use the computer"),
+        )
+    )
+
+    serve.assert_awaited_once_with(rfb, encoding)
+    assert agent._mcp_servers["computer-use"] == {
+        "type": "http",
+        "url": "http://127.0.0.1:8765/mcp",
+    }

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -18,8 +18,11 @@ from fastmcp.client.transports import SSETransport, StreamableHttpTransport
 from hud.agents.openai.tools.coding import OpenAIShellTool
 from hud.agents.openai.tools.mcp_proxy import OpenAIMCPProxyTool
 from hud.agents.tool_agent import RunState, ToolAgent
-from hud.agents.types import AgentConfig, AgentStep, ToolStep
+from hud.agents.tools.base import AgentToolSpec
+from hud.agents.tools.rfb import RFBTool
+from hud.agents.types import AgentConfig, AgentStep, ClaudeConfig, ClaudeSDKConfig, ToolStep
 from hud.capabilities import Capability, CapabilityClient, MCPClient, RFBClient, SSHClient
+from hud.capabilities.rfb import PngScreenshotEncoding, WebPScreenshotEncoding
 from hud.types import MCPToolCall, MCPToolResult, Step, Trace
 
 _Msg = dict[str, Any]
@@ -67,6 +70,52 @@ def test_init_subclass_derives_clients_from_catalog() -> None:
         tool_catalog = (OpenAIShellTool,)
 
     assert WithCatalog.clients == (SSHClient,)
+
+
+def test_claude_defaults_to_configurable_webp_screenshots() -> None:
+    assert AgentConfig().screenshot_encoding == PngScreenshotEncoding()
+    assert ClaudeConfig().screenshot_encoding == WebPScreenshotEncoding()
+    assert ClaudeSDKConfig().screenshot_encoding == WebPScreenshotEncoding()
+
+    configured = ClaudeConfig.model_validate(
+        {"screenshot_encoding": {"mime_type": "image/webp", "quality": 42}},
+    )
+    assert configured.screenshot_encoding == WebPScreenshotEncoding(quality=42)
+
+    with pytest.raises(ValueError):
+        ClaudeConfig.model_validate(
+            {"screenshot_encoding": {"mime_type": "image/webp", "quality": 101}},
+        )
+
+
+async def test_agent_passes_screenshot_encoding_to_rfb_tools() -> None:
+    class ScreenTool(RFBTool):
+        name = "screen"
+
+        @classmethod
+        def default_spec(cls, model: str) -> AgentToolSpec:
+            del model
+            return AgentToolSpec(api_type="screen", api_name="screen")
+
+        async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
+            del arguments
+            return MCPToolResult(content=[])
+
+        def to_params(self) -> dict[str, str]:
+            return {"name": self.name}
+
+    class ScreenAgent(DictAgent):
+        tool_catalog = (ScreenTool,)
+
+    encoding = {"mime_type": "image/webp", "quality": 42}
+    agent = ScreenAgent([AgentStep(content="done", done=True)], screenshot_encoding=encoding)
+    rfb = object.__new__(RFBClient)
+
+    tools, _ = await agent._build_tools({"screen": rfb})
+
+    tool = tools["screen"]
+    assert isinstance(tool, ScreenTool)
+    assert tool.screenshot_encoding == WebPScreenshotEncoding(quality=42)
 
 
 async def test_agent_opens_every_mcp_capability_by_name() -> None:

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -29,8 +29,9 @@ from hud.agents.base import Agent
 from hud.agents.misc import auto_respond
 from hud.agents.tools.base import AgentTool, provider_tool_name
 from hud.agents.tools.mcp import MCPTool
+from hud.agents.tools.rfb import RFBTool
 from hud.agents.types import AgentStep, ToolStep
-from hud.capabilities import MCPClient
+from hud.capabilities import MCPClient, RFBClient
 from hud.types import AgentType, MCPToolCall, MCPToolResult, Step, StopCondition
 from hud.utils.time import now_iso
 
@@ -190,7 +191,15 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                         tools[tool.provider_name] = tool
                         params.append(tool.to_params())
                 else:
-                    tool = tool_cls(spec=spec, client=client)
+                    if issubclass(tool_cls, RFBTool):
+                        assert isinstance(client, RFBClient)
+                        tool = tool_cls(
+                            spec=spec,
+                            client=client,
+                            screenshot_encoding=self.config.screenshot_encoding,
+                        )
+                    else:
+                        tool = tool_cls(spec=spec, client=client)
                     tools[tool.provider_name] = tool
                     params.append(tool.to_params())
 

--- a/hud/agents/tools/rfb.py
+++ b/hud/agents/tools/rfb.py
@@ -18,17 +18,17 @@ import mcp.types as mcp_types
 
 from hud.agents.tools.base import AgentTool, AgentToolSpec
 from hud.capabilities import RFBClient
+from hud.capabilities.rfb import PngScreenshotEncoding, ScreenshotEncoding
 from hud.types import MCPToolResult
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterable
 
-    from hud.capabilities.rfb import ScreenshotMimeType
-
 
 #: VNC button index (asyncvnc uses 0 = left, 1 = middle, 2 = right, 3 = wheel-up, 4 = wheel-down).
 Button = Literal["left", "middle", "right"]
 _BUTTON_INDEX: dict[Button, int] = {"left": 0, "middle": 1, "right": 2}
+_DEFAULT_SCREENSHOT_ENCODING = PngScreenshotEncoding()
 
 
 class RFBTool(AgentTool[RFBClient]):
@@ -41,10 +41,10 @@ class RFBTool(AgentTool[RFBClient]):
         *,
         spec: AgentToolSpec,
         client: RFBClient,
-        screenshot_mime_type: ScreenshotMimeType = "image/webp",
+        screenshot_encoding: ScreenshotEncoding = _DEFAULT_SCREENSHOT_ENCODING,
     ) -> None:
         super().__init__(spec=spec, client=client)
-        self.screenshot_mime_type: ScreenshotMimeType = screenshot_mime_type
+        self.screenshot_encoding = screenshot_encoding
 
     # ─── geometry ────────────────────────────────────────────────────
 
@@ -60,7 +60,7 @@ class RFBTool(AgentTool[RFBClient]):
 
     async def screenshot(self) -> MCPToolResult:
         """Capture a screenshot and return it as a single ``ImageContent`` block."""
-        screenshot, mime_type = await self.client.screenshot_png(self.screenshot_mime_type)
+        screenshot, mime_type = await self.client.screenshot_png(self.screenshot_encoding)
         return MCPToolResult(
             content=[
                 mcp_types.ImageContent(

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -28,6 +28,11 @@ from pydantic import (
 )
 
 from hud.agents.tools.hosted import HostedTool
+from hud.capabilities.rfb import (
+    PngScreenshotEncoding,
+    ScreenshotEncoding,
+    WebPScreenshotEncoding,
+)
 from hud.types import (
     ROBOT_STEP_SCHEMA,
     MCPToolCall,
@@ -56,6 +61,7 @@ class AgentConfig(BaseModel):
     #: result the model can react to; training configs typically stop on both.
     stop_on: set[StopCondition] = Field(default_factory=set[StopCondition])
     hosted_tools: list[HostedTool[object]] = Field(default_factory=list[HostedTool[object]])
+    screenshot_encoding: ScreenshotEncoding = Field(default_factory=PngScreenshotEncoding)
 
     model_name: str = "Agent"
     model: str = Field(default="unknown", validation_alias=_model_alias)
@@ -74,6 +80,7 @@ class ClaudeConfig(AgentConfig):
     model: str = Field(default="claude-sonnet-4-6", validation_alias=_model_alias)
     max_tokens: int = 16384
     use_computer_beta: bool = True
+    screenshot_encoding: ScreenshotEncoding = Field(default_factory=WebPScreenshotEncoding)
 
 
 # -----------------------------------------------------------------------------
@@ -147,6 +154,7 @@ class ClaudeSDKConfig(AgentConfig):
     model: str = Field(default="claude-sonnet-4-6", validation_alias=_model_alias)
     permission_mode: str = "bypassPermissions"
     max_steps: int = -1
+    screenshot_encoding: ScreenshotEncoding = Field(default_factory=WebPScreenshotEncoding)
     allowed_tools: list[str] = Field(
         default_factory=lambda: [
             "Read",

--- a/hud/capabilities/rfb.py
+++ b/hud/capabilities/rfb.py
@@ -24,17 +24,37 @@ import contextlib
 import io
 import logging
 from contextlib import AsyncExitStack
-from typing import ClassVar, Literal, Self
+from typing import Annotated, ClassVar, Literal, Self
 from urllib.parse import urlsplit
 
 import asyncvnc
 from PIL import Image
+from pydantic import BaseModel, ConfigDict, Field
 
 from .base import Capability, CapabilityClient
 
 LOGGER = logging.getLogger("hud.capabilities.rfb")
 
 ScreenshotMimeType = Literal["image/png", "image/webp"]
+
+
+class PngScreenshotEncoding(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    mime_type: Literal["image/png"] = "image/png"
+
+
+class WebPScreenshotEncoding(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    mime_type: Literal["image/webp"] = "image/webp"
+    quality: int = Field(default=85, ge=0, le=100)
+
+
+ScreenshotEncoding = Annotated[
+    PngScreenshotEncoding | WebPScreenshotEncoding,
+    Field(discriminator="mime_type"),
+]
 
 
 class RFBClient(CapabilityClient):
@@ -114,19 +134,23 @@ class RFBClient(CapabilityClient):
 
     async def screenshot_png(
         self,
-        mime_type: ScreenshotMimeType = "image/png",
+        encoding: ScreenshotEncoding | ScreenshotMimeType = "image/png",
     ) -> tuple[bytes, ScreenshotMimeType]:
         """Capture the framebuffer in the requested format; reconnect on desync."""
+        if isinstance(encoding, str):
+            encoding = (
+                WebPScreenshotEncoding() if encoding == "image/webp" else PngScreenshotEncoding()
+            )
         for attempt in range(3):
             try:
                 rgba = await self._conn.screenshot()
                 image = Image.fromarray(rgba)
                 buf = io.BytesIO()
-                if mime_type == "image/webp":
-                    image.save(buf, format="WEBP", quality=85)
+                if isinstance(encoding, WebPScreenshotEncoding):
+                    image.save(buf, format="WEBP", quality=encoding.quality)
                 else:
                     image.save(buf, format="PNG")
-                return buf.getvalue(), mime_type
+                return buf.getvalue(), encoding.mime_type
             except (ValueError, ConnectionError, OSError, EOFError) as exc:
                 LOGGER.warning("screenshot failed (attempt %d): %s", attempt + 1, exc)
                 if attempt == 2:
@@ -142,4 +166,10 @@ class RFBClient(CapabilityClient):
         await self._exit_stack.aclose()
 
 
-__all__ = ["RFBClient", "ScreenshotMimeType"]
+__all__ = [
+    "PngScreenshotEncoding",
+    "RFBClient",
+    "ScreenshotEncoding",
+    "ScreenshotMimeType",
+    "WebPScreenshotEncoding",
+]

--- a/hud/capabilities/tests/test_rfb.py
+++ b/hud/capabilities/tests/test_rfb.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import mcp.types as mcp_types
 from PIL import Image
 
 from hud.agents.tools.rfb import RFBTool
-from hud.capabilities.rfb import RFBClient
+from hud.capabilities.rfb import RFBClient, WebPScreenshotEncoding
 
 
 class RecordingRFBTool(RFBTool):
@@ -16,7 +16,7 @@ class RecordingRFBTool(RFBTool):
     client: Any
 
     def __init__(self) -> None:
-        self.screenshot_mime_type = "image/webp"
+        self.screenshot_encoding = WebPScreenshotEncoding(quality=42)
         self.client = SimpleNamespace(
             screenshot_png=AsyncMock(return_value=(b"webp", "image/webp")),
         )
@@ -39,14 +39,13 @@ async def test_screenshot_uses_requested_webp_mime_type() -> None:
         ),
     )
 
-    with patch(
-        "hud.capabilities.rfb.Image.fromarray", return_value=Image.effect_noise((128, 128), 100)
-    ):
-        data, mime_type = await client.screenshot_png("image/webp")
+    save = Mock(side_effect=lambda buffer, **_kwargs: buffer.write(b"webp"))
+    with patch("hud.capabilities.rfb.Image.fromarray", return_value=SimpleNamespace(save=save)):
+        data, mime_type = await client.screenshot_png(WebPScreenshotEncoding(quality=42))
 
     assert mime_type == "image/webp"
-    assert data.startswith(b"RIFF")
-    assert data[8:12] == b"WEBP"
+    assert data == b"webp"
+    save.assert_called_once_with(ANY, format="WEBP", quality=42)
 
 
 async def test_screenshot_uses_requested_png_mime_type() -> None:
@@ -74,3 +73,4 @@ async def test_screenshot_reports_encoded_mime_type() -> None:
     image = result.content[0]
     assert isinstance(image, mcp_types.ImageContent)
     assert image.mimeType == "image/webp"
+    tool.client.screenshot_png.assert_awaited_once_with(tool.screenshot_encoding)


### PR DESCRIPTION
## Summary

- add a typed, discriminated screenshot encoding config for PNG and WebP
- default Claude and Claude SDK computer-use screenshots to WebP quality 85 while keeping generic agents on PNG
- propagate the selected encoding and WebP quality through direct tools, Claude SDK MCP, RFB capture, and zoom crops

## Why

Claude computer-use trajectories can hit Anthropic's 32 MB request-body limit before reaching the model context limit because screenshots are embedded as base64. WebP reduces that transport overhead without rewriting message history or disrupting prompt caching, while the quality setting allows workload-specific tuning.

## Validation

- `uv run --extra dev pytest -q` — 960 passed, 9 deselected
- `uv run ruff format . --check`
- `uv run ruff check .`
- `uv run pyright` — 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to screenshot format/defaults on computer-use paths; no auth or persistence changes, and generic agents remain PNG by default.
> 
> **Overview**
> Introduces **typed screenshot encoding** (`PngScreenshotEncoding` / `WebPScreenshotEncoding` with configurable WebP quality) and wires it through agent config, RFB capture, computer tools, and Claude SDK computer-use MCP.
> 
> **Defaults:** generic `AgentConfig` stays PNG; `ClaudeConfig` and `ClaudeSDKConfig` default to WebP (quality 85) to shrink base64 screenshot payloads toward Anthropic’s request-body limits. `ToolAgent._build_tools` passes `config.screenshot_encoding` into `RFBTool` subclasses; `ClaudeSDKAgent` forwards the same setting when starting `serve_computer_mcp`. Zoom crops and `RFBClient.screenshot_png` honor the encoding object (including WebP quality) instead of a bare mime string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85b177364726071384558295b72d3bf009fa4d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->