### PR TITLE
HUD-2444: Surface tunnel and sync input failures

### DIFF
--- a/hud/cli/sync.py
+++ b/hud/cli/sync.py
@@ -427,7 +427,7 @@ def sync_env_command(
         hud_console.info("")
         try:
             selection = input("Select environment number (or paste full name): ").strip()
-        except (EOFError, KeyboardInterrupt):
+        except (EOFError, KeyboardInterrupt, OSError):
             hud_console.info("\nAborted.")
             raise typer.Exit(0) from None
 

--- a/hud/cli/tests/test_sync_export.py
+++ b/hud/cli/tests/test_sync_export.py
@@ -1,10 +1,16 @@
-"""``hud sync tasks --export``: the CSV spreadsheet view of task rows."""
+"""Focused behavior for ``hud sync`` commands."""
 
 from __future__ import annotations
 
+import builtins
 from typing import TYPE_CHECKING
 
+import pytest
+import typer
+
+import hud.cli.sync as sync_module
 from hud.cli.sync import _write_csv
+from hud.cli.utils.registry import RegistryEnvironment
 from hud.eval import Task
 
 if TYPE_CHECKING:
@@ -25,3 +31,28 @@ def test_write_csv_flattens_args(tmp_path: Path) -> None:
     assert "slug,id,env,arg:n" in csv_text
     assert "one,solve,e,1" in csv_text
     assert 'two,solve,e,"{""x"": 2}"' in csv_text
+
+
+def test_sync_env_closed_stdin_aborts_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(sync_module, "require_api_key", lambda _: None)
+    monkeypatch.setattr(sync_module.PlatformClient, "from_settings", lambda: object())
+    monkeypatch.setattr(
+        sync_module,
+        "list_registry_environments",
+        lambda _: [RegistryEnvironment(id="env-1", name="example")],
+    )
+
+    def closed_input(_: str) -> str:
+        raise OSError("stdin is closed")
+
+    monkeypatch.setattr(builtins, "input", closed_input)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        sync_module.sync_env_command(name=None, directory=str(tmp_path), yes=False)
+
+    assert exc_info.value.exit_code == 0
+    assert "Aborted." in capsys.readouterr().err

--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -174,7 +174,13 @@ class HudClient:
                 try:
                     try:
                         up_reader, up_writer = await asyncio.open_connection(host, port)
-                    except OSError:
+                    except OSError as exc:
+                        LOGGER.warning(
+                            "tunnel peer %s:%d connection failed: %s",
+                            host,
+                            port,
+                            exc,
+                        )
                         writer.close()
                         return
                     await send_frame(

--- a/hud/clients/tests/test_connect.py
+++ b/hud/clients/tests/test_connect.py
@@ -10,6 +10,8 @@ handshake EOFs until ``hello`` answers or the deadline passes.
 from __future__ import annotations
 
 import asyncio
+import logging
+from urllib.parse import urlsplit
 
 import pytest
 
@@ -52,6 +54,62 @@ async def test_connect_retries_through_accept_then_eof_until_the_env_serves() ->
         await server.wait_closed()
 
     assert attempts == 3
+
+
+async def test_tunnel_connection_failure_warns_with_peer(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            hello = await read_frame(reader)
+            assert hello is not None
+            await send_frame(
+                writer,
+                {
+                    "jsonrpc": "2.0",
+                    "id": hello["id"],
+                    "result": {
+                        **HELLO_RESULT,
+                        "bindings": [
+                            {
+                                "name": "shell",
+                                "protocol": "ssh/2",
+                                "url": "ssh://agent@environment:22",
+                            }
+                        ],
+                    },
+                },
+            )
+            await read_frame(reader)
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    open_connection = asyncio.open_connection
+
+    async def fail_tunnel_connection(host: str, peer_port: int):
+        assert (host, peer_port) == ("127.0.0.1", port)
+        raise OSError("peer unavailable")
+
+    try:
+        async with connect(Runtime(f"tcp://127.0.0.1:{port}")) as client:
+            route = urlsplit(client.binding("shell").url)
+            monkeypatch.setattr(client_module.asyncio, "open_connection", fail_tunnel_connection)
+            caplog.set_level(logging.WARNING, logger="hud.clients")
+
+            reader, writer = await open_connection(route.hostname, route.port)
+            try:
+                assert await reader.read() == b""
+            finally:
+                writer.close()
+                await writer.wait_closed()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert f"tunnel peer 127.0.0.1:{port} connection failed: peer unavailable" in caplog.messages
 
 
 async def test_heartbeat_serializes_calls_without_aborting_on_protocol_errors(


### PR DESCRIPTION
## Summary

- warn with the peer host and port when a capability tunnel cannot connect to the control endpoint
- treat `OSError` from closed stdin during interactive environment selection as a clean abort
- add regression coverage for both failure paths

## Root cause

The tunnel forwarder closed the local writer and returned when its peer connection raised `OSError`, leaving no diagnostic signal. The interactive `hud sync env` prompt handled EOF and interrupts but allowed a closed-stdin `OSError` to escape in non-interactive shells.

## Impact

Task authors now get an actionable warning for dead tunnel peers, while environment sync exits cleanly when stdin is unavailable.

## Testing

- `uv run --with='.[dev]' pytest -q hud/clients hud/cli/tests/test_sync_export.py` (8 passed)
- `uv run ruff format hud/clients/client.py hud/clients/tests/test_connect.py hud/cli/sync.py hud/cli/tests/test_sync_export.py --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling and logging changes with no auth, data, or protocol behavior changes beyond clearer failures and graceful CLI exit.
> 
> **Overview**
> Improves **diagnostics and CLI robustness** when capability tunnels or interactive sync cannot read stdin.
> 
> The tunnel forwarder in `HudClient` now **logs a warning** with peer host, port, and the `OSError` when `asyncio.open_connection` to the control endpoint fails, instead of closing the local writer with no signal. Interactive **`hud sync env`** treats **`OSError`** from closed stdin (along with EOF and Ctrl-C) as a clean abort with exit code 0.
> 
> Regression tests cover closed stdin during environment selection and tunnel peer connection failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9546bde759a45c18db997e0103da786ff86856c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->