### PR TITLE
Expose granted workspace isolation

### DIFF
--- a/hud/capabilities/base.py
+++ b/hud/capabilities/base.py
@@ -92,6 +92,7 @@ class Capability:
         client_key_path: str | os.PathLike[str] | None = None,
         shell: str | None = None,
         cwd: str | None = None,
+        isolation: Literal["bwrap", "none"] | None = None,
     ) -> Capability:
         """``ssh/2`` — SSH daemon with publickey auth.
 
@@ -103,7 +104,8 @@ class Capability:
         from ``sys.platform`` at construction time. Agents read this to
         format commands correctly. ``cwd`` is the absolute path sessions
         start in. Paths are the session namespace's own — clients pass them
-        verbatim, and nothing is anchored or rewritten.
+        verbatim, and nothing is anchored or rewritten. ``isolation`` records
+        the sandbox actually granted to the served workspace.
         """
         normalized = normalize_url(url, default_scheme="ssh", default_port=22)
         if shell is None:
@@ -115,6 +117,8 @@ class Capability:
             params["client_key_path"] = os.fspath(client_key_path)
         if cwd is not None:
             params["cwd"] = cwd
+        if isolation is not None:
+            params["isolation"] = isolation
         return cls(name=name, protocol="ssh/2", url=normalized, params=params)
 
     @classmethod

--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -47,10 +47,14 @@ async def test_serving_publishes_the_workspace_capability(
     from hud.settings import settings
 
     monkeypatch.setattr(settings, "file_tracking_enabled", True)
+    monkeypatch.setattr(workspace_module, "usable_bwrap", lambda: None)
     env = Environment("ws-env")
     env.workspace(tmp_path / "root")
 
     async with served(env) as client:
+        assert client.manifest is not None
+        shell = next(cap for cap in client.manifest.bindings if cap.name == "shell")
+        assert shell.params["isolation"] == "none"
         cap = client.binding("shell")
         assert cap.protocol == "ssh/2"
         assert cap.url.startswith("ssh://")
@@ -63,6 +67,23 @@ async def test_serving_publishes_the_workspace_capability(
         }
         # Key material lives outside the served root (the agent's surface).
         assert not (tmp_path / "root" / ".hud").exists()
+
+
+async def test_serving_reports_granted_bwrap_isolation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        workspace_module,
+        "usable_bwrap",
+        lambda: workspace_module.Bubblewrap("/usr/bin/bwrap"),
+    )
+    env = Environment("ws-env")
+    env.workspace(tmp_path / "root")
+
+    async with served(env) as client:
+        assert client.manifest is not None
+        shell = next(cap for cap in client.manifest.bindings if cap.name == "shell")
+        assert shell.params["isolation"] == "bwrap"
 
 
 async def test_workspace_file_tracking_can_be_opted_out(

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -688,6 +688,7 @@ class Workspace:
             client_key=key_path.read_text() if key_path else None,
             client_key_path=key_path,
             cwd=self._guest_path,
+            isolation="bwrap" if self.bwrap_available else "none",
         )
 
     @property


### PR DESCRIPTION
## Summary

- report `bwrap` or `none` in the workspace-backed SSH capability parameters
- derive the value from the workspace that was actually constructed
- keep the top-level hello/`Manifest` schema unchanged

## Why

When bubblewrap is unavailable and isolation is not required, a workspace can serve unisolated with only a log warning. Publishing the granted level on the workspace capability lets clients and the platform detect that degradation programmatically and avoid treating contaminated evaluations as valid.

## Validation

- `uv run --with='.[dev]' pytest -q hud/environment/tests hud/clients/tests/test_connect.py hud/capabilities/tests` — 157 passed
- `uv run --with='.[dev]' ruff check hud/capabilities/base.py hud/environment/workspace.py hud/environment/tests/test_capability_backing.py`
- `uv run --with='.[dev]' ruff format --check hud/capabilities/base.py hud/environment/workspace.py hud/environment/tests/test_capability_backing.py`
- `uv run --extra dev --extra train ty check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive manifest metadata on workspace SSH capabilities; isolation behavior is unchanged and covered by tests.
> 
> **Overview**
> Workspace-backed **`ssh/2`** shell capabilities now include an **`isolation`** param (`**bwrap**` or `**none**`) so clients and the platform can see whether bubblewrap sandboxing was actually granted, not only inferred from logs when bwrap is missing or unusable.
> 
> `Capability.ssh()` accepts optional `isolation` and serializes it into manifest params. `Workspace.capability()` sets it from `bwrap_available` at serve time. Manifest/hello schema is unchanged aside from this new param on published bindings.
> 
> Tests assert `none` when `usable_bwrap` is stubbed unavailable and `bwrap` when a working bwrap launch is reported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60938dc83064408e7e30b313e3f3744cf01a664a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->