### PR TITLE
feat(runtime): support hosted Modal Compose environments

### DIFF
--- a/docs/v6/advanced/harbor-convert.mdx
+++ b/docs/v6/advanced/harbor-convert.mdx
@@ -6,9 +6,10 @@ tag: "Experimental"
 ---
 
 `adapt()` turns Harbor task directories into the same `Environment`, `Task`, and
-`Taskset` primitives used by authored HUD environments. It builds the Harbor
-environment first, then wraps that image with the Harbor runtime files packaged
-with the SDK. The generated directory contains task data, not generated source.
+`Taskset` primitives used by authored HUD environments. It is a file-only
+transformation: every environment gets a self-contained `compose-project/`, and
+no image is built or published during adaptation. Task instructions and grading
+configuration live in the generated task rows, outside the image build inputs.
 
 ## Prerequisites
 
@@ -17,27 +18,96 @@ with the SDK. The generated directory contains task data, not generated source.
 
 ## Run Harbor tasks
 
-Build the images and receive a runnable taskset:
+Adapt the tasks and receive a runnable taskset:
 
 ```python
 from hud.integrations import harbor
 from hud.eval import DockerRuntime
 
-taskset = await harbor.adapt("./terminal-bench")
+taskset = harbor.adapt("./terminal-bench")
 job = await taskset.run(agent, runtime=DockerRuntime())
 ```
 
 `DockerRuntime` supplies the inner workspace sandbox needed by adapted images;
 the setting is automatic for all HUD Docker environments.
 
-`adapt(path, push="registry.io/acme")` pushes the wrapped images and returns
-rows bound to those refs. The readable build inputs are left under
-`.hud-adapt/`; `adapt()` owns the two-image build because the wrapper's base is
-the Harbor environment it just built.
+The returned task rows point at `compose-project/compose.json`, making their
+runtime configuration self-contained for local evaluation and task sync. The
+artifact root has a `compose.yaml` build recipe plus `env.py`, `tasks.json`, and
+the contexts under `compose-project/`; no runtime sidecar is involved.
+Inline-verifier image tasks have one `main` service. Their original
+`environment/` is copied unchanged. The carrier's `Dockerfile` appends the HUD
+runtime to the user's final stage and reads `env.py`, environment configuration,
+and the SDK wheel from a BuildKit named context in `hud/`. Inline tests remain in
+`compose-project/tests/<task-id>/` and are mounted read-only when the project
+runs; they are not copied into the image. A separate verifier retains its own
+unchanged `tests/` build input. Multi-service tasks retain their authored
+project: build contexts are rebased inside the artifact, and build-only base and
+verifier services use `scale: 0`.
 
-Each row carries `[metadata]` as `columns` and CPU, memory, and GPU requirements
-as `runtime_config`. The image's `tasks.json` carries workdir, environment,
-network, and phase-user declarations into the authored HUD environment.
+Deploy the generated `.hud-adapt/<environment>/` directory and sync the returned
+taskset; hosted Modal builds multi-service projects inside its DinD sandbox
+without publishing private images. Registry sidecars must be anonymously
+pullable. Private ECR component images are rejected until sandbox-side ECR
+authentication is available.
+
+Bare `hud deploy .hud-adapt/<environment>` discovers `compose.yaml` as the build
+recipe. Multi-service projects use Modal; a single-service project can use the
+default HUD runtime. `--runtime hud|modal` persists a registry default for tasks
+that do not carry their own `Task.runtime_config`; adapted task rows already do.
+
+The artifact also works without HUD infrastructure. Its build script first
+builds or pulls each authored base image, records Docker's resolved OCI config,
+then builds the adapted services:
+
+```bash
+cd compose-project
+sh build.sh registry.example/acme/task:tag
+docker push registry.example/acme/task:tag
+```
+
+This path requires Docker Compose and a BuildKit-era Docker builder because the
+HUD payload is a named context rather than content injected into the user's
+environment.
+
+For any generated project, assign a registry `image:` to every service with a
+`build:` (replace the generated HUD tags and add tags to authored build-only
+sidecars), then run the project build before pushing the Compose services:
+
+```bash
+sh compose-project/build.sh
+docker compose push
+```
+
+The former `push=` argument to `adapt()` was removed: adaptation only packages
+the project, while these ordinary Docker commands make registry publication an
+explicit owner-infrastructure step.
+
+Changing an instruction or per-task verifier setting only changes `tasks.json`;
+sync the tasks again without redeploying the environment. Inline verifier tests
+also stay outside the image. At run time the generic Harbor template uses the
+row's task ID to select `compose-project/tests/<task-id>/`. Separate verifiers
+remain one environment group per task: the verifier row carries that same task
+ID and runs the matching unchanged `tests/` context at `/tests/test.sh`.
+
+Running an adapted image directly requires the same sandbox permissions as
+`DockerRuntime`. Use the `docker-seccomp.json` profile installed at
+`hud/eval/docker-seccomp.json` in the HUD package; without both options, Harbor
+environments that require user-namespace isolation refuse to serve:
+
+```bash
+HUD_SECCOMP=/path/to/site-packages/hud/eval/docker-seccomp.json
+docker run \
+  --rm -p 8765:8765 \
+  --security-opt "seccomp=$HUD_SECCOMP" \
+  --security-opt systempaths=unconfined \
+  registry.example/acme/task:tag
+```
+
+Each row carries its instruction and task-specific grading configuration in
+`args`, `[metadata]` as `columns`, and CPU, memory, and GPU requirements as
+`runtime_config`. The image's `config.json` carries only environment-wide
+workdir, environment, network, and phase-user declarations.
 
 Tasks whose declared behaviour cannot be reproduced faithfully are refused
 rather than silently downgraded. Compose environments, network MCP servers,
@@ -45,7 +115,10 @@ healthchecks, and separate verifier Dockerfiles are translated into the HUD
 runtime contract; Docker and Modal can run the resulting Compose environments,
 while Daytona rejects Compose runtime configuration. Stdio MCP servers,
 non-Linux tasks, TPUs, skills directories, and multi-step tasks are refused.
-Prebuilt images, allowlists, and distinct agent/verifier users are supported.
+An `environment.docker_image` without an `environment/Dockerfile` is also
+refused because adaptation cannot recover the image's user, workdir,
+entrypoint, environment, and exposed ports without inspecting Docker. Allowlists
+and distinct agent/verifier users are supported.
 
 ## Export HUD tasks to Harbor
 

--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -151,6 +151,10 @@ ModalRuntime(image_name=None, *, image=None, command=None, app_name="hud-envs", 
 - **`workdir`** - working directory inside the sandbox. Left unset, Modal keeps the image's `WORKDIR`.
 - **`app_name`** / **`port`** / **`env_vars`** - Modal app name, in-sandbox serving port, and extra environment variables.
 
+Compose runs inside a Docker-in-Docker sandbox with a minimum allocation of 4 CPUs and 8192 MiB.
+`env_vars` are merged into the Compose `main` service at acquisition time; they are not written
+into the Compose file or `RuntimeConfig` payload.
+
 Requires the `modal` extra and a configured token.
 
 ### `DaytonaRuntime`

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -45,6 +45,8 @@ class SSHClient(CapabilityClient):
             username=cap.params.get("user", "agent"),
             client_keys=client_keys,
             known_hosts=None,
+            keepalive_interval=15,
+            keepalive_count_max=4,
         )
         return cls(cap, conn)
 

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import AsyncMock
+
+import asyncssh
+
+from hud.capabilities.base import Capability
+from hud.capabilities.ssh import SSHClient
+
+if TYPE_CHECKING:
+    import pytest
+
+
+async def test_connect_keeps_tunneled_connection_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = cast("asyncssh.SSHClientConnection", object())
+    connect = AsyncMock(return_value=connection)
+    monkeypatch.setattr(asyncssh, "connect", connect)
+
+    client = await SSHClient.connect(
+        Capability(name="shell", protocol="ssh/2", url="ssh://sandbox.example:8765")
+    )
+
+    assert client.conn is connection
+    connect.assert_awaited_once_with(
+        host="sandbox.example",
+        port=8765,
+        username="agent",
+        client_keys=None,
+        known_hosts=None,
+        keepalive_interval=15,
+        keepalive_count_max=4,
+    )

--- a/hud/cli/deploy.py
+++ b/hud/cli/deploy.py
@@ -9,7 +9,7 @@ import os
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import typer
@@ -28,7 +28,13 @@ from hud.utils.naming import normalize_environment_name
 from hud.utils.platform import PlatformClient
 
 LOGGER = logging.getLogger(__name__)
-_VALID_RUNTIMES = {"modal"}
+_VALID_RUNTIMES = {"hud", "modal"}
+_COMPOSE_RECIPE_NAMES = (
+    "compose.yaml",
+    "compose.yml",
+    "docker-compose.yaml",
+    "docker-compose.yml",
+)
 
 
 @dataclass(frozen=True)
@@ -36,7 +42,7 @@ class _DeployPlan:
     name: str
     registry_id: str | None
     runtime: str | None
-    runtime_config: dict[str, Any] | None
+    runtime_config: RuntimeConfig | None
     env_vars: dict[str, str]
     build_args: dict[str, str]
     build_secrets: dict[str, str]
@@ -80,12 +86,38 @@ def _normalize_runtime(runtime: str | None, console: HUDConsole) -> str | None:
     raise typer.Exit(1)
 
 
-def _load_runtime_config(path: str | None, console: HUDConsole) -> dict[str, Any] | None:
+def _compose_recipe(context: Path) -> Path | None:
+    for name in _COMPOSE_RECIPE_NAMES:
+        candidate = context / name
+        if candidate.is_file():
+            return candidate
+    return next(
+        (
+            candidate
+            for candidate in sorted(context.glob("docker-compose.*"))
+            if ".override." not in candidate.name and candidate.is_file()
+        ),
+        None,
+    )
+
+
+def _load_runtime_config(path: str | None, console: HUDConsole) -> RuntimeConfig | None:
     if path is None:
         return None
     config_path = Path(path).expanduser()
     try:
         raw = json.loads(config_path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            raw_config = cast("dict[str, Any]", raw)
+            for field in ("compose", "compose_project"):
+                value = raw_config.get(field)
+                if isinstance(value, str):
+                    candidate = Path(value).expanduser()
+                    raw_config[field] = str(
+                        candidate
+                        if candidate.is_absolute()
+                        else (config_path.parent / candidate).resolve()
+                    )
         config = RuntimeConfig.model_validate(raw)
     except FileNotFoundError:
         console.error(f"Runtime config file not found: {config_path}")
@@ -96,8 +128,7 @@ def _load_runtime_config(path: str | None, console: HUDConsole) -> dict[str, Any
     except ValidationError as exc:
         console.error(f"Invalid runtime config in {config_path}: {exc}")
         raise typer.Exit(1) from exc
-    payload = config.request_payload()
-    return payload or None
+    return config
 
 
 def _load_env_vars(path: Path, console: HUDConsole, *, warn_missing: bool) -> dict[str, str]:
@@ -380,12 +411,33 @@ def _prepare_deploy_plan(
     if build_args_dict and verbose:
         console.info(f"Build arguments: {', '.join(build_args_dict.keys())}")
     normalized_runtime = _normalize_runtime(runtime, console)
+    loaded_runtime_config = _load_runtime_config(runtime_config, console)
+    recipe = _compose_recipe(env_dir)
+    if recipe is not None:
+        if loaded_runtime_config is not None and (
+            loaded_runtime_config.image is not None
+            or loaded_runtime_config.compose is not None
+            or loaded_runtime_config.compose_project is not None
+        ):
+            console.error("--runtime-config cannot set image or Compose for a Compose context")
+            raise typer.Exit(1)
+        loaded_runtime_config = RuntimeConfig.model_validate(
+            {
+                **(
+                    loaded_runtime_config.model_dump(exclude_unset=True)
+                    if loaded_runtime_config is not None
+                    else {}
+                ),
+                "compose": recipe,
+                "compose_project": env_dir,
+            }
+        )
 
     return _DeployPlan(
         name=resolved_name,
         registry_id=registry_id,
         runtime=normalized_runtime,
-        runtime_config=_load_runtime_config(runtime_config, console),
+        runtime_config=loaded_runtime_config,
         env_vars=env_vars,
         build_args=build_args_dict,
         build_secrets=_collect_build_secrets(build_secrets, env_dir=env_dir, console=console),
@@ -415,14 +467,19 @@ def deploy_environment(
     from hud.cli.utils.api import require_api_key
 
     require_api_key("deploy environments")
+    recipe = _compose_recipe(env_dir)
     dockerfile = env_source.dockerfile
-    if dockerfile is None:
-        hud_console.error("No Dockerfile.hud or Dockerfile found")
+    if recipe is None and dockerfile is None:
+        hud_console.error("No compose.yaml, compose.yml, docker-compose.*, or Dockerfile found")
         hud_console.info(f"Directory: {env_dir}")
-        hud_console.info("\nCreate a Dockerfile.hud with your environment setup.")
+        hud_console.info("\nCreate a Compose or Dockerfile build recipe.")
         hud_console.info("Run 'hud init' to create a template.")
         raise typer.Exit(1)
-    hud_console.info(f"Using Dockerfile: {dockerfile.name}")
+    if recipe is not None:
+        hud_console.info(f"Using Compose recipe: {recipe.name}")
+    else:
+        assert dockerfile is not None
+        hud_console.info(f"Using Dockerfile: {dockerfile.name}")
     _validate_before_deploy(env_source, hud_console)
 
     platform = PlatformClient.from_settings()
@@ -468,22 +525,10 @@ class _DeployResult:
     status: str = ""
 
 
-@dataclass(frozen=True)
-class _BuildUpload:
-    upload_url: str
-    build_id: str
-
-
-async def _create_build_upload(platform: PlatformClient) -> _BuildUpload:
-    data = await platform.apost("/builds/upload-url")
-    return _BuildUpload(upload_url=data["upload_url"], build_id=data["build_id"])
-
-
-async def _upload_build_context(upload_url: str, tarball_path: Path) -> None:
-    """PUT the tarball to the presigned S3 URL (not a platform API call)."""
-    content = await asyncio.to_thread(tarball_path.read_bytes)
-    async with httpx.AsyncClient(timeout=300.0) as s3_client:
-        response = await s3_client.put(
+async def _upload_context(upload_url: str, tarball: Path) -> None:
+    content = await asyncio.to_thread(tarball.read_bytes)
+    async with httpx.AsyncClient(timeout=300.0) as client:
+        response = await client.put(
             upload_url,
             content=content,
             headers={"Content-Type": "application/gzip"},
@@ -497,40 +542,32 @@ async def _trigger_build(
     build_id: str,
     plan: _DeployPlan,
     no_cache: bool,
-    console: HUDConsole,
-) -> dict[str, Any] | None:
-    """Trigger the direct build. The platform resolves the registry by name
-    (get-or-rebuild), so an existing environment with this name is rebuilt."""
+) -> tuple[str, str]:
     payload: dict[str, Any] = {
         "source": "direct",
         "build_id": build_id,
         "name": plan.name,
         "no_cache": no_cache,
     }
-    if plan.registry_id:
-        payload["registry_id"] = plan.registry_id
-    if plan.runtime:
-        payload["runtime_provider"] = plan.runtime
-    if plan.runtime_config:
-        payload["runtime_config"] = plan.runtime_config
-    if plan.env_vars:
-        payload["environment_variables"] = plan.env_vars
-    if plan.build_args:
-        payload["build_args"] = plan.build_args
-    if plan.build_secrets:
-        payload["build_secrets"] = plan.build_secrets
-
-    try:
-        return await platform.apost("/builds/trigger", json=payload)
-    except HudRequestError as e:
-        console.error(f"Failed to trigger build: {e.status_code or e}")
-        detail = (e.response_json or {}).get("detail", "")
-        if detail:
-            console.error(f"Error: {detail}")
-        return None
-    except Exception as e:
-        console.error(f"Failed to trigger build: {e}")
-        return None
+    payload.update(
+        {
+            key: value
+            for key, value in (
+                ("registry_id", plan.registry_id),
+                ("runtime_provider", plan.runtime),
+                (
+                    "runtime_config",
+                    plan.runtime_config.request_payload() if plan.runtime_config else None,
+                ),
+                ("environment_variables", plan.env_vars),
+                ("build_args", plan.build_args),
+                ("build_secrets", plan.build_secrets),
+            )
+            if value
+        }
+    )
+    data = await platform.apost("/builds/trigger", json=payload)
+    return data["id"], data["registry_id"]
 
 
 async def _deploy_async(
@@ -541,12 +578,13 @@ async def _deploy_async(
     console: HUDConsole,
     env_dir: Path | None = None,
 ) -> _DeployResult:
-    """Async deployment flow: upload context, trigger build, stream logs."""
+    """Narrate the library-owned exchange, stream logs, and save the link."""
     console.progress_message("Getting upload URL...")
     step_start = time.time()
 
     try:
-        upload = await _create_build_upload(platform)
+        upload = await platform.apost("/builds/upload-url")
+        upload_url, reserved_id = upload["upload_url"], upload["build_id"]
     except HudRequestError as e:
         console.error(f"Failed to get upload URL: {e.status_code or e}")
         if e.status_code == 401:
@@ -559,13 +597,13 @@ async def _deploy_async(
         return _DeployResult(success=False)
 
     console.success(f"Got upload URL [{time.time() - step_start:.1f}s]")
-    console.info(f"Build ID: {upload.build_id}")
+    console.info(f"Build ID: {reserved_id}")
 
     console.progress_message("Uploading build context...")
     step_start = time.time()
 
     try:
-        await _upload_build_context(upload.upload_url, tarball_path)
+        await _upload_context(upload_url, tarball_path)
         console.success(f"Upload complete [{time.time() - step_start:.1f}s]")
     except Exception as e:
         console.error(f"Failed to upload build context: {e}")
@@ -574,18 +612,22 @@ async def _deploy_async(
     console.progress_message("Triggering build...")
     step_start = time.time()
 
-    trigger_data = await _trigger_build(
-        platform,
-        build_id=upload.build_id,
-        plan=plan,
-        no_cache=no_cache,
-        console=console,
-    )
-    if trigger_data is None:
+    try:
+        build_id, registry_id = await _trigger_build(
+            platform,
+            build_id=reserved_id,
+            plan=plan,
+            no_cache=no_cache,
+        )
+    except HudRequestError as e:
+        console.error(f"Failed to trigger build: {e.status_code or e}")
+        detail = (e.response_json or {}).get("detail", "")
+        if detail:
+            console.error(f"Error: {detail}")
         return _DeployResult(success=False)
-
-    build_id = trigger_data["id"]
-    registry_id = trigger_data["registry_id"]
+    except Exception as e:
+        console.error(f"Failed to trigger build: {e}")
+        return _DeployResult(success=False)
 
     # Save immediately after trigger so rebuilds work even if streaming crashes.
     if env_dir and registry_id:
@@ -658,7 +700,8 @@ def discover_environments(directory: Path) -> list[Path]:
     return [
         child
         for child in sorted(directory.iterdir())
-        if child.is_dir() and EnvironmentSource.open(child).is_environment
+        if child.is_dir()
+        and (EnvironmentSource.open(child).is_environment or _compose_recipe(child) is not None)
     ]
 
 
@@ -790,7 +833,7 @@ def deploy_command(
     runtime: str | None = typer.Option(
         None,
         "--runtime",
-        help="Persist Modal as the hosted runtime for this registry",
+        help="Persist a registry default runtime for tasks that do not specify one: hud or modal",
     ),
     runtime_config: str | None = typer.Option(
         None,

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -729,15 +729,17 @@ def _spawn_target(source: Path) -> Path:
     return resolved.parent
 
 
-def _resolve_placement(cfg: EvalConfig, source_path: Path | None) -> Any:
+def _resolve_placement(cfg: EvalConfig, source_path: Path | None, taskset: Any) -> Any:
     """Map the config's ``runtime`` onto a placement for ``Taskset.run``.
 
-    "local" spawns each row's env from the source next to the tasks file;
+    "local" runs each row's env beside the tasks file: rows that declare a
+    container substrate (``runtime_config`` image or compose) get
+    ``DockerRuntime``, otherwise the env source is served in a subprocess;
     "hud" opens the HUD runtime tunnel while keeping the agent loop local;
     ``--remote`` submits every rollout for platform-hosted execution; a
     ``tcp://`` url attaches to an env served elsewhere.
     """
-    from hud.eval import HostedRuntime, HUDRuntime, Runtime, SubprocessRuntime
+    from hud.eval import DockerRuntime, HostedRuntime, HUDRuntime, Runtime, SubprocessRuntime
 
     if cfg.remote:
         require_api_key("run remote hosted evals")
@@ -745,7 +747,18 @@ def _resolve_placement(cfg: EvalConfig, source_path: Path | None) -> Any:
     if cfg.runtime == "local":
         if source_path is None:
             raise ValueError("local placement requires a local source path")
-        return SubprocessRuntime(_spawn_target(source_path))
+        docker = DockerRuntime()
+        subprocess = SubprocessRuntime(_spawn_target(source_path))
+
+        def local(task: Any) -> Any:
+            config = task.runtime_config
+            return (
+                docker(task)
+                if config is not None and (config.image is not None or config.compose is not None)
+                else subprocess(task)
+            )
+
+        return local
     if cfg.runtime == "hud":
         require_api_key("run HUD runtime tunnel evals")
         return HUDRuntime()
@@ -833,7 +846,7 @@ async def _run_evaluation(cfg: EvalConfig) -> Any:
         )
 
     agent = _build_agent(cfg)
-    placement = _resolve_placement(cfg, source_path if is_local else None)
+    placement = _resolve_placement(cfg, source_path if is_local else None, taskset)
 
     job = await taskset.run(
         agent,

--- a/hud/cli/tests/test_deploy.py
+++ b/hud/cli/tests/test_deploy.py
@@ -16,6 +16,20 @@ from hud.utils.hud_console import HUDConsole
 from hud.utils.platform import PlatformClient
 
 
+@pytest.mark.parametrize(("value", "expected"), [("HUD", "hud"), ("modal", "modal")])
+def test_normalize_runtime_uses_public_runtime_names(value: str, expected: str) -> None:
+    from hud.cli.deploy import _normalize_runtime
+
+    assert _normalize_runtime(value, HUDConsole()) == expected
+
+
+def test_normalize_runtime_rejects_internal_provider_name() -> None:
+    from hud.cli.deploy import _normalize_runtime
+
+    with pytest.raises(typer.Exit):
+        _normalize_runtime("ec2", HUDConsole())
+
+
 class TestResolveEnvironmentName:
     """Tests for code-authoritative environment name resolution."""
 
@@ -194,6 +208,44 @@ class TestCollectEnvironmentVariables:
 
 
 class TestRuntimeConfigFile:
+    @pytest.mark.parametrize("filename", ["compose.yaml", "compose.yml", "docker-compose.json"])
+    def test_prepare_deploy_uses_context_recipe(
+        self,
+        tmp_path: Path,
+        filename: str,
+    ) -> None:
+        from hud.cli.deploy import _prepare_deploy_plan
+
+        (tmp_path / "env.py").write_text(
+            'env = Environment("compose-env")\n',
+            encoding="utf-8",
+        )
+        (tmp_path / filename).write_text(
+            "services:\n  main:\n    build: ./main\n  redis:\n    image: redis:7\n",
+            encoding="utf-8",
+        )
+
+        plan = _prepare_deploy_plan(
+            EnvironmentSource.open(tmp_path),
+            env_dir=tmp_path,
+            env=None,
+            env_file=None,
+            no_env=True,
+            registry_id=None,
+            build_args=None,
+            build_secrets=None,
+            runtime=None,
+            runtime_config=None,
+            verbose=False,
+            platform=PlatformClient("https://api.example", "key"),
+            console=HUDConsole(),
+        )
+
+        assert plan.runtime_config is not None
+        payload = plan.runtime_config.request_payload()
+        assert payload["compose_project"] == {"compose_path": filename}
+        assert set(payload["compose"]["services"]) == {"main", "redis"}
+
     def test_load_runtime_config_uses_sdk_shape(self, tmp_path: Path) -> None:
         from hud.cli.deploy import _load_runtime_config
         from hud.utils.hud_console import HUDConsole
@@ -209,7 +261,9 @@ class TestRuntimeConfigFile:
             encoding="utf-8",
         )
 
-        assert _load_runtime_config(str(config_path), HUDConsole()) == {
+        config = _load_runtime_config(str(config_path), HUDConsole())
+        assert config is not None
+        assert config.request_payload() == {
             "resources": {"gpu": {"type": "A10G", "count": 2}},
             "limits": {"startup_timeout_s": 300},
         }
@@ -221,7 +275,29 @@ class TestRuntimeConfigFile:
         config_path = tmp_path / "runtime.json"
         config_path.write_text(json.dumps({"resources": None}), encoding="utf-8")
 
-        assert _load_runtime_config(str(config_path), HUDConsole()) == {"resources": None}
+        config = _load_runtime_config(str(config_path), HUDConsole())
+        assert config is not None
+        assert config.request_payload() == {"resources": None}
+
+    def test_load_runtime_config_resolves_compose_project_from_config_directory(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from hud.cli.deploy import _load_runtime_config
+
+        project = tmp_path / "project"
+        project.mkdir()
+        compose = project / "compose.json"
+        compose.write_text('{"services":{"main":{"image":"postgres:16"}}}')
+        config_path = tmp_path / "runtime.json"
+        config_path.write_text('{"compose":"project/compose.json","compose_project":"."}')
+
+        config = _load_runtime_config(str(config_path), HUDConsole())
+
+        assert config is not None
+        assert config.request_payload()["compose_project"] == {
+            "compose_path": "project/compose.json"
+        }
 
     def test_load_runtime_config_rejects_unknown_fields(self, tmp_path: Path) -> None:
         from hud.cli.deploy import _load_runtime_config
@@ -232,6 +308,37 @@ class TestRuntimeConfigFile:
 
         with pytest.raises(typer.Exit):
             _load_runtime_config(str(config_path), HUDConsole())
+
+    def test_prepare_deploy_rejects_image_config_for_compose_context(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from hud.cli.deploy import _prepare_deploy_plan
+
+        (tmp_path / "env.py").write_text(
+            'env = Environment("compose-env")\n',
+            encoding="utf-8",
+        )
+        (tmp_path / "compose.yaml").write_text("services:\n  main:\n    image: example\n")
+        runtime_config = tmp_path / "runtime.json"
+        runtime_config.write_text('{"image":"other:latest"}', encoding="utf-8")
+
+        with pytest.raises(typer.Exit):
+            _prepare_deploy_plan(
+                EnvironmentSource.open(tmp_path),
+                env_dir=tmp_path,
+                env=None,
+                env_file=None,
+                no_env=True,
+                registry_id=None,
+                build_args=None,
+                build_secrets=None,
+                runtime=None,
+                runtime_config=str(runtime_config),
+                verbose=False,
+                platform=PlatformClient("https://api.example", "key"),
+                console=HUDConsole(),
+            )
 
 
 class TestDeployEnvironment:
@@ -253,6 +360,33 @@ class TestDeployEnvironment:
             deploy_environment(directory=str(tmp_path))
 
         assert exc_info.value.exit_code == 1
+
+    def test_compose_recipe_does_not_require_a_dockerfile(self, tmp_path: Path) -> None:
+        from hud.cli.deploy import _compose_recipe
+
+        (tmp_path / "compose.yaml").write_text("services: {main: {image: alpine}}\n")
+
+        assert _compose_recipe(tmp_path) == tmp_path / "compose.yaml"
+
+    def test_compose_recipe_prefers_base_file_over_override(self, tmp_path: Path) -> None:
+        from hud.cli.deploy import _compose_recipe
+
+        base = tmp_path / "docker-compose.yml"
+        base.write_text("services: {main: {image: alpine}}\n")
+        (tmp_path / "docker-compose.override.yml").write_text(
+            "services: {main: {environment: {DEBUG: '1'}}}\n"
+        )
+
+        assert _compose_recipe(tmp_path) == base
+
+    def test_compose_recipe_ignores_override_without_base(self, tmp_path: Path) -> None:
+        from hud.cli.deploy import _compose_recipe
+
+        (tmp_path / "docker-compose.override.yml").write_text(
+            "services: {main: {environment: {DEBUG: '1'}}}\n"
+        )
+
+        assert _compose_recipe(tmp_path) is None
 
     def test_no_dockerfile_error(self, tmp_path: Path) -> None:
         """Test error when no Dockerfile found."""
@@ -358,90 +492,6 @@ class TestDeployAsync:
             )
 
         assert result.success is False
-
-    @pytest.mark.asyncio
-    async def test_trigger_build_sends_runtime_provider(self) -> None:
-        """Test deploy runtime flag maps to the platform runtime_provider field."""
-        from hud.cli.deploy import _DeployPlan, _trigger_build
-        from hud.utils.hud_console import HUDConsole
-        from hud.utils.platform import PlatformClient
-
-        class FakePlatform(PlatformClient):
-            payload: dict[str, object] | None = None
-
-            async def apost(
-                self,
-                path: str,
-                *,
-                json: object | None = None,
-            ) -> dict[str, object]:
-                assert path == "/builds/trigger"
-                assert isinstance(json, dict)
-                object.__setattr__(self, "payload", json)
-                return {"id": "build-1", "registry_id": "registry-1"}
-
-        platform = FakePlatform("https://api.example", "key")
-        result = await _trigger_build(
-            platform,
-            build_id="build-1",
-            plan=_DeployPlan(
-                name="test-env",
-                registry_id=None,
-                runtime="modal",
-                runtime_config=None,
-                env_vars={},
-                build_args={},
-                build_secrets={},
-            ),
-            no_cache=False,
-            console=HUDConsole(),
-        )
-
-        assert result == {"id": "build-1", "registry_id": "registry-1"}
-        assert platform.payload is not None
-        assert platform.payload["runtime_provider"] == "modal"
-
-    @pytest.mark.asyncio
-    async def test_trigger_build_sends_runtime_config(self) -> None:
-        from hud.cli.deploy import _DeployPlan, _trigger_build
-        from hud.utils.hud_console import HUDConsole
-        from hud.utils.platform import PlatformClient
-
-        class FakePlatform(PlatformClient):
-            payload: dict[str, object] | None = None
-
-            async def apost(
-                self,
-                path: str,
-                *,
-                json: object | None = None,
-            ) -> dict[str, object]:
-                assert path == "/builds/trigger"
-                assert isinstance(json, dict)
-                object.__setattr__(self, "payload", json)
-                return {"id": "build-1", "registry_id": "registry-1"}
-
-        runtime_config = {"resources": {"gpu": {"type": "A10G", "count": 1}}}
-        platform = FakePlatform("https://api.example", "key")
-        result = await _trigger_build(
-            platform,
-            build_id="build-1",
-            plan=_DeployPlan(
-                name="test-env",
-                registry_id=None,
-                runtime="modal",
-                runtime_config=runtime_config,
-                env_vars={},
-                build_args={},
-                build_secrets={},
-            ),
-            no_cache=False,
-            console=HUDConsole(),
-        )
-
-        assert result == {"id": "build-1", "registry_id": "registry-1"}
-        assert platform.payload is not None
-        assert platform.payload["runtime_config"] == runtime_config
 
 
 class TestSaveDeployLink:

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -130,7 +130,7 @@ def test_resolve_placement_runtime_hud_uses_tunnel(
 
     monkeypatch.setattr(settings, "api_key", "sk-hud-test")
 
-    placement = eval_mod._resolve_placement(EvalConfig(runtime="hud"), tmp_path)
+    placement = eval_mod._resolve_placement(EvalConfig(runtime="hud"), tmp_path, [])
 
     assert isinstance(placement, HUDRuntime)
 
@@ -144,9 +144,36 @@ def test_resolve_placement_remote_uses_hosted_runtime(
 
     monkeypatch.setattr(settings, "api_key", "sk-hud-test")
 
-    placement = eval_mod._resolve_placement(EvalConfig(remote=True), tmp_path)
+    placement = eval_mod._resolve_placement(EvalConfig(remote=True), tmp_path, [])
 
     assert isinstance(placement, HostedRuntime)
+
+
+def test_resolve_placement_routes_each_local_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hud.eval as eval_api
+    from hud.eval import RuntimeConfig, Task
+
+    docker = lambda task: ("docker", task)
+    subprocess = lambda task: ("subprocess", task)
+    monkeypatch.setattr(eval_api, "DockerRuntime", lambda: docker)
+    monkeypatch.setattr(eval_api, "SubprocessRuntime", lambda _path: subprocess)
+
+    placement = eval_mod._resolve_placement(
+        EvalConfig(runtime="local"),
+        tmp_path,
+        [
+            Task(env="source", id="run"),
+            Task(env="image", id="run", runtime_config=RuntimeConfig(image="example:latest")),
+        ],
+    )
+
+    source = Task(env="source", id="run")
+    image = Task(env="image", id="run", runtime_config=RuntimeConfig(image="example:latest"))
+    assert placement(source) == ("subprocess", source)
+    assert placement(image) == ("docker", image)
 
 
 def test_runtime_cli_override_clears_config_remote() -> None:

--- a/hud/cli/utils/context.py
+++ b/hud/cli/utils/context.py
@@ -1,4 +1,4 @@
-"""Build context tarball creation for direct deploys."""
+"""Build context tarball creation for the deploy command."""
 
 from __future__ import annotations
 

--- a/hud/cli/utils/tests/test_context.py
+++ b/hud/cli/utils/tests/test_context.py
@@ -1,4 +1,4 @@
-"""``hud.cli.utils.context`` — build-context tarball + ignore-pattern matching."""
+"""Deploy build-context tarball and ignore-pattern tests."""
 
 from __future__ import annotations
 

--- a/hud/eval/compose.py
+++ b/hud/eval/compose.py
@@ -2,53 +2,22 @@
 
 from __future__ import annotations
 
+import contextlib
+import json
+import posixpath
+import re
 import shlex
-from collections.abc import Awaitable, Callable
+import tarfile
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, ConfigDict, Field
-
-DockerCommand = Callable[..., Awaitable[tuple[str, str]]]
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
-
-class ImageConfig(BaseModel):
-    """OCI image defaults that Compose applies when service fields are unset."""
-
-    model_config = ConfigDict(extra="ignore", populate_by_name=True)
-
-    user: str | None = Field(default=None, alias="User")
-    working_dir: str | None = Field(default=None, alias="WorkingDir")
-    entrypoint: list[str] | None = Field(default=None, alias="Entrypoint")
-    command: list[str] | None = Field(default=None, alias="Cmd")
-    environment: list[str] = Field(default_factory=list, alias="Env")
-    exposed_ports: dict[str, Any] = Field(default_factory=dict, alias="ExposedPorts")
-
-    @classmethod
-    async def inspect(cls, image: str, docker: DockerCommand) -> ImageConfig:
-        output, _ = await docker("image", "inspect", "--format", "{{json .Config}}", image)
-        return cls.model_validate_json(output)
-
-    @classmethod
-    async def inspect_registry(
-        cls,
-        image: str,
-        docker: DockerCommand,
-        *,
-        platform: str = "linux/amd64",
-    ) -> ImageConfig:
-        template = f'{{{{json (index .Image "{platform}").Config}}}}'
-        output, _ = await docker(
-            "buildx",
-            "imagetools",
-            "inspect",
-            "--format",
-            template,
-            image,
-        )
-        return cls.model_validate_json(output)
+    from collections.abc import Iterator, Mapping
 
 
 class ComposeHealthcheck(BaseModel):
@@ -87,22 +56,69 @@ class ComposeService(BaseModel):
     ports: list[ComposePort] = Field(default_factory=list)
     volumes: list[str | dict[str, Any]] = Field(default_factory=list)
 
-    def with_image(self, image: str, config: ImageConfig) -> ComposeService:
-        entrypoint = (config.entrypoint or []) if self.entrypoint is None else self.entrypoint
-        if self.command is not None:
-            command = self.command
-        elif self.entrypoint is not None:
-            command = []
-        else:
-            command = config.command or []
-        return self.model_copy(
-            update={
-                "image": image,
-                "entrypoint": entrypoint,
-                "command": command,
-                "working_dir": self.working_dir or config.working_dir or "/",
+    @field_validator("environment", mode="before")
+    @classmethod
+    def normalize_environment(cls, value: Any) -> Any:
+        if isinstance(value, list):
+            environment: dict[str, str] = {}
+            for item in value:
+                if not isinstance(item, str) or "=" not in item:
+                    raise ValueError("Compose environment entries must use KEY=VALUE")
+                key, _, item_value = item.partition("=")
+                environment[key] = item_value
+            return environment
+        if isinstance(value, dict):
+            if any(item is None for item in value.values()):
+                raise ValueError("Compose environment values cannot come from the host")
+            return {
+                key: str(item).lower() if isinstance(item, bool) else str(item)
+                for key, item in value.items()
             }
-        )
+        return value
+
+    @field_validator("entrypoint", "command", mode="before")
+    @classmethod
+    def normalize_command(cls, value: Any) -> Any:
+        return shlex.split(value) if isinstance(value, str) else value
+
+    @field_validator("expose", mode="before")
+    @classmethod
+    def normalize_expose(cls, value: Any) -> Any:
+        return [str(port) for port in value] if isinstance(value, list) else value
+
+    @field_validator("ports", mode="before")
+    @classmethod
+    def normalize_ports(cls, value: Any) -> Any:
+        if not isinstance(value, list):
+            return value
+        ports: list[Any] = []
+        for item in value:
+            if isinstance(item, int):
+                ports.append({"target": item})
+                continue
+            if not isinstance(item, str):
+                ports.append(item)
+                continue
+            address, separator, protocol = item.partition("/")
+            if separator and protocol not in {"tcp", "udp"}:
+                raise ValueError(f"unsupported Compose port protocol {protocol!r}")
+            parts = address.rsplit(":", 2)
+            target = parts[-1]
+            if "-" in target or not target.isdigit():
+                raise ValueError(f"unsupported Compose port syntax {item!r}")
+            port: dict[str, Any] = {"target": int(target)}
+            if separator:
+                port["protocol"] = protocol
+            if len(parts) >= 2:
+                published = parts[-2]
+                if published and ("-" in published or not published.isdigit()):
+                    raise ValueError(f"unsupported Compose port syntax {item!r}")
+                if published:
+                    port["published"] = int(published)
+            if len(parts) == 3:
+                port["host_ip"] = parts[0]
+            ports.append(port)
+        return ports
 
     @property
     def argv(self) -> list[str]:
@@ -127,46 +143,233 @@ class ComposeConfig(BaseModel):
     networks: dict[str, dict[str, Any] | None] = Field(default_factory=dict)
 
     @classmethod
-    async def load(
-        cls,
-        *files: Path,
-        docker: DockerCommand,
-        project_directory: Path | None = None,
-        project_name: str | None = None,
-    ) -> ComposeConfig:
-        if not files:
-            raise ValueError("ComposeConfig.load requires at least one file")
-        command = ["compose"]
-        if project_name is not None:
-            command.extend(("--project-name", project_name))
-        if project_directory is not None:
-            command.extend(("--project-directory", str(project_directory)))
-        for file in files:
-            command.extend(("--file", str(file)))
-        output, _ = await docker(*command, "config", "--format", "json")
-        return cls.model_validate_json(output)
+    def from_file(cls, path: Path) -> ComposeConfig:
+        """Load a self-contained authored Compose document without Docker."""
+        source = path.read_text(encoding="utf-8")
+        if re.search(r"(?<!\$)\$(?:\{|[A-Za-z_])", source):
+            raise ValueError("remote adaptation does not support Compose interpolation")
+        raw = yaml.safe_load(source)
+        if not isinstance(raw, dict):
+            raise ValueError(f"{path.name} is not a Compose document")
+        document = raw
+        services = document.get("services")
+        if "include" in document or (
+            isinstance(services, dict)
+            and any(
+                isinstance(service, dict) and "extends" in service for service in services.values()
+            )
+        ):
+            raise ValueError("remote adaptation does not support Compose include or extends")
+        return cls.model_validate(document)
 
-    async def resolve_registry_images(
+    def with_project_directory(self, directory: str) -> ComposeConfig:
+        """Relocate local Compose paths beneath an artifact directory."""
+        prefix = posixpath.normpath(directory)
+        if prefix == ".." or prefix.startswith(("/", "../")):
+            raise ValueError("Compose project directory must stay inside the artifact")
+
+        def relocate(path: str) -> str:
+            if path.startswith("/") or "://" in path:
+                raise ValueError(f"Compose path {path!r} is outside the artifact")
+            source = posixpath.normpath(path)
+            if source == ".." or source.startswith("../"):
+                raise ValueError(f"Compose path {path!r} escapes its project directory")
+            resolved = posixpath.normpath(posixpath.join(prefix, source))
+            if resolved == ".." or resolved.startswith("../"):
+                raise ValueError(f"Compose path {path!r} escapes the artifact")
+            return f"./{resolved.removeprefix('./')}"
+
+        document = self.model_dump(mode="json", exclude_none=True)
+        services = document["services"]
+        assert isinstance(services, dict)
+        for raw_service in services.values():
+            assert isinstance(raw_service, dict)
+            build = raw_service.get("build")
+            if isinstance(build, str):
+                raw_service["build"] = relocate(build)
+            elif isinstance(build, dict):
+                context = build.get("context", ".")
+                if not isinstance(context, str):
+                    raise ValueError("Compose build context must be a path")
+                build["context"] = relocate(context)
+                additional_contexts = build.get("additional_contexts")
+                if isinstance(additional_contexts, dict):
+                    build["additional_contexts"] = {
+                        name: (
+                            value
+                            if not isinstance(value, str) or value.startswith("service:")
+                            else relocate(value)
+                        )
+                        for name, value in additional_contexts.items()
+                    }
+                elif additional_contexts is not None:
+                    raise ValueError("Compose additional_contexts must be a mapping")
+
+            for field in ("env_file", "label_file"):
+                files = raw_service.get(field)
+                if isinstance(files, str):
+                    raw_service[field] = relocate(files)
+                elif isinstance(files, list):
+                    raw_service[field] = [
+                        ({**item, "path": relocate(item["path"])})
+                        if isinstance(item, dict) and isinstance(item.get("path"), str)
+                        else relocate(item)
+                        if isinstance(item, str)
+                        else item
+                        for item in files
+                    ]
+
+            volumes = raw_service.get("volumes")
+            if isinstance(volumes, list):
+                relocated_volumes: list[Any] = []
+                for volume in volumes:
+                    if isinstance(volume, str):
+                        source, separator, target = volume.partition(":")
+                        if separator:
+                            if source.startswith("/"):
+                                raise ValueError(
+                                    f"Compose bind mount {source!r} is outside the artifact"
+                                )
+                            if source.startswith("."):
+                                volume = f"{relocate(source)}:{target}"
+                    elif isinstance(volume, dict) and volume.get("type") == "bind":
+                        source = volume.get("source")
+                        if isinstance(source, str):
+                            volume = {**volume, "source": relocate(source)}
+                    relocated_volumes.append(volume)
+                raw_service["volumes"] = relocated_volumes
+
+        for field in ("configs", "secrets"):
+            resources = document.get(field)
+            if isinstance(resources, dict):
+                for resource in resources.values():
+                    if isinstance(resource, dict) and isinstance(resource.get("file"), str):
+                        resource["file"] = relocate(resource["file"])
+        return ComposeConfig.model_validate(document)
+
+
+class ComposeProjectRef(BaseModel):
+    """Platform reference to a Compose file within an uploaded project."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    compose_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class ComposeSource:
+    """One authored or platform-wire Compose runtime source."""
+
+    document: Path | ComposeConfig
+    project: Path | ComposeProjectRef | None = None
+
+    def request_payload(self) -> dict[str, Any]:
+        if isinstance(self.document, Path):
+            document = ComposeConfig.from_file(self.document)
+        else:
+            document = self.document
+        payload: dict[str, Any] = {
+            "compose": document.model_dump(mode="json", exclude_none=True),
+        }
+        if isinstance(self.project, Path):
+            if not isinstance(self.document, Path):
+                raise ValueError("compose_project as a path requires compose as a path")
+            try:
+                compose_path = (
+                    self.document.resolve().relative_to(self.project.resolve()).as_posix()
+                )
+            except ValueError:
+                raise ValueError("runtime_config.compose must be inside compose_project") from None
+            payload["compose_project"] = {"compose_path": compose_path}
+        elif self.project is not None:
+            payload["compose_project"] = self.project.model_dump(mode="json")
+        return payload
+
+    def runnable_path(self, provider: str) -> Path:
+        if not isinstance(self.document, Path):
+            raise ValueError(f"{provider} requires runtime_config.compose as a local file path")
+        return self.document.resolve()
+
+
+@dataclass(frozen=True, slots=True)
+class ComposeLaunchFiles:
+    compose: Path
+    override: Path
+    ports: Path
+    archive: Path | None
+
+
+@dataclass(frozen=True, slots=True)
+class ComposeProject:
+    """A local Compose project staged with HUD's main-service overrides."""
+
+    compose: Path
+
+    @contextlib.contextmanager
+    def stage(
         self,
-        docker: DockerCommand,
+        published_port: str,
         *,
-        platform: str = "linux/amd64",
-    ) -> ComposeConfig:
-        images: dict[str, ImageConfig] = {}
-        services: dict[str, ComposeService] = {}
-        for name, service in self.services.items():
-            if service.image is None:
-                raise ValueError(f"Compose service {name!r} requires an image")
-            if service.entrypoint is None or service.command is None or service.working_dir is None:
-                if service.image not in images:
-                    images[service.image] = await ImageConfig.inspect_registry(
-                        service.image,
-                        docker,
-                        platform=platform,
-                    )
-                service = service.with_image(service.image, images[service.image])
-            services[name] = service
-        return self.model_copy(update={"services": services})
+        seccomp: str | Path,
+        service_socket: str | None = None,
+        env_vars: Mapping[str, str] | None = None,
+        cpu: float | None = None,
+        memory_mb: int | None = None,
+        gpu_count: int | None = None,
+        archive: bool = False,
+    ) -> Iterator[ComposeLaunchFiles]:
+        main: dict[str, Any] = {
+            "security_opt": [f"seccomp={seccomp}", "systempaths=unconfined"],
+        }
+        if service_socket is not None:
+            main["volumes"] = [
+                {
+                    "type": "bind",
+                    "source": service_socket,
+                    "target": "/media/hud/docker.sock",
+                }
+            ]
+        if env_vars:
+            main["environment"] = dict(env_vars)
+        if cpu is not None:
+            main["cpus"] = cpu
+        if memory_mb is not None:
+            main["mem_limit"] = f"{memory_mb}m"
+        if gpu_count is not None:
+            main["gpus"] = gpu_count
+
+        with tempfile.TemporaryDirectory(prefix="hud-compose-") as directory:
+            root = Path(directory)
+            override = root / "override.json"
+            override.write_text(
+                json.dumps({"services": {"main": main}}),
+                encoding="utf-8",
+            )
+            ports = root / "ports.yaml"
+            ports.write_text(
+                f'services:\n  main:\n    ports: !override ["{published_port}"]\n',
+                encoding="utf-8",
+            )
+            archive_path = None
+            if archive:
+                archive_path = root / "project.tar.gz"
+                with tarfile.open(archive_path, "w:gz") as tar:
+                    for entry in self.compose.parent.iterdir():
+                        tar.add(entry, arcname=entry.name)
+            yield ComposeLaunchFiles(
+                compose=self.compose,
+                override=override,
+                ports=ports,
+                archive=archive_path,
+            )
 
 
-__all__ = ["ComposeConfig", "ComposeHealthcheck", "ComposePort", "ComposeService", "ImageConfig"]
+__all__ = [
+    "ComposeConfig",
+    "ComposeHealthcheck",
+    "ComposePort",
+    "ComposeProject",
+    "ComposeProjectRef",
+    "ComposeService",
+    "ComposeSource",
+]

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -34,13 +34,10 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import importlib
-import json
 import logging
 import os
 import shlex
 import sys
-import tarfile
-import tempfile
 import uuid
 from collections import deque
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
@@ -58,6 +55,7 @@ from hud.utils.docker import docker as _docker
 from hud.utils.platform import PlatformClient
 from hud.utils.process import ProcessGroup, create_process_group_exec
 
+from .compose import ComposeConfig, ComposeProject, ComposeProjectRef, ComposeSource
 from .run import Grade, Run, rollout
 
 if TYPE_CHECKING:
@@ -78,7 +76,26 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hud.eval.runtime")
 
-_COMPOSE_SERVICE_SOCKET = "/media/hud/docker.sock"
+_MODAL_COMPOSE_CPU = 4.0
+_MODAL_COMPOSE_MEMORY_MB = 8192
+
+
+async def _prepare_compose_project(compose: Path) -> bool:
+    script = compose.parent / "build.sh"
+    if not script.is_file():
+        return False
+    process = await create_process_group_exec(
+        "sh",
+        str(script),
+        cwd=str(compose.parent),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    result = await process.complete()
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).decode("utf-8", "replace").strip()
+        raise RuntimeError(f"Compose project build failed: {detail}")
+    return True
 
 
 class RuntimeGPU(BaseModel):
@@ -114,12 +131,18 @@ class RuntimeConfig(BaseModel):
 
     ``Task.runtime_config`` is requested construction input. ``Runtime.config``
     is the effective config used to construct a runtime.
+
+    ``compose`` and ``compose_project`` are authored as local paths; platform
+    task records carry them as the serialized compose document and a
+    :class:`ComposeProjectRef`. Both forms validate; only the path form is
+    runnable by local providers.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     image: str | None = Field(default=None, min_length=1)
-    compose: Path | None = None
+    compose: Path | ComposeConfig | None = None
+    compose_project: Path | ComposeProjectRef | None = None
     compose_service_access: bool | None = None
     resources: RuntimeResources | None = None
     limits: RuntimeLimits | None = None
@@ -128,6 +151,8 @@ class RuntimeConfig(BaseModel):
     def validate_source(self) -> Self:
         if self.image is not None and self.compose is not None:
             raise ValueError("runtime_config accepts either image or compose, not both")
+        if self.compose_project is not None and self.compose is None:
+            raise ValueError("compose_project requires runtime_config.compose")
         if self.compose_service_access and self.compose is None:
             raise ValueError("compose_service_access requires runtime_config.compose")
         return self
@@ -139,13 +164,25 @@ class RuntimeConfig(BaseModel):
         changes = override.model_dump(exclude_unset=True)
         if override.image is not None:
             config["compose"] = None
+            config["compose_project"] = None
             config["compose_service_access"] = None
         elif override.compose is not None:
             config["image"] = None
+            config["compose_project"] = None
         return RuntimeConfig.model_validate(config | changes)
 
     def request_payload(self) -> dict[str, Any]:
-        return self.model_dump(mode="json", exclude_unset=True)
+        payload = self.model_dump(mode="json", exclude_unset=True)
+        source = self.compose_source()
+        if source is not None:
+            payload.update(source.request_payload())
+        return payload
+
+    def compose_source(self) -> ComposeSource | None:
+        """The authored or wire-form Compose source, when configured."""
+        if self.compose is None:
+            return None
+        return ComposeSource(self.compose, self.compose_project)
 
 
 class Provider(Protocol):
@@ -261,64 +298,6 @@ _DOCKER_SECURITY_ARGS = (
     "--security-opt",
     "systempaths=unconfined",
 )
-
-
-def _docker_compose_main(
-    published_port: str,
-    resources: RuntimeResources | None,
-    *,
-    seccomp: str | Path = _DOCKER_SECCOMP_PROFILE,
-    service_socket: str | None = None,
-) -> dict[str, Any]:
-    main: dict[str, Any] = {
-        "ports": [published_port],
-        "security_opt": [f"seccomp={seccomp}", "systempaths=unconfined"],
-    }
-    if service_socket is not None:
-        main["volumes"] = [
-            {
-                "type": "bind",
-                "source": service_socket,
-                "target": _COMPOSE_SERVICE_SOCKET,
-            }
-        ]
-    if resources is None:
-        return main
-    if resources.cpu is not None:
-        main["cpus"] = resources.cpu
-    if resources.memory_mb is not None:
-        main["mem_limit"] = f"{resources.memory_mb}m"
-    if resources.gpu is not None:
-        main["gpus"] = resources.gpu.count
-    return main
-
-
-def _compose_overrides(directory: Path, main: dict[str, Any]) -> tuple[Path, Path]:
-    main = dict(main)
-    (published_port,) = main.pop("ports")
-    override = directory / "override.json"
-    override.write_text(json.dumps({"services": {"main": main}}), encoding="utf-8")
-    ports = directory / "ports.yaml"
-    ports.write_text(
-        f'services:\n  main:\n    ports: !override ["{published_port}"]\n',
-        encoding="utf-8",
-    )
-    return override, ports
-
-
-@contextlib.contextmanager
-def _compose_payload(
-    compose: Path,
-    main: dict[str, Any],
-) -> Iterator[tuple[Path, Path, Path]]:
-    with tempfile.TemporaryDirectory(prefix="hud-compose-") as directory:
-        root = Path(directory)
-        archive = root / "project.tar.gz"
-        with tarfile.open(archive, "w:gz") as tar:
-            for entry in compose.parent.iterdir():
-                tar.add(entry, arcname=entry.name)
-        override, ports = _compose_overrides(root, main)
-        yield archive, override, ports
 
 
 class LocalRuntime:
@@ -612,16 +591,18 @@ class DockerRuntime:
         if runtime_config is not None:
             config = config.with_overrides(RuntimeConfig.model_validate(runtime_config))
         self.runtime_config = config if config.model_dump(exclude_none=True) else None
+        self._compose_preparation_locks: dict[Path, asyncio.Lock] = {}
 
     @asynccontextmanager
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
         if config.limits is not None and config.limits.model_dump(exclude_none=True):
             raise ValueError("DockerRuntime does not support runtime_config limits")
-        if config.compose is not None:
+        compose_source = config.compose_source()
+        if compose_source is not None:
             if self.run_args:
                 raise ValueError("DockerRuntime run_args apply only to image environments")
-            compose = config.compose.resolve()
+            compose = compose_source.runnable_path("DockerRuntime")
             resources = config.resources
             if (
                 resources is not None
@@ -647,27 +628,42 @@ class DockerRuntime:
                         f"Docker endpoint, got {endpoint!r}"
                     )
                 service_socket = parsed.path
-            main = _docker_compose_main(
-                f"127.0.0.1::{self.port}",
-                resources,
-                service_socket=service_socket,
-            )
+            project_files = ComposeProject(compose)
             project = f"hud-{uuid.uuid4().hex[:12]}"
-            with tempfile.TemporaryDirectory(prefix="hud-compose-") as directory:
-                override, ports = _compose_overrides(Path(directory), main)
+            lock = self._compose_preparation_locks.setdefault(compose, asyncio.Lock())
+            async with lock:
+                prepared = await _prepare_compose_project(compose)
+            with project_files.stage(
+                f"127.0.0.1::{self.port}",
+                seccomp=_DOCKER_SECCOMP_PROFILE,
+                service_socket=service_socket,
+                cpu=resources.cpu if resources is not None else None,
+                memory_mb=resources.memory_mb if resources is not None else None,
+                gpu_count=(
+                    resources.gpu.count
+                    if resources is not None and resources.gpu is not None
+                    else None
+                ),
+            ) as files:
                 command = (
                     "compose",
                     "--project-name",
                     project,
                     "--file",
-                    str(compose),
+                    str(files.compose),
                     "--file",
-                    str(override),
+                    str(files.override),
                     "--file",
-                    str(ports),
+                    str(files.ports),
                 )
                 try:
-                    await _docker(*command, "up", "--detach", "--build", "--remove-orphans")
+                    await _docker(
+                        *command,
+                        "up",
+                        "--detach",
+                        "--no-build" if prepared else "--build",
+                        "--remove-orphans",
+                    )
                     mapping, _ = await _docker(*command, "port", "main", str(self.port))
                     if not mapping.strip():
                         logs_out, logs_err = await _docker(
@@ -800,7 +796,10 @@ class ModalRuntime:
     @asynccontextmanager
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
-        compose = config.compose.resolve() if config.compose is not None else None
+        compose_source = config.compose_source()
+        compose = (
+            compose_source.runnable_path("ModalRuntime") if compose_source is not None else None
+        )
         modal = cast("ModalModule", importlib.import_module("modal"))
 
         app = None
@@ -826,7 +825,7 @@ class ModalRuntime:
                         await self._image.build.aio(app=app)
                         self._resolved = self._image
             image = self._resolved
-        if self.env_vars:
+        if self.env_vars and compose is None:
             image = image.env(self.env_vars)
 
         if app is None:
@@ -834,10 +833,24 @@ class ModalRuntime:
 
         sandbox_kwargs: dict[str, Any] = {}
         resources = config.resources
-        if resources is not None and resources.cpu is not None:
-            sandbox_kwargs["cpu"] = resources.cpu
-        if resources is not None and resources.memory_mb is not None:
-            sandbox_kwargs["memory"] = resources.memory_mb
+        if compose is not None:
+            sandbox_kwargs["cpu"] = max(
+                resources.cpu if resources is not None and resources.cpu is not None else 0,
+                _MODAL_COMPOSE_CPU,
+            )
+            sandbox_kwargs["memory"] = max(
+                (
+                    resources.memory_mb
+                    if resources is not None and resources.memory_mb is not None
+                    else 0
+                ),
+                _MODAL_COMPOSE_MEMORY_MB,
+            )
+        else:
+            if resources is not None and resources.cpu is not None:
+                sandbox_kwargs["cpu"] = resources.cpu
+            if resources is not None and resources.memory_mb is not None:
+                sandbox_kwargs["memory"] = resources.memory_mb
         if resources is not None and resources.gpu is not None:
             gpu_type = resources.gpu.type or "any"
             gpu = gpu_type if resources.gpu.count == 1 else f"{gpu_type}:{resources.gpu.count}"
@@ -865,22 +878,27 @@ class ModalRuntime:
             if compose is None:
                 await sb.wait_until_ready.aio(timeout=ready_timeout)
             else:
-                main = _docker_compose_main(
+                project = ComposeProject(compose)
+                with project.stage(
                     f"{self.port}:{self.port}",
-                    resources,
                     seccomp="/hud/docker-seccomp.json",
                     service_socket=(
                         "/var/run/docker.sock" if config.compose_service_access else None
                     ),
-                )
-                with _compose_payload(compose, main) as (
-                    archive,
-                    override,
-                    ports,
-                ):
-                    await sb.filesystem.copy_from_local.aio(archive, "/hud/project.tar.gz")
-                    await sb.filesystem.copy_from_local.aio(override, "/hud/override.json")
-                    await sb.filesystem.copy_from_local.aio(ports, "/hud/ports.yaml")
+                    env_vars=self.env_vars,
+                    cpu=resources.cpu if resources is not None else None,
+                    memory_mb=resources.memory_mb if resources is not None else None,
+                    gpu_count=(
+                        resources.gpu.count
+                        if resources is not None and resources.gpu is not None
+                        else None
+                    ),
+                    archive=True,
+                ) as files:
+                    assert files.archive is not None
+                    await sb.filesystem.copy_from_local.aio(files.archive, "/hud/project.tar.gz")
+                    await sb.filesystem.copy_from_local.aio(files.override, "/hud/override.json")
+                    await sb.filesystem.copy_from_local.aio(files.ports, "/hud/ports.yaml")
                     await sb.filesystem.copy_from_local.aio(
                         _DOCKER_SECCOMP_PROFILE, "/hud/docker-seccomp.json"
                     )
@@ -888,10 +906,13 @@ class ModalRuntime:
                     "mkdir -p /hud/project && "
                     "tar -xzf /hud/project.tar.gz -C /hud/project && "
                     "until docker info >/dev/null 2>&1; do sleep 1; done && "
+                    "BUILD_FLAG=--build && "
+                    "if [ -f /hud/project/build.sh ]; then "
+                    "sh /hud/project/build.sh && BUILD_FLAG=--no-build; fi && "
                     "docker compose --project-directory /hud/project "
                     f"--file /hud/project/{shlex.quote(compose.name)} "
                     "--file /hud/override.json --file /hud/ports.yaml "
-                    "up --detach --build --remove-orphans"
+                    'up --detach "$BUILD_FLAG" --remove-orphans'
                 )
                 process = await sb.exec.aio("sh", "-c", command, timeout=ready_timeout)
                 if await process.wait.aio() != 0:

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -22,7 +22,7 @@ from typing import Any
 import pytest
 
 import hud.eval.runtime as runtime_module
-from hud.eval.compose import ComposeHealthcheck, ComposeService, ImageConfig
+from hud.eval.compose import ComposeConfig, ComposeHealthcheck, ComposeService
 from hud.eval.runtime import (
     DaytonaRuntime,
     DockerRuntime,
@@ -594,6 +594,7 @@ def test_runtime_config_overrides_only_explicit_top_level_fields() -> None:
 
 def test_runtime_config_source_override_is_mutually_exclusive(tmp_path: Path) -> None:
     compose = tmp_path / "compose.yaml"
+    replacement = tmp_path / "replacement.yaml"
 
     assert RuntimeConfig(image="img:default").with_overrides(
         RuntimeConfig(compose=compose)
@@ -601,6 +602,9 @@ def test_runtime_config_source_override_is_mutually_exclusive(tmp_path: Path) ->
     assert RuntimeConfig(compose=compose).with_overrides(
         RuntimeConfig(image="img:task")
     ) == RuntimeConfig(image="img:task")
+    assert RuntimeConfig(compose=compose, compose_project=tmp_path).with_overrides(
+        RuntimeConfig(compose=replacement)
+    ) == RuntimeConfig(compose=replacement)
 
 
 async def test_runtime_config_rejects_unsupported_docker_fields() -> None:
@@ -644,13 +648,18 @@ async def test_docker_runtime_starts_compose_with_a_main_service_override(
         "services:\n  main:\n    image: hud-env:one\n  db:\n    image: postgres:17\n",
         encoding="utf-8",
     )
+    marker = tmp_path / "prepared"
+    (tmp_path / "build.sh").write_text(
+        f"#!/bin/sh\nprintf prepared > {marker}\n",
+        encoding="utf-8",
+    )
 
     async def fake_docker(*args: str, **_kwargs: Any) -> tuple[str, str]:
         nonlocal port_override
         calls.append(args)
         if args[:2] == ("context", "inspect"):
             return "unix:///Users/test/.docker/run/docker.sock\n", ""
-        if args[-4:] == ("up", "--detach", "--build", "--remove-orphans"):
+        if args[-4:] == ("up", "--detach", "--no-build", "--remove-orphans"):
             files = [Path(args[index + 1]) for index, value in enumerate(args) if value == "--file"]
             _, override, ports = files
             rendered.update(json.loads(override.read_text("utf-8")))
@@ -674,6 +683,7 @@ async def test_docker_runtime_starts_compose_with_a_main_service_override(
         assert runtime.url == "tcp://127.0.0.1:43210"
         assert runtime.config == task.runtime_config
 
+    assert marker.read_text("utf-8") == "prepared"
     assert rendered["services"]["main"] == {
         "security_opt": [
             f"seccomp={runtime_module._DOCKER_SECCOMP_PROFILE}",
@@ -691,10 +701,46 @@ async def test_docker_runtime_starts_compose_with_a_main_service_override(
     }
     assert 'ports: !override ["127.0.0.1::8765"]' in port_override
     up = next(
-        call for call in calls if call[-4:] == ("up", "--detach", "--build", "--remove-orphans")
+        call for call in calls if call[-4:] == ("up", "--detach", "--no-build", "--remove-orphans")
     )
     assert str(compose.resolve()) in up
     assert calls[-1][-3:] == ("down", "--volumes", "--remove-orphans")
+
+
+async def test_docker_runtime_serializes_shared_compose_preparation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
+    active = 0
+    peak = 0
+
+    async def prepare(_compose: Path) -> bool:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return True
+
+    async def fake_docker(*args: str, **_kwargs: Any) -> tuple[str, str]:
+        if args[-3:] == ("port", "main", "8765"):
+            return "127.0.0.1:43210\n", ""
+        return "", ""
+
+    monkeypatch.setattr(runtime_module, "_prepare_compose_project", prepare)
+    monkeypatch.setattr(runtime_module, "_docker", fake_docker)
+    task = Task(env="any-env", id="t", runtime_config=RuntimeConfig(compose=compose))
+    provider = DockerRuntime()
+
+    async def acquire() -> None:
+        async with provider(task):
+            pass
+
+    await asyncio.gather(acquire(), acquire())
+
+    assert peak == 1
 
 
 async def test_docker_runtime_rejects_remote_compose_service_access(
@@ -799,7 +845,8 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
 
     async with ModalRuntime(
-        runtime_config=RuntimeConfig(compose=compose, compose_service_access=True)
+        runtime_config=RuntimeConfig(compose=compose, compose_service_access=True),
+        env_vars={"HUD_API_KEY": "secret"},
     )(_row()) as runtime:
         assert runtime.url == "tcp://modal.host:4567"
 
@@ -808,6 +855,9 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     assert isinstance(kwargs, dict)
     assert kwargs["experimental_options"] == {"vm_runtime": True}
     assert kwargs["readiness_probe"] is None
+    assert kwargs["cpu"] == 4
+    assert kwargs["memory"] == 8192
+    assert kwargs["image"] == _ModalImageRef("registry", "docker:28.3.3-dind")
     assert calls["uploads"] == [
         ("project.tar.gz", "/hud/project.tar.gz"),
         ("override.json", "/hud/override.json"),
@@ -823,10 +873,12 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
             "target": "/media/hud/docker.sock",
         }
     ]
+    assert override["services"]["main"]["environment"] == {"HUD_API_KEY": "secret"}
     execs = calls["execs"]
     assert isinstance(execs, list)
     assert "docker compose" in execs[0][0][-1]
-    assert "up --detach --build --remove-orphans" in execs[0][0][-1]
+    assert "sh /hud/project/build.sh" in execs[0][0][-1]
+    assert 'up --detach "$BUILD_FLAG" --remove-orphans' in execs[0][0][-1]
     assert "down" in execs[1][0]
 
 
@@ -997,22 +1049,120 @@ async def test_daytona_runtime_rejects_compose(
     assert client.created == []
 
 
-def test_compose_service_applies_image_defaults_once() -> None:
-    image = ImageConfig(
-        Entrypoint=["docker-entrypoint.sh"],
-        Cmd=["redis-server"],
-        WorkingDir="/data",
+def test_compose_config_normalizes_supported_short_syntax(tmp_path: Path) -> None:
+    compose = tmp_path / "compose.yaml"
+    compose.write_text(
+        """
+services:
+  main:
+    image: example:latest
+    environment:
+      - FIRST=one
+      - EMPTY=
+    entrypoint: /bin/start --flag
+    command: serve --port 8000
+    expose: [8000]
+    ports:
+      - 8000
+      - 127.0.0.1:8080:80/tcp
+""",
+        encoding="utf-8",
     )
 
-    inherited = ComposeService(image="redis:7").with_image("redis:7", image)
-    assert inherited.argv == ["docker-entrypoint.sh", "redis-server"]
-    assert inherited.working_dir == "/data"
+    service = ComposeConfig.from_file(compose).services["main"]
 
-    overridden = ComposeService(
-        image="redis:7",
-        entrypoint=["custom-entrypoint"],
-    ).with_image("redis:7", image)
-    assert overridden.argv == ["custom-entrypoint"]
+    assert service.environment == {"FIRST": "one", "EMPTY": ""}
+    assert service.entrypoint == ["/bin/start", "--flag"]
+    assert service.command == ["serve", "--port", "8000"]
+    assert service.expose == ["8000"]
+    assert [port.model_dump(exclude_none=True) for port in service.ports] == [
+        {"target": 8000, "protocol": "tcp"},
+        {
+            "target": 80,
+            "protocol": "tcp",
+            "published": 8080,
+            "host_ip": "127.0.0.1",
+        },
+    ]
+
+    mapped = ComposeService.model_validate({"environment": {"COUNT": 2, "ENABLED": True}})
+    assert mapped.environment == {"COUNT": "2", "ENABLED": "true"}
+
+
+@pytest.mark.parametrize(
+    "service",
+    [
+        "command: echo $VALUE",
+        "extends: {file: base.yaml, service: base}",
+    ],
+)
+def test_compose_config_rejects_external_resolution(tmp_path: Path, service: str) -> None:
+    compose = tmp_path / "compose.yaml"
+    compose.write_text(f"services:\n  main:\n    {service}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not support Compose"):
+        ComposeConfig.from_file(compose)
+
+
+def test_compose_config_relocates_project_paths() -> None:
+    compose = ComposeConfig.model_validate(
+        {
+            "services": {
+                "main": {
+                    "build": {
+                        "context": ".",
+                        "additional_contexts": {
+                            "fixture": "./fixture",
+                            "base": "service:base",
+                        },
+                    },
+                    "env_file": [".env", {"path": "./optional.env", "required": False}],
+                    "label_file": "./labels",
+                    "volumes": [
+                        "./data:/data:ro",
+                        "cache:/cache",
+                        {"type": "bind", "source": "./config", "target": "/config"},
+                    ],
+                },
+                "base": {"image": "alpine"},
+            },
+            "configs": {"settings": {"file": "./settings.json"}},
+            "secrets": {"token": {"file": "./token"}},
+        }
+    )
+
+    relocated = compose.with_project_directory("./environment").model_dump(
+        mode="json", exclude_none=True
+    )
+    main = relocated["services"]["main"]
+
+    assert main["build"] == {
+        "context": "./environment",
+        "additional_contexts": {
+            "fixture": "./environment/fixture",
+            "base": "service:base",
+        },
+    }
+    assert main["env_file"] == [
+        "./environment/.env",
+        {"path": "./environment/optional.env", "required": False},
+    ]
+    assert main["label_file"] == "./environment/labels"
+    assert main["volumes"] == [
+        "./environment/data:/data:ro",
+        "cache:/cache",
+        {"type": "bind", "source": "./environment/config", "target": "/config"},
+    ]
+    assert relocated["configs"] == {"settings": {"file": "./environment/settings.json"}}
+    assert relocated["secrets"] == {"token": {"file": "./environment/token"}}
+
+
+@pytest.mark.parametrize("path", ["../data", "./nested/../../data"])
+def test_compose_config_rejects_paths_outside_project(path: str) -> None:
+    compose = ComposeConfig.model_validate({"services": {"main": {"volumes": [f"{path}:/data"]}}})
+
+    with pytest.raises(ValueError, match="escapes its project directory"):
+        compose.with_project_directory("./environment")
 
 
 def test_compose_healthcheck_does_not_invent_duration_values() -> None:

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -12,6 +12,7 @@ Run the caller gets back, and the dispatch.
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
@@ -34,6 +35,8 @@ from hud.eval.runtime import (
 from hud.eval.task import Task
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from hud.agents.base import Agent
 from hud.settings import settings
 from hud.telemetry.context import set_trace_context
@@ -254,6 +257,45 @@ async def test_run_preserves_runtime_config_null_override(
     )
 
     assert platform.posts[0][1]["runtime_config"] == {"resources": None}
+
+
+@pytest.mark.asyncio
+async def test_run_submits_compose_document(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compose = tmp_path / "compose.json"
+    compose.write_text(
+        json.dumps(
+            {
+                "services": {
+                    "main": {"image": "ghcr.io/hud-evals/harbor-main:latest"},
+                    "database": {"image": "postgres:16"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    platform = _FakePlatform([{"status": "completed", "reward": 0.5}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+
+    await HostedRuntime(poll_interval=0.0).run(
+        Task(
+            env="harbor",
+            id="solve",
+            runtime_config=RuntimeConfig(compose=compose, compose_service_access=True),
+        ),
+        _agent(),
+        job_id=uuid.uuid4().hex,
+        trace_id=uuid.uuid4().hex,
+    )
+
+    runtime_config = platform.posts[0][1]["runtime_config"]
+    assert runtime_config["compose"]["services"]["database"]["image"] == "postgres:16"
+    assert runtime_config["compose_service_access"] is True
+    assert str(compose) not in json.dumps(runtime_config)
 
 
 @pytest.mark.asyncio

--- a/hud/eval/tests/test_sync.py
+++ b/hud/eval/tests/test_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
 
 from hud.eval import Task, Taskset
@@ -16,6 +17,8 @@ from hud.eval.sync import (
 from hud.utils.platform import PlatformClient
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
 
 
@@ -150,6 +153,32 @@ def test_task_upload_payload_includes_runtime_config() -> None:
     payload = task_upload_payload(task)
 
     assert payload["runtime_config"] == {"image": "img:tag"}
+
+
+def test_task_upload_payload_embeds_compose_document(tmp_path: Path) -> None:
+    compose = tmp_path / "compose.json"
+    compose.write_text(
+        json.dumps(
+            {
+                "services": {
+                    "main": {"image": "registry.example/hud-main:latest"},
+                    "database": {"image": "postgres:16"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    task = Task(
+        env="e",
+        id="solve",
+        runtime_config=RuntimeConfig(compose=compose, compose_service_access=True),
+    )
+
+    payload = task_upload_payload(task)
+
+    assert payload["runtime_config"]["compose"]["services"]["database"]["image"] == "postgres:16"
+    assert payload["runtime_config"]["compose_service_access"] is True
+    assert str(compose) not in json.dumps(payload)
 
 
 def test_task_upload_payload_preserves_runtime_config_null_override() -> None:

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -24,6 +24,7 @@ from hud.eval import (
     Task,
     Taskset,
 )
+from hud.eval.compose import ComposeConfig, ComposeProjectRef
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -194,14 +195,75 @@ def test_runtime_config_rejects_unknown_fields() -> None:
 
 
 def test_compose_runtime_config_serializes_as_task_data(tmp_path: Path) -> None:
-    compose = tmp_path / "compose.yaml"
+    compose = tmp_path / "compose.json"
+    compose.write_text(
+        json.dumps({"services": {"main": {"image": "hud-env:latest"}}}),
+        encoding="utf-8",
+    )
     config = RuntimeConfig(compose=compose)
     task = Task(env="database", id="cutover", runtime_config=config)
 
     rebuilt = Task.model_validate(task.model_dump())
 
     assert rebuilt.runtime_config == config
-    assert config.request_payload() == {"compose": str(compose)}
+    assert config.request_payload() == {
+        "compose": {
+            "services": {
+                "main": {
+                    "image": "hud-env:latest",
+                    "environment": {},
+                    "expose": [],
+                    "ports": [],
+                    "volumes": [],
+                }
+            },
+            "networks": {},
+        }
+    }
+
+
+def test_compose_project_serializes_document_location_not_author_path(tmp_path: Path) -> None:
+    project = tmp_path / "artifact"
+    project.mkdir()
+    compose = project / "compose-project" / "compose.json"
+    compose.parent.mkdir()
+    compose.write_text(
+        json.dumps(
+            {
+                "services": {
+                    "main": {
+                        "image": "hud-harbor:local",
+                        "build": {"context": "./main"},
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    payload = RuntimeConfig(compose=compose, compose_project=project).request_payload()
+
+    assert payload["compose_project"] == {"compose_path": "compose-project/compose.json"}
+    assert str(tmp_path) not in json.dumps(payload)
+
+
+def test_compose_runtime_config_round_trips_platform_records() -> None:
+    record = {
+        "compose": {
+            "services": {"main": {"image": "hud-harbor:local"}},
+            "networks": {},
+        },
+        "compose_project": {"compose_path": "compose-project/compose.json"},
+    }
+
+    config = RuntimeConfig.model_validate(record)
+
+    assert isinstance(config.compose, ComposeConfig)
+    assert isinstance(config.compose_project, ComposeProjectRef)
+    payload = config.request_payload()
+    assert payload["compose"]["services"]["main"]["image"] == "hud-harbor:local"
+    assert payload["compose_project"] == {"compose_path": "compose-project/compose.json"}
+    assert RuntimeConfig.model_validate(payload) == config
 
 
 def test_row_validation_rejects_malformed_entries() -> None:

--- a/hud/integrations/harbor/Dockerfile
+++ b/hud/integrations/harbor/Dockerfile
@@ -8,8 +8,7 @@ FROM ${BASE_IMAGE} AS runtime
 USER root
 ARG HUD_REQUIREMENT=hud
 COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /media/hud/bin/uv
-COPY env.py install.sh tasks.json /media/hud/
-COPY tasks /media/hud/tasks
+COPY env.py install.sh config.json image-config.json verifier-image-config.json /media/hud/
 COPY packages /media/hud/packages
 RUN sh /media/hud/install.sh "${HUD_REQUIREMENT}"
 

--- a/hud/integrations/harbor/__init__.py
+++ b/hud/integrations/harbor/__init__.py
@@ -1,6 +1,7 @@
 """Experimental Harbor task interop.
 
-``adapt()`` builds Harbor task directories as runnable HUD tasksets.
+``adapt()`` packages Harbor task directories as runnable HUD tasksets and
+self-contained Compose projects for the selected runtime to build.
 ``export()`` writes HUD tasks back to Harbor directories.
 
 This API may change between minor releases while the integration is experimental.

--- a/hud/integrations/harbor/adapt.py
+++ b/hud/integrations/harbor/adapt.py
@@ -1,8 +1,7 @@
-"""Build Harbor task directories as runnable HUD environments."""
+"""Adapt Harbor task directories into runnable HUD environments."""
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 import logging
@@ -10,9 +9,7 @@ import os
 import re
 import shlex
 import shutil
-import tempfile
 import tomllib
-import uuid
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Literal, cast
@@ -22,9 +19,8 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_valida
 from hud.capabilities import Capability
 from hud.environment.egress import BRIDGE_PORT, VISITOR_PORT
 from hud.eval import Task, Taskset
-from hud.eval.compose import ComposeConfig, ComposeHealthcheck, ComposeService, ImageConfig
+from hud.eval.compose import ComposeConfig, ComposeHealthcheck, ComposeService
 from hud.eval.runtime import RuntimeConfig, RuntimeGPU, RuntimeResources
-from hud.utils.docker import docker
 from hud.utils.naming import normalize_environment_name
 
 LOGGER = logging.getLogger(__name__)
@@ -138,7 +134,6 @@ class MCPServerConfig(BaseModel):
 class EnvironmentConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    build_timeout_sec: float = Field(default=600.0, gt=0)
     docker_image: str | None = None
     os: str = "linux"
     cpus: float | None = Field(default=None, gt=0)
@@ -198,18 +193,29 @@ class TaskConfig(BaseModel):
 class HarborTask:
     path: Path
     config: TaskConfig
+    instruction: str
     environment_hash: str
     compose: ComposeConfig | None
 
 
-async def adapt(
+def _tree_hash(root: Path) -> str:
+    digest = hashlib.sha256()
+    for entry in sorted(root.rglob("*")):
+        relative_path = entry.relative_to(root).as_posix().encode()
+        if entry.is_symlink():
+            digest.update(relative_path + b"\0symlink\0" + os.readlink(entry).encode())
+        elif entry.is_file():
+            digest.update(relative_path + b"\0" + entry.read_bytes())
+    return digest.hexdigest()[:16]
+
+
+def adapt(
     path: str | Path,
     *,
-    push: str | None = None,
     hud_requirement: str = "hud",
 ) -> Taskset:
-    """Build a runnable HUD image for each distinct Harbor environment."""
-    root = await asyncio.to_thread(Path(path).resolve)
+    """Package Harbor tasks as buildable Compose projects."""
+    root = Path(path).resolve()
     if (root / "task.toml").is_file():
         task_dirs = [root]
         dataset = root.parent
@@ -232,7 +238,6 @@ async def adapt(
             raise ValueError(
                 f"{task_dir.name}/task.toml is not a valid Harbor task: {error}"
             ) from error
-
         unsupported = []
         if config.environment.os != "linux":
             unsupported.append(f"os={config.environment.os!r}")
@@ -290,55 +295,44 @@ async def adapt(
         )
         compose = None
         if authored_compose is not None:
-            with tempfile.TemporaryDirectory(prefix="hud-harbor-compose-") as directory:
-                base_compose = Path(directory) / "base.json"
-                base_compose.write_text(json.dumps({"services": {"main": {"image": "hud-main"}}}))
-                try:
-                    compose = await ComposeConfig.load(
-                        base_compose,
-                        authored_compose,
-                        docker=docker,
-                        project_name="hud",
-                        project_directory=environment_dir,
-                    )
-                    compose.services["main"]
-                except (ValidationError, KeyError) as error:
-                    raise ValueError(
-                        f"{task_dir.name} did not resolve to a Compose project"
-                    ) from error
+            try:
+                compose = ComposeConfig.from_file(authored_compose)
+                compose.services["main"]
+            except (ValidationError, KeyError) as error:
+                raise ValueError(f"{task_dir.name} did not resolve to a Compose project") from error
             compose.name = None
-            if "default" in compose.networks and compose.networks["default"] == {
-                "name": "hud_default"
-            }:
-                compose.networks["default"] = {}
 
-        environment_digest = hashlib.sha256()
-        if environment_dir.exists():
-            for entry in sorted(environment_dir.rglob("*")):
-                relative_path = entry.relative_to(environment_dir).as_posix().encode()
-                if entry.is_symlink():
-                    environment_digest.update(
-                        relative_path + b"\0symlink\0" + os.readlink(entry).encode()
-                    )
-                elif entry.is_file():
-                    environment_digest.update(relative_path + b"\0" + entry.read_bytes())
-            environment_hash = environment_digest.hexdigest()[:16]
-        else:
-            environment_hash = "missing"
+        instruction = task_dir / "instruction.md"
+        if not instruction.is_file():
+            raise FileNotFoundError(f"{task_dir.name} has no instruction.md")
 
         tasks.append(
             HarborTask(
                 path=task_dir,
                 config=config,
-                environment_hash=environment_hash,
+                instruction=instruction.read_text("utf-8"),
+                environment_hash=_tree_hash(environment_dir)
+                if environment_dir.exists()
+                else "missing",
                 compose=compose,
             )
         )
 
     grouped: dict[tuple[str, str, str], list[HarborTask]] = {}
     for task in tasks:
+        group_config = task.config.model_dump(
+            mode="json",
+            exclude={
+                "task": True,
+                "metadata": True,
+                "steps": True,
+                "artifacts": True,
+                "agent": {"timeout_sec"},
+                "verifier": {"timeout_sec", "collect"},
+            },
+        )
         config_json = json.dumps(
-            task.config.model_dump(mode="json", exclude={"task", "metadata", "steps"}),
+            group_config,
             sort_keys=True,
         )
         grouped.setdefault(
@@ -353,80 +347,59 @@ async def adapt(
     rows = []
     base_name = normalize_environment_name(dataset.name, default="harbor")
     for group_key, group in sorted(grouped.items()):
-        environment_hash, config_json, _ = group_key
         digest = hashlib.sha256("\0".join(group_key).encode()).hexdigest()[:12]
         name = f"{base_name}-{digest}"
         source = group[0]
         environment = source.config.environment
         compose = source.compose.model_copy(deep=True) if source.compose is not None else None
+        compose_project = (
+            compose.with_project_directory("./environment") if compose is not None else None
+        )
         compose_main = compose.services["main"] if compose is not None else ComposeService()
         dockerfile = source.path / "environment" / "Dockerfile"
-        compose_image = compose_main.image
-        base_image = environment.docker_image or (
-            compose_image if compose_image != "hud-main" else None
-        )
-        build_timeout = max(task.config.environment.build_timeout_sec for task in group)
-        if compose_main.build is not None and environment.docker_image is None:
-            assert compose is not None
-            base_image = f"hud-harbor-base:{source.environment_hash}"
-            compose.services["main"] = compose_main.model_copy(update={"image": base_image})
-            with tempfile.TemporaryDirectory(prefix="hud-harbor-main-") as directory:
-                compose_file = Path(directory) / "compose.json"
-                compose_file.write_text(
-                    compose.model_dump_json(exclude_none=True),
-                    encoding="utf-8",
+        base_image = environment.docker_image or compose_main.image
+        if compose is not None:
+            build = compose_main.build
+            if build is not None:
+                build_config = {"context": build} if isinstance(build, str) else build
+                build_context = build_config.get("context", ".")
+                build_dockerfile = build_config.get("dockerfile", "Dockerfile")
+                if not isinstance(build_context, str) or not isinstance(build_dockerfile, str):
+                    raise ValueError("Compose main build paths must be strings")
+                dockerfile = (
+                    source.path / "environment" / build_context / build_dockerfile
+                ).resolve()
+                try:
+                    dockerfile.relative_to((source.path / "environment").resolve())
+                except ValueError:
+                    raise ValueError("Compose main build escapes environment") from None
+            if dockerfile.is_file():
+                base_image = f"hud-harbor-base:{source.environment_hash}"
+            elif build is not None:
+                raise FileNotFoundError(
+                    f"{source.path.name} Compose main Dockerfile does not exist"
                 )
-                await docker(
-                    "compose",
-                    "--file",
-                    str(compose_file),
-                    "build",
-                    "main",
-                    deadline=build_timeout,
+            elif base_image is None:
+                raise FileNotFoundError(
+                    f"{source.path.name} Compose main has neither image nor build"
                 )
-        elif base_image and not dockerfile.is_file():
-            await docker("pull", base_image)
         elif dockerfile.is_file():
             base_image = f"hud-harbor-base:{source.environment_hash}"
-            await docker(
-                "build",
-                "--tag",
-                base_image,
-                str(dockerfile.parent),
-                deadline=build_timeout,
+        elif base_image is None:
+            raise FileNotFoundError(
+                f"{source.path.name} has neither environment/Dockerfile nor docker_image"
             )
-        else:
-            raise FileNotFoundError(f"{source.path.name} has no environment/Dockerfile")
 
-        image_config = await ImageConfig.inspect(base_image, docker)
         separate = source.config.verifier.separate
         verifier_environment = source.config.verifier.environment or EnvironmentConfig()
         verifier_image = base_image
-        verifier_config = image_config
         if separate:
             verifier_dockerfile = source.path / "tests" / "Dockerfile"
             if not verifier_dockerfile.is_file():
                 raise FileNotFoundError(
                     f"{source.path.name} uses a separate verifier but has no tests/Dockerfile"
                 )
-            verifier_digest = hashlib.sha256()
-            for entry in sorted(verifier_dockerfile.parent.rglob("*")):
-                relative_path = entry.relative_to(verifier_dockerfile.parent).as_posix().encode()
-                if entry.is_symlink():
-                    verifier_digest.update(
-                        relative_path + b"\0symlink\0" + os.readlink(entry).encode()
-                    )
-                elif entry.is_file():
-                    verifier_digest.update(relative_path + b"\0" + entry.read_bytes())
-            verifier_image = f"hud-harbor-verifier:{name}-{verifier_digest.hexdigest()[:16]}"
-            await docker(
-                "build",
-                "--tag",
-                verifier_image,
-                str(verifier_dockerfile.parent),
-                deadline=verifier_environment.build_timeout_sec,
-            )
-            verifier_config = await ImageConfig.inspect(verifier_image, docker)
+            verifier_image = f"hud-harbor-verifier:{name}-{_tree_hash(verifier_dockerfile.parent)}"
 
         peers = []
         if compose is not None:
@@ -441,87 +414,44 @@ async def adapt(
                 ports.update(
                     published.target for published in service.ports if published.protocol == "tcp"
                 )
-                source_image = service.image
-                if service.build is not None:
-                    source_image = f"hud-harbor-sidecar-build:{uuid.uuid4().hex}"
-                    compose.services[service_name] = service.model_copy(
-                        update={"image": source_image}
-                    )
-                    with tempfile.TemporaryDirectory(prefix="hud-harbor-sidecar-") as directory:
-                        compose_file = Path(directory) / "compose.json"
-                        compose_file.write_text(
-                            compose.model_dump_json(exclude_none=True),
-                            encoding="utf-8",
-                        )
-                        await docker("compose", "--file", str(compose_file), "build", service_name)
-                elif source_image:
-                    await docker("pull", source_image)
-                else:
+                if service.build is None and service.image is None:
                     raise ValueError(
                         f"Compose service {service_name!r} has neither image nor build"
                     )
-                sidecar_config = await ImageConfig.inspect(source_image, docker)
-                if not ports:
-                    for value in sidecar_config.exposed_ports:
-                        port, separator, protocol = value.partition("/")
-                        if port.isdigit() and separator and protocol == "tcp":
-                            ports.add(int(port))
                 if len(ports) > 1:
                     raise NotImplementedError(
                         f"Compose service {service_name!r} exposes multiple ports; "
                         "Peer names one endpoint"
                     )
                 if not ports:
-                    raise ValueError(
-                        f"Compose service {service_name!r} declares no TCP port in Compose "
-                        "or its image"
-                    )
+                    raise ValueError(f"Compose service {service_name!r} declares no TCP port")
                 peers.append({"name": service_name, "port": next(iter(ports))})
-                image_id, _ = await docker("image", "inspect", "--format", "{{.Id}}", source_image)
-                fingerprint = image_id.strip().removeprefix("sha256:")[:16]
-                component = normalize_environment_name(f"{name}-{service_name}", default="sidecar")
-                sidecar_image = (
-                    f"{push}/{component}:{fingerprint}"
-                    if push
-                    else f"hud-harbor-sidecar:{component}-{fingerprint}"
-                )
-                await docker("tag", source_image, sidecar_image)
-                if push:
-                    await docker("push", sidecar_image)
-                compose.services[service_name] = service.with_image(
-                    sidecar_image,
-                    sidecar_config,
-                ).model_copy(update={"build": None})
         context = dataset / ".hud-adapt" / name
         if context.exists():
             shutil.rmtree(context)
-        (context / "tasks").mkdir(parents=True)
-        (context / "packages").mkdir()
-        for asset in ("Dockerfile", "install.sh"):
-            shutil.copy2(ASSETS / asset, context / asset)
+        project = context / "compose-project"
+        payload = project / ("main" if compose is not None else "hud")
+        (payload / "packages").mkdir(parents=True)
+        shutil.copy2(ASSETS / "install.sh", payload / "install.sh")
+        if compose is not None:
+            shutil.copy2(ASSETS / "Dockerfile", payload / "Dockerfile")
         # ``hud deploy`` resolves the context's identity from a literal
         # Environment(...) name in source, so the copy carries the group's
-        # name as a literal; the value is the same one tasks.json serves.
+        # name as a literal; the value is the same one config.json serves.
         served = (ASSETS / "env.py").read_text("utf-8")
         sentinel = 'Environment(CONFIG["name"])'
         if sentinel not in served:
             raise RuntimeError(f"env.py asset no longer constructs {sentinel}")
-        (context / "env.py").write_text(
-            served.replace(sentinel, f'Environment("{name}")'),
-            encoding="utf-8",
-            newline="\n",
-        )
+        served = served.replace(sentinel, f'Environment("{name}")')
+        for target in (context / "env.py", payload / "env.py"):
+            target.write_text(served, encoding="utf-8", newline="\n")
 
-        workdir = environment.workdir or compose_main.working_dir or image_config.working_dir or "/"
-        if Path(workdir).is_relative_to(HUD_ROOT):
+        workdir = environment.workdir or compose_main.working_dir
+        if workdir is not None and Path(workdir).is_relative_to(HUD_ROOT):
             raise ValueError(f"Harbor workdir {workdir!r} is inside reserved path {HUD_ROOT}")
-        image_env = {}
-        for entry in image_config.environment:
-            key, _, value = entry.partition("=")
-            image_env[key] = value
         ports = {
             int(port)
-            for exposed in (*image_config.exposed_ports, *compose_main.expose)
+            for exposed in compose_main.expose
             if (port := str(exposed).partition("/")[0]).isdigit()
         }
         ports.update(
@@ -534,11 +464,6 @@ async def adapt(
         healthcheck = environment.healthcheck
         if healthcheck is None and compose_main.healthcheck is not None:
             healthcheck = HealthcheckConfig.from_compose(compose_main.healthcheck)
-        verifier_env = {
-            key: value
-            for entry in verifier_config.environment
-            for key, _, value in (entry.partition("="),)
-        }
         verifier_phase = source.config.verifier
         verifier_policy = verifier_phase.model_dump(
             include={"user", "network_mode", "allowed_hosts", "env"}
@@ -554,21 +479,15 @@ async def adapt(
         manifest = {
             "name": name,
             "workdir": workdir,
-            "image_user": (
-                compose_main.user if compose_main.user is not None else image_config.user or None
-            ),
-            "image_env": image_env,
-            "entrypoint": (
-                compose_main.entrypoint
-                if compose is not None and compose_main.entrypoint is not None
-                else image_config.entrypoint or []
-            ),
+            "image_user": compose_main.user,
+            "image_env": {},
+            "entrypoint": compose_main.entrypoint if compose is not None else None,
             "ports": sorted(ports),
             "verifier_root": str(HUD_ROOT / "verifier") if separate else None,
             "verifier_image": {
-                "user": verifier_config.user or None,
-                "workdir": verifier_environment.workdir or verifier_config.working_dir or "/",
-                "env": verifier_env,
+                "user": None,
+                "workdir": verifier_environment.workdir,
+                "env": {},
             },
             "environment": {
                 "env": {
@@ -591,73 +510,150 @@ async def adapt(
                 ).to_manifest()
                 for server in environment.mcp_servers
             ],
-            "local_aliases": ["main"] if compose is not None else [],
+            "local_aliases": ["main"],
             "peers": peers,
-            "tasks": [],
         }
-        for task in group:
-            if not (task.path / "instruction.md").is_file():
-                raise FileNotFoundError(f"{task.path.name} has no instruction.md")
-            target = context / "tasks" / task.path.name
-            target.mkdir()
-            shutil.copy2(task.path / "instruction.md", target / "instruction.md")
-            task_separate = task.config.verifier.separate
-            if not task_separate:
-                shutil.copytree(
-                    task.path / "tests",
-                    target / "tests",
-                    symlinks=True,
-                    ignore=IGNORED,
-                )
-            manifest["tasks"].append(
-                {
-                    "id": task.path.name,
-                    "description": task.config.task.description,
-                    "verifier_timeout": task.config.verifier.timeout_sec or 600.0,
-                    "separate_verifier": task_separate,
-                    "collect": [hook.model_dump() for hook in task.config.verifier.collect],
-                    "artifacts": [artifact.model_dump() for artifact in task.config.artifacts],
-                }
-            )
-        (context / "tasks.json").write_text(
+        (payload / "config.json").write_text(
             json.dumps(manifest, indent=2, sort_keys=True) + "\n",
             encoding="utf-8",
         )
 
         wheel = Path(hud_requirement)
         requirement = hud_requirement
-        if wheel.suffix == ".whl" and await asyncio.to_thread(wheel.is_file):
-            shutil.copy2(wheel, context / "packages" / wheel.name)
+        if wheel.suffix == ".whl" and wheel.is_file():
+            shutil.copy2(wheel, payload / "packages" / wheel.name)
             requirement = f"{HUD_ROOT}/packages/{wheel.name}"
 
-        context_digest = hashlib.sha256()
-        for entry in sorted(context.rglob("*")):
-            relative_path = entry.relative_to(context).as_posix().encode()
-            if entry.is_symlink():
-                context_digest.update(relative_path + b"\0symlink\0" + os.readlink(entry).encode())
-            elif entry.is_file():
-                context_digest.update(relative_path + b"\0" + entry.read_bytes())
-        tag = context_digest.hexdigest()[:16]
-        image = f"{push}/{name}:{tag}" if push else f"hud-harbor:{name}-{tag}"
-        await docker(
-            "build",
-            "--target",
-            "verifier" if separate else "plain",
-            "--build-arg",
-            f"BASE_IMAGE={base_image}",
-            "--build-arg",
-            f"VERIFIER_IMAGE={verifier_image}",
-            "--build-arg",
-            f"HUD_REQUIREMENT={requirement}",
-            "--tag",
-            image,
-            str(context),
-        )
-        if push:
-            await docker("push", image)
+        tag = _tree_hash(payload)
+        image = f"hud-harbor:{name}-{tag}"
+        runtime_command = [
+            "/media/hud/venv/bin/hud",
+            "serve",
+            "/media/hud/env.py",
+            "--host",
+            "0.0.0.0",  # noqa: S104 - container control channel
+            "--port",
+            "8765",
+        ]
+        base_target: str | None = None
+        base_build: str | dict[str, Any] | None = None
+        if compose is None:
+            project_environment = project / "environment"
+            source_environment = source.path / "environment"
+            if source_environment.is_dir():
+                shutil.copytree(source_environment, project_environment, symlinks=True)
+            else:
+                project_environment.mkdir(parents=True)
+            dockerfile_source = (
+                dockerfile.read_bytes().decode("utf-8")
+                if dockerfile.is_file()
+                else f"FROM {base_image} AS hud-base\n"
+            )
+
+            lines = dockerfile_source.splitlines(keepends=True)
+            stages: list[tuple[int, re.Match[str]]] = []
+            from_pattern = re.compile(
+                r"^(?P<from>\s*FROM\s+(?:--platform=\S+\s+)?\S+)"
+                r"(?P<alias>\s+AS\s+(?P<name>[A-Za-z0-9_.-]+))?"
+                r"(?P<suffix>\s*(?:#.*)?)$",
+                re.IGNORECASE,
+            )
+            for index, raw_line in enumerate(lines):
+                line = raw_line.rstrip("\r\n")
+                if not re.match(r"^\s*FROM\b", line, re.IGNORECASE):
+                    continue
+                match = from_pattern.fullmatch(line)
+                if match is None:
+                    raise ValueError(
+                        f"{source.path.name} environment/Dockerfile has an unsupported "
+                        "multi-line FROM instruction"
+                    )
+                stages.append((index, match))
+            if not stages:
+                raise ValueError(f"{source.path.name} environment/Dockerfile has no FROM stage")
+            stage_names = {
+                match.group("name").lower()
+                for _, match in stages
+                if match.group("name") is not None
+            }
+            reserved_names = {"hud-base", "hud-runtime"}
+            if separate:
+                reserved_names.update({"hud-docker-cli", "hud-verifier", "hud-verifier-root"})
+            reserved = reserved_names & stage_names if dockerfile.is_file() else set()
+            if reserved:
+                raise ValueError(
+                    f"{source.path.name} environment/Dockerfile uses reserved stage "
+                    f"{min(reserved)!r}"
+                )
+            final_index, final = stages[-1]
+            base_stage = final.group("name")
+            if base_stage is None:
+                ending = lines[final_index][len(lines[final_index].rstrip("\r\n")) :]
+                lines[final_index] = (
+                    f"{final.group('from')} AS hud-base{final.group('suffix')}{ending}"
+                )
+                base_stage = "hud-base"
+            base_target = base_stage
+            combined = "".join(lines)
+            if combined and not combined.endswith("\n"):
+                combined += "\n"
+            verifier_stages = (
+                "\nFROM hud-verifier AS hud-verifier-root\n"
+                "FROM docker:28.3.3-cli AS hud-docker-cli\n"
+                if separate
+                else ""
+            )
+            verifier_copies = (
+                "COPY --from=hud-docker-cli /usr/local/bin/docker /media/hud/bin/docker\n"
+                "COPY --from=hud-verifier-root / /media/hud/verifier\n"
+                if separate
+                else ""
+            )
+            combined += f"""{verifier_stages}
+FROM {base_stage} AS hud-runtime
+
+USER root
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /media/hud/bin/uv
+COPY --from=hud env.py install.sh config.json image-config.json /media/hud/
+COPY --from=hud verifier-image-config.json /media/hud/
+COPY --from=hud packages /media/hud/packages
+RUN sh /media/hud/install.sh {shlex.quote(requirement)}
+{verifier_copies}
+ENV HUD_SKIP_VERSION_CHECK=1
+EXPOSE 8765
+ENTRYPOINT []
+CMD ["/media/hud/venv/bin/hud", "serve", "/media/hud/env.py", "--host", "0.0.0.0", "--port", "8765"]
+"""
+            (project / "Dockerfile").write_bytes(combined.encode("utf-8"))
+
+            main_build: dict[str, Any] = {
+                "context": "./environment",
+                # dockerfile resolves relative to the context; additional
+                # context paths resolve relative to the project directory.
+                "dockerfile": "../Dockerfile",
+                "additional_contexts": {"hud": "./hud"},
+            }
+            services: dict[str, ComposeService] = {}
+            if separate:
+                shutil.copytree(source.path / "tests", project / "verifier", symlinks=True)
+                services["hud-verifier"] = ComposeService(
+                    image=verifier_image,
+                    build={"context": "./verifier"},
+                ).model_copy(update={"scale": 0})
+                main_build["additional_contexts"]["hud-verifier"] = "service:hud-verifier"
+            runtime_main = ComposeService(
+                image=image,
+                build=main_build,
+                entrypoint=[],
+                command=runtime_command,
+            )
+            services["main"] = runtime_main
+            compose_project = ComposeConfig(services=services)
 
         if compose is not None:
-            main = compose.services["main"].model_copy(
+            assert compose_project is not None
+            authored_main = compose_project.services["main"]
+            main = authored_main.model_copy(
                 update={
                     "build": None,
                     "command": None,
@@ -667,23 +663,154 @@ async def adapt(
                     "healthcheck": None,
                 }
             )
-            compose.services["main"] = main.with_image(
-                image,
-                await ImageConfig.inspect(image, docker),
-            )
-            (context / "compose.json").write_text(
-                json.dumps(
-                    compose.model_dump(mode="json", exclude_none=True),
-                    indent=2,
-                    sort_keys=True,
-                )
-                + "\n",
-                encoding="utf-8",
+            runtime_main = main.model_copy(
+                update={
+                    "image": image,
+                    "entrypoint": [],
+                    "command": runtime_command,
+                }
             )
 
+            source_environment = source.path / "environment"
+            project_environment = project / "environment"
+            shutil.copytree(source_environment, project_environment, symlinks=True)
+            if "hud-base" in compose_project.services or "hud-verifier" in compose_project.services:
+                raise ValueError("Compose service names 'hud-base' and 'hud-verifier' are reserved")
+            base_build = authored_main.build
+            if base_build is None and dockerfile.is_file():
+                base_build = {"context": "./environment"}
+            if base_build is not None:
+                # scale: 0 keeps build-only services in the Compose model so
+                # service: additional contexts resolve, without starting them.
+                compose_project.services["hud-base"] = ComposeService(
+                    image=base_image,
+                    build=base_build,
+                ).model_copy(update={"scale": 0})
+            elif base_image is None:
+                raise ValueError("Compose main service requires an image or build")
+
+            additional_contexts: dict[str, str] = {}
+            if base_build is not None:
+                additional_contexts["hud-base"] = "service:hud-base"
+            if separate:
+                shutil.copytree(source.path / "tests", project / "verifier", symlinks=True)
+                compose_project.services["hud-verifier"] = ComposeService(
+                    image=verifier_image,
+                    build={"context": "./verifier"},
+                ).model_copy(update={"scale": 0})
+                additional_contexts["hud-verifier"] = "service:hud-verifier"
+
+            wrapper_build: dict[str, Any] = {
+                "context": "./main",
+                "target": "verifier" if separate else "plain",
+                "args": {
+                    "BASE_IMAGE": "hud-base" if base_build is not None else base_image,
+                    "VERIFIER_IMAGE": "hud-verifier" if separate else base_image,
+                    "HUD_REQUIREMENT": requirement,
+                },
+            }
+            if additional_contexts:
+                wrapper_build["additional_contexts"] = additional_contexts
+            compose_project.services["main"] = runtime_main.model_copy(
+                update={"build": wrapper_build}
+            )
+
+        assert compose_project is not None
+        if not separate:
+            tests_root = project / "tests"
+            tests_root.mkdir()
+            for task in group:
+                shutil.copytree(
+                    task.path / "tests",
+                    tests_root / task.path.name,
+                    symlinks=True,
+                    ignore=IGNORED,
+                )
+            main = compose_project.services["main"]
+            compose_project.services["main"] = main.model_copy(
+                update={"volumes": [*main.volumes, "./tests:/media/hud/tests:ro"]}
+            )
+        project_compose = context / "compose-project" / "compose.json"
+        project_compose.write_text(
+            json.dumps(
+                compose_project.model_dump(mode="json", exclude_none=True),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        assert base_image is not None
+        compose_command = (
+            'docker compose --project-directory "$PROJECT" --file "$PROJECT/compose.json"'
+        )
+        if compose is not None and base_build is not None:
+            prepare_base = f"{compose_command} build hud-base"
+        elif compose is None and dockerfile.is_file():
+            assert base_target is not None
+            prepare_base = (
+                f"docker build --target {shlex.quote(base_target)} "
+                f'--tag {shlex.quote(base_image)} --file "$PROJECT/Dockerfile" '
+                '"$PROJECT/environment"'
+            )
+        else:
+            prepare_base = f"docker pull {shlex.quote(base_image)}"
+        image_config_path = f'"$PROJECT/{payload.name}/image-config.json"'
+        verifier_config_path = f'"$PROJECT/{payload.name}/verifier-image-config.json"'
+        prepare_verifier = (
+            f"{compose_command} build hud-verifier"
+            if separate
+            else f"cp {image_config_path} {verifier_config_path}"
+        )
+        inspect_verifier = (
+            f"inspect_image {shlex.quote(str(verifier_image))} > {verifier_config_path}"
+            if separate
+            else ""
+        )
+        build_script = f"""#!/bin/sh
+set -eu
+PROJECT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+cleanup() {{
+  rm -f {image_config_path} {verifier_config_path}
+}}
+trap cleanup EXIT HUP INT TERM
+inspect_image() {{
+  docker image inspect --format '{{{{json .Config}}}}' "$1"
+}}
+{prepare_base}
+inspect_image {shlex.quote(base_image)} > {image_config_path}
+{prepare_verifier}
+{inspect_verifier}
+{compose_command} build
+if [ "$#" -gt 0 ]; then
+  docker tag "$({compose_command} images -q main)" "$1"
+fi
+"""
+        script = project / "build.sh"
+        script.write_text(build_script, encoding="utf-8", newline="\n")
+        script.chmod(0o755)
+        recipe = compose_project.with_project_directory("./compose-project")
+        (context / "compose.yaml").write_text(
+            json.dumps(
+                recipe.model_dump(mode="json", exclude_none=True),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        group_rows = []
         for task in group:
             config = task.config
             task_separate = config.verifier.separate
+            task_config = {
+                "id": task.path.name,
+                "description": config.task.description,
+                "verifier_timeout": config.verifier.timeout_sec or 600.0,
+                "separate_verifier": task_separate,
+                "collect": [hook.model_dump() for hook in config.verifier.collect],
+                "artifacts": [artifact.model_dump() for artifact in config.artifacts],
+            }
             phase_environment = config.verifier.environment or EnvironmentConfig()
             gpu_count = max(config.environment.gpus or 0, phase_environment.gpus or 0)
             gpu_types = config.environment.gpu_types or phase_environment.gpu_types
@@ -706,29 +833,40 @@ async def adapt(
             columns = dict(config.metadata)
             if config.task.keywords:
                 columns.setdefault("keywords", config.task.keywords)
-            rows.append(
-                Task(
-                    env=name,
-                    id=task.path.name,
-                    agent_config=(
-                        {"timeout_seconds": config.agent.timeout_sec}
-                        if config.agent.timeout_sec is not None
-                        else None
-                    ),
-                    columns=columns or None,
-                    runtime_config=RuntimeConfig(
-                        image=image if compose is None else None,
-                        compose=context / "compose.json" if compose is not None else None,
-                        compose_service_access=(
-                            True if compose is not None and task_separate else None
-                        ),
-                        resources=resources if resources.model_dump(exclude_none=True) else None,
-                    ),
-                    verifier=(
-                        Task(env=name, id=f"{task.path.name}:verify") if task_separate else None
-                    ),
-                )
+            row = Task(
+                env=name,
+                id="run",
+                args={
+                    "instruction": task.instruction,
+                    "task": task_config,
+                },
+                slug=task.path.name,
+                agent_config=(
+                    {"timeout_seconds": config.agent.timeout_sec}
+                    if config.agent.timeout_sec is not None
+                    else None
+                ),
+                columns=columns or None,
+                runtime_config=RuntimeConfig(
+                    compose=context / "compose-project" / "compose.json",
+                    compose_project=context,
+                    compose_service_access=(True if task_separate else None),
+                    resources=resources if resources.model_dump(exclude_none=True) else None,
+                ),
+                verifier=(
+                    Task(
+                        env=name,
+                        id="verify",
+                        args={"task": task_config},
+                        slug=f"{task.path.name}:verify",
+                    )
+                    if task_separate
+                    else None
+                ),
             )
+            rows.append(row)
+            group_rows.append(row)
+        Taskset(dataset.name, group_rows).to_file(context / "tasks.json")
 
-    LOGGER.info("adapted %d Harbor image(s)", len({task.env for task in rows}))
+    LOGGER.info("adapted %d Harbor project(s)", len({task.env for task in rows}))
     return Taskset(dataset.name, rows, origin=f"harbor:{dataset}")

--- a/hud/integrations/harbor/env.py
+++ b/hud/integrations/harbor/env.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, Any
 
 from hud.capabilities import Capability
 from hud.environment import Environment, Mount, Peer, Workspace
-from hud.environment.egress import ANY_HOST
+from hud.environment.egress import ANY_HOST, BRIDGE_PORT, VISITOR_PORT
 from hud.graders import EvaluationResult
 from hud.utils.process import ProcessResult, create_process_group_exec
 
@@ -33,7 +33,54 @@ AGENT_ANSWER = LOGS / "agent_answer.txt"
 ARTIFACTS = ROOT / "artifacts"
 DOCKER_SOCKET = ROOT / "docker.sock"
 DOCKER = ROOT / "bin" / "docker"
-CONFIG = json.loads((ROOT / "tasks.json").read_text("utf-8"))
+CONFIG = json.loads((ROOT / "config.json").read_text("utf-8"))
+
+
+def load_image_config(name: str) -> dict[str, Any]:
+    value = json.loads((ROOT / name).read_text("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must contain an OCI image config object")
+    return value
+
+
+def image_environment(config: dict[str, Any]) -> dict[str, str]:
+    entries = config.get("Env") or []
+    if not isinstance(entries, list) or not all(isinstance(entry, str) for entry in entries):
+        raise ValueError("OCI image Env must be a list of strings")
+    return {
+        key: value
+        for entry in entries
+        for key, separator, value in (entry.partition("="),)
+        if separator
+    }
+
+
+IMAGE_CONFIG = load_image_config("image-config.json")
+VERIFIER_IMAGE_CONFIG = load_image_config("verifier-image-config.json")
+CONFIG["image_env"] = image_environment(IMAGE_CONFIG)
+if CONFIG["image_user"] is None:
+    CONFIG["image_user"] = IMAGE_CONFIG.get("User") or None
+if CONFIG["workdir"] is None:
+    CONFIG["workdir"] = IMAGE_CONFIG.get("WorkingDir") or "/"
+if CONFIG["entrypoint"] is None:
+    CONFIG["entrypoint"] = IMAGE_CONFIG.get("Entrypoint") or []
+exposed = IMAGE_CONFIG.get("ExposedPorts") or {}
+if not isinstance(exposed, dict):
+    raise ValueError("OCI image ExposedPorts must be an object")
+CONFIG["ports"] = sorted(
+    {
+        *CONFIG["ports"],
+        *(int(port) for value in exposed if (port := str(value).partition("/")[0]).isdigit()),
+    }
+)
+if conflict := set(CONFIG["ports"]) & {BRIDGE_PORT, VISITOR_PORT, 8765}:
+    raise ValueError(f"Harbor main service port {min(conflict)} conflicts with a HUD reserved port")
+verifier_image = CONFIG["verifier_image"]
+if verifier_image["user"] is None:
+    verifier_image["user"] = VERIFIER_IMAGE_CONFIG.get("User") or None
+if verifier_image["workdir"] is None:
+    verifier_image["workdir"] = VERIFIER_IMAGE_CONFIG.get("WorkingDir") or "/"
+verifier_image["env"] = image_environment(VERIFIER_IMAGE_CONFIG)
 
 os.environ.update(CONFIG["environment"]["env"])
 WORKDIR = Path(CONFIG["workdir"])
@@ -397,56 +444,44 @@ async def collect(task: dict[str, Any]) -> None:
             raise RuntimeError(f"artifact {source} contains a symbolic link")
 
 
-def register(task: dict[str, Any]) -> None:
-    task_dir = ROOT / "tasks" / task["id"]
-
-    @env.template(
-        id=task["id"],
-        description=task["description"] or f"Harbor task {task['id']}",
-    )
-    async def run() -> AsyncGenerator[Any, Any]:
+@env.template(id="run", description="Run a Harbor task")
+async def run(instruction: str, task: dict[str, Any]) -> AsyncGenerator[Any, Any]:
+    clear_grading_files()
+    AGENT_ANSWER.parent.mkdir(parents=True, exist_ok=True)
+    AGENT_ANSWER.touch()
+    entrypoint = None
+    try:
+        entrypoint = await start_entrypoint()
+        await wait_until_healthy(entrypoint)
+        answer = yield instruction
+        if entrypoint is not None and entrypoint.returncode is not None:
+            raise RuntimeError(
+                f"Harbor environment entrypoint exited with status {entrypoint.returncode}"
+            )
+        if task["separate_verifier"]:
+            await workspace.terminate_sessions()
+            await collect(task)
+            yield 0.0
+        else:
+            yield await grade(task["id"], task["verifier_timeout"], answer)
+    finally:
         clear_grading_files()
-        AGENT_ANSWER.parent.mkdir(parents=True, exist_ok=True)
-        AGENT_ANSWER.touch()
-        entrypoint = None
+        await workspace.discard_sandbox()
+        if entrypoint is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(entrypoint.wait(), 10.0)
+
+
+if CONFIG["verifier_root"] is not None:
+
+    @env.template(id="verify", description="Verify a Harbor task")
+    async def verify(task: dict[str, Any]) -> AsyncGenerator[Any, Any]:
+        answer = yield ""
         try:
-            entrypoint = await start_entrypoint()
-            await wait_until_healthy(entrypoint)
-            answer = yield (task_dir / "instruction.md").read_text("utf-8")
-            if entrypoint is not None and entrypoint.returncode is not None:
-                raise RuntimeError(
-                    f"Harbor environment entrypoint exited with status {entrypoint.returncode}"
-                )
-            if task["separate_verifier"]:
-                await workspace.terminate_sessions()
-                await collect(task)
-                yield 0.0
-            else:
-                yield await grade(task_dir, task["verifier_timeout"], answer)
+            yield await grade_separate(task, answer)
         finally:
             clear_grading_files()
-            await workspace.discard_sandbox()
-            if entrypoint is not None:
-                with contextlib.suppress(Exception):
-                    await asyncio.wait_for(entrypoint.wait(), 10.0)
-
-    if task["separate_verifier"]:
-
-        @env.template(
-            id=f"{task['id']}:verify",
-            description=f"Verify Harbor task {task['id']}",
-        )
-        async def verify() -> AsyncGenerator[Any, Any]:
-            answer = yield ""
-            try:
-                yield await grade_separate(task, answer)
-            finally:
-                clear_grading_files()
-                shutil.rmtree(ARTIFACTS, ignore_errors=True)
-
-
-for task_config in CONFIG["tasks"]:
-    register(task_config)
+            shutil.rmtree(ARTIFACTS, ignore_errors=True)
 
 
 def clear(path: Path) -> None:
@@ -473,9 +508,9 @@ def clear_grading_files() -> None:
             AGENT_ANSWER.unlink()
 
 
-async def grade(task_dir: Path, timeout_sec: float, answer: Any) -> EvaluationResult:
+async def grade(task_id: str, timeout_sec: float, answer: Any) -> EvaluationResult:
     clear(TESTS)
-    shutil.copytree(task_dir / "tests", TESTS, symlinks=True, dirs_exist_ok=True)
+    shutil.copytree(ROOT / "tests" / task_id, TESTS, symlinks=True, dirs_exist_ok=True)
     test_script = TESTS / "test.sh"
     test_script.chmod(test_script.stat().st_mode | 0o111)
 

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import importlib
 import json
 import os
 import subprocess
@@ -18,182 +16,209 @@ from hud.integrations import harbor
 from .conftest import make_harbor_task, make_multi_step_task
 
 
-@pytest.fixture(autouse=True)
-def fake_docker(monkeypatch):
-    calls: list[tuple[str, ...]] = []
-
-    async def run(*args: str, **_kwargs):
-        calls.append(args)
-        if args[:4] == ("image", "inspect", "--format", "{{json .Config}}"):
-            if args[-1] == "no-ports:latest":
-                return json.dumps(
-                    {
-                        "User": "",
-                        "WorkingDir": "/workspace",
-                        "Entrypoint": None,
-                        "Cmd": ["serve"],
-                    }
-                ), ""
-            if args[-1].startswith("hud-harbor:"):
-                return json.dumps(
-                    {
-                        "User": "",
-                        "WorkingDir": "/workspace",
-                        "Entrypoint": [],
-                        "Cmd": ["/media/hud/venv/bin/hud", "serve", "/media/hud/env.py"],
-                    }
-                ), ""
-            if args[-1].startswith("hud-harbor-base:"):
-                return json.dumps(
-                    {
-                        "User": "",
-                        "WorkingDir": "/workspace",
-                        "Entrypoint": None,
-                        "Cmd": None,
-                    }
-                ), ""
-            return json.dumps(
-                {
-                    "User": "",
-                    "WorkingDir": "/workspace",
-                    "Entrypoint": None,
-                    "Cmd": None,
-                    "ExposedPorts": {"6379/tcp": {}},
-                }
-            ), ""
-        if args[:4] == ("image", "inspect", "--format", "{{.Id}}"):
-            return "sha256:0123456789abcdef0123456789abcdef\n", ""
-        if args[0] == "compose" and args[-3:] == ("config", "--format", "json"):
-            project: Any = {
-                "name": "task",
-                "services": {
-                    "main": {
-                        "image": "hud-main",
-                        "environment": {"FROM_COMPOSE": "yes"},
-                        "expose": ["8080/tcp"],
-                        "healthcheck": {
-                            "test": ["CMD-SHELL", "curl -f http://localhost:8080/health"],
-                            "interval": "2s",
-                            "timeout": "3s",
-                            "retries": 5,
-                            "start_period": "1s",
-                        },
-                        "depends_on": {
-                            "redis": {
-                                "condition": "service_healthy",
-                                "required": True,
-                            }
-                        },
-                        "networks": {"default": None},
-                    },
-                    "redis": {
-                        "image": "redis:7-alpine",
-                        "entrypoint": None,
-                        "command": ["redis-server", "--save", ""],
-                        "environment": {"SIDE": "car"},
-                        "expose": ["6379/tcp"],
-                        "healthcheck": {
-                            "test": ["CMD", "redis-cli", "ping"],
-                            "interval": "2s",
-                            "timeout": "3s",
-                            "retries": 5,
-                            "start_period": "1s",
-                        },
-                        "networks": {"default": None},
-                    },
-                },
-                "networks": {"default": {"name": "task_default"}},
-            }
-            authored_file = Path(args[-4])
-            authored = await asyncio.to_thread(authored_file.read_text, "utf-8")
-            if "dockerfile: Containerfile" in authored:
-                project["services"] = {
-                    "main": {
-                        "image": "hud-main",
-                        "build": {
-                            "context": str(authored_file.parent),
-                            "dockerfile": "Containerfile",
-                            "args": {"FLAVOR": "compose"},
-                        },
-                        "environment": {"FROM_COMPOSE": "yes"},
-                        "networks": {"default": None},
-                    }
-                }
-            elif "no-ports:latest" in authored:
-                project["services"]["main"].pop("depends_on")
-                project["services"].pop("redis")
-                project["services"]["worker"] = {
-                    "image": "no-ports:latest",
-                    "networks": {"default": None},
-                }
-            elif "main-healthcheck" in authored:
-                project["services"]["main"]["healthcheck"] = {
-                    "test": ["CMD-SHELL", "curl -f http://localhost:8080/health"],
-                    "interval": "2s",
-                    "timeout": "3s",
-                    "retries": 5,
-                    "start_period": "1s",
-                }
-            elif "healthcheck-defaults" in authored:
-                project["services"]["main"]["healthcheck"] = {
-                    "test": ["CMD", "true"],
-                }
-            for port in (3128, 3129, 8765):
-                if f"expose: [{port}]" in authored:
-                    project["services"]["main"]["expose"] = [f"{port}/tcp"]
-            if "expose:" not in authored and "redis" in project["services"]:
-                project["services"]["redis"].pop("expose")
-            if "user: 1001:1002" in authored:
-                project["services"]["main"]["user"] = "1001:1002"
-                project["services"]["main"]["entrypoint"] = ["/compose-init"]
-                project["services"]["main"]["working_dir"] = "/compose-work"
-            return json.dumps(project), ""
-        if args[0] == "compose" and args[-2] == "build":
-            compose_file = Path(args[args.index("--file") + 1])
-            compose = await asyncio.to_thread(compose_file.read_text, "utf-8")
-            calls.append(("compose-build-config", args[-1], compose))
-        return "", ""
-
-    module = importlib.import_module("hud.integrations.harbor.adapt")
-    monkeypatch.setattr(module, "docker", run)
-    return calls
+def _tree_snapshot(root: Path) -> dict[str, tuple[str, bytes | str]]:
+    snapshot: dict[str, tuple[str, bytes | str]] = {}
+    for entry in sorted(root.rglob("*")):
+        relative = entry.relative_to(root).as_posix()
+        if entry.is_symlink():
+            snapshot[relative] = ("symlink", os.readlink(entry))
+        elif entry.is_file():
+            snapshot[relative] = ("file", entry.read_bytes())
+        else:
+            snapshot[relative] = ("directory", b"")
+    return snapshot
 
 
-async def test_adapt_builds_the_source_then_an_authored_hud_environment(
-    tmp_path: Path,
-    fake_docker,
-) -> None:
-    make_harbor_task(tmp_path, "task-a")
+def _assert_stock_compose_complete(compose_path: Path) -> dict[str, Any]:
+    project = json.loads(compose_path.read_text("utf-8"))
+    services = project["services"]
+    assert isinstance(services, dict)
+    for name, service in services.items():
+        assert isinstance(service, dict)
+        assert service.get("image") or service.get("build"), name
+        for volume in service.get("volumes", []):
+            if not isinstance(volume, str):
+                continue
+            source, separator, target = volume.partition(":")
+            if separator and target == "/media/hud/tests:ro":
+                tests = (compose_path.parent / source).resolve()
+                tests.relative_to(compose_path.parent.resolve())
+                assert tests.is_dir(), (name, tests)
+        build = service.get("build")
+        if build is None:
+            continue
+        build_config = {"context": build} if isinstance(build, str) else build
+        assert isinstance(build_config, dict)
+        context_value = build_config.get("context", ".")
+        assert isinstance(context_value, str)
+        context = (compose_path.parent / context_value).resolve()
+        context.relative_to(compose_path.parent.resolve())
+        assert context.is_dir(), (name, context)
+        dockerfile_value = build_config.get("dockerfile", "Dockerfile")
+        assert isinstance(dockerfile_value, str)
+        assert (context / dockerfile_value).is_file(), (name, dockerfile_value)
+        additional_contexts = build_config.get("additional_contexts", {})
+        assert isinstance(additional_contexts, dict)
+        for target in additional_contexts.values():
+            assert isinstance(target, str)
+            if target.startswith("service:"):
+                assert target.removeprefix("service:") in services
+            else:
+                # Local additional-context paths resolve against the project
+                # directory (the compose file's directory), not the service
+                # build context.
+                named_context = (compose_path.parent / target).resolve()
+                named_context.relative_to(compose_path.parent.resolve())
+                assert named_context.is_dir(), (name, named_context)
+    return project
 
-    taskset = await harbor.adapt(tmp_path)
+
+def _environment_config(context: Path) -> dict[str, Any]:
+    paths = list((context / "compose-project").glob("*/config.json"))
+    assert len(paths) == 1
+    config = json.loads(paths[0].read_text("utf-8"))
+    assert isinstance(config, dict)
+    return config
+
+
+def test_adapt_packages_an_image_task_as_a_compose_project(tmp_path: Path) -> None:
+    task_dir = make_harbor_task(tmp_path, "task-a")
+    authored_environment = _tree_snapshot(task_dir / "environment")
+
+    taskset = harbor.adapt(tmp_path)
 
     (task,) = list(taskset)
-    assert task.id == "task-a"
+    assert task.id == "run"
+    assert task.slug == "task-a"
+    assert task.args["instruction"] == "Solve the task."
+    assert task.args["task"] == {
+        "artifacts": [],
+        "collect": [],
+        "description": "",
+        "id": "task-a",
+        "separate_verifier": False,
+        "verifier_timeout": 120.0,
+    }
     assert task.runtime_config is not None
-    assert task.runtime_config.image is not None
-    assert task.runtime_config.image.startswith("hud-harbor:")
-
-    builds = [call for call in fake_docker if call[0] == "build"]
-    assert len(builds) == 2
-    assert "BASE_IMAGE=hud-harbor-base:" in " ".join(builds[1])
+    assert task.runtime_config.image is None
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    integration = Path(__file__).parents[1]
-    for asset in ("Dockerfile", "install.sh"):
-        assert (context / asset).read_bytes() == (integration / asset).read_bytes()
+    assert not (context / "Dockerfile").exists()
+    assert not any(path.name == ".hud" for path in context.rglob(".hud"))
+    assert {entry.name for entry in context.iterdir()} == {
+        "compose-project",
+        "compose.yaml",
+        "env.py",
+        "tasks.json",
+    }
     # env.py names the environment as a literal — `hud deploy` resolves the
     # context's identity from source, and refuses a computed name.
     served = (context / "env.py").read_text(encoding="utf-8")
     assert f'Environment("{context.name}")' in served
     assert 'Environment(CONFIG["name"])' not in served
-    assert (context / "tasks" / "task-a" / "instruction.md").is_file()
-    assert (context / "tasks" / "task-a" / "tests" / "test.sh").is_file()
+    project_root = context / "compose-project"
+    assert _tree_snapshot(project_root / "environment") == authored_environment
+    payload = project_root / "hud"
+    assert {entry.name for entry in payload.iterdir()} == {
+        "config.json",
+        "env.py",
+        "install.sh",
+        "packages",
+    }
+    build_script = (project_root / "build.sh").read_text("utf-8")
+    assert "docker image inspect" in build_script
+    assert 'docker tag "$(docker compose' in build_script
+    subprocess.run(["sh", "-n", project_root / "build.sh"], check=True)
+    assert (project_root / "tests" / "task-a" / "test.sh").is_file()
+    assert not any(path.name in {"tasks", "tasks.json"} for path in payload.rglob("*"))
     assert not (context / "compose.json").exists()
+    assert task.runtime_config.compose == context / "compose-project" / "compose.json"
+    assert task.runtime_config.compose_project == context
+    compose_path = context / "compose-project" / "compose.json"
+    project = _assert_stock_compose_complete(compose_path)
+    assert set(project["services"]) == {"main"}
+    main = project["services"]["main"]
+    assert main["image"].startswith("hud-harbor:")
+    assert main["build"] == {
+        "additional_contexts": {"hud": "./hud"},
+        "context": "./environment",
+        "dockerfile": "../Dockerfile",
+    }
+    assert main["volumes"] == ["./tests:/media/hud/tests:ro"]
+    combined = project_root / "Dockerfile"
+    assert combined.read_text("utf-8").startswith("FROM python:3.11-slim AS hud-base\n")
+    recipe = _assert_stock_compose_complete(context / "compose.yaml")
+    assert recipe["services"]["main"]["build"]["context"] == ("./compose-project/environment")
+    assert recipe["services"]["main"]["volumes"] == ["./compose-project/tests:/media/hud/tests:ro"]
 
 
-async def test_adapt_honors_compose_main_build_settings(
+def test_task_content_changes_do_not_rebuild_the_environment(tmp_path: Path) -> None:
+    task_dir = make_harbor_task(tmp_path, "task-a", instruction="First instruction")
+
+    (before,) = list(harbor.adapt(tmp_path))
+    assert before.runtime_config is not None
+    assert isinstance(before.runtime_config.compose, Path)
+    before_compose = json.loads(before.runtime_config.compose.read_text("utf-8"))
+    before_image = before_compose["services"]["main"]["image"]
+
+    (task_dir / "instruction.md").write_text("Second instruction", encoding="utf-8")
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    (after,) = list(harbor.adapt(tmp_path))
+    assert after.runtime_config is not None
+    assert isinstance(after.runtime_config.compose, Path)
+    after_compose = json.loads(after.runtime_config.compose.read_text("utf-8"))
+
+    assert after_compose["services"]["main"]["image"] == before_image
+    assert after.args["instruction"] == "Second instruction"
+    assert (after.runtime_config.compose.parent / "tests" / "task-a" / "test.sh").read_text(
+        "utf-8"
+    ) == "#!/bin/sh\nexit 1\n"
+
+
+def test_image_task_preserves_a_named_final_stage_verbatim(tmp_path: Path) -> None:
+    dockerfile = 'FROM alpine AS build\r\nRUN true\r\nFROM alpine AS final\r\nCMD ["sh"]\r\n'
+    make_harbor_task(tmp_path, "task-a", dockerfile=dockerfile)
+
+    harbor.adapt(tmp_path)
+
+    (context,) = (tmp_path / ".hud-adapt").iterdir()
+    environment = context / "compose-project" / "environment"
+    assert (environment / "Dockerfile").read_bytes() == dockerfile.encode("utf-8")
+    combined = (environment.parent / "Dockerfile").read_bytes().decode("utf-8")
+    assert combined.startswith(dockerfile + "\nFROM final AS hud-runtime\n")
+
+
+@pytest.mark.parametrize("stage", ["hud-base", "HUD-RUNTIME"])
+def test_image_task_rejects_reserved_user_stage_names(
     tmp_path: Path,
-    fake_docker,
+    stage: str,
+) -> None:
+    make_harbor_task(tmp_path, "task-a", dockerfile=f"FROM alpine AS {stage}\n")
+
+    with pytest.raises(ValueError, match="reserved stage"):
+        harbor.adapt(tmp_path)
+
+
+def test_image_task_preserves_environment_ignored_paths_verbatim(
+    tmp_path: Path,
+) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    environment = task / "environment"
+    (environment / ".dockerignore").write_text("hud/\nDockerfile\n", encoding="utf-8")
+    (environment / "ignored.txt").write_bytes(b"unchanged\x00payload")
+    authored = _tree_snapshot(environment)
+
+    harbor.adapt(tmp_path)
+
+    (context,) = (tmp_path / ".hud-adapt").iterdir()
+    project = context / "compose-project"
+    assert _tree_snapshot(project / "environment") == authored
+    assert (project / "hud").is_dir()
+    assert (project / "Dockerfile").is_file()
+
+
+def test_adapt_honors_compose_main_build_settings(
+    tmp_path: Path,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a", dockerfile=None)
     environment = task / "environment"
@@ -210,49 +235,84 @@ services:
 """,
         encoding="utf-8",
     )
+    (environment / "Containerfile").write_text("FROM python:3.12\n", encoding="utf-8")
 
-    await harbor.adapt(tmp_path)
+    (row,) = list(harbor.adapt(tmp_path))
 
-    compose_build = next(call for call in fake_docker if call[:2] == ("compose", "--file"))
-    assert compose_build[-2:] == ("build", "main")
-    _, _, serialized = next(call for call in fake_docker if call[0] == "compose-build-config")
-    main = json.loads(serialized)["services"]["main"]
-    assert main["build"]["dockerfile"] == "Containerfile"
-    assert main["build"]["args"] == {"FLAVOR": "compose"}
-    assert main["image"].startswith("hud-harbor-base:")
-    wrapper_build = next(call for call in fake_docker if call[0] == "build")
-    assert any(value.startswith("BASE_IMAGE=hud-harbor-base:") for value in wrapper_build)
+    assert row.runtime_config is not None
+    compose_path = row.runtime_config.compose
+    assert isinstance(compose_path, Path)
+    project = _assert_stock_compose_complete(compose_path)
+    base = project["services"]["hud-base"]
+    assert base["build"]["dockerfile"] == "Containerfile"
+    assert base["build"]["args"] == {"FLAVOR": "compose"}
+    assert base["scale"] == 0
 
 
-async def test_adapt_emits_compose_with_pinned_sidecars_and_peers(
+def test_adapt_emits_compose_project_and_peers(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "environment" / "compose.yaml").write_text(
-        "services:\n  main: {}\n  redis:\n    image: redis:7-alpine\n    expose: [6379]\n",
+        """\
+services:
+  main:
+    environment: {FROM_COMPOSE: "yes"}
+    expose: [8080]
+    healthcheck:
+      test: [CMD-SHELL, curl -f http://localhost:8080/health]
+      interval: 2s
+      timeout: 3s
+      retries: 5
+      start_period: 1s
+  redis:
+    image: redis:7-alpine
+    command: [redis-server, --save, ""]
+    environment: {SIDE: car}
+    expose: [6379]
+    healthcheck:
+      test: [CMD, redis-cli, ping]
+      interval: 2s
+      timeout: 3s
+      retries: 5
+      start_period: 1s
+""",
         encoding="utf-8",
     )
 
-    (row,) = list(await harbor.adapt(tmp_path))
+    (row,) = list(harbor.adapt(tmp_path))
 
     assert row.runtime_config is not None
     assert row.runtime_config.image is None
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    assert row.runtime_config.compose == context / "compose.json"
-    compose = json.loads((context / "compose.json").read_text("utf-8"))
-    redis = compose["services"]["redis"]
-    assert redis["image"].startswith("hud-harbor-sidecar:")
-    assert redis["image"].endswith("-0123456789abcdef")
+    assert row.runtime_config.compose == context / "compose-project" / "compose.json"
+    assert row.runtime_config.compose_project == context
+    assert not (context / "compose.json").exists()
+    compose_path = row.runtime_config.compose
+    assert isinstance(compose_path, Path)
+    project = _assert_stock_compose_complete(compose_path)
+    assert project["services"]["redis"]["image"] == "redis:7-alpine"
+    assert "build" not in project["services"]["redis"]
+    assert project["services"]["main"]["build"]["context"] == "./main"
+    assert project["services"]["main"]["build"]["additional_contexts"] == {
+        "hud-base": "service:hud-base"
+    }
+    assert project["services"]["main"]["image"].startswith("hud-harbor:")
+    assert project["services"]["hud-base"]["image"].startswith("hud-harbor-base:")
+    assert project["services"]["hud-base"]["build"]["context"] == "./environment"
+    assert (context / "compose-project" / "environment" / "Dockerfile").is_file()
+    assert not any(path.name == ".hud" for path in context.rglob(".hud"))
+    recipe = _assert_stock_compose_complete(context / "compose.yaml")
+    assert recipe["services"]["main"]["build"]["context"] == "./compose-project/main"
+    assert recipe["services"]["redis"]["image"] == "redis:7-alpine"
+    redis = project["services"]["redis"]
+    assert redis["image"] == "redis:7-alpine"
     assert redis["environment"] == {"SIDE": "car"}
     assert redis["command"] == ["redis-server", "--save", ""]
-    assert redis["expose"] == ["6379/tcp"]
+    assert redis["expose"] == ["6379"]
     assert redis["healthcheck"]["test"] == ["CMD", "redis-cli", "ping"]
-    assert redis["entrypoint"] == []
-    assert redis["working_dir"] == "/workspace"
-    assert redis["networks"] == {"default": None}
     assert "build" not in redis
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    manifest = _environment_config(context)
     assert manifest["environment"]["env"] == {"FROM_COMPOSE": "yes"}
     assert manifest["environment"]["healthcheck"] == {
         "command": "curl -f http://localhost:8080/health",
@@ -266,19 +326,74 @@ async def test_adapt_emits_compose_with_pinned_sidecars_and_peers(
     assert manifest["ports"] == [8080]
     assert manifest["capabilities"] == []
     assert manifest["peers"] == [{"name": "redis", "port": 6379}]
-    assert compose["services"]["main"]["command"] == [
+    assert project["services"]["main"]["command"] == [
         "/media/hud/venv/bin/hud",
         "serve",
         "/media/hud/env.py",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8765",
     ]
-    assert "healthcheck" not in compose["services"]["main"]
-    assert ("pull", "redis:7-alpine") in fake_docker
-    assert any(call[:2] == ("tag", "redis:7-alpine") for call in fake_docker)
+    assert "healthcheck" not in project["services"]["main"]
 
 
-async def test_adapt_moves_compose_main_process_settings_into_the_workspace(
+def test_compose_adapt_retains_builds_without_local_docker(
     tmp_path: Path,
-    fake_docker,
+) -> None:
+    """Hosted adaptation produces a private-build project without a local daemon."""
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "environment" / "Dockerfile").write_text(
+        'FROM python:3.12\nWORKDIR /app\nENTRYPOINT ["/app/start"]\n',
+        encoding="utf-8",
+    )
+    database = task / "environment" / "database"
+    database.mkdir()
+    (database / "Dockerfile").write_text("FROM postgres:16\n", encoding="utf-8")
+    (database / "db.env").write_text("POSTGRES_DB=test\n", encoding="utf-8")
+    (database / "data").mkdir()
+    (task / "environment" / "compose.yaml").write_text(
+        """\
+services:
+  main:
+    env_file: ./main.env
+    volumes: [./main-data:/var/lib/main]
+  database:
+    build:
+      context: ./database
+    env_file: ./database/db.env
+    volumes: [./database/data:/var/lib/postgresql/data]
+    expose: [5432]
+  redis:
+    image: redis:7-alpine
+    expose: [6379]
+""",
+        encoding="utf-8",
+    )
+    (task / "environment" / "main.env").write_text("MAIN=true\n", encoding="utf-8")
+    (task / "environment" / "main-data").mkdir()
+
+    (row,) = list(harbor.adapt(tmp_path))
+
+    assert row.runtime_config is not None
+    compose_path = row.runtime_config.compose
+    assert isinstance(compose_path, Path)
+    project = json.loads(compose_path.read_text("utf-8"))
+    assert project["services"]["database"]["build"]["context"] == ("./environment/database")
+    assert project["services"]["database"]["env_file"] == "./environment/database/db.env"
+    assert project["services"]["database"]["volumes"] == [
+        "./environment/database/data:/var/lib/postgresql/data"
+    ]
+    assert project["services"]["main"]["env_file"] == "./environment/main.env"
+    assert "./environment/main-data:/var/lib/main" in project["services"]["main"]["volumes"]
+    assert project["services"]["redis"]["image"] == "redis:7-alpine"
+    assert project["services"]["main"]["build"]["additional_contexts"] == {
+        "hud-base": "service:hud-base"
+    }
+
+
+def test_adapt_moves_compose_main_process_settings_into_the_workspace(
+    tmp_path: Path,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "environment" / "compose.yaml").write_text(
@@ -292,11 +407,11 @@ services:
         encoding="utf-8",
     )
 
-    await harbor.adapt(tmp_path)
+    harbor.adapt(tmp_path)
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
-    compose = json.loads((context / "compose.json").read_text("utf-8"))
+    manifest = _environment_config(context)
+    compose = _assert_stock_compose_complete(context / "compose-project" / "compose.json")
     assert manifest["image_user"] == "1001:1002"
     assert manifest["entrypoint"] == ["/compose-init"]
     assert manifest["workdir"] == "/compose-work"
@@ -304,21 +419,29 @@ services:
     assert compose["services"]["main"]["entrypoint"] == []
 
 
-async def test_adapt_moves_compose_main_healthcheck_into_the_workspace(
+def test_adapt_moves_compose_main_healthcheck_into_the_workspace(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "environment" / "compose.yaml").write_text(
-        "# main-healthcheck\nservices:\n  main: {}\n",
+        """\
+services:
+  main:
+    healthcheck:
+      test: [CMD-SHELL, curl -f http://localhost:8080/health]
+      interval: 2s
+      timeout: 3s
+      retries: 5
+      start_period: 1s
+""",
         encoding="utf-8",
     )
 
-    await harbor.adapt(tmp_path)
+    harbor.adapt(tmp_path)
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
-    compose = json.loads((context / "compose.json").read_text("utf-8"))
+    manifest = _environment_config(context)
+    compose = json.loads((context / "compose-project" / "compose.json").read_text("utf-8"))
     assert manifest["environment"]["healthcheck"] == {
         "command": "curl -f http://localhost:8080/health",
         "interval_sec": 2.0,
@@ -330,17 +453,17 @@ async def test_adapt_moves_compose_main_healthcheck_into_the_workspace(
     assert "healthcheck" not in compose["services"]["main"]
 
 
-async def test_adapt_uses_compose_healthcheck_defaults(tmp_path: Path) -> None:
+def test_adapt_uses_compose_healthcheck_defaults(tmp_path: Path) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "environment" / "compose.yaml").write_text(
-        "# healthcheck-defaults\nservices:\n  main: {}\n",
+        "services:\n  main:\n    healthcheck:\n      test: [CMD, 'true']\n",
         encoding="utf-8",
     )
 
-    await harbor.adapt(tmp_path)
+    harbor.adapt(tmp_path)
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    manifest = _environment_config(context)
     assert manifest["environment"]["healthcheck"] == {
         "command": "true",
         "interval_sec": 30.0,
@@ -351,9 +474,8 @@ async def test_adapt_uses_compose_healthcheck_defaults(tmp_path: Path) -> None:
     }
 
 
-async def test_adapt_derives_implicit_peer_port_from_image(
+def test_adapt_requires_peer_port_in_the_compose_project(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "environment" / "compose.yaml").write_text(
@@ -361,16 +483,12 @@ async def test_adapt_derives_implicit_peer_port_from_image(
         encoding="utf-8",
     )
 
-    await harbor.adapt(tmp_path)
-
-    (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
-    assert manifest["peers"] == [{"name": "redis", "port": 6379}]
+    with pytest.raises(ValueError, match="declares no TCP port"):
+        harbor.adapt(tmp_path)
 
 
-async def test_adapt_rejects_sidecar_without_a_tcp_port(
+def test_adapt_rejects_sidecar_without_a_tcp_port(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "environment" / "compose.yaml").write_text(
@@ -379,12 +497,11 @@ async def test_adapt_rejects_sidecar_without_a_tcp_port(
     )
 
     with pytest.raises(ValueError, match="declares no TCP port"):
-        await harbor.adapt(tmp_path)
+        harbor.adapt(tmp_path)
 
 
-async def test_network_mcp_servers_become_named_capabilities(
+def test_network_mcp_servers_become_named_capabilities(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "environment" / "compose.yaml").write_text(
@@ -402,10 +519,10 @@ args = []
         encoding="utf-8",
     )
 
-    await harbor.adapt(tmp_path)
+    harbor.adapt(tmp_path)
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    manifest = _environment_config(context)
     assert manifest["capabilities"] == [
         {
             "name": "redis-tools",
@@ -417,9 +534,8 @@ args = []
 
 
 @pytest.mark.parametrize("name", ["shell", "filetracking"])
-async def test_mcp_server_names_cannot_shadow_workspace_capabilities(
+def test_mcp_server_names_cannot_shadow_workspace_capabilities(
     tmp_path: Path,
-    fake_docker,
     name: str,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
@@ -434,16 +550,30 @@ url = "http://server:8000/mcp"
     )
 
     with pytest.raises(ValueError, match=f"MCP server name {name!r} is reserved"):
-        await harbor.adapt(tmp_path)
-
-    assert fake_docker == []
+        harbor.adapt(tmp_path)
 
 
-async def test_adapt_groups_identical_images_and_keeps_row_metadata(
+def test_adapt_groups_identical_images_and_keeps_row_metadata(
     dataset_same_env: Path,
-    fake_docker,
 ) -> None:
-    taskset = await harbor.adapt(dataset_same_env)
+    (dataset_same_env / "build-pmars" / "task.toml").write_text(
+        """\
+artifacts = ["/tmp/result"]
+
+[metadata]
+category = "systems"
+difficulty = "medium"
+tags = ["bash", "linux"]
+
+[agent]
+timeout_sec = 45
+
+[verifier]
+timeout_sec = 30
+""",
+        encoding="utf-8",
+    )
+    taskset = harbor.adapt(dataset_same_env)
 
     assert len(taskset) == 3
     assert len(taskset.environment_names()) == 1
@@ -456,20 +586,26 @@ async def test_adapt_groups_identical_images_and_keeps_row_metadata(
         }
         for task in taskset
     )
-    assert len([call for call in fake_docker if call[0] == "build"]) == 2
+    assert all(task.runtime_config is not None for task in taskset)
+    assert all(task.runtime_config.compose is not None for task in taskset if task.runtime_config)
+    assert taskset["build-pmars"].agent_config == {"timeout_seconds": 45.0}
+    assert taskset["build-pmars"].args["task"]["verifier_timeout"] == 30.0
+    assert taskset["build-pmars"].args["task"]["artifacts"] == [
+        {"service": "main", "source": "/tmp/result"}
+    ]
 
 
-async def test_distinct_environments_build_distinct_images(
+def test_distinct_environments_build_distinct_images(
     dataset_multi_env: Path,
-    fake_docker,
 ) -> None:
-    taskset = await harbor.adapt(dataset_multi_env)
+    taskset = harbor.adapt(dataset_multi_env)
 
     assert len(taskset.environment_names()) == 2
-    assert len([call for call in fake_docker if call[0] == "build"]) == 4
+    assert all(task.runtime_config is not None for task in taskset)
+    assert all(task.runtime_config.compose is not None for task in taskset if task.runtime_config)
 
 
-async def test_adapt_maps_resources_and_pushes_the_images(tmp_path: Path, fake_docker) -> None:
+def test_adapt_maps_resources_onto_the_compose_runtime(tmp_path: Path) -> None:
     task = make_harbor_task(tmp_path, "gpu")
     (task / "task.toml").write_text(
         """
@@ -485,52 +621,57 @@ gpu_types = ["H100"]
         encoding="utf-8",
     )
 
-    (row,) = list(await harbor.adapt(tmp_path, push="registry.example/hud"))
+    (row,) = list(harbor.adapt(tmp_path))
 
     assert row.columns == {"difficulty": "hard"}
     assert row.runtime_config is not None
-    assert row.runtime_config.image is not None
-    assert row.runtime_config.image.startswith("registry.example/hud/")
+    assert row.runtime_config.image is None
+    assert isinstance(row.runtime_config.compose, Path)
     assert row.runtime_config.resources is not None
     assert row.runtime_config.resources.cpu == 4
     assert row.runtime_config.resources.memory_mb == 8192
     assert row.runtime_config.resources.gpu is not None
     assert row.runtime_config.resources.gpu.count == 2
     assert row.runtime_config.resources.gpu.type == "H100"
-    assert any(call[0] == "push" for call in fake_docker)
 
 
-async def test_prebuilt_harbor_image_skips_the_source_build(tmp_path: Path, fake_docker) -> None:
+def test_prebuilt_harbor_image_is_inspected_by_the_project_build(
+    tmp_path: Path,
+) -> None:
     task = make_harbor_task(tmp_path, "prebuilt", dockerfile=None)
     (task / "task.toml").write_text(
         '[environment]\ndocker_image = "registry.example/base:latest"\n',
         encoding="utf-8",
     )
 
-    await harbor.adapt(tmp_path)
+    harbor.adapt(tmp_path)
 
-    builds = [call for call in fake_docker if call[0] == "build"]
-    assert len(builds) == 1
-    assert "BASE_IMAGE=registry.example/base:latest" in builds[0]
-    assert ("pull", "registry.example/base:latest") in fake_docker
+    (context,) = (tmp_path / ".hud-adapt").iterdir()
+    project = context / "compose-project"
+    assert (
+        (project / "Dockerfile")
+        .read_text("utf-8")
+        .startswith("FROM registry.example/base:latest AS hud-base\n")
+    )
+    script = (project / "build.sh").read_text("utf-8")
+    assert "docker pull registry.example/base:latest" in script
+    assert "inspect_image registry.example/base:latest" in script
 
 
-async def test_zero_gpus_is_a_valid_harbor_resource_declaration(
+def test_zero_gpus_is_a_valid_harbor_resource_declaration(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "cpu-only")
     (task / "task.toml").write_text("[environment]\ngpus = 0\n", encoding="utf-8")
 
-    (row,) = list(await harbor.adapt(tmp_path))
+    (row,) = list(harbor.adapt(tmp_path))
 
     assert row.runtime_config is not None
     assert row.runtime_config.resources is None
 
 
-async def test_runtime_configuration_is_data_not_dockerfile_codegen(
+def test_runtime_configuration_is_data_not_dockerfile_codegen(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "task.toml").write_text(
@@ -567,10 +708,10 @@ VERIFIER_ONLY = "yes"
         encoding="utf-8",
     )
 
-    await harbor.adapt(tmp_path)
+    harbor.adapt(tmp_path)
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    manifest = _environment_config(context)
     assert manifest["workdir"] == "/app"
     assert manifest["environment"] == {
         "env": {"SHARED": "yes"},
@@ -590,46 +731,35 @@ VERIFIER_ONLY = "yes"
     assert manifest["verifier"]["user"] == 0
     assert manifest["verifier"]["network_mode"] == "no-network"
     assert manifest["verifier"]["env"] == {"VERIFIER_ONLY": "yes"}
-    dockerfile = (context / "Dockerfile").read_text("utf-8")
+    dockerfile = (context / "compose-project" / "Dockerfile").read_text("utf-8")
     assert "SHARED" not in dockerfile
     assert "WORKDIR /app" not in dockerfile
 
 
-async def test_image_entrypoint_is_preserved_as_runtime_data(
+def test_image_entrypoint_is_preserved_as_runtime_data(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    make_harbor_task(tmp_path, "task-a")
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "environment" / "Dockerfile").write_text(
+        """\
+FROM python:3.12
+USER 1000:2000
+WORKDIR /workspace
+ENV IMAGE_ONLY=present VALUE_WITH_EQUALS=one=two
+ENTRYPOINT ["/usr/local/bin/start-environment"]
+CMD ["ignored-by-harbor"]
+""",
+        encoding="utf-8",
+    )
 
-    async def docker(*args: str, **_kwargs):
-        if args[:3] == ("image", "inspect", "--format"):
-            return (
-                json.dumps(
-                    {
-                        "User": "1000:2000",
-                        "WorkingDir": "/workspace",
-                        "Env": ["IMAGE_ONLY=present", "VALUE_WITH_EQUALS=one=two"],
-                        "Entrypoint": ["/usr/local/bin/start-environment"],
-                        "Cmd": ["ignored-by-harbor"],
-                    }
-                ),
-                "",
-            )
-        return "", ""
-
-    module = importlib.import_module("hud.integrations.harbor.adapt")
-    monkeypatch.setattr(module, "docker", docker)
-
-    await harbor.adapt(tmp_path)
+    harbor.adapt(tmp_path)
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
-    assert manifest["image_env"] == {
-        "IMAGE_ONLY": "present",
-        "VALUE_WITH_EQUALS": "one=two",
-    }
-    assert manifest["entrypoint"] == ["/usr/local/bin/start-environment"]
-    assert "ignored-by-harbor" not in json.dumps(manifest)
+    manifest = _environment_config(context)
+    assert manifest["image_env"] == {}
+    assert manifest["entrypoint"] is None
+    script = (context / "compose-project" / "build.sh").read_text("utf-8")
+    assert "docker image inspect" in script
 
 
 @pytest.mark.parametrize(
@@ -648,9 +778,8 @@ async def test_image_entrypoint_is_preserved_as_runtime_data(
         ),
     ],
 )
-async def test_unsupported_harbor_behaviour_fails_before_building(
+def test_unsupported_harbor_behaviour_fails_before_building(
     tmp_path: Path,
-    fake_docker,
     declaration: str,
     expected: str,
 ) -> None:
@@ -658,15 +787,12 @@ async def test_unsupported_harbor_behaviour_fails_before_building(
     (task / "task.toml").write_text(declaration, encoding="utf-8")
 
     with pytest.raises(NotImplementedError, match=expected):
-        await harbor.adapt(tmp_path)
-
-    assert fake_docker == []
+        harbor.adapt(tmp_path)
 
 
 @pytest.mark.parametrize("port", [3128, 3129, 8765])
-async def test_adapt_rejects_main_ports_reserved_by_hud(
+def test_adapt_rejects_main_ports_reserved_by_hud(
     tmp_path: Path,
-    fake_docker,
     port: int,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
@@ -676,12 +802,11 @@ async def test_adapt_rejects_main_ports_reserved_by_hud(
     )
 
     with pytest.raises(ValueError, match=f"port {port} conflicts with a HUD reserved port"):
-        await harbor.adapt(tmp_path)
+        harbor.adapt(tmp_path)
 
 
-async def test_adapt_builds_a_separate_verifier_and_reuses_the_runtime(
+def test_adapt_builds_a_separate_verifier_and_reuses_the_runtime(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "separate")
     (task / "environment" / "compose.yaml").write_text(
@@ -726,9 +851,16 @@ timeout_sec = 10
         encoding="utf-8",
     )
 
-    (row,) = list(await harbor.adapt(tmp_path))
+    (row,) = list(harbor.adapt(tmp_path))
 
-    assert row.verifier == Task(env=row.env, id="separate:verify")
+    assert row.id == "run"
+    assert row.slug == "separate"
+    assert row.verifier == Task(
+        env=row.env,
+        id="verify",
+        args={"task": row.args["task"]},
+        slug="separate:verify",
+    )
     assert row.runtime_config is not None
     assert row.runtime_config.resources is not None
     assert row.runtime_config.resources.cpu == 4
@@ -736,7 +868,7 @@ timeout_sec = 10
     assert row.runtime_config.compose_service_access is True
 
     (context,) = (tmp_path / ".hud-adapt").iterdir()
-    manifest = json.loads((context / "tasks.json").read_text("utf-8"))
+    manifest = _environment_config(context)
     assert manifest["verifier_root"] == "/media/hud/verifier"
     assert manifest["verifier_image"]["workdir"] == "/judge"
     assert manifest["verifier"] == {
@@ -745,27 +877,63 @@ timeout_sec = 10
         "allowed_hosts": ["verifier.example"],
         "env": {"NESTED_ONLY": "yes", "SHARED": "phase"},
     }
-    assert manifest["tasks"] == [
-        {
-            "artifacts": [{"service": "main", "source": "/tmp/agent.patch"}],
-            "collect": [{"command": "redis-cli save", "service": "redis", "timeout_sec": 10.0}],
-            "description": "",
-            "id": "separate",
-            "separate_verifier": True,
-            "verifier_timeout": 30.0,
-        }
-    ]
-    assert not (context / "tasks" / "separate" / "tests").exists()
-    compose = json.loads((context / "compose.json").read_text("utf-8"))
+    assert "tasks" not in manifest
+    assert row.args["task"] == {
+        "artifacts": [{"service": "main", "source": "/tmp/agent.patch"}],
+        "collect": [{"command": "redis-cli save", "service": "redis", "timeout_sec": 10.0}],
+        "description": "",
+        "id": "separate",
+        "separate_verifier": True,
+        "verifier_timeout": 30.0,
+    }
+    assert not (context / "compose-project" / "main" / "tasks").exists()
+    compose = json.loads((context / "compose-project" / "compose.json").read_text("utf-8"))
     assert compose["services"]["main"].get("volumes", []) == []
-    wrapper = [call for call in fake_docker if call[0] == "build"][-1]
-    assert wrapper[1:3] == ("--target", "verifier")
-    assert any(value.startswith("VERIFIER_IMAGE=hud-harbor-verifier:") for value in wrapper)
+    assert compose["services"]["main"]["build"]["target"] == "verifier"
+    assert compose["services"]["main"]["build"]["additional_contexts"] == {
+        "hud-base": "service:hud-base",
+        "hud-verifier": "service:hud-verifier",
+    }
+    assert compose["services"]["hud-verifier"]["scale"] == 0
+    assert compose["services"]["hud-verifier"]["image"].startswith("hud-harbor-verifier:")
 
 
-async def test_separate_verifier_groups_have_distinct_environment_names(
+def test_image_task_keeps_only_the_verifier_as_a_build_service(
     tmp_path: Path,
-    fake_docker,
+) -> None:
+    task = make_harbor_task(tmp_path, "separate-image")
+    (task / "tests" / "Dockerfile").write_text(
+        "FROM python:3.12-alpine\nCOPY . /tests\n",
+        encoding="utf-8",
+    )
+    (task / "task.toml").write_text(
+        '[verifier]\nenvironment_mode = "separate"\n',
+        encoding="utf-8",
+    )
+
+    (row,) = list(harbor.adapt(tmp_path))
+
+    assert row.runtime_config is not None
+    assert row.runtime_config.compose_service_access is True
+    assert isinstance(row.runtime_config.compose, Path)
+    project = _assert_stock_compose_complete(row.runtime_config.compose)
+    assert set(project["services"]) == {"main", "hud-verifier"}
+    assert project["services"]["main"]["build"] == {
+        "additional_contexts": {
+            "hud": "./hud",
+            "hud-verifier": "service:hud-verifier",
+        },
+        "context": "./environment",
+        "dockerfile": "../Dockerfile",
+    }
+    assert project["services"]["hud-verifier"]["scale"] == 0
+    combined = (row.runtime_config.compose.parent / "Dockerfile").read_text("utf-8")
+    assert "FROM hud-verifier AS hud-verifier-root" in combined
+    assert "COPY --from=hud-verifier-root / /media/hud/verifier" in combined
+
+
+def test_separate_verifier_groups_have_distinct_environment_names(
+    tmp_path: Path,
 ) -> None:
     declaration = '[verifier]\nenvironment_mode = "separate"\n'
     compose = "services:\n  main: {}\n  redis:\n    image: redis:7-alpine\n    expose: [6379]\n"
@@ -776,101 +944,92 @@ async def test_separate_verifier_groups_have_distinct_environment_names(
         (task / "environment" / "compose.yaml").write_text(compose, encoding="utf-8")
         (task / "tests" / "Dockerfile").write_text(verifier, encoding="utf-8")
 
-    rows = list(await harbor.adapt(tmp_path))
+    rows = list(harbor.adapt(tmp_path))
 
     assert len({row.env for row in rows}) == 2
     compose_paths = {
-        row.runtime_config.compose
+        compose
         for row in rows
-        if row.runtime_config is not None and row.runtime_config.compose is not None
+        if row.runtime_config is not None
+        and isinstance((compose := row.runtime_config.compose), Path)
     }
     assert len(compose_paths) == 2
     assert all(path.is_file() for path in compose_paths)
-    manifests = [
-        json.loads((path.parent / "tasks.json").read_text("utf-8")) for path in compose_paths
+    task_files = [
+        json.loads((path.parents[1] / "tasks.json").read_text("utf-8")) for path in compose_paths
     ]
-    assert {manifest["tasks"][0]["id"] for manifest in manifests} == {"task-a", "task-b"}
+    assert {rows[0]["slug"] for rows in task_files} == {"task-a", "task-b"}
+    assert {rows[0]["args"]["task"]["id"] for rows in task_files} == {"task-a", "task-b"}
 
 
-async def test_multi_step_tasks_are_refused_directly(tmp_path: Path, fake_docker) -> None:
+def test_multi_step_tasks_are_refused_directly(tmp_path: Path) -> None:
     make_multi_step_task(tmp_path, "multi")
 
     with pytest.raises(NotImplementedError, match="multi-step"):
-        await harbor.adapt(tmp_path)
-
-    assert fake_docker == []
+        harbor.adapt(tmp_path)
 
 
-async def test_invalid_task_config_is_not_silently_defaulted(
+def test_invalid_task_config_is_not_silently_defaulted(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "task.toml").write_text("[environment]\ncpus = 'many'\n", encoding="utf-8")
 
     with pytest.raises(ValueError, match="not a valid Harbor task"):
-        await harbor.adapt(tmp_path)
-
-    assert fake_docker == []
+        harbor.adapt(tmp_path)
 
 
 @pytest.mark.parametrize("source", ["/", "//", "/workspace/../secret"])
-async def test_artifacts_must_name_normalized_paths_beneath_root(
+def test_artifacts_must_name_normalized_paths_beneath_root(
     tmp_path: Path,
-    fake_docker,
     source: str,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "task.toml").write_text(f'artifacts = ["{source}"]\n', encoding="utf-8")
 
     with pytest.raises(ValueError, match="artifact source must name a path beneath /"):
-        await harbor.adapt(tmp_path)
-
-    assert fake_docker == []
+        harbor.adapt(tmp_path)
 
 
-async def test_agent_timeout_becomes_per_task_agent_policy(
+def test_agent_timeout_becomes_per_task_agent_policy(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     task = make_harbor_task(tmp_path, "task-a")
     (task / "task.toml").write_text("[agent]\ntimeout_sec = 60\n", encoding="utf-8")
 
-    taskset = await harbor.adapt(tmp_path)
+    taskset = harbor.adapt(tmp_path)
 
     (row,) = list(taskset)
     assert row.agent_config == {"timeout_seconds": 60.0}
 
 
-async def test_task_symlinks_are_copied_without_reading_host_files(
+def test_task_symlinks_are_copied_without_reading_host_files(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     outside = tmp_path / "outside.txt"
     outside.write_text("host secret", encoding="utf-8")
     task = make_harbor_task(tmp_path / "dataset", "task-a")
     (task / "tests" / "link").symlink_to(outside)
 
-    await harbor.adapt(task.parent)
+    harbor.adapt(task.parent)
 
     (context,) = (task.parent / ".hud-adapt").iterdir()
-    copied = context / "tasks" / "task-a" / "tests" / "link"
+    copied = context / "compose-project" / "tests" / "task-a" / "link"
     assert copied.is_symlink()
     assert os.readlink(copied) == str(outside)
 
 
-async def test_adapt_hashes_links_not_their_targets(
+def test_adapt_hashes_links_not_their_targets(
     tmp_path: Path,
-    fake_docker,
 ) -> None:
     outside = tmp_path / "outside.txt"
     outside.write_text("first", encoding="utf-8")
     task = make_harbor_task(tmp_path / "dataset", "task-a")
     (task / "environment" / "link").symlink_to(outside)
 
-    (before,) = list(await harbor.adapt(task.parent))
+    (before,) = list(harbor.adapt(task.parent))
     outside.write_text("changed", encoding="utf-8")
-    (after,) = list(await harbor.adapt(task.parent))
+    (after,) = list(harbor.adapt(task.parent))
 
     assert before.runtime_config == after.runtime_config
 

--- a/hud/integrations/harbor/tests/test_integration.py
+++ b/hud/integrations/harbor/tests/test_integration.py
@@ -52,8 +52,18 @@ class Oracle(Agent):
         self.solutions = solutions
 
     async def __call__(self, run: Run) -> None:
+        setup = next(
+            step.task_call
+            for step in run.trace.steps
+            if step.task_call is not None and step.task_call.phase == "setup"
+        )
+        assert isinstance(setup.arguments, dict)
+        task = setup.arguments.get("task")
+        assert isinstance(task, dict)
+        task_id = task.get("id")
+        assert isinstance(task_id, str)
         ssh = cast("SSHClient", await run.client.open("ssh/2"))
-        if run.task_id == "agent-lifecycle":
+        if task_id == "agent-lifecycle":
             for index in range(40):
                 result = await ssh.conn.run(f"printf '%s' {index}", check=False)
                 assert result.exit_status == 0, f"command session {index} failed: {result.stderr!r}"
@@ -61,7 +71,7 @@ class Oracle(Agent):
             await ssh.conn.run("cat > session-input", input="written", check=True)
             written = await ssh.conn.run("cat session-input", check=True)
             assert written.stdout == "written"
-        if run.task_id == "hello-mcp":
+        if task_id == "hello-mcp":
             mcp = cast("MCPClient", await run.client.open("mcp-server"))
             assert {tool.name for tool in await mcp.list_tools()} == {"get_secret"}
             assert run.client.manifest is not None
@@ -117,7 +127,7 @@ Path("/app/secret.txt").write_text(result["result"]["content"][0]["text"])
                 raise RuntimeError("workspace MCP client closed without an exit status")
             run.trace.content = "called get_secret from inside the workspace"
             return
-        result = await ssh.conn.run(self.solutions[run.task_id], check=False)
+        result = await ssh.conn.run(self.solutions[task_id], check=False)
         if result.exit_status is None:
             run.trace.content = (
                 "solution SSH channel closed without an exit status:\n"
@@ -139,13 +149,13 @@ async def _grade_every_task(dataset: Path, wheel: Path) -> dict[str, Run]:
         }
 
     solutions = await asyncio.to_thread(load_solutions)
-    taskset = await harbor.adapt(dataset, hud_requirement=str(wheel))
+    taskset = harbor.adapt(dataset, hud_requirement=str(wheel))
     job = await taskset.run(
         Oracle(solutions),
         runtime=DockerRuntime(),
         max_concurrent=1,
     )
-    return {run.task_id: run for run in job.runs}
+    return {cast("str", run.slug): run for run in job.runs}
 
 
 @pytest.fixture(scope="module")
@@ -285,7 +295,7 @@ timeout_sec = 30
     (task / "solution" / "solve.sh").write_text("true\n", encoding="utf-8")
 
     async def grade_twice() -> list[Run]:
-        taskset = await harbor.adapt(dataset, hud_requirement=str(wheel))
+        taskset = harbor.adapt(dataset, hud_requirement=str(wheel))
         job = await taskset.run(
             Oracle({"sidecar-reachability": "true"}),
             runtime=Shared(DockerRuntime(), width=1),
@@ -301,7 +311,7 @@ timeout_sec = 30
         assert any(
             step.task_call is not None
             and step.task_call.phase == "evaluate"
-            and step.task_call.name == "sidecar-reachability:verify"
+            and step.task_call.name == "verify"
             for step in run.trace.steps
         )
 


### PR DESCRIPTION
## Summary

- transport authored Compose files as normalized documents plus their private project contexts
- expose deploy and build-context packaging as SDK library surfaces, with the CLI limited to discovery and presentation
- make Harbor adaptation a Docker-free file transformation that emits portable, task-agnostic Compose projects
- keep hosted SSH capability tunnels alive during long agent runs

## Behavior

- task rows remain the source of truth for runtime configuration
- Compose recipes infer Modal builds unless the artifact is a single-image BuildKit project supported by HUD builds
- image-task artifacts use a named `hud` BuildKit context without modifying the user's environment context
- multi-service artifacts retain service build contexts for private DinD builds
- Harbor task instructions and verifier configuration travel in task arguments rather than image contents

## Validation

- `uv run pytest hud/eval/tests hud/cli/tests/test_deploy.py hud/integrations/harbor/tests hud/capabilities/tests/test_ssh.py`: 283 passed, 9 integration tests deselected
- Harbor Docker integration suite after rebase: 8 passed; one local `hello-mcp` build was blocked by invalid GPG signatures returned from `ports.ubuntu.com` during `apt-get update`
- the same nine Docker integration tests passed before the rebase
- dev hosted-Modal E2E: trace `4e7c993b-7d92-434e-a25d-467f419f55eb`, 35 real `claude-sonnet-4-5` steps, completed through DinD and grading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to runtime acquisition, deploy payloads, and Harbor adaptation affect how environments are built and run locally and on Modal; mis-staged Compose or build scripts could break evals and hosted rollouts.
> 
> **Overview**
> **Compose becomes the primary transport** for multi-service and Harbor environments: `RuntimeConfig` now carries embedded compose documents and `compose_project` refs for the platform, while local Docker/Modal providers run projects via `ComposeProject` staging, optional `build.sh` preparation, and Modal DinD with minimum 4 CPU / 8 GiB.
> 
> **Harbor `adapt()` is synchronous and Docker-free** — it packages `compose-project/` artifacts (with `build.sh`, `config.json`, and task data in row `args` instead of baked image contents) and drops the `push=` argument. **Deploy and local eval** discover `compose.yaml` contexts, accept `--runtime hud|modal`, and route local eval rows with compose/image config through `DockerRuntime` per task.
> 
> **SSH capabilities** use TCP keepalives so long tunneled sessions stay up during agent runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 728547c3b1c21b672b1e48acd69d9033337f7641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->