### PR TITLE
fix(eval): reject unscored grade frames

### DIFF
--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -285,6 +285,7 @@ class Run:
 
         try:
             evaluation = await self.client.grade(answer)
+            grade = Grade.from_dict(evaluation)
         except Exception as grade_exc:
             if exc_type is None and not self._best_effort_grade:
                 raise
@@ -294,7 +295,7 @@ class Run:
             self.record(Step(source="system", error=f"[grading] {detail}"))
             return False
 
-        self.grade = Grade.from_dict(evaluation)
+        self.grade = grade
         self.record(
             Step(
                 source="task",

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Any, Literal, Self, cast
 
 import mcp.types as mcp_types
 
-from hud.clients import connect
+from hud.clients import HudProtocolError, connect
 from hud.graders.results import SubScore
 from hud.telemetry.context import set_trace_context
 from hud.types import Step, TaskCall, Trace
@@ -108,6 +108,9 @@ class Grade:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Grade:
         """Parse the wire grade frame (canonical keys: the server guarantees them)."""
+        score = data.get("score")
+        if isinstance(score, bool) or not isinstance(score, (int, float)):
+            raise HudProtocolError(-32603, "tasks.grade: result must include a numeric 'score'")
         raw_info = data.get("info")
         raw = dict(data)
         if isinstance(subscores := data.get("subscores"), list):
@@ -115,7 +118,7 @@ class Grade:
                 SubScore.model_validate(subscore).to_summary() for subscore in subscores
             ]
         return cls(
-            reward=float(data.get("score") or 0.0),
+            reward=float(score),
             done=bool(data.get("done", True)),
             content=data.get("content") if isinstance(data.get("content"), str) else None,
             info=raw_info if isinstance(raw_info, dict) else {},

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -304,6 +304,57 @@ async def test_verifier_remains_authoritative_when_actor_grading_fails(
     assert placements == ["actor", "judge"]
 
 
+async def test_verifier_remains_authoritative_when_actor_grade_is_scoreless(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.clients import HudClient
+
+    actor_env = Environment("actor")
+    verifier_env = Environment("judge")
+    placements: list[str] = []
+
+    @actor_env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @verifier_env.template()
+    async def verify():
+        answer = yield ""
+        yield 1.0 if answer == "secret" else 0.0
+
+    @asynccontextmanager
+    async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
+        placements.append(row.env)
+        async with _local(actor_env if row.env == "actor" else verifier_env) as runtime:
+            yield runtime
+
+    original_grade = HudClient.grade
+    grade_calls = 0
+
+    async def return_scoreless_actor_grade(
+        self: HudClient, payload: dict[str, Any]
+    ) -> dict[str, Any]:
+        nonlocal grade_calls
+        grade_calls += 1
+        if grade_calls == 1:
+            return {"reward": 1.0}
+        return await original_grade(self, payload)
+
+    monkeypatch.setattr(HudClient, "grade", return_scoreless_actor_grade)
+    task = Task(env="actor", id="solve", verifier=Task(env="judge", id="verify"))
+
+    run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=provider)
+    job = Job(id="actor-scoreless", name="actor-scoreless", runs=[run])
+
+    assert run.trace.is_error
+    assert "numeric 'score'" in (run.trace.error or "")
+    assert run.reward == 1.0
+    assert run.grade.raw["score"] == 1.0
+    assert placements == ["actor", "judge"]
+    assert job.errors == []
+
+
 async def test_verifier_provisioning_failure_leaves_the_run_ungraded() -> None:
     actor_env = Environment("actor")
 

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -328,6 +328,123 @@ async def test_verifier_provisioning_failure_leaves_the_run_ungraded() -> None:
     assert run.reward == 0.0
 
 
+async def test_verifier_channel_failure_leaves_the_run_ungraded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.clients import HudClient
+
+    env = Environment("reviewed")
+
+    @env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @env.template()
+    async def verify():
+        yield ""
+        yield 1.0
+
+    original_grade = HudClient.grade
+    grade_calls = 0
+
+    async def fail_verifier_grade(self: HudClient, payload: dict[str, Any]) -> dict[str, Any]:
+        nonlocal grade_calls
+        grade_calls += 1
+        if grade_calls == 2:
+            raise ConnectionError("channel died after a partial grade frame")
+        return await original_grade(self, payload)
+
+    monkeypatch.setattr(HudClient, "grade", fail_verifier_grade)
+    task = Task(
+        env="reviewed",
+        id="solve",
+        verifier=Task(env="reviewed", id="verify"),
+    )
+
+    run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=lambda _row: _local(env))
+    job = Job(id="verify-failed", name="verify-failed", runs=[run])
+
+    assert run.trace.is_error
+    assert "channel died after a partial grade frame" in (run.trace.error or "")
+    assert run.grade.raw == {}
+    assert job.errors == [run]
+
+
+async def test_scoreless_verifier_frame_is_an_ungraded_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.clients import HudClient
+
+    env = Environment("reviewed")
+
+    @env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @env.template()
+    async def verify():
+        yield ""
+        yield 1.0
+
+    original_grade = HudClient.grade
+    grade_calls = 0
+
+    async def return_scoreless_frame(self: HudClient, payload: dict[str, Any]) -> dict[str, Any]:
+        nonlocal grade_calls
+        grade_calls += 1
+        if grade_calls == 2:
+            return {"reward": 1.0}
+        return await original_grade(self, payload)
+
+    monkeypatch.setattr(HudClient, "grade", return_scoreless_frame)
+    task = Task(
+        env="reviewed",
+        id="solve",
+        verifier=Task(env="reviewed", id="verify"),
+    )
+
+    run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=lambda _row: _local(env))
+    job = Job(id="verify-scoreless", name="verify-scoreless", runs=[run])
+
+    assert run.trace.is_error
+    assert "numeric 'score'" in (run.trace.error or "")
+    assert run.grade.raw == {}
+    assert job.errors == [run]
+
+
+async def test_zero_score_verifier_grade_counts_an_errored_rollout() -> None:
+    env = Environment("reviewed")
+
+    @env.template()
+    async def solve():
+        yield "answer secret"
+        yield 0.25
+
+    @env.template()
+    async def verify():
+        yield ""
+        yield 0.0
+
+    task = Task(
+        env="reviewed",
+        id="solve",
+        verifier=Task(env="reviewed", id="verify"),
+    )
+    run = await rollout(
+        task,
+        _AnswerThenBoomAgent(lambda _prompt: "secret"),
+        runtime=lambda _row: _local(env),
+    )
+    job = Job(id="verify-zero", name="verify-zero", runs=[run])
+
+    assert run.trace.is_error
+    assert run.grade.raw["score"] == 0.0
+    assert job.reward == 0.0
+    assert job.errors == []
+
+
 def _bindings_env(published: Any) -> Environment:
     """An env whose task publishes per-episode binding data alongside the prompt."""
     env = Environment("slots")


### PR DESCRIPTION
Reject grade responses that do not include a numeric `score`, leaving failed verifier exchanges ungraded so errored runs are reported in `Job.errors`. Valid zero-score grades continue to count as completed results.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes grading wire validation and how errored vs completed runs are classified in Job aggregation; behavior shift for malformed grade payloads but covered by rollout tests.
> 
> **Overview**
> **Grade parsing** now requires a numeric `score` on wire grade frames. Missing `score`, booleans, or non-numeric values raise `HudProtocolError` instead of silently treating the outcome as **0.0** reward.
> 
> Rollout exit grading parses the frame before assigning `run.grade`, so invalid actor grades surface as grading errors while a **verifier** can still replace the outcome when it returns a valid score.
> 
> Failed verifier grading (transport errors or scoreless frames) leaves the run **ungraded** (`grade.raw` empty), so those runs appear in **`Job.errors`**. A legitimate **0.0** verifier score still counts as a completed graded rollout and is not listed as a job error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab4902fc23ec5e7f09542f13bf0a2602bd35fc03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->