### PR TITLE
fix(ssh): harden persistent tool connections

### DIFF
--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -152,7 +152,7 @@ class ClaudeSDKAgent(Agent):
         logger.info("SSH exec claude CLI (%d chars)", len(full_cmd))
         logger.info("Full command: %s", full_cmd)
 
-        completed = await self._ssh.conn.run(full_cmd, check=False)
+        completed = await self._ssh.run(full_cmd, check=False)
         stdout = completed.stdout if isinstance(completed.stdout, str) else ""
         stderr = completed.stderr if isinstance(completed.stderr, str) else ""
 

--- a/hud/agents/openai/tools/coding.py
+++ b/hud/agents/openai/tools/coding.py
@@ -7,6 +7,12 @@ from typing import Any, cast
 import mcp.types as mcp_types
 
 from hud.agents.tools import SSHTool
+from hud.agents.tools.ssh import (
+    DEFAULT_SSH_COMMAND_TIMEOUT_S,
+    MAX_SHELL_OUTPUT_LENGTH,
+    SSHInfrastructureErrorResult,
+    bound_shell_output,
+)
 from hud.types import MCPToolResult
 
 from .base import OpenAIToolSpec
@@ -15,9 +21,6 @@ OPENAI_SHELL_SPEC = OpenAIToolSpec(
     api_type="shell",
     api_name="shell",
 )
-
-MAX_SHELL_OUTPUT_LENGTH = 10 * 1024 * 1024
-TRUNCATION_MARKER = "[truncated]"
 
 
 class OpenAIShellTool(SSHTool):
@@ -85,11 +88,29 @@ class OpenAIShellTool(SSHTool):
                 full_cmd = f"timeout {int(env_arguments['timeout_seconds'])} {command}"
             else:
                 full_cmd = command
-            completed = await self.client.conn.run(full_cmd, check=False)
+            try:
+                completed = await self.client.run(
+                    full_cmd,
+                    check=False,
+                    timeout=self._remaining_timeout(),
+                )
+            except TimeoutError:
+                text = f"tool error: command timed out after {DEFAULT_SSH_COMMAND_TIMEOUT_S:g}s"
+                outputs.append(shell_output("", text, 1))
+                display_outputs.append(text)
+                return _shell_result(
+                    display_outputs,
+                    is_error=True,
+                    infrastructure_error=True,
+                    structured={
+                        "output": outputs,
+                        "max_output_length": max_output_length,
+                    },
+                )
             stdout = completed.stdout if isinstance(completed.stdout, str) else ""
             stderr = completed.stderr if isinstance(completed.stderr, str) else ""
             exit_code = completed.exit_status if completed.exit_status is not None else 1
-            stdout, stderr = _bound_output(stdout, stderr, max_output_length)
+            stdout, stderr = bound_shell_output(stdout, stderr, max_output_length)
             outputs.append(shell_output(stdout, stderr, exit_code))
             display_outputs.append(stdout + stderr)
             is_error = is_error or bool(exit_code)
@@ -108,39 +129,16 @@ def _shell_result(
     texts: list[str],
     *,
     is_error: bool = False,
+    infrastructure_error: bool = False,
     structured: dict[str, Any] | None = None,
 ) -> MCPToolResult:
     payload = {"provider_tool": "shell", **(structured or {})}
-    return MCPToolResult(
+    result_type = SSHInfrastructureErrorResult if infrastructure_error else MCPToolResult
+    return result_type(
         content=[mcp_types.TextContent(type="text", text=text) for text in texts if text],
         isError=is_error,
         structuredContent=payload,
     )
-
-
-def _bound_output(stdout: str, stderr: str, limit: int) -> tuple[str, str]:
-    total_length = len(stdout) + len(stderr)
-    if total_length <= limit:
-        return stdout, stderr
-
-    marker = TRUNCATION_MARKER[:limit]
-    available = limit - len(marker)
-    prefix_length = (available + 1) // 2
-    suffix_length = available // 2
-
-    stdout_prefix = stdout[:prefix_length]
-    stderr_prefix = stderr[: max(0, prefix_length - len(stdout))]
-    stderr_suffix = stderr[-suffix_length:] if suffix_length else ""
-    stdout_suffix_length = max(0, suffix_length - len(stderr))
-    stdout_suffix = stdout[-stdout_suffix_length:] if stdout_suffix_length else ""
-
-    if len(stdout_prefix) + len(stdout_suffix) < len(stdout):
-        stdout = stdout_prefix + marker + stdout_suffix
-        stderr = stderr_prefix + stderr_suffix
-    else:
-        stdout = stdout_prefix + stdout_suffix
-        stderr = stderr_prefix + marker + stderr_suffix
-    return stdout, stderr
 
 
 def shell_output(stdout: str, stderr: str, exit_code: int) -> dict[str, Any]:

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -55,6 +55,9 @@ class _FakeConn:
         self.ran: list[str] = []
         self.write_commands: list[str] = []
 
+    def is_closed(self) -> bool:
+        return False
+
     async def run(
         self,
         cmd: str,

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -7,6 +7,7 @@ client and assert the command translation + result shape, fully offline.
 
 from __future__ import annotations
 
+import asyncio
 import shlex
 from typing import Any, cast
 
@@ -19,9 +20,12 @@ from hud.agents.gemini.tools.coding import GeminiEditTool, GeminiShellTool
 from hud.agents.openai.tools.coding import OpenAIShellTool
 from hud.agents.openai_compatible.agent import OpenAIChatAgent
 from hud.agents.openai_compatible.tools import BashTool, EditTool, ReadTool, WriteTool
+from hud.agents.tool_agent import RunState
 from hud.agents.tools.base import result_text
+from hud.agents.tools.ssh import SSHInfrastructureErrorResult, bound_shell_output
 from hud.agents.types import OpenAIChatConfig
 from hud.capabilities import Capability, SSHClient
+from hud.types import MCPToolCall
 
 
 class _Completed:
@@ -36,6 +40,9 @@ class _Conn:
         self._completed = completed
         self._store = store
         self.commands: list[str] = []
+
+    def is_closed(self) -> bool:
+        return False
 
     async def run(
         self,
@@ -91,6 +98,36 @@ class _Conn:
             return _Completed(exit_status=0)
         return self._completed
 
+    async def create_process(self, command: str, **kwargs: Any) -> _Process:
+        return _Process(await self.run(command, **kwargs))
+
+
+class _Process:
+    def __init__(self, completed: _Completed) -> None:
+        self.completed = completed
+        self.closed = False
+
+    async def wait(self, *, check: bool, timeout: float) -> _Completed:  # noqa: ASYNC109
+        del timeout
+        if check and self.completed.exit_status:
+            raise asyncssh.ProcessError(
+                env=None,
+                command=None,
+                subsystem=None,
+                exit_status=self.completed.exit_status,
+                exit_signal=None,
+                returncode=self.completed.exit_status,
+                stdout=self.completed.stdout,
+                stderr=self.completed.stderr,
+            )
+        return self.completed
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
 
 class _FakeSSH(SSHClient):
     """SSH client with an in-memory exec-channel filesystem."""
@@ -116,6 +153,20 @@ class _FakeSSH(SSHClient):
                 ),
             ),
         )
+
+
+class _TimedSSH:
+    def __init__(self) -> None:
+        self.timeouts: list[float] = []
+
+    async def run(self, command: str, **kwargs: Any) -> _Completed:
+        self.timeouts.append(kwargs["timeout"])
+        await asyncio.sleep(0.01)
+        return _Completed(exit_status=1 if command.startswith("test ") else 0)
+
+    async def write_text(self, path: str, content: str, *, timeout_s: float) -> None:
+        del path, content
+        self.timeouts.append(timeout_s)
 
 
 def _ssh(**kwargs: Any) -> SSHClient:
@@ -154,34 +205,32 @@ async def test_openai_shell_runs_each_command_without_timeout() -> None:
     assert _commands(tool) == ["echo a", "echo b"]
 
 
-async def test_openai_shell_bounds_large_output_in_every_result_field() -> None:
-    limit = 20_000
-    stderr_prefix = "stderr-start\n"
-    stderr_suffix = "\nstderr-end"
-    stderr = (
-        stderr_prefix + "x" * (10_523_560 - len(stderr_prefix) - len(stderr_suffix)) + stderr_suffix
-    )
-    tool = OpenAIShellTool(
-        spec=OpenAIShellTool.default_spec("gpt-5.5"),
-        client=_ssh(stderr=stderr, exit_status=1),
+async def test_openai_shell_shares_timeout_across_command_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
+    timeouts: list[float] = []
+
+    async def run(*args: object, **kwargs: Any) -> _Completed:
+        del args
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, float)
+        timeouts.append(timeout)
+        await asyncio.sleep(0.01)
+        return _Completed()
+
+    monkeypatch.setattr(tool.client, "run", run)
+    agent = _OpenAIChatAgentForTest(
+        OpenAIChatConfig(model="test", model_client=cast("Any", object()))
     )
 
-    result = await tool.execute({"commands": ["noisy-command"], "max_output_length": limit})
+    await agent._dispatch_call(
+        MCPToolCall(name="shell", arguments={"commands": ["echo a", "echo b"]}),
+        RunState(tools={"shell": tool}),
+    )
 
-    assert result.structuredContent is not None
-    assert result.structuredContent["max_output_length"] == limit
-    output = result.structuredContent["output"][0]
-    assert len(output["stdout"]) + len(output["stderr"]) == limit
-    assert output["stderr"].startswith(stderr_prefix)
-    assert output["stderr"].endswith(stderr_suffix)
-    assert "[truncated]" in output["stderr"]
-    text_blocks = [
-        block.text for block in result.content if isinstance(block, mcp_types.TextContent)
-    ]
-    assert len(text_blocks) == 1
-    assert len(text_blocks[0]) == limit
-    assert text_blocks[0] == output["stdout"] + output["stderr"]
-    assert "[truncated]" in text_blocks[0]
+    assert len(timeouts) == 2
+    assert timeouts[0] > timeouts[1]
 
 
 async def test_openai_shell_applies_limit_independently_to_each_command() -> None:
@@ -210,30 +259,12 @@ async def test_openai_shell_applies_limit_independently_to_each_command() -> Non
     assert text_blocks == [output["stdout"] + output["stderr"] for output in outputs]
 
 
-@pytest.mark.parametrize(
-    ("max_output_length", "expected_output"),
-    [(1, "["), (10, "[truncated")],
-)
-async def test_openai_shell_honors_small_positive_output_limits(
-    max_output_length: int,
-    expected_output: str,
+@pytest.mark.parametrize(("limit", "expected"), [(1, "["), (10, "[truncated")])
+def test_shared_output_bound_handles_limits_smaller_than_marker(
+    limit: int,
+    expected: str,
 ) -> None:
-    tool = OpenAIShellTool(
-        spec=OpenAIShellTool.default_spec("gpt-5.5"),
-        client=_ssh(stdout="x" * 100),
-    )
-
-    result = await tool.execute(
-        {"commands": ["noisy-command"], "max_output_length": max_output_length}
-    )
-
-    assert _commands(tool) == ["noisy-command"]
-    assert result.structuredContent is not None
-    assert result.structuredContent["max_output_length"] == max_output_length
-    output = result.structuredContent["output"][0]
-    assert output["stdout"] == expected_output
-    assert output["stderr"] == ""
-    assert result_text(result) == expected_output
+    assert bound_shell_output("x" * 100, "", limit) == (expected, "")
 
 
 @pytest.mark.parametrize("max_output_length", [0, -1, "20000", 20_000.0, True])
@@ -307,6 +338,89 @@ async def test_openai_compatible_bash_uses_workdir_and_timeout() -> None:
     await tool.execute({"command": "echo hi", "workdir": "/tmp/my dir", "timeout": 2500})
 
     assert _commands(tool) == ["cd '/tmp/my dir' && timeout 3s bash -lc 'echo hi'"]
+
+
+async def test_shared_ssh_timeout_returns_infrastructure_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ssh = _ssh()
+
+    async def timeout(*args: object, **kwargs: Any) -> _Completed:
+        del args, kwargs
+        raise TimeoutError
+
+    monkeypatch.setattr(ssh, "run", timeout)
+    tool = BashTool(spec=BashTool.default_spec("qwen"), client=ssh)
+
+    result = await tool.execute({"command": "sleep forever"})
+
+    assert result.isError is True
+    assert isinstance(result, SSHInfrastructureErrorResult)
+    assert result_text(result) == "tool error: command timed out after 300s"
+
+
+async def test_openai_shell_uses_the_same_ssh_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ssh = _ssh()
+
+    async def timeout(*args: object, **kwargs: Any) -> _Completed:
+        del args, kwargs
+        raise TimeoutError
+
+    monkeypatch.setattr(ssh, "run", timeout)
+    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=ssh)
+
+    result = await tool.execute({"commands": ["sleep forever"]})
+
+    assert isinstance(result, SSHInfrastructureErrorResult)
+    assert result.structuredContent is not None
+    assert result.structuredContent["output"][0]["stderr"] == (
+        "tool error: command timed out after 300s"
+    )
+
+
+async def test_composite_ssh_tool_shares_one_operation_deadline() -> None:
+    ssh = _TimedSSH()
+    tool = EditTool(spec=EditTool.default_spec("test"), client=cast("SSHClient", ssh))
+    agent = _OpenAIChatAgentForTest(
+        OpenAIChatConfig(model="test", model_client=cast("Any", object()))
+    )
+
+    result = await agent._dispatch_call(
+        MCPToolCall(
+            name="edit",
+            arguments={"filePath": "/work/f.txt", "oldString": "", "newString": "new"},
+        ),
+        RunState(tools={"edit": tool}),
+    )
+
+    assert result.isError is False
+    assert len(ssh.timeouts) == 3
+    assert ssh.timeouts[0] > ssh.timeouts[1] > ssh.timeouts[2]
+
+
+async def test_shared_ssh_tool_bounds_combined_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("hud.agents.tools.ssh.MAX_SHELL_OUTPUT_LENGTH", 80)
+    tool = BashTool(
+        spec=BashTool.default_spec("qwen"),
+        client=_ssh(
+            stdout="stdout-start-" + "a" * 100,
+            stderr="b" * 100 + "-stderr-end",
+        ),
+    )
+
+    result = await tool.execute({"command": "noisy"})
+
+    text = result_text(result)
+    output = text.split("\n", 1)[1].rsplit("\n(exit 0)", 1)[0]
+    stdout, stderr = output.split("\nstderr:\n", 1)
+    assert len(stdout) + len(stderr) == 80
+    assert stdout.startswith("stdout-start-")
+    assert stderr.endswith("-stderr-end")
+    assert "[truncated]" in output
 
 
 async def test_openai_compatible_write_stores_file_via_ssh_exec() -> None:

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal, cast
+from unittest.mock import AsyncMock
 
 import fastmcp
 import mcp.types as mcp_types
@@ -19,9 +20,11 @@ from hud.agents.openai.tools.mcp_proxy import OpenAIMCPProxyTool
 from hud.agents.tool_agent import RunState, ToolAgent
 from hud.agents.tools.base import AgentToolSpec
 from hud.agents.tools.rfb import RFBTool
+from hud.agents.tools.ssh import SSHInfrastructureErrorResult
 from hud.agents.types import AgentConfig, AgentStep, ClaudeConfig, ClaudeSDKConfig, ToolStep
 from hud.capabilities import Capability, CapabilityClient, MCPClient, RFBClient, SSHClient
 from hud.capabilities.rfb import PngScreenshotEncoding, WebPScreenshotEncoding
+from hud.capabilities.ssh import SSHConnectionError
 from hud.types import MCPToolCall, MCPToolResult, Step, Trace
 
 if TYPE_CHECKING:
@@ -368,6 +371,19 @@ async def test_dispatch_unparsed_arguments_returns_error_result() -> None:
     assert '{"command": "' in content.text  # the raw prefix re-anchors the model
 
 
+async def test_dispatch_marks_exhausted_ssh_reconnect_as_infrastructure_error() -> None:
+    agent = DictAgent([])
+    tool = SimpleNamespace(
+        execute=AsyncMock(side_effect=SSHConnectionError("SSH reconnect failed after 3 attempts"))
+    )
+    state: RunState[_Msg] = RunState(tools={"bash": cast("Any", tool)})
+
+    result = await agent._dispatch_call(MCPToolCall(name="bash"), state)
+
+    assert result.isError is True
+    assert isinstance(result, SSHInfrastructureErrorResult)
+
+
 async def test_loop_finishes_on_done_response() -> None:
     agent = DictAgent([AgentStep(content="final answer", done=True)])
     run = cast("Run", _FakeRun())
@@ -408,6 +424,35 @@ async def test_loop_dispatches_tool_calls_then_finishes() -> None:
     assert tool_step.call.name == "ghost"
     assert tool_step.result is not None
     assert tool_step.result.isError is True  # unknown tool → error result
+
+
+async def test_loop_resets_infrastructure_error_count_after_other_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    turns = [
+        AgentStep(content="", done=False, tool_calls=[MCPToolCall(name="bash")]) for _ in range(5)
+    ]
+    agent = DictAgent(turns)
+    infrastructure_error = SSHInfrastructureErrorResult(content=[], isError=True)
+    ordinary_error = MCPToolResult(content=[], isError=True)
+    dispatch = AsyncMock(
+        side_effect=[
+            infrastructure_error,
+            ordinary_error,
+            infrastructure_error,
+            infrastructure_error,
+            infrastructure_error,
+        ]
+    )
+    monkeypatch.setattr(agent, "_dispatch_call", dispatch)
+    run = cast("Run", _FakeRun())
+
+    await agent._loop(run, RunState(), max_steps=10)
+
+    assert dispatch.await_count == 5
+    assert run.trace.status == "error"
+    assert run.trace.stop_reason is None
+    assert run.trace.error == ("SSH tool failure limit reached after 3 consecutive errors")
 
 
 async def test_loop_max_steps_is_normal_termination() -> None:

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -30,8 +30,10 @@ from hud.agents.misc import auto_respond
 from hud.agents.tools.base import AgentTool, provider_tool_name
 from hud.agents.tools.mcp import MCPTool
 from hud.agents.tools.rfb import RFBTool
+from hud.agents.tools.ssh import SSHInfrastructureErrorResult, SSHTool
 from hud.agents.types import AgentStep, ToolStep
 from hud.capabilities import MCPClient, RFBClient
+from hud.capabilities.ssh import SSHConnectionError
 from hud.types import AgentType, MCPToolCall, MCPToolResult, Step, StopCondition
 from hud.utils.time import now_iso
 
@@ -45,6 +47,7 @@ logger = logging.getLogger(__name__)
 # Output-token-cap finish reasons: OpenAI chat "length", Responses "max_output_tokens",
 # Claude "max_tokens", Gemini "MAX_TOKENS".
 TRUNCATION_FINISH_REASONS = frozenset({"length", "max_output_tokens", "max_tokens", "MAX_TOKENS"})
+MAX_CONSECUTIVE_SSH_FAILURES = 3
 
 MessageT = TypeVar("MessageT")
 ConfigT = TypeVar("ConfigT", bound="AgentConfig")
@@ -221,6 +224,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
             step: AgentStep | None = None
             hit_max = False
             stopped: StopCondition | None = None
+            consecutive_ssh_failures = 0
 
             for turn in range(1, max_steps + 1):
                 logger.info("step %d/%d", turn, max_steps)
@@ -258,12 +262,24 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                     result = await self._dispatch_call(call, state)
                     run.record(ToolStep(call=call, result=result, started_at=call_started_at))
                     msg = self._format_result(call, result, state)
-                    if msg is None:
-                        continue
                     if isinstance(msg, list):
                         state.messages.extend(msg)
-                    else:
+                    elif msg is not None:
                         state.messages.append(cast("MessageT", msg))
+
+                    if isinstance(result, SSHInfrastructureErrorResult):
+                        consecutive_ssh_failures += 1
+                    else:
+                        consecutive_ssh_failures = 0
+                    if consecutive_ssh_failures >= MAX_CONSECUTIVE_SSH_FAILURES:
+                        error = (
+                            "SSH tool failure limit reached "
+                            f"after {MAX_CONSECUTIVE_SSH_FAILURES} consecutive errors"
+                        )
+                        trace.content = step.content
+                        trace.status = "error"
+                        run.record(Step(source="system", error=error))
+                        return
 
                 if turn == max_steps:
                     hit_max = True
@@ -323,9 +339,17 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
             )
         args = call.arguments or {}
         try:
+            if isinstance(tool, SSHTool):
+                return await tool.execute_with_deadline(args)
             return await tool.execute(args)
         except (TimeoutError, asyncio.CancelledError):
             raise
+        except SSHConnectionError as exc:
+            logger.exception("tool %s lost its SSH connection", call.name)
+            return SSHInfrastructureErrorResult(
+                content=[mcp_types.TextContent(type="text", text=f"tool error: {exc}")],
+                isError=True,
+            )
         except Exception as exc:
             logger.exception("tool %s failed", call.name)
             return MCPToolResult(

--- a/hud/agents/tools/ssh.py
+++ b/hud/agents/tools/ssh.py
@@ -7,12 +7,25 @@ differs between providers.
 
 from __future__ import annotations
 
+import asyncio
+from contextvars import ContextVar
+from typing import Any
+
 import asyncssh
 import mcp.types as mcp_types
 
 from hud.agents.tools.base import AgentTool, tool_err, tool_ok
 from hud.capabilities import SSHClient
 from hud.types import MCPToolResult
+
+DEFAULT_SSH_COMMAND_TIMEOUT_S = 300.0
+MAX_SHELL_OUTPUT_LENGTH = 10 * 1024 * 1024
+TRUNCATION_MARKER = "[truncated]"
+_OPERATION_DEADLINE: ContextVar[float | None] = ContextVar("ssh_operation_deadline", default=None)
+
+
+class SSHInfrastructureErrorResult(MCPToolResult):
+    """Internal marker for SSH failures which count toward the circuit breaker."""
 
 
 def _remote_error(exc: asyncssh.ProcessError) -> str:
@@ -30,11 +43,33 @@ class SSHTool(AgentTool[SSHClient]):
 
     # ─── action helpers ───────────────────────────────────────────────
 
+    async def execute_with_deadline(self, arguments: dict[str, Any]) -> MCPToolResult:
+        deadline = asyncio.get_running_loop().time() + DEFAULT_SSH_COMMAND_TIMEOUT_S
+        token = _OPERATION_DEADLINE.set(deadline)
+        try:
+            return await self.execute(arguments)
+        finally:
+            _OPERATION_DEADLINE.reset(token)
+
+    def _remaining_timeout(self) -> float:
+        deadline = _OPERATION_DEADLINE.get()
+        if deadline is None:
+            return DEFAULT_SSH_COMMAND_TIMEOUT_S
+        return max(0.0, deadline - asyncio.get_running_loop().time())
+
     async def bash(self, command: str) -> MCPToolResult:
         """Run a shell command. Returns combined stdout/stderr + exit code."""
-        completed = await self.client.conn.run(command, check=False)
+        try:
+            completed = await self.client.run(
+                command,
+                check=False,
+                timeout=self._remaining_timeout(),
+            )
+        except TimeoutError:
+            return _timeout_error(f"command timed out after {DEFAULT_SSH_COMMAND_TIMEOUT_S:g}s")
         stdout = completed.stdout if isinstance(completed.stdout, str) else ""
         stderr = completed.stderr if isinstance(completed.stderr, str) else ""
+        stdout, stderr = bound_shell_output(stdout, stderr, MAX_SHELL_OUTPUT_LENGTH)
         body = f"$ {command}\n{stdout}"
         if stderr:
             body += f"\nstderr:\n{stderr}"
@@ -47,14 +82,27 @@ class SSHTool(AgentTool[SSHClient]):
     async def file_read(self, path: str) -> MCPToolResult:
         """Read a text file through SSH exec."""
         try:
-            return tool_ok(await self.client.read_text(path))
+            return tool_ok(
+                await self.client.read_text(
+                    path,
+                    timeout_s=self._remaining_timeout(),
+                )
+            )
+        except TimeoutError:
+            return _timeout_error(f"reading {path} timed out")
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
 
     async def file_write(self, path: str, content: str) -> MCPToolResult:
         """Write a text file through SSH exec."""
         try:
-            await self.client.write_text(path, content)
+            await self.client.write_text(
+                path,
+                content,
+                timeout_s=self._remaining_timeout(),
+            )
+        except TimeoutError:
+            return _timeout_error(f"writing {path} timed out")
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
         return tool_ok(f"wrote {len(content)} bytes to {path}")
@@ -62,10 +110,46 @@ class SSHTool(AgentTool[SSHClient]):
     async def file_list(self, path: str = "/") -> MCPToolResult:
         """List directory entries through SSH exec."""
         try:
-            names = await self.client.listdir(path)
+            names = await self.client.listdir(
+                path,
+                timeout_s=self._remaining_timeout(),
+            )
+        except TimeoutError:
+            return _timeout_error(f"listing {path} timed out")
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
         return tool_ok("\n".join(names) if names else "(empty)")
+
+
+def _timeout_error(detail: str) -> SSHInfrastructureErrorResult:
+    return SSHInfrastructureErrorResult(
+        content=[mcp_types.TextContent(type="text", text=f"tool error: {detail}")],
+        isError=True,
+    )
+
+
+def bound_shell_output(stdout: str, stderr: str, limit: int) -> tuple[str, str]:
+    if len(stdout) + len(stderr) <= limit:
+        return stdout, stderr
+
+    marker = TRUNCATION_MARKER[:limit]
+    available = limit - len(marker)
+    prefix_length = (available + 1) // 2
+    suffix_length = available // 2
+
+    stdout_prefix = stdout[:prefix_length]
+    stderr_prefix = stderr[: max(0, prefix_length - len(stdout))]
+    stderr_suffix = stderr[-suffix_length:] if suffix_length else ""
+    stdout_suffix_length = max(0, suffix_length - len(stderr))
+    stdout_suffix = stdout[-stdout_suffix_length:] if stdout_suffix_length else ""
+
+    if len(stdout_prefix) + len(stdout_suffix) < len(stdout):
+        stdout = stdout_prefix + marker + stdout_suffix
+        stderr = stderr_prefix + stderr_suffix
+    else:
+        stdout = stdout_prefix + stdout_suffix
+        stderr = stderr_prefix + marker + stderr_suffix
+    return stdout, stderr
 
 
 __all__ = ["SSHTool"]

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import contextlib
 import shlex
 from typing import Any, ClassVar, Self
 from urllib.parse import urlsplit
@@ -10,6 +12,14 @@ from urllib.parse import urlsplit
 import asyncssh
 
 from .base import Capability, CapabilityClient
+
+SSH_RECONNECT_ATTEMPTS = 3
+SSH_RECONNECT_BASE_DELAY_S = 0.25
+SSH_SESSION_CLOSE_TIMEOUT_S = 5.0
+
+
+class SSHConnectionError(ConnectionError):
+    """SSH transport was unavailable for an operation."""
 
 
 class SSHClient(CapabilityClient):
@@ -26,9 +36,15 @@ class SSHClient(CapabilityClient):
     def __init__(self, capability: Capability, conn: asyncssh.SSHClientConnection) -> None:
         self.capability = capability
         self._conn = conn
+        self._reconnect_lock = asyncio.Lock()
+        self._closing = False
 
     @classmethod
     async def connect(cls, cap: Capability) -> Self:
+        return cls(cap, await cls._connect(cap))
+
+    @staticmethod
+    async def _connect(cap: Capability) -> asyncssh.SSHClientConnection:
         parts = urlsplit(cap.url)
         if parts.hostname is None or parts.port is None:
             raise ValueError(f"ssh capability missing host or port: {cap.url!r}")
@@ -39,7 +55,7 @@ class SSHClient(CapabilityClient):
             client_keys = [asyncssh.import_private_key(client_key)]
         elif client_key_path := cap.params.get("client_key_path"):
             client_keys = [client_key_path]
-        conn = await asyncssh.connect(
+        return await asyncssh.connect(
             host=parts.hostname,
             port=parts.port,
             username=cap.params.get("user", "agent"),
@@ -48,31 +64,113 @@ class SSHClient(CapabilityClient):
             keepalive_interval=15,
             keepalive_count_max=4,
         )
-        return cls(cap, conn)
 
     @property
     def conn(self) -> asyncssh.SSHClientConnection:
         """Raw asyncssh connection for commands and port forwarding."""
         return self._conn
 
-    async def read_text(self, path: str) -> str:
+    async def run(self, *args: object, **kwargs: Any) -> asyncssh.SSHCompletedProcess:
+        """Run one command, reconnecting first when the transport is closed."""
+        run_kwargs = dict(kwargs)
+        timeout = run_kwargs.pop("timeout", None)
+        check = bool(run_kwargs.pop("check", False))
+        conn: asyncssh.SSHClientConnection | None = None
+        process = None
+        try:
+            if timeout is None:
+                conn = await self._connection()
+                return await conn.run(*args, check=check, **run_kwargs)
+            async with asyncio.timeout(timeout):
+                conn = await self._connection()
+                process = await conn.create_process(*args, **run_kwargs)
+                return await process.wait(check=check, timeout=None)
+        except (TimeoutError, asyncio.CancelledError):
+            if process is not None:
+                process.close()
+                with contextlib.suppress(OSError, TimeoutError, asyncssh.Error):
+                    async with asyncio.timeout(SSH_SESSION_CLOSE_TIMEOUT_S):
+                        await process.wait_closed()
+            raise
+        except asyncssh.ChannelOpenError as exc:
+            raise SSHConnectionError("SSH server rejected the session") from exc
+        except asyncssh.ConnectionLost as exc:
+            raise SSHConnectionError("SSH connection lost during operation") from exc
+        except (OSError, asyncssh.Error) as exc:
+            if conn is not None and _is_closed(conn):
+                raise SSHConnectionError("SSH connection lost during operation") from exc
+            raise
+
+    async def _connection(self) -> asyncssh.SSHClientConnection:
+        if self._closing:
+            raise SSHConnectionError("SSH client is closed")
+        if not _is_closed(self._conn):
+            return self._conn
+
+        async with self._reconnect_lock:
+            if self._closing:
+                raise SSHConnectionError("SSH client is closed")
+            if not _is_closed(self._conn):
+                return self._conn
+
+            last_error: Exception | None = None
+            for attempt in range(SSH_RECONNECT_ATTEMPTS):
+                if self._closing:
+                    raise SSHConnectionError("SSH client is closed")
+                try:
+                    conn = await self._connect(self.capability)
+                except (OSError, asyncssh.Error) as exc:
+                    last_error = exc
+                    if self._closing:
+                        raise SSHConnectionError("SSH client is closed") from exc
+                    if attempt + 1 < SSH_RECONNECT_ATTEMPTS:
+                        await asyncio.sleep(SSH_RECONNECT_BASE_DELAY_S * 2**attempt)
+                    continue
+                if self._closing:
+                    conn.close()
+                    await conn.wait_closed()
+                    raise SSHConnectionError("SSH client is closed")
+                self._conn = conn
+                return conn
+            raise SSHConnectionError(
+                f"SSH reconnect failed after {SSH_RECONNECT_ATTEMPTS} attempts"
+            ) from last_error
+
+    async def read_text(self, path: str, *, timeout_s: float | None = None) -> str:
         """Read a UTF-8 text file through the exec channel."""
         if self._is_windows:
             quoted = _powershell_quote(path)
             script = f"[Convert]::ToBase64String([IO.File]::ReadAllBytes({quoted}))"
-            result = await self._conn.run(_powershell(script), check=True)
+            result = await self.run(_powershell(script), check=True, timeout=timeout_s)
             return base64.b64decode(_stdout(result)).decode("utf-8", errors="replace")
         # encoding=None transports raw bytes: a strict connection-level UTF-8
         # decode would raise on files with invalid UTF-8 instead of replacing.
-        result = await self._conn.run(f"cat -- {shlex.quote(path)}", check=True, encoding=None)
+        result = await self.run(
+            f"cat -- {shlex.quote(path)}",
+            check=True,
+            encoding=None,
+            timeout=timeout_s,
+        )
         return _decode(result.stdout)
 
-    async def write_text(self, path: str, content: str) -> None:
+    async def write_text(
+        self,
+        path: str,
+        content: str,
+        *,
+        timeout_s: float | None = None,
+    ) -> None:
         """Write UTF-8 text through the exec channel without command interpolation."""
         if self._is_windows:
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + timeout_s if timeout_s is not None else None
+
+            def remaining_timeout() -> float | None:
+                return None if deadline is None else max(0.0, deadline - loop.time())
+
             quoted = _powershell_quote(path)
             truncate = f"[IO.File]::WriteAllBytes({quoted},[byte[]]@())"
-            await self._conn.run(_powershell(truncate), check=True)
+            await self.run(_powershell(truncate), check=True, timeout=remaining_timeout())
             raw = content.encode("utf-8")
             for offset in range(0, len(raw), 6144):
                 payload = base64.b64encode(raw[offset : offset + 6144]).decode("ascii")
@@ -82,19 +180,24 @@ class SSHClient(CapabilityClient):
                     "[IO.FileAccess]::Write,[IO.FileShare]::Read);"
                     "try{$f.Write($b,0,$b.Length)}finally{$f.Dispose()}"
                 )
-                await self._conn.run(_powershell(script), check=True)
+                await self.run(_powershell(script), check=True, timeout=remaining_timeout())
             return
-        await self._conn.run(f"cat > {shlex.quote(path)}", input=content, check=True)
+        await self.run(
+            f"cat > {shlex.quote(path)}",
+            input=content,
+            check=True,
+            timeout=timeout_s,
+        )
 
-    async def listdir(self, path: str) -> list[str]:
+    async def listdir(self, path: str, *, timeout_s: float | None = None) -> list[str]:
         """List direct children through the exec channel."""
         if self._is_windows:
             script = f"Get-ChildItem -Force -Name -LiteralPath {_powershell_quote(path)}"
-            result = await self._conn.run(_powershell(script), check=True)
+            result = await self.run(_powershell(script), check=True, timeout=timeout_s)
             listing = _stdout(result)
         else:
             command = f"ls -1A -- {shlex.quote(path)}"
-            result = await self._conn.run(command, check=True, encoding=None)
+            result = await self.run(command, check=True, encoding=None, timeout=timeout_s)
             listing = _decode(result.stdout)
         return sorted(line for line in listing.splitlines() if line not in (".", ".."))
 
@@ -103,8 +206,14 @@ class SSHClient(CapabilityClient):
         return self.capability.params.get("shell") in ("cmd", "powershell")
 
     async def close(self) -> None:
-        self._conn.close()
-        await self._conn.wait_closed()
+        self._closing = True
+        async with self._reconnect_lock:
+            self._conn.close()
+            await self._conn.wait_closed()
+
+
+def _is_closed(conn: asyncssh.SSHClientConnection) -> bool:
+    return conn.is_closed()
 
 
 def _powershell(script: str) -> str:

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -1,15 +1,113 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+import asyncio
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock
 
 import asyncssh
+import pytest
 
 from hud.capabilities.base import Capability
-from hud.capabilities.ssh import SSHClient
+from hud.capabilities.ssh import SSHClient, SSHConnectionError
 
 if TYPE_CHECKING:
-    import pytest
+    from collections.abc import Callable
+
+
+class _Completed:
+    stdout = "ok"
+    stderr = ""
+    exit_status = 0
+
+
+class _Process:
+    def __init__(self, *, wait_error: BaseException | None = None, block: bool = False) -> None:
+        self.wait_error = wait_error
+        self.block = block
+        self.on_wait: Callable[[], None] | None = None
+        self.started = asyncio.Event()
+        self.closed = False
+        self.waited_closed = False
+
+    async def wait(self, *, check: bool, **kwargs: Any) -> _Completed:
+        assert kwargs == {"timeout": None}
+        del check
+        self.started.set()
+        if self.on_wait is not None:
+            self.on_wait()
+        if self.block:
+            await asyncio.Event().wait()
+        if self.wait_error is not None:
+            raise self.wait_error
+        return _Completed()
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.waited_closed = True
+
+
+class _Connection:
+    def __init__(
+        self,
+        *,
+        closed: bool = False,
+        run_error: Exception | None = None,
+        process: _Process | None = None,
+        stall_open: bool = False,
+        open_error: Exception | None = None,
+    ) -> None:
+        self.closed = closed
+        self.run_error = run_error
+        self.process = process or _Process()
+        self.stall_open = stall_open
+        self.open_error = open_error
+        self.open_cancelled = False
+        self.commands: list[str] = []
+
+    def is_closed(self) -> bool:
+        return self.closed
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        pass
+
+    async def run(self, command: str, **kwargs: Any) -> _Completed:
+        del kwargs
+        self.commands.append(command)
+        if self.run_error is not None:
+            if isinstance(self.run_error, asyncssh.ConnectionLost):
+                self.closed = True
+            raise self.run_error
+        return _Completed()
+
+    async def create_process(self, *args: object, **kwargs: Any) -> _Process:
+        del args, kwargs
+        if self.stall_open:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                self.open_cancelled = True
+                raise
+        if self.open_error is not None:
+            raise self.open_error
+        return self.process
+
+
+def _capability() -> Capability:
+    return Capability(
+        name="shell",
+        protocol="ssh/2",
+        url="ssh://workspace.example:2222",
+        params={"user": "agent", "client_key_path": "/tmp/key"},
+    )
+
+
+def _client(connection: object) -> SSHClient:
+    return SSHClient(_capability(), cast("asyncssh.SSHClientConnection", connection))
 
 
 async def test_connect_keeps_tunneled_connection_active(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -31,3 +129,171 @@ async def test_connect_keeps_tunneled_connection_active(monkeypatch: pytest.Monk
         keepalive_interval=15,
         keepalive_count_max=4,
     )
+
+
+async def test_run_does_not_replay_a_command_lost_in_flight(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dropped = _Connection(run_error=asyncssh.ConnectionLost("dropped"))
+    replacement = _Connection()
+    client = _client(dropped)
+    reconnect = AsyncMock(return_value=replacement)
+    monkeypatch.setattr(client, "_connect", reconnect)
+
+    with pytest.raises(SSHConnectionError, match="lost during operation"):
+        await client.run("apply-side-effect")
+
+    reconnect.assert_not_awaited()
+    assert dropped.commands == ["apply-side-effect"]
+
+    await client.run("next-command")
+    reconnect.assert_awaited_once_with(client.capability)
+    assert replacement.commands == ["next-command"]
+
+
+async def test_run_classifies_rejected_session_as_connection_error() -> None:
+    connection = _Connection(
+        open_error=asyncssh.ChannelOpenError(asyncssh.OPEN_RESOURCE_SHORTAGE, "busy")
+    )
+    client = _client(connection)
+
+    with pytest.raises(SSHConnectionError, match="rejected the session"):
+        await client.run("echo never", timeout=1)
+
+    assert connection.closed is False
+
+
+async def test_run_timeout_includes_opening_the_process() -> None:
+    connection = _Connection(stall_open=True)
+    client = _client(connection)
+
+    with pytest.raises(TimeoutError):
+        await client.run("echo never", timeout=0.01)
+
+    assert connection.open_cancelled is True
+
+
+async def test_run_timeout_includes_reconnecting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _Connection(closed=True)
+    client = _client(connection)
+    cancelled = False
+
+    async def reconnect(capability: Capability) -> asyncssh.SSHClientConnection:
+        nonlocal cancelled
+        assert capability is client.capability
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+        raise AssertionError("reconnect unexpectedly completed")
+
+    monkeypatch.setattr(client, "_connect", reconnect)
+
+    with pytest.raises(TimeoutError):
+        await client.run("echo never", timeout=0.01)
+
+    assert cancelled is True
+
+
+async def test_run_preserves_timeout_when_the_connection_closes() -> None:
+    process = _Process(wait_error=TimeoutError())
+    connection = _Connection(process=process)
+    process.on_wait = lambda: setattr(connection, "closed", True)
+    client = _client(connection)
+
+    with pytest.raises(TimeoutError):
+        await client.run("echo never", timeout=1)
+
+
+async def test_run_cancellation_closes_the_remote_process() -> None:
+    connection = _Connection(process=_Process(block=True))
+    client = _client(connection)
+    run = asyncio.create_task(client.run("echo never", timeout=300))
+    await connection.process.started.wait()
+
+    run.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run
+    assert connection.process.closed is True
+    assert connection.process.waited_closed is True
+
+
+async def test_windows_write_uses_one_timeout_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = SSHClient(
+        Capability(
+            name="shell",
+            protocol="ssh/2",
+            url="ssh://workspace.example:2222",
+            params={"shell": "powershell"},
+        ),
+        cast("asyncssh.SSHClientConnection", _Connection()),
+    )
+    timeouts: list[float] = []
+
+    async def run(*args: object, **kwargs: Any) -> _Completed:
+        del args
+        timeout = kwargs["timeout"]
+        assert isinstance(timeout, float)
+        timeouts.append(timeout)
+        await asyncio.sleep(0.01)
+        return _Completed()
+
+    monkeypatch.setattr(client, "run", run)
+
+    await client.write_text("C:\\file.txt", "x" * 7000, timeout_s=1)
+
+    assert len(timeouts) == 3
+    assert timeouts[0] > timeouts[1] > timeouts[2]
+
+
+async def test_close_during_reconnect_discards_the_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dropped = _Connection(closed=True)
+    replacement = _Connection()
+    reconnect_started = asyncio.Event()
+    allow_reconnect = asyncio.Event()
+
+    async def reconnect(capability: Capability) -> asyncssh.SSHClientConnection:
+        assert capability is client.capability
+        reconnect_started.set()
+        await allow_reconnect.wait()
+        return cast("asyncssh.SSHClientConnection", replacement)
+
+    client = _client(dropped)
+    monkeypatch.setattr(client, "_connect", reconnect)
+
+    run = asyncio.create_task(client.run("echo never"))
+    await reconnect_started.wait()
+    close = asyncio.create_task(client.close())
+    await asyncio.sleep(0)
+    allow_reconnect.set()
+
+    with pytest.raises(SSHConnectionError, match="client is closed"):
+        await run
+    await close
+
+    assert replacement.closed is True
+    assert replacement.commands == []
+
+
+async def test_reconnect_exhaustion_raises_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(_Connection(closed=True))
+    reconnect = AsyncMock(side_effect=OSError("unreachable"))
+    sleep = AsyncMock()
+    monkeypatch.setattr(client, "_connect", reconnect)
+    monkeypatch.setattr("hud.capabilities.ssh.asyncio.sleep", sleep)
+
+    with pytest.raises(SSHConnectionError, match="failed after 3 attempts"):
+        await client.run("echo never")
+
+    assert reconnect.await_count == 3
+    assert [call.args for call in sleep.await_args_list] == [(0.25,), (0.5,)]


### PR DESCRIPTION
## Summary

- reconnect a closed persistent SSH transport before the next operation without replaying commands which may have started
- bound SSH tool operations and close timed-out sessions
- truncate model-facing shell output and stop after three consecutive SSH infrastructure failures

The SSH tool path previously depended on one transport for the full run, allowed operations to wait indefinitely, and only capped output for one provider adapter.

This builds on the persistent capability connection support merged in #559.

## Validation

- focused SSH capability, provider tool, tool agent, Claude SDK, and result contract tests: 102 passed
- full test suite: 1001 passed, 9 deselected
- `ruff format . --check`
- `ruff check .`
- `ty check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core SSH transport, timeout, and reconnect semantics for all remote shell/file tools, with a new circuit breaker that can terminate rollouts after repeated infrastructure failures.
> 
> **Overview**
> Hardens the **SSH-backed tool path** so long agent runs don’t hang on a dead transport or unbounded remote work.
> 
> **`SSHClient`** adds **`run()`** with optional timeouts (including process open/reconnect), **reconnect before the next op** when the session is closed, and **no automatic replay** of a command that may have started before `ConnectionLost`. Transport failures surface as **`SSHConnectionError`**; timed-out sessions are closed. File helpers and Windows chunked writes honor a **shared timeout budget**.
> 
> **`SSHTool`** routes execution through **`execute_with_deadline`** (300s operation window via context), uses **`client.run`** with **shrinking per-step timeouts** for multi-step tools, returns **`SSHInfrastructureErrorResult`** on SSH timeouts, and applies **shared shell output truncation** (`bound_shell_output`).
> 
> **`ToolAgent`** treats infrastructure SSH results as a **circuit breaker**: **three consecutive** such failures end the rollout with a system error; ordinary tool errors reset the counter. **`SSHConnectionError`** at dispatch is mapped to the same infrastructure result type.
> 
> Provider adapters (e.g. **OpenAI shell**, **Claude SDK** remote exec) switch from raw **`conn.run`** to the hardened **`SSHClient.run`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 785d19497042e38638c1bb951ffd841ed30455f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->