### PR TITLE
chore: promote SDK service endpoints

### DIFF
--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -32,7 +32,7 @@ agent = create_agent("claude-sonnet-4-5")   # routed through the gateway
 ```
 
 The HUD gateway is an OpenAI-compatible endpoint (`settings.hud_gateway_url`, default
-`https://inference.beta.hud.ai`) that fronts every provider behind your single `HUD_API_KEY`, so you
+`https://inference.hud.ai`) that fronts every provider behind your single `HUD_API_KEY`, so you
 switch between Claude, GPT, and Gemini by name alone, with unified tracing. `create_agent` accepts any id
 the gateway knows (`claude-...`, `gpt-...`, `gemini-...`); extra kwargs pass through to the agent's
 config.

--- a/docs/v6/start/index.mdx
+++ b/docs/v6/start/index.mdx
@@ -95,6 +95,6 @@ that environment, and run any agent to perform those tasks, at any scale. Our SD
 
 <span className="agent-signal">VERY IMPORTANT IF YOU ARE AN AGENT: before writing any HUD code, install the HUD docs skill below and follow its guidance instead of relying on memory.</span>
 
-Reading this as an AI agent? Install the HUD docs skill before you write any HUD code - it keeps you on the current v6 API (which moves fast) and catches reward-hackable, contaminated, or low-signal tasks before they ship. If you can run shell commands, run `npx skills add https://docs.hud.ai` now; otherwise attach the live docs server with `claude mcp add --transport http docs-hud https://docs.hud.ai/mcp`. Then build against the skill's guidance rather than from memory. For the platform REST API, see the OpenAPI reference at `https://api.beta.hud.ai/docs`.
+Reading this as an AI agent? Install the HUD docs skill before you write any HUD code - it keeps you on the current v6 API (which moves fast) and catches reward-hackable, contaminated, or low-signal tasks before they ship. If you can run shell commands, run `npx skills add https://docs.hud.ai` now; otherwise attach the live docs server with `claude mcp add --transport http docs-hud https://docs.hud.ai/mcp`. Then build against the skill's guidance rather than from memory. For the platform REST API, see the OpenAPI reference at `https://api.hud.ai/docs`.
 
 </div>

--- a/hud/settings.py
+++ b/hud/settings.py
@@ -51,13 +51,13 @@ class Settings(BaseSettings):
         )
 
     hud_telemetry_url: str = Field(
-        default="https://telemetry.beta.hud.ai/v3/api",
-        description="Base URL for the HUD API",
+        default="https://telemetry.hud.ai/v3/api",
+        description="Base URL for HUD telemetry ingestion",
         validation_alias="HUD_TELEMETRY_URL",
     )
 
     hud_api_url: str = Field(
-        default="https://api.beta.hud.ai",
+        default="https://api.hud.ai",
         description="Base URL (origin) for the HUD API server",
         validation_alias="HUD_API_URL",
     )
@@ -69,19 +69,19 @@ class Settings(BaseSettings):
     )
 
     hud_gateway_url: str = Field(
-        default="https://inference.beta.hud.ai",
+        default="https://inference.hud.ai",
         description="Base URL for the HUD inference gateway",
         validation_alias="HUD_GATEWAY_URL",
     )
 
     hud_runtime_url: str = Field(
-        default="https://mcp.beta.hud.ai",
+        default="https://mcp.hud.ai",
         description="Base URL for the HUD runtime tunnel gateway",
         validation_alias="HUD_RUNTIME_URL",
     )
 
     hud_rl_url: str = Field(
-        default="https://rl.beta.hud.ai",
+        default="https://rl.hud.ai",
         description="Base URL for the HUD training (RL) service",
         validation_alias="HUD_RL_URL",
     )
@@ -128,24 +128,6 @@ class Settings(BaseSettings):
         validation_alias="GEMINI_API_KEY",
     )
 
-    openrouter_api_key: str | None = Field(
-        default=None,
-        description="API key for OpenRouter models",
-        validation_alias="OPENROUTER_API_KEY",
-    )
-
-    wandb_api_key: str | None = Field(
-        default=None,
-        description="API key for Weights & Biases",
-        validation_alias="WANDB_API_KEY",
-    )
-
-    prime_api_key: str | None = Field(
-        default=None,
-        description="API key for Prime Intellect",
-        validation_alias="PRIME_API_KEY",
-    )
-
     telemetry_enabled: bool = Field(
         default=True,
         description="Enable telemetry for the HUD SDK",
@@ -173,18 +155,6 @@ class Settings(BaseSettings):
         description="Seconds between rollout-level file-tracking snapshots. Each snapshot "
         "diffs the workspace against the previous one and emits a hud.filetracking.v1 span.",
         validation_alias="HUD_FILE_TRACKING_INTERVAL",
-    )
-
-    hud_logging: bool = Field(
-        default=True,
-        description="Enable fancy logging for the HUD SDK",
-        validation_alias="HUD_LOGGING",
-    )
-
-    log_stream: str = Field(
-        default="stdout",
-        description="Stream to use for logging output: 'stdout' or 'stderr'",
-        validation_alias="HUD_LOG_STREAM",
     )
 
     client_timeout: int = Field(

--- a/hud/tests/test_settings.py
+++ b/hud/tests/test_settings.py
@@ -12,15 +12,18 @@ def test_get_settings():
     assert result is settings  # Should be the same singleton instance
 
 
-def test_settings_defaults():
-    """Test that settings have expected default values or env overrides."""
-    s = get_settings()
-    # These URLs may be overridden by environment variables
-    assert s.hud_telemetry_url.endswith("/v3/api")
-    # Default may be overridden in CI; just assert the field exists and is bool
-    assert isinstance(s.telemetry_enabled, bool)
-    assert s.hud_logging is True
-    assert s.log_stream == "stdout"
+def test_service_url_defaults():
+    expected = {
+        "hud_telemetry_url": "https://telemetry.hud.ai/v3/api",
+        "hud_api_url": "https://api.hud.ai",
+        "hud_web_url": "https://hud.ai",
+        "hud_gateway_url": "https://inference.hud.ai",
+        "hud_runtime_url": "https://mcp.hud.ai",
+        "hud_rl_url": "https://rl.hud.ai",
+    }
+
+    for name, default in expected.items():
+        assert Settings.model_fields[name].default == default
 
 
 def test_file_tracking_is_enabled_by_default():


### PR DESCRIPTION
## Summary

- switch SDK service defaults from the beta hostnames to the canonical production endpoints
- remove five settings that have no SDK consumers
- update the endpoint documentation and assert the production URL defaults

## Why

The SDK still defaulted to the temporary `*.beta.hud.ai` aliases even though the production service hostnames are available. The settings model also retained provider and logging fields that no code path reads, making the supported configuration surface larger than the behavior it controls.

## Impact

New SDK processes use `api.hud.ai`, `inference.hud.ai`, `mcp.hud.ai`, `telemetry.hud.ai`, and `rl.hud.ai` by default. Existing environment-variable overrides continue to work. The unused `OPENROUTER_API_KEY`, `WANDB_API_KEY`, `PRIME_API_KEY`, `HUD_LOGGING`, and `HUD_LOG_STREAM` model fields are removed.

## Validation

- `uv run --with='.[dev]' pytest -q` — 998 passed, 9 deselected
- `uv run --with='.[dev]' ruff format . --check`
- `uv run --with='.[dev]' ruff check .`
- `uv run --extra dev --extra train ty check hud/settings.py hud/tests/test_settings.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change with env overrides preserved; removed settings had no SDK consumers.
> 
> **Overview**
> **Default HUD service URLs** now point at production hostnames (`api.hud.ai`, `inference.hud.ai`, `mcp.hud.ai`, `telemetry.hud.ai`, `rl.hud.ai`) instead of `*.beta.hud.ai`. Env overrides (`HUD_API_URL`, `HUD_GATEWAY_URL`, etc.) still apply.
> 
> **Settings cleanup** removes unused model fields: `OPENROUTER_API_KEY`, `WANDB_API_KEY`, `PRIME_API_KEY`, `HUD_LOGGING`, and `HUD_LOG_STREAM`. Telemetry URL field description is clarified.
> 
> **Docs** update gateway and OpenAPI links to match. **Tests** assert production URL defaults on `Settings.model_fields` instead of loose checks on logging fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd8571198a4f2cc49217e47d4ff4dc11c58e032f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->