### PR TITLE
fix(harbor): make Compose artifacts portable

### DIFF
--- a/docs/v6/advanced/harbor-convert.mdx
+++ b/docs/v6/advanced/harbor-convert.mdx
@@ -61,7 +61,6 @@ builds or pulls each authored base image, records Docker's resolved OCI config,
 then builds the adapted services:
 
 ```bash
-cd compose-project
 sh build.sh registry.example/acme/task:tag
 docker push registry.example/acme/task:tag
 ```
@@ -70,12 +69,11 @@ This path requires Docker Compose and a BuildKit-era Docker builder because the
 HUD payload is a named context rather than content injected into the user's
 environment.
 
-For any generated project, assign a registry `image:` to every service with a
-`build:` (replace the generated HUD tags and add tags to authored build-only
-sidecars), then run the project build before pushing the Compose services:
+For any generated project, replace each generated or local `image:` with your
+registry tag, then run the project build before pushing the Compose services:
 
 ```bash
-sh compose-project/build.sh
+sh build.sh
 docker compose push
 ```
 

--- a/hud/integrations/harbor/adapt.py
+++ b/hud/integrations/harbor/adapt.py
@@ -355,6 +355,15 @@ def adapt(
         compose_project = (
             compose.with_project_directory("./environment") if compose is not None else None
         )
+        if compose_project is not None:
+            for service_name, service in compose_project.services.items():
+                if service_name != "main" and service.build is not None and service.image is None:
+                    sidecar_tag = hashlib.sha256(
+                        f"{source.environment_hash}\0{service_name}".encode()
+                    ).hexdigest()[:16]
+                    compose_project.services[service_name] = service.model_copy(
+                        update={"image": f"hud-harbor-sidecar:{sidecar_tag}"}
+                    )
         compose_main = compose.services["main"] if compose is not None else ComposeService()
         dockerfile = source.path / "environment" / "Dockerfile"
         base_image = environment.docker_image or compose_main.image
@@ -789,6 +798,13 @@ fi
         script = project / "build.sh"
         script.write_text(build_script, encoding="utf-8", newline="\n")
         script.chmod(0o755)
+        launcher = context / "build.sh"
+        launcher.write_text(
+            '#!/bin/sh\nset -eu\nexec sh "$(dirname -- "$0")/compose-project/build.sh" "$@"\n',
+            encoding="utf-8",
+            newline="\n",
+        )
+        launcher.chmod(0o755)
         recipe = compose_project.with_project_directory("./compose-project")
         (context / "compose.yaml").write_text(
             json.dumps(

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -35,7 +35,7 @@ def _assert_stock_compose_complete(compose_path: Path) -> dict[str, Any]:
     assert isinstance(services, dict)
     for name, service in services.items():
         assert isinstance(service, dict)
-        assert service.get("image") or service.get("build"), name
+        assert service.get("image"), name
         for volume in service.get("volumes", []):
             if not isinstance(volume, str):
                 continue
@@ -106,6 +106,7 @@ def test_adapt_packages_an_image_task_as_a_compose_project(tmp_path: Path) -> No
     assert not (context / "Dockerfile").exists()
     assert not any(path.name == ".hud" for path in context.rglob(".hud"))
     assert {entry.name for entry in context.iterdir()} == {
+        "build.sh",
         "compose-project",
         "compose.yaml",
         "env.py",
@@ -128,6 +129,8 @@ def test_adapt_packages_an_image_task_as_a_compose_project(tmp_path: Path) -> No
     build_script = (project_root / "build.sh").read_text("utf-8")
     assert "docker image inspect" in build_script
     assert 'docker tag "$(docker compose' in build_script
+    assert "compose-project/build.sh" in (context / "build.sh").read_text("utf-8")
+    subprocess.run(["sh", "-n", context / "build.sh"], check=True)
     subprocess.run(["sh", "-n", project_root / "build.sh"], check=True)
     assert (project_root / "tests" / "task-a" / "test.sh").is_file()
     assert not any(path.name in {"tasks", "tasks.json"} for path in payload.rglob("*"))
@@ -380,6 +383,7 @@ services:
     assert isinstance(compose_path, Path)
     project = json.loads(compose_path.read_text("utf-8"))
     assert project["services"]["database"]["build"]["context"] == ("./environment/database")
+    assert project["services"]["database"]["image"].startswith("hud-harbor-sidecar:")
     assert project["services"]["database"]["env_file"] == "./environment/database/db.env"
     assert project["services"]["database"]["volumes"] == [
         "./environment/database/data:/var/lib/postgresql/data"


### PR DESCRIPTION
## Summary

- assign deterministic image tags to authored build-only sidecars
- expose Harbor's Compose preparation script at the artifact root
- document and test stock Compose build/push behavior

## Root cause

Build-only sidecars inherited Compose's project-name-dependent implicit tags, so building and running under different project names could not resolve the same image. Hosted deploy also discovered the root Compose recipe while the preparation script existed only beside the nested task recipe, so Modal introspection skipped image preparation.

## Validation

- `uv run pytest hud/eval/tests hud/cli/tests/test_deploy.py hud/integrations/harbor/tests -m 'not integration' --tb=short` (283 passed)
- `uv run pytest hud/integrations/harbor/tests -m integration --tb=short` (9 passed)
- `uv run --with='.[dev]' ruff format . --check`
- `uv run --with='.[dev]' ruff check .`
- `uv run --extra dev --extra train ty check --error-on-warning`
- dev Modal build `b2203497-1b95-4b7e-a0d4-00ae6b7c7589` and completed hosted trace `525a4b14-df66-4db4-857c-cfe31a70eb3f`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Harbor image tagging and the build entrypoint used by local and Modal Compose deploy; scope is narrow but touches multi-service build/run paths.
> 
> **Overview**
> Harbor **Compose adaptation** now tags **build-only sidecars** (non-`main` services with `build` but no `image`) with deterministic `hud-harbor-sidecar:{hash}` names instead of Compose’s project-dependent implicit tags, so the same images resolve when project names differ between build and run.
> 
> Adapted artifacts also ship a **root `build.sh`** that forwards to `compose-project/build.sh`, aligning with deploy’s root `compose.yaml` discovery and Modal’s `/hud/project/build.sh` prep step. Docs now point owners at `sh build.sh` from the artifact root before `docker compose push`, and contract tests require every Compose service to declare an `image`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 655556daf77d5ffd0702d1b3c4750635a6b2f191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->