### PR TITLE
fix(modal): honor Compose startup timeouts

### DIFF
--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -921,7 +921,11 @@ class ModalRuntime:
             host, port = (await sb.tunnels.aio())[self.port].tcp_socket
             yield Runtime(
                 f"tcp://{host}:{port}",
-                params={"provider": "modal", "instance_id": sb.object_id},
+                params={
+                    "provider": "modal",
+                    "instance_id": sb.object_id,
+                    **({"ready_timeout": ready_timeout} if compose is not None else {}),
+                },
                 config=config if config.model_dump(exclude_none=True) else None,
             )
         finally:

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -845,10 +845,15 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
 
     async with ModalRuntime(
-        runtime_config=RuntimeConfig(compose=compose, compose_service_access=True),
+        runtime_config=RuntimeConfig(
+            compose=compose,
+            compose_service_access=True,
+            limits=RuntimeLimits(startup_timeout_s=600),
+        ),
         env_vars={"HUD_API_KEY": "secret"},
     )(_row()) as runtime:
         assert runtime.url == "tcp://modal.host:4567"
+        assert runtime.params == {"provider": "modal", "instance_id": "sb-1", "ready_timeout": 600}
 
     assert calls["registry_image"] == "docker:28.3.3-dind"
     kwargs = calls["sandbox_kwargs"]
@@ -880,6 +885,7 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     assert "sh /hud/project/build.sh" in execs[0][0][-1]
     assert 'up --detach "$BUILD_FLAG" --remove-orphans' in execs[0][0][-1]
     assert "down" in execs[1][0]
+    assert execs[0][1]["timeout"] == 600
 
 
 async def test_modal_runtime_accepts_modal_image_uri(


### PR DESCRIPTION
## Summary
- propagate Modal Compose startup_timeout_s to the control-channel readiness handshake
- keep image-backed Modal runtime behavior unchanged
- cover both Compose startup and yielded runtime parameters

## Testing
- uv run --with=.[dev] pytest hud/eval/tests/test_docker_provider.py --tb=short
- uv run --extra dev --extra train ty check hud/eval/runtime.py hud/eval/tests/test_docker_provider.py --error-on-warning
- uv run --with=.[dev] ruff check hud/eval/runtime.py hud/eval/tests/test_docker_provider.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Modal Compose startup and client readiness timing; image-backed Modal behavior is unchanged.
> 
> **Overview**
> Modal Compose rollouts now pass **`runtime_config.limits.startup_timeout_s`** through to both the in-sandbox `docker compose up` exec and the **`ready_timeout`** field on the yielded **`Runtime.params`**, so **`connect()`** can wait as long as Compose startup before the control-channel handshake.
> 
> Image-only Modal sandboxes are unchanged: they still use Modal’s TCP readiness probe and do not add **`ready_timeout`** to **`params`**.
> 
> Tests assert the Compose path sets **`params["ready_timeout"]`** (e.g. 600) and that the compose startup exec receives the same timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5caa60894e5430a5f3aeee29aa33aa2208de2633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->