### PR TITLE
feat(eval): add per-run lazy loading option

### DIFF
--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -551,6 +551,7 @@ class EvalConfig(BaseModel):
 
         if runtime is not None:
             overrides["remote"] = False
+            overrides["lazy_load"] = False
 
         for key, value in {
             "all": all,

--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -170,6 +170,7 @@ _DEFAULT_CONFIG_TEMPLATE = """# HUD Eval Configuration
 # gateway = false  # Route LLM API calls through HUD Gateway
 # runtime = "local"  # local, hud, or tcp://host:port
 # remote = false  # Run the whole rollout remotely on HUD
+# lazy_load = false  # Lazily load the remote environment filesystem
 
 [claude]
 # model = "claude-sonnet-4-6"
@@ -267,6 +268,7 @@ class EvalConfig(BaseModel):
         "gateway",
         "runtime",
         "remote",
+        "lazy_load",
     }
     source: str | None = None
     agent_type: AgentType | None = None
@@ -287,6 +289,8 @@ class EvalConfig(BaseModel):
     runtime: str | None = None
     #: Run the whole rollout remotely on the HUD platform.
     remote: bool = False
+    #: Lazily load the environment filesystem for remote platform execution.
+    lazy_load: bool = False
 
     agent_config: dict[str, Any] = Field(default_factory=dict)
 
@@ -397,6 +401,11 @@ class EvalConfig(BaseModel):
         if not settings.api_key:
             hud_console.warning("HUD_API_KEY not set. Some features may be limited.")
 
+    def validate_placement(self) -> None:
+        """Validate options that depend on the resolved execution placement."""
+        if self.lazy_load and not self.remote:
+            raise ValueError("--lazy-load requires remote platform execution")
+
     def get_agent_kwargs(self) -> dict[str, Any]:
         """Build agent kwargs from config.
 
@@ -505,6 +514,7 @@ class EvalConfig(BaseModel):
         task_ids: str | None = None,
         runtime: str | None = None,
         remote: bool = False,
+        lazy_load: bool = False,
     ) -> EvalConfig:
         """Merge CLI args (non-None values override config)."""
         if runtime is not None and remote:
@@ -549,6 +559,7 @@ class EvalConfig(BaseModel):
             "auto_respond": auto_respond,
             "gateway": gateway,
             "remote": remote,
+            "lazy_load": lazy_load,
         }.items():
             if value:
                 overrides[key] = True
@@ -626,6 +637,7 @@ class EvalConfig(BaseModel):
             table.add_row("gateway", "[bold green]True[/bold green] (routing via HUD Gateway)")
         if self.remote:
             table.add_row("remote", "[bold green]True[/bold green]")
+        table.add_row("lazy_load", str(self.lazy_load))
 
         if self.agent_type:
             table.add_row("", "")
@@ -743,7 +755,7 @@ def _resolve_placement(cfg: EvalConfig, source_path: Path | None, taskset: Any) 
 
     if cfg.remote:
         require_api_key("run remote hosted evals")
-        return HostedRuntime()
+        return HostedRuntime(lazy_load=cfg.lazy_load)
     if cfg.runtime == "local":
         if source_path is None:
             raise ValueError("local placement requires a local source path")
@@ -913,6 +925,11 @@ def eval_command(
         "--remote",
         help="Run the whole rollout remotely on the HUD platform",
     ),
+    lazy_load: bool = typer.Option(
+        False,
+        "--lazy-load",
+        help="Lazily load the remote environment filesystem",
+    ),
 ) -> None:
     """Run evaluation on datasets or individual tasks with agents.
 
@@ -954,6 +971,7 @@ def eval_command(
             gateway=gateway,
             runtime=runtime,
             remote=remote,
+            lazy_load=lazy_load,
         )
     except ValueError as e:
         hud_console.error(str(e))
@@ -973,6 +991,11 @@ def eval_command(
 
     cfg = cfg.resolve_agent_interactive()
     cfg = cfg.resolve_runtime()
+    try:
+        cfg.validate_placement()
+    except ValueError as e:
+        hud_console.error(str(e))
+        raise typer.Exit(1) from None
 
     if cfg.very_verbose:
         logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(message)s")

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -144,9 +144,14 @@ def test_resolve_placement_remote_uses_hosted_runtime(
 
     monkeypatch.setattr(settings, "api_key", "sk-hud-test")
 
-    placement = eval_mod._resolve_placement(EvalConfig(remote=True), tmp_path, [])
+    placement = eval_mod._resolve_placement(
+        EvalConfig(remote=True, lazy_load=True),
+        tmp_path,
+        [],
+    )
 
     assert isinstance(placement, HostedRuntime)
+    assert placement.lazy_load is True
 
 
 def test_resolve_placement_routes_each_local_row(
@@ -186,6 +191,16 @@ def test_runtime_cli_override_clears_config_remote() -> None:
 def test_runtime_cli_rejects_remote_flag_conflict() -> None:
     with pytest.raises(ValueError, match="--runtime and --remote are mutually exclusive"):
         EvalConfig().merge_cli(runtime="hud", remote=True)
+
+
+def test_lazy_load_cli_override_and_placement_validation() -> None:
+    cfg = EvalConfig().merge_cli(lazy_load=True)
+    assert cfg.lazy_load is True
+
+    with pytest.raises(ValueError, match="requires remote platform execution"):
+        EvalConfig(runtime="local", lazy_load=True).validate_placement()
+
+    EvalConfig(remote=True, lazy_load=True).validate_placement()
 
 
 def test_load_missing_writes_template(tmp_path: Path) -> None:

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -1482,9 +1482,11 @@ class HostedRuntime:
         *,
         poll_interval: float = 5.0,
         run_timeout: float = 3600.0,
+        lazy_load: bool = False,
     ) -> None:
         self.poll_interval = poll_interval
         self.run_timeout = run_timeout
+        self.lazy_load = lazy_load
         self._cancellations: set[asyncio.Task[None]] = set()
 
     async def run(
@@ -1568,6 +1570,7 @@ class HostedRuntime:
             "task": task.id,
             "slug": task.slug,
             "args": task.args,
+            "lazy_load": self.lazy_load,
             "agent": spec,
         }
         if group_id is not None:

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -196,7 +196,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
         "hud.eval.runtime.PlatformClient.from_settings", classmethod(lambda cls: platform)
     )
 
-    hosted = HostedRuntime(poll_interval=0.0)
+    hosted = HostedRuntime(poll_interval=0.0, lazy_load=True)
     trace_id = uuid.uuid4().hex
     job_id = uuid.uuid4().hex
     task = Task(
@@ -229,6 +229,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert payload["task"] == "add"
     assert payload["slug"] == "sums-add"
     assert payload["args"] == {"a": 1, "b": 2}
+    assert payload["lazy_load"] is True
     assert payload["runtime_config"] == {
         "image": "registry.example/sums:latest",
         "resources": {"cpu": 2.0, "gpu": {"type": "L4", "count": 1}},


### PR DESCRIPTION
Adds the SDK half of HUD per-run lazy filesystem loading.

- exposes `EvalConfig.lazy_load` and `hud eval --lazy-load`
- restricts the option to remote platform execution
- sends `lazy_load` as a top-level `/rollouts/submit` field
- covers config, placement, and hosted payload behavior

Stacked with hud-evals/hud-monorepo#1093 and the follow-up monorepo per-run selection PR.


Related PRs:
- Parent monorepo implementation: https://github.com/hud-evals/hud-monorepo/pull/1095

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional flag and API field for remote-only execution; default behavior stays unchanged and placement is validated before run.
> 
> **Overview**
> Adds **`lazy_load`** for remote platform evals so the environment filesystem can be loaded lazily instead of upfront.
> 
> **Config & CLI:** `EvalConfig.lazy_load`, TOML `lazy_load`, and `hud eval --lazy-load`. The option is shown in the eval settings table. **`validate_placement`** rejects `--lazy-load` unless execution is remote; passing **`--runtime`** clears `lazy_load` like `remote`.
> 
> **Runtime:** `HostedRuntime` accepts `lazy_load` and sends it as a top-level field on **`/rollouts/submit`**. Placement wiring passes `cfg.lazy_load` when building `HostedRuntime` for `--remote`.
> 
> Tests cover CLI merge, placement validation, hosted payload, and `HostedRuntime.lazy_load`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0048e44c8ced848ee4c9ad759b2490ae85dc8c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->