### PR TITLE
feat(eval): add before_agent and after_agent rollout hooks

### DIFF
--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -170,6 +170,7 @@ _DEFAULT_CONFIG_TEMPLATE = """# HUD Eval Configuration
 # gateway = false  # Route LLM API calls through HUD Gateway
 # runtime = "local"  # local, hud, or tcp://host:port
 # remote = false  # Run the whole rollout remotely on HUD
+# lazy_load = false  # Lazily load the remote environment filesystem
 
 [claude]
 # model = "claude-sonnet-4-6"
@@ -267,6 +268,7 @@ class EvalConfig(BaseModel):
         "gateway",
         "runtime",
         "remote",
+        "lazy_load",
     }
     source: str | None = None
     agent_type: AgentType | None = None
@@ -287,6 +289,8 @@ class EvalConfig(BaseModel):
     runtime: str | None = None
     #: Run the whole rollout remotely on the HUD platform.
     remote: bool = False
+    #: Lazily load the environment filesystem for remote platform execution.
+    lazy_load: bool = False
 
     agent_config: dict[str, Any] = Field(default_factory=dict)
 
@@ -397,6 +401,11 @@ class EvalConfig(BaseModel):
         if not settings.api_key:
             hud_console.warning("HUD_API_KEY not set. Some features may be limited.")
 
+    def validate_placement(self) -> None:
+        """Validate options that depend on the resolved execution placement."""
+        if self.lazy_load and not self.remote:
+            raise ValueError("--lazy-load requires remote platform execution")
+
     def get_agent_kwargs(self) -> dict[str, Any]:
         """Build agent kwargs from config.
 
@@ -505,6 +514,7 @@ class EvalConfig(BaseModel):
         task_ids: str | None = None,
         runtime: str | None = None,
         remote: bool = False,
+        lazy_load: bool = False,
     ) -> EvalConfig:
         """Merge CLI args (non-None values override config)."""
         if runtime is not None and remote:
@@ -549,6 +559,7 @@ class EvalConfig(BaseModel):
             "auto_respond": auto_respond,
             "gateway": gateway,
             "remote": remote,
+            "lazy_load": lazy_load,
         }.items():
             if value:
                 overrides[key] = True
@@ -626,6 +637,7 @@ class EvalConfig(BaseModel):
             table.add_row("gateway", "[bold green]True[/bold green] (routing via HUD Gateway)")
         if self.remote:
             table.add_row("remote", "[bold green]True[/bold green]")
+        table.add_row("lazy_load", str(self.lazy_load))
 
         if self.agent_type:
             table.add_row("", "")
@@ -743,7 +755,7 @@ def _resolve_placement(cfg: EvalConfig, source_path: Path | None, taskset: Any) 
 
     if cfg.remote:
         require_api_key("run remote hosted evals")
-        return HostedRuntime()
+        return HostedRuntime(lazy_load=cfg.lazy_load)
     if cfg.runtime == "local":
         if source_path is None:
             raise ValueError("local placement requires a local source path")
@@ -913,6 +925,11 @@ def eval_command(
         "--remote",
         help="Run the whole rollout remotely on the HUD platform",
     ),
+    lazy_load: bool = typer.Option(
+        False,
+        "--lazy-load",
+        help="Lazily load the remote environment filesystem",
+    ),
 ) -> None:
     """Run evaluation on datasets or individual tasks with agents.
 
@@ -954,6 +971,7 @@ def eval_command(
             gateway=gateway,
             runtime=runtime,
             remote=remote,
+            lazy_load=lazy_load,
         )
     except ValueError as e:
         hud_console.error(str(e))
@@ -973,6 +991,11 @@ def eval_command(
 
     cfg = cfg.resolve_agent_interactive()
     cfg = cfg.resolve_runtime()
+    try:
+        cfg.validate_placement()
+    except ValueError as e:
+        hud_console.error(str(e))
+        raise typer.Exit(1) from None
 
     if cfg.very_verbose:
         logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(name)s - %(message)s")

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -144,9 +144,14 @@ def test_resolve_placement_remote_uses_hosted_runtime(
 
     monkeypatch.setattr(settings, "api_key", "sk-hud-test")
 
-    placement = eval_mod._resolve_placement(EvalConfig(remote=True), tmp_path, [])
+    placement = eval_mod._resolve_placement(
+        EvalConfig(remote=True, lazy_load=True),
+        tmp_path,
+        [],
+    )
 
     assert isinstance(placement, HostedRuntime)
+    assert placement.lazy_load is True
 
 
 def test_resolve_placement_routes_each_local_row(
@@ -186,6 +191,16 @@ def test_runtime_cli_override_clears_config_remote() -> None:
 def test_runtime_cli_rejects_remote_flag_conflict() -> None:
     with pytest.raises(ValueError, match="--runtime and --remote are mutually exclusive"):
         EvalConfig().merge_cli(runtime="hud", remote=True)
+
+
+def test_lazy_load_cli_override_and_placement_validation() -> None:
+    cfg = EvalConfig().merge_cli(lazy_load=True)
+    assert cfg.lazy_load is True
+
+    with pytest.raises(ValueError, match="requires remote platform execution"):
+        EvalConfig(runtime="local", lazy_load=True).validate_placement()
+
+    EvalConfig(remote=True, lazy_load=True).validate_placement()
 
 
 def test_load_missing_writes_template(tmp_path: Path) -> None:

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -476,9 +476,10 @@ async def rollout(
                             logger.warning("rollout failed mid-run (%s): %s", _phase, detail)
                             run.trace.status = "error"
                             run.record(Step(source="system", error=f"[{_phase}] {detail}"))
-                        if after_agent is not None:
-                            _phase = "post-agent checkpoint"
-                            await after_agent(live)
+                        finally:
+                            if after_agent is not None:
+                                _phase = "post-agent checkpoint"
+                                await after_agent(live)
                         _phase = "grading"
 
                     verifier = task.verifier

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -488,9 +488,13 @@ async def rollout(
                                     # Preserve an agent failure when both the
                                     # agent and checkpoint fail; the checkpoint
                                     # must not replace the primary error.
-                                    if pending_exception is None:
+                                    if pending_exception is not None:
+                                        _phase = phase_before_hook
+                                    else:
+                                        # Keep "post-agent checkpoint" for
+                                        # outer error attribution.
                                         raise
-                                finally:
+                                else:
                                     _phase = phase_before_hook
                         _phase = "grading"
 

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import sys
 import traceback
 import uuid
 from dataclasses import dataclass, field
@@ -478,8 +479,19 @@ async def rollout(
                             run.record(Step(source="system", error=f"[{_phase}] {detail}"))
                         finally:
                             if after_agent is not None:
+                                phase_before_hook = _phase
+                                pending_exception = sys.exc_info()[1]
                                 _phase = "post-agent checkpoint"
-                                await after_agent(live)
+                                try:
+                                    await after_agent(live)
+                                except Exception:
+                                    # Preserve an agent failure when both the
+                                    # agent and checkpoint fail; the checkpoint
+                                    # must not replace the primary error.
+                                    if pending_exception is None:
+                                        raise
+                                finally:
+                                    _phase = phase_before_hook
                         _phase = "grading"
 
                     verifier = task.verifier

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -41,6 +41,7 @@ from .file_tracking import file_tracking_observer
 from .job import job_enter, trace_enter, trace_exit
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
     from types import TracebackType
 
     from hud.agents.base import Agent
@@ -371,6 +372,8 @@ async def rollout(
     group_id: str | None = None,
     trace_id: str | None = None,
     rollout_timeout: float | None = None,
+    before_agent: Callable[[Run], Awaitable[None]] | None = None,
+    after_agent: Callable[[Run], Awaitable[None]] | None = None,
 ) -> Run:
     """Drive one task to a graded :class:`Run` here, against ``runtime``'s channel.
 
@@ -445,6 +448,9 @@ async def rollout(
                     live._runtime = addr.url  # the placement record for the receipt
                     async with live:  # start on enter; complete on exit
                         run = live  # bound only once live: an earlier failure synthesizes
+                        if before_agent is not None:
+                            _phase = "pre-agent checkpoint"
+                            await before_agent(live)
                         _phase = "agent loop"
                         try:
                             async with file_tracking_observer(actor_client):
@@ -470,6 +476,9 @@ async def rollout(
                             logger.warning("rollout failed mid-run (%s): %s", _phase, detail)
                             run.trace.status = "error"
                             run.record(Step(source="system", error=f"[{_phase}] {detail}"))
+                        if after_agent is not None:
+                            _phase = "post-agent checkpoint"
+                            await after_agent(live)
                         _phase = "grading"
 
                     verifier = task.verifier

--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -1482,9 +1482,11 @@ class HostedRuntime:
         *,
         poll_interval: float = 5.0,
         run_timeout: float = 3600.0,
+        lazy_load: bool = False,
     ) -> None:
         self.poll_interval = poll_interval
         self.run_timeout = run_timeout
+        self.lazy_load = lazy_load
         self._cancellations: set[asyncio.Task[None]] = set()
 
     async def run(
@@ -1568,6 +1570,7 @@ class HostedRuntime:
             "task": task.id,
             "slug": task.slug,
             "args": task.args,
+            "lazy_load": self.lazy_load,
             "agent": spec,
         }
         if group_id is not None:

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -196,7 +196,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
         "hud.eval.runtime.PlatformClient.from_settings", classmethod(lambda cls: platform)
     )
 
-    hosted = HostedRuntime(poll_interval=0.0)
+    hosted = HostedRuntime(poll_interval=0.0, lazy_load=True)
     trace_id = uuid.uuid4().hex
     job_id = uuid.uuid4().hex
     task = Task(
@@ -229,6 +229,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert payload["task"] == "add"
     assert payload["slug"] == "sums-add"
     assert payload["args"] == {"a": 1, "b": 2}
+    assert payload["lazy_load"] is True
     assert payload["runtime_config"] == {
         "image": "registry.example/sums:latest",
         "resources": {"cpu": 2.0, "gpu": {"type": "L4", "count": 1}},

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -646,6 +646,48 @@ async def test_mid_run_failure_keeps_the_real_run_and_its_evidence(env_file: Pat
     assert run.reward == 0.0  # graded best-effort, but the agent never answered → 0.0
 
 
+async def test_after_agent_runs_when_agent_raises(env_file: Path) -> None:
+    calls: list[Run] = []
+
+    def boom(prompt: str) -> str:
+        raise RuntimeError("agent exploded")
+
+    async def after_agent(run: Run) -> None:
+        calls.append(run)
+
+    run = await rollout(
+        _add_task(2, 3),
+        _FnAgent(boom),
+        runtime=SubprocessRuntime(env_file),
+        after_agent=after_agent,
+    )
+
+    assert calls == [run]
+    assert run.trace.is_error
+
+
+async def test_agent_hooks_wrap_agent_before_grading(env_file: Path) -> None:
+    calls: list[str] = []
+
+    async def before_agent(_run: Run) -> None:
+        calls.append("before")
+
+    async def after_agent(run: Run) -> None:
+        calls.append("after")
+        run.trace.content = "5"
+
+    run = await rollout(
+        _add_task(2, 3),
+        _FnAgent(lambda _prompt: "wrong"),
+        runtime=SubprocessRuntime(env_file),
+        before_agent=before_agent,
+        after_agent=after_agent,
+    )
+
+    assert calls == ["before", "after"]
+    assert run.reward == 1.0
+
+
 class _AnswerThenBoomAgent(Agent):
     """Records a correct answer, then raises — a mid-run failure after the env
     already has a gradable answer in hand."""

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -666,6 +666,23 @@ async def test_after_agent_runs_when_agent_raises(env_file: Path) -> None:
     assert run.trace.is_error
 
 
+async def test_after_agent_failure_attributes_post_agent_phase(env_file: Path) -> None:
+    async def after_agent(_run: Run) -> None:
+        raise RuntimeError("checkpoint exploded")
+
+    run = await rollout(
+        _add_task(2, 3),
+        _FnAgent(_solve_add),
+        runtime=SubprocessRuntime(env_file),
+        after_agent=after_agent,
+    )
+
+    assert run.trace.is_error
+    assert "[post-agent checkpoint]" in (run.trace.error or "")
+    assert "checkpoint exploded" in (run.trace.error or "")
+    assert "[agent loop]" not in (run.trace.error or "")
+
+
 async def test_agent_hooks_wrap_agent_before_grading(env_file: Path) -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
## Summary

- Add optional `before_agent` / `after_agent` async hooks on `rollout()` so host drivers can checkpoint filesystem state around the agent loop.
- Required by OverlayBD staged checkpoints (`pre_agent` / `post_agent`) in hud-monorepo #1103; grading still runs on live-context exit after `after_agent`.

## Stack

- Built on #568 (`codex/lazy-load-per-run` @ `dd1cbce3`); this PR tip is hooks-only on top of that commit.
- Consumed by [hud-monorepo#1103](https://github.com/hud-evals/hud-monorepo/pull/1103).

## Test plan

- [ ] Unit/typecheck for `hud/eval/run.py` hooks
- [ ] Confirm `after_agent` still runs when the agent loop errors
- [ ] Confirm grading still runs after `after_agent` on live exit


Made with [Cursor](https://cursor.com)