### PR TITLE
fix(ssh): make posix file writes atomic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,30 @@ jobs:
       - name: Install Python
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Install Workspace filesystem server
+        run: sudo apt-get update && sudo apt-get install -y openssh-sftp-server
+
       - name: Run tests
         run: uv run --python ${{ matrix.python-version }} --with=".[dev]" pytest --cov --cov-report=''
+
+  test-native-workspace:
+    name: Native Workspace (macOS)
+    runs-on: macos-14
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python
+        run: uv python install 3.12
+
+      - name: Run native Workspace tests
+        run: >-
+          uv run --python 3.12 --with=".[dev]" pytest -q
+          hud/environment/tests/test_workspace_native.py
 
   lint-ruff:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,9 @@ git config core.hooksPath .githooks
 uv run pytest -q
 ```
 
-Tests run on Python 3.11 and 3.12 in CI.
+Tests run on Python 3.11 and 3.12 in CI. Workspace's native SSH contracts also
+run on macOS so Darwin shell and filesystem behavior is tested on the operating
+system that owns it.
 
 Integration tests are excluded by default because they may use external
 services, network access, or container builds. Run them explicitly:

--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -47,7 +47,7 @@ Bind every daemon to `127.0.0.1`: the environment exposes a single control port,
 ### `ssh` - a sandboxed shell
 
 ```text
-Capability.ssh(*, name="shell", url, user="agent", host_pubkey, client_key=None, client_key_path=None, shell=None, cwd=None)
+Capability.ssh(*, name="shell", url, user="agent", host_pubkey, client_key=None, client_key_path=None, shell=None, cwd=None, sftp_subsystem="sftp")
 ```
 
 The shell case is built in via [`Workspace`](#workspace), so you rarely call this factory directly. [`env.workspace(root)`](/v6/reference/environment#methods) starts a workspace, publishes its `ssh` capability, and stops it with the env.
@@ -61,7 +61,10 @@ The shell case is built in via [`Workspace`](#workspace), so you rarely call thi
 | `client_key` | `str \| None` | Private key *content*; authenticates across a container boundary. |
 | `client_key_path` | `str \| None` | Path to a key file; only works when client and daemon share a filesystem. |
 | `shell` | `str \| None` | Remote shell type (`bash` / `powershell` / `cmd`); auto-detected from `sys.platform`. |
-| `cwd` | `str \| None` | Absolute path sessions start in (the served workspace). File helpers anchor absolute paths to it. |
+| `cwd` | `str \| None` | Absolute path sessions start in (the served workspace). Relative paths resolve there; absolute paths pass through verbatim. |
+| `sftp_subsystem` | `str \| None` | SFTP subsystem used for file operations. Defaults to `"sftp"`; pass `None` only for command-only SSH endpoints. Atomic writes require the OpenSSH `posix-rename` extension. |
+
+On POSIX, `Workspace` runs SFTP as an isolated SSH session so filesystem operations have the same namespace and identity as shell commands. Install the `openssh-sftp-server` OS package when constructing an environment image; the `hud init` Dockerfile includes it. Workspace startup fails explicitly when it is unavailable. Windows workspaces retain their PowerShell file path and do not require this package.
 
 ### `mcp` - your own tools
 
@@ -271,7 +274,7 @@ The bundled provider agents open these automatically based on which capabilities
 
 A `Workspace` is not itself a capability - it's the built-in workspace daemon. It serves `ssh` for agent access and, when enabled, file tracking for rollout telemetry. For `mcp`, `cdp`, and `rfb` you stand up the daemon yourself.
 
-Concretely it's a directory plus a `bwrap`-isolated SSH exec server. Shell commands and file operations run through the same exec channel. [`env.workspace(root, ...)`](/v6/reference/environment#methods) wires its whole lifecycle; construction is pure data, with keys, sockets, and the root directory materializing only at serve time. To run one outside an env, drive its lifecycle directly and publish `ws.capability()`:
+Concretely it's a directory plus a `bwrap`-isolated SSH server. Shell commands use SSH exec channels; filesystem operations use an SFTP server launched through the same session boundary. [`env.workspace(root, ...)`](/v6/reference/environment#methods) wires its whole lifecycle; construction is pure data, with keys, sockets, and the root directory materializing only at serve time. To run one outside an env, drive its lifecycle directly and publish `ws.capability()`:
 
 ```python
 from hud.environment import Environment, Workspace

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -69,7 +69,7 @@ class _FakeConn:
         self,
         cmd: str,
         *,
-        input: str | None = None,
+        input: str | bytes | None = None,
         check: bool = True,
         encoding: str | None = "utf-8",
     ) -> Any:
@@ -84,7 +84,7 @@ class _FakeConn:
                 if path in script
             )
             if input is not None:
-                self._sink[name] = input.encode()
+                self._sink[name] = input.encode() if isinstance(input, str) else input
             elif match := re.search(r"FromBase64String\('([^']+)'\)", script):
                 self._sink[name] += base64.b64decode(match.group(1))
             else:
@@ -129,6 +129,20 @@ _STREAM_JSON = (
 )
 
 
+class _FakeFileSSH(SSHClient):
+    async def write_text(
+        self,
+        path: str,
+        content: str,
+        *,
+        timeout_s: float | None = None,
+    ) -> None:
+        del timeout_s
+        connection = self.conn
+        assert isinstance(connection, _FakeConn)
+        connection._sink[path] = content.encode()
+
+
 def _ssh_with_conn(shell: str, conn: _FakeConn) -> SSHClient:
     capability = Capability(
         name="shell",
@@ -136,7 +150,8 @@ def _ssh_with_conn(shell: str, conn: _FakeConn) -> SSHClient:
         url="ssh://localhost:22",
         params={"shell": shell},
     )
-    return SSHClient(capability, cast("Any", conn))
+    client_type = SSHClient if shell in {"cmd", "powershell"} else _FakeFileSSH
+    return client_type(capability, cast("Any", conn))
 
 
 async def test_exec_on_windows_writes_batch_and_execs_via_cmd() -> None:
@@ -172,7 +187,7 @@ async def test_exec_on_bash_runs_inline_without_batch() -> None:
     await agent._exec(run, ssh=ssh, shell="bash", mcp_servers={}, prompt="build it", max_steps=5)
 
     assert ".hud_run.bat" not in sink
-    assert conn.write_commands == ["cat > .hud_prompt.txt"]
+    assert sink[".hud_prompt.txt"] == b"build it"
     assert len(conn.ran) == 1
     assert "install.sh" in conn.ran[0]
     assert "claude" in conn.ran[0]

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -49,7 +49,7 @@ class _Conn:
         self,
         command: str,
         *,
-        input: str | None = None,
+        input: str | bytes | None = None,
         check: bool = False,
         encoding: str | None = "utf-8",
     ) -> _Completed:
@@ -72,9 +72,10 @@ class _Conn:
                     stderr=f"cat: {parts[2]}: No such file or directory", exit_status=1
                 )
             return _Completed(stdout=self._store[parts[2]].decode())
-        if len(parts) == 3 and parts[:2] == ["cat", ">"]:
-            assert input is not None
-            self._store[parts[2]] = input.encode()
+        if input is not None and command.startswith("d=") and ".hud-write.XXXXXX" in command:
+            assignment = command.removeprefix("d=").partition(";n=0;")[0]
+            path = shlex.split(assignment)[0]
+            self._store[path] = input.encode() if isinstance(input, str) else input
             return _Completed()
         if len(parts) == 4 and parts[:3] == ["ls", "-1A", "--"]:
             prefix = parts[3].rstrip("/")
@@ -134,7 +135,7 @@ class _Process:
 
 
 class _FakeSSH(SSHClient):
-    """SSH client with an in-memory exec-channel filesystem."""
+    """SSH client with an in-memory filesystem."""
 
     def __init__(
         self,
@@ -157,6 +158,16 @@ class _FakeSSH(SSHClient):
                 ),
             ),
         )
+
+    async def write_text(
+        self,
+        path: str,
+        content: str,
+        *,
+        timeout_s: float | None = None,
+    ) -> None:
+        del timeout_s
+        self.files[path] = content.encode()
 
 
 def _ssh(**kwargs: Any) -> SSHClient:
@@ -409,7 +420,7 @@ async def test_shared_ssh_tool_bounds_combined_output(
     assert "[truncated]" in output
 
 
-async def test_openai_compatible_write_stores_file_via_ssh_exec() -> None:
+async def test_openai_compatible_write_stores_file_via_ssh() -> None:
     ssh = _FakeSSH()
     tool = WriteTool(spec=WriteTool.default_spec("qwen"), client=cast("SSHClient", ssh))
 

--- a/hud/capabilities/base.py
+++ b/hud/capabilities/base.py
@@ -93,6 +93,7 @@ class Capability:
         shell: str | None = None,
         cwd: str | None = None,
         isolation: Literal["bwrap", "none"] | None = None,
+        sftp_subsystem: str | None = "sftp",
     ) -> Capability:
         """``ssh/2`` — SSH daemon with publickey auth.
 
@@ -106,6 +107,8 @@ class Capability:
         start in. Paths are the session namespace's own — clients pass them
         verbatim, and nothing is anchored or rewritten. ``isolation`` records
         the sandbox actually granted to the served workspace.
+        ``sftp_subsystem`` names the SSH subsystem used for file operations;
+        pass ``None`` for command-only endpoints.
         """
         normalized = normalize_url(url, default_scheme="ssh", default_port=22)
         if shell is None:
@@ -119,6 +122,8 @@ class Capability:
             params["cwd"] = cwd
         if isolation is not None:
             params["isolation"] = isolation
+        if sftp_subsystem is not None:
+            params["sftp_subsystem"] = sftp_subsystem
         return cls(name=name, protocol="ssh/2", url=normalized, params=params)
 
     @classmethod

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -5,13 +5,21 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import posixpath
+import secrets
 import shlex
-from typing import Any, ClassVar, Self
+import stat
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 from urllib.parse import urlsplit
 
 import asyncssh
+from asyncssh.constants import FXF_WRITE
+from asyncssh.sftp import start_sftp_client
 
 from .base import Capability, CapabilityClient
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
 
 SSH_RECONNECT_ATTEMPTS = 3
 SSH_RECONNECT_BASE_DELAY_S = 0.25
@@ -169,12 +177,15 @@ class SSHClient(CapabilityClient):
             ) from last_error
 
     async def read_text(self, path: str, *, timeout_s: float | None = None) -> str:
-        """Read a UTF-8 text file through the exec channel."""
+        """Read a UTF-8 text file through SFTP or a command-only endpoint."""
         if self._is_windows:
             quoted = _powershell_quote(path)
             script = f"[Convert]::ToBase64String([IO.File]::ReadAllBytes({quoted}))"
             result = await self.run(_powershell(script), check=True, timeout=timeout_s)
             return base64.b64decode(_stdout(result)).decode("utf-8", errors="replace")
+        if self._sftp_subsystem is not None:
+            async with self._sftp(timeout_s) as sftp, sftp.open(path, "rb") as remote:
+                return (await remote.read()).decode("utf-8", errors="replace")
         # encoding=None transports raw bytes: a strict connection-level UTF-8
         # decode would raise on files with invalid UTF-8 instead of replacing.
         result = await self.run(
@@ -192,7 +203,8 @@ class SSHClient(CapabilityClient):
         *,
         timeout_s: float | None = None,
     ) -> None:
-        """Write UTF-8 text through the exec channel without command interpolation."""
+        """Atomically write UTF-8 text through SFTP on POSIX."""
+        payload = content.encode("utf-8")
         if self._is_windows:
             loop = asyncio.get_running_loop()
             deadline = loop.time() + timeout_s if timeout_s is not None else None
@@ -203,35 +215,133 @@ class SSHClient(CapabilityClient):
             quoted = _powershell_quote(path)
             truncate = f"[IO.File]::WriteAllBytes({quoted},[byte[]]@())"
             await self.run(_powershell(truncate), check=True, timeout=remaining_timeout())
-            raw = content.encode("utf-8")
-            for offset in range(0, len(raw), 6144):
-                payload = base64.b64encode(raw[offset : offset + 6144]).decode("ascii")
+            for offset in range(0, len(payload), 6144):
+                encoded = base64.b64encode(payload[offset : offset + 6144]).decode("ascii")
                 script = (
-                    f"$b=[Convert]::FromBase64String('{payload}');"
+                    f"$b=[Convert]::FromBase64String('{encoded}');"
                     f"$f=[IO.File]::Open({quoted},[IO.FileMode]::Append,"
                     "[IO.FileAccess]::Write,[IO.FileShare]::Read);"
                     "try{$f.Write($b,0,$b.Length)}finally{$f.Dispose()}"
                 )
                 await self.run(_powershell(script), check=True, timeout=remaining_timeout())
             return
-        await self.run(
-            f"cat > {shlex.quote(path)}",
-            input=content,
-            check=True,
-            timeout=timeout_s,
+        if self._sftp_subsystem is not None:
+            async with self._sftp(timeout_s) as sftp:
+                await self._write_text_sftp(sftp, path, payload)
+            return
+        raise RuntimeError(
+            "atomic file writes require an SFTP subsystem with the OpenSSH posix-rename extension"
         )
 
     async def listdir(self, path: str, *, timeout_s: float | None = None) -> list[str]:
-        """List direct children through the exec channel."""
+        """List direct children through SFTP or a command-only endpoint."""
         if self._is_windows:
             script = f"Get-ChildItem -Force -Name -LiteralPath {_powershell_quote(path)}"
             result = await self.run(_powershell(script), check=True, timeout=timeout_s)
             listing = _stdout(result)
+        elif self._sftp_subsystem is not None:
+            async with self._sftp(timeout_s) as sftp:
+                return sorted(
+                    str(name)
+                    for name in await sftp.listdir(path)
+                    if name not in (".", "..", b".", b"..")
+                )
         else:
             command = f"ls -1A -- {shlex.quote(path)}"
             result = await self.run(command, check=True, encoding=None, timeout=timeout_s)
             listing = _decode(result.stdout)
         return sorted(line for line in listing.splitlines() if line not in (".", ".."))
+
+    @property
+    def _sftp_subsystem(self) -> str | None:
+        subsystem = self.capability.params.get("sftp_subsystem")
+        if subsystem is not None and not isinstance(subsystem, str):
+            raise ValueError("ssh capability sftp_subsystem must be a string")
+        return subsystem
+
+    async def _start_sftp(self) -> asyncssh.SFTPClient:
+        subsystem = self._sftp_subsystem
+        if subsystem is None:
+            raise RuntimeError("ssh capability does not advertise an SFTP subsystem")
+        try:
+            conn = await self._connection()
+            writer, reader, _ = await conn.open_session(subsystem=subsystem, encoding=None)
+            return await start_sftp_client(
+                conn,
+                asyncio.get_running_loop(),
+                "strict",
+                reader,
+                writer,
+                "utf-8",
+                "strict",
+                3,
+            )
+        except asyncssh.ChannelOpenError as exc:
+            raise SSHConnectionError("SSH server rejected the SFTP subsystem") from exc
+        except asyncssh.ConnectionLost as exc:
+            raise SSHConnectionError("SSH connection lost while opening SFTP") from exc
+
+    @contextlib.asynccontextmanager
+    async def _sftp(self, timeout_s: float | None) -> AsyncIterator[asyncssh.SFTPClient]:
+        sftp: asyncssh.SFTPClient | None = None
+        try:
+            async with asyncio.timeout(timeout_s):
+                sftp = await self._start_sftp()
+                yield sftp
+        except (asyncssh.SFTPConnectionLost, asyncssh.SFTPNoConnection) as exc:
+            if _is_closed(self._conn):
+                raise SSHConnectionError("SSH connection lost during file operation") from exc
+            raise
+        finally:
+            if sftp is not None:
+                sftp.exit()
+
+    async def _write_text_sftp(
+        self,
+        sftp: asyncssh.SFTPClient,
+        path: str,
+        payload: bytes,
+    ) -> None:
+        resolved = await sftp.realpath(path)
+        if not isinstance(resolved, str):
+            raise TypeError("SFTP returned a non-text destination path")
+
+        metadata: asyncssh.SFTPAttrs | None = None
+        with contextlib.suppress(asyncssh.SFTPNoSuchFile):
+            metadata = await sftp.stat(resolved)
+        if metadata is not None:
+            permissions = metadata.permissions
+            if permissions is None or not stat.S_ISREG(permissions):
+                raise OSError("destination is not a regular file")
+            async with sftp.open(resolved, FXF_WRITE):
+                pass
+
+        directory = posixpath.dirname(resolved) or "."
+        staged = posixpath.join(directory, f".hud-write.{secrets.token_hex(16)}")
+        committed = False
+        try:
+            async with sftp.open(staged, "xb") as remote:
+                await remote.write(payload)
+                if metadata is not None:
+                    if metadata.uid is None or metadata.gid is None or metadata.permissions is None:
+                        raise OSError("destination metadata is incomplete")
+                    await remote.setstat(
+                        asyncssh.SFTPAttrs(
+                            uid=metadata.uid,
+                            gid=metadata.gid,
+                            permissions=metadata.permissions,
+                        )
+                    )
+            await sftp.posix_rename(staged, resolved)
+            committed = True
+        finally:
+            if not committed:
+                with contextlib.suppress(
+                    asyncssh.SFTPConnectionLost,
+                    asyncssh.SFTPNoConnection,
+                    asyncssh.SFTPNoSuchFile,
+                ):
+                    await sftp.remove(staged)
 
     @property
     def _is_windows(self) -> bool:

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -325,6 +325,13 @@ async def test_windows_write_uses_one_timeout_budget(
     assert timeouts[0] > timeouts[1] > timeouts[2]
 
 
+async def test_posix_write_requires_an_sftp_subsystem() -> None:
+    client = _client(_Connection())
+
+    with pytest.raises(RuntimeError, match="atomic file writes require an SFTP subsystem"):
+        await client.write_text("target.txt", "héllo", timeout_s=1)
+
+
 async def test_close_during_reconnect_discards_the_replacement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/hud/cli/templates.py
+++ b/hud/cli/templates.py
@@ -3,7 +3,7 @@
 DOCKERFILE_HUD = """\
 FROM python:3.11-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl \\
+RUN apt-get update && apt-get install -y --no-install-recommends curl openssh-sftp-server \\
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/hud/cli/tests/test_init.py
+++ b/hud/cli/tests/test_init.py
@@ -50,6 +50,7 @@ def test_init_scaffolds_a_runnable_package(tmp_path: Path) -> None:
 
     dockerfile = (target / "Dockerfile.hud").read_text()
     assert 'CMD ["uv", "run", "hud", "serve"' in dockerfile
+    assert "openssh-sftp-server" in dockerfile
     assert '"dev"' not in dockerfile
 
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -52,6 +52,16 @@ async def _connect(ws: Workspace) -> asyncssh.SSHClientConnection:
     )
 
 
+async def test_workspace_requires_an_isolated_sftp_server(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(workspace_mod, "_SFTP_SERVER_PATHS", ())
+
+    with pytest.raises(RuntimeError, match="install openssh-sftp-server"):
+        await Workspace(tmp_path / "root").start()
+
+
 @pytest.mark.asyncio
 async def test_start_waits_until_the_ssh_acceptor_is_ready(
     tmp_path: Path,
@@ -103,7 +113,7 @@ async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sftp_subsystem_is_not_served(tmp_path: Path) -> None:
+async def test_in_process_sftp_subsystem_is_not_served(tmp_path: Path) -> None:
     ws = Workspace(tmp_path / "root")
     await ws.start()
     try:
@@ -115,12 +125,13 @@ async def test_sftp_subsystem_is_not_served(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_file_operations_use_the_exec_channel(tmp_path: Path) -> None:
+async def test_file_operations_use_the_isolated_sftp_subsystem(tmp_path: Path) -> None:
     ws = Workspace(tmp_path / "root")
     await ws.start()
     try:
         async with await _connect(ws) as conn:
             client = SSHClient(ws.capability(), conn)
+            assert client.capability.params["sftp_subsystem"] == "hud-sftp"
             await client.write_text("hello world.txt", "héllo\n")
             assert await client.read_text("hello world.txt") == "héllo\n"
             assert await client.listdir(".") == ["hello world.txt"]
@@ -1527,7 +1538,7 @@ async def test_session_wrapper_environment_contains_no_server_secrets(
     ws = Workspace(tmp_path / "root")
     monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=7))
     ws._namespace = cast("Any", SimpleNamespace(spawn=capture_spawn))
-    process = SimpleNamespace(term_type=None, command="true")
+    process = SimpleNamespace(term_type=None, command="true", subsystem=None)
 
     with pytest.raises(SpawnCaptured) as captured:
         await ws._handle_process(cast("Any", process))
@@ -1565,6 +1576,7 @@ async def test_namespace_wait_status_is_forwarded_to_ssh_client(
     process = SimpleNamespace(
         term_type=None,
         command="true",
+        subsystem=None,
         stdin=SimpleNamespace(read=AsyncMock(return_value=b"")),
         stdout=SimpleNamespace(write=Mock(), drain=AsyncMock()),
         stderr=SimpleNamespace(write=Mock(), drain=AsyncMock()),
@@ -1695,6 +1707,7 @@ async def test_windows_channel_close_terminates_the_process_job(
     process = SimpleNamespace(
         term_type=None,
         command="cmd /c echo hello",
+        subsystem=None,
         channel=channel,
         stdout=SimpleNamespace(write=Mock()),
         stderr=SimpleNamespace(write=Mock()),

--- a/hud/environment/tests/test_workspace_native.py
+++ b/hud/environment/tests/test_workspace_native.py
@@ -1,0 +1,227 @@
+"""Native Workspace SSH file-write contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from typing import TYPE_CHECKING
+
+import asyncssh
+import pytest
+
+from hud.capabilities import SSHClient
+from hud.capabilities.ssh import SSHConnectionError
+from hud.environment.workspace import Workspace, _sftp_server_path
+
+if TYPE_CHECKING:
+    from pathlib import Path, PurePath
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform == "win32", reason="POSIX workspace semantics"),
+    pytest.mark.skipif(_sftp_server_path() is None, reason="OpenSSH sftp-server is unavailable"),
+]
+
+
+async def _connect(ws: Workspace) -> asyncssh.SSHClientConnection:
+    host, port = ws.ssh_url.removeprefix("ssh://").split(":")
+    key_path = ws.ssh_client_key_path
+    assert key_path is not None
+    return await asyncssh.connect(
+        host,
+        int(port),
+        username=ws.ssh_user,
+        client_keys=[str(key_path)],
+        known_hosts=None,
+    )
+
+
+def _staged_files(root: Path) -> list[Path]:
+    return list(root.glob(".hud-write.*"))
+
+
+async def test_cancelled_file_write_keeps_existing_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    destination = root / "destination.txt"
+    destination.write_text("old", encoding="utf-8")
+    commit_ready = asyncio.Event()
+
+    async def block_commit(
+        client: asyncssh.SFTPClient,
+        staged: str | bytes | PurePath,
+        target: str | bytes | PurePath,
+    ) -> None:
+        del client, staged, target
+        commit_ready.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(asyncssh.SFTPClient, "posix_rename", block_commit)
+    ws = Workspace(root)
+    await ws.start()
+    try:
+        async with await _connect(ws) as connection:
+            write = asyncio.create_task(
+                SSHClient(ws.capability(), connection).write_text("destination.txt", "new")
+            )
+            await commit_ready.wait()
+
+            assert destination.read_text(encoding="utf-8") == "old"
+            write.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await write
+    finally:
+        await ws.stop()
+
+    assert destination.read_text(encoding="utf-8") == "old"
+    assert not _staged_files(root)
+
+
+async def test_timed_out_file_write_keeps_existing_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    destination = root / "destination.txt"
+    destination.write_text("old", encoding="utf-8")
+
+    async def block_commit(
+        client: asyncssh.SFTPClient,
+        staged: str | bytes | PurePath,
+        target: str | bytes | PurePath,
+    ) -> None:
+        del client, staged, target
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(asyncssh.SFTPClient, "posix_rename", block_commit)
+    ws = Workspace(root)
+    await ws.start()
+    try:
+        async with await _connect(ws) as connection:
+            with pytest.raises(TimeoutError):
+                await SSHClient(ws.capability(), connection).write_text(
+                    "destination.txt",
+                    "new",
+                    timeout_s=0.05,
+                )
+    finally:
+        await ws.stop()
+
+    assert destination.read_text(encoding="utf-8") == "old"
+    assert not _staged_files(root)
+
+
+async def test_connection_loss_before_commit_keeps_existing_destination(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    destination = root / "destination.txt"
+    destination.write_text("old", encoding="utf-8")
+    commit_ready = asyncio.Event()
+    connection: asyncssh.SSHClientConnection
+    original_commit = asyncssh.SFTPClient.posix_rename
+
+    async def lose_before_commit(
+        client: asyncssh.SFTPClient,
+        staged: str | bytes | PurePath,
+        target: str | bytes | PurePath,
+    ) -> None:
+        commit_ready.set()
+        await connection.wait_closed()
+        await original_commit(client, staged, target)
+
+    monkeypatch.setattr(asyncssh.SFTPClient, "posix_rename", lose_before_commit)
+    ws = Workspace(root)
+    await ws.start()
+    connection = await _connect(ws)
+    try:
+        write = asyncio.create_task(
+            SSHClient(ws.capability(), connection).write_text("destination.txt", "new")
+        )
+        await commit_ready.wait()
+        connection.abort()
+
+        with pytest.raises(SSHConnectionError, match="lost during file operation"):
+            await write
+    finally:
+        connection.abort()
+        await connection.wait_closed()
+        await ws.stop()
+
+    assert destination.read_text(encoding="utf-8") == "old"
+
+
+async def test_file_write_atomically_replaces_symlink_target_with_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    target = root / "target with [spaces]*.txt"
+    target.write_text("old", encoding="utf-8")
+    target.chmod(0o640)
+    metadata = (target.stat().st_mode, target.stat().st_uid, target.stat().st_gid)
+    link = root / "link.txt"
+    link.symlink_to(target.name)
+    commit_ready = asyncio.Event()
+    allow_commit = asyncio.Event()
+    original_commit = asyncssh.SFTPClient.posix_rename
+
+    async def block_commit(
+        client: asyncssh.SFTPClient,
+        staged: str | bytes | PurePath,
+        destination: str | bytes | PurePath,
+    ) -> None:
+        commit_ready.set()
+        await allow_commit.wait()
+        await original_commit(client, staged, destination)
+
+    monkeypatch.setattr(asyncssh.SFTPClient, "posix_rename", block_commit)
+    ws = Workspace(root)
+    await ws.start()
+    try:
+        async with await _connect(ws) as connection:
+            write = asyncio.create_task(
+                SSHClient(ws.capability(), connection).write_text(
+                    "link.txt",
+                    "complete new content",
+                )
+            )
+            await commit_ready.wait()
+
+            assert target.read_text(encoding="utf-8") == "old"
+            assert link.is_symlink()
+            staged = _staged_files(root)
+            assert len(staged) == 1
+            assert staged[0].read_text(encoding="utf-8") == "complete new content"
+
+            allow_commit.set()
+            await write
+    finally:
+        await ws.stop()
+
+    assert target.read_text(encoding="utf-8") == "complete new content"
+    assert link.is_symlink()
+    assert (target.stat().st_mode, target.stat().st_uid, target.stat().st_gid) == metadata
+    assert not _staged_files(root)
+
+
+async def test_new_file_write_observes_the_process_umask(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    ws = Workspace(root)
+    previous_umask = os.umask(0o027)
+    try:
+        await ws.start()
+        async with await _connect(ws) as connection:
+            await SSHClient(ws.capability(), connection).write_text("new.txt", "content")
+    finally:
+        os.umask(previous_umask)
+        await ws.stop()
+
+    assert (root / "new.txt").stat().st_mode & 0o777 == 0o640

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import secrets
+import shlex
 import shutil
 import socket
 import struct
@@ -336,6 +337,24 @@ DEFAULT_SYSTEM_MOUNTS: tuple[Mount, ...] = (
 
 
 _DEFAULT_USER = "agent"
+# AsyncSSH reserves the standard name for its in-process SFTP server. This
+# distinct subsystem goes through ``process_factory`` and the session wall.
+_SFTP_SUBSYSTEM = "hud-sftp"
+_SFTP_SERVER_PATHS = (
+    "/usr/lib/openssh/sftp-server",
+    "/usr/lib/ssh/sftp-server",
+    "/usr/libexec/sftp-server",
+)
+
+
+def _sftp_server_path() -> str | None:
+    if sys.platform == "win32":
+        return None
+    return next(
+        (path for path in _SFTP_SERVER_PATHS if Path(path).is_file() and os.access(path, os.X_OK)),
+        None,
+    )
+
 
 #: What the sandbox runs so it stays alive between sessions. It must outlast
 #: every rollout without waking (a sandbox is discarded, never expired) and
@@ -660,6 +679,11 @@ class Workspace:
         """Materialize filesystem credentials and bind the SSH socket."""
         if self._sock is not None:
             return
+        if sys.platform != "win32" and _sftp_server_path() is None:
+            raise RuntimeError(
+                "POSIX Workspace filesystem access requires OpenSSH sftp-server; "
+                "install openssh-sftp-server"
+            )
         if self._shell_uid is not None and _is_root() and not self._drops_privileges():
             # Fail closed: serving as root while unable to drop would run every
             # agent shell as root, exactly what shell_uid exists to prevent.
@@ -830,6 +854,7 @@ class Workspace:
             client_key_path=key_path,
             cwd=self._guest_path,
             isolation="bwrap" if self.bwrap_available else "none",
+            sftp_subsystem=_SFTP_SUBSYSTEM if sys.platform != "win32" else None,
         )
 
     @property
@@ -1378,7 +1403,7 @@ class Workspace:
 
     def shell_argv(
         self,
-        command: str | None = None,
+        command: str | list[str] | None = None,
         *,
         cwd: str | None = None,
         env: Mapping[str, str] | None = None,
@@ -1395,11 +1420,16 @@ class Workspace:
         root, the same path ``_guest_path`` takes when bwrap is unavailable.
         """
         if sys.platform == "win32":
+            if isinstance(command, list):
+                return command
             if command is not None:
                 return ["cmd.exe", "/c", command]
             return ["cmd.exe"]
         if self._bwrap is not None:
-            inner: list[str] | str = ["bash", "-lc", command] if command else ["bash", "-l"]
+            if isinstance(command, list):
+                inner: list[str] | str = command
+            else:
+                inner = ["bash", "-lc", command] if command else ["bash", "-l"]
             if self._drops_privileges():
                 # Don't let bwrap re-inject host secrets via --setenv; feed it
                 # the same minimal environment as the non-bwrap dropped shell,
@@ -1423,7 +1453,7 @@ class Workspace:
 
     def session_argv(
         self,
-        command: str | None = None,
+        command: str | list[str] | None = None,
         *,
         cwd: str | None = None,
         env: Mapping[str, str] | None = None,
@@ -1565,13 +1595,21 @@ class Workspace:
             # Sessions start from an exact environment, so a terminal's TERM has to
             # be put there deliberately: without it curses and tput have no
             # terminal description and fall back or fail outright.
+            command = process.command
+            if process.subsystem is not None:
+                if process.subsystem != _SFTP_SUBSYSTEM:
+                    raise ValueError(f"unsupported SSH subsystem {process.subsystem!r}")
+                sftp_server = _sftp_server_path()
+                if sftp_server is None:
+                    raise RuntimeError("OpenSSH sftp-server is not installed")
+                command = [sftp_server]
             term_type = process.term_type
             wants_tty = bool(term_type)
             session_env = {"TERM": term_type} if term_type else None
             argv = (
-                self.shell_argv(process.command, env=session_env, tty=wants_tty)
+                self.shell_argv(command, env=session_env, tty=wants_tty)
                 if pid is None
-                else self.session_argv(process.command, env=session_env, tty=wants_tty)
+                else self.session_argv(command, env=session_env, tty=wants_tty)
             )
             if sys.platform != "win32":
                 # Namespace/process wrappers must not receive caller-controlled
@@ -1606,7 +1644,6 @@ class Workspace:
             # Additionally, cmd.exe launched via CreateProcess does NOT search the
             # CWD for batch files (only PATH), so relative .bat paths are resolved
             # to absolute below.
-            import shlex
             import subprocess as _subprocess
 
             if process.command:


### PR DESCRIPTION
## Summary

- use SFTP for POSIX SSH file operations and atomically replace a sibling staged file only after the complete payload is written
- launch the system OpenSSH `sftp-server` through the existing Workspace process boundary, so filesystem access shares the shell namespace and identity wall instead of running in the trusted environment process
- preserve symlink-target behavior plus existing mode and ownership; keep the Windows PowerShell path unchanged
- install the Workspace filesystem server in generated images and Linux CI, with native interruption and atomic-visibility coverage

## Root cause

The POSIX write path streamed directly into the destination. Truncation happened before the complete payload arrived, so timeout, cancellation, or transport loss could expose an empty or partial file.

## Validation

- `uv run ruff format . --check`
- `uv run ruff check .`
- `uv run --extra dev --extra train ty check --error-on-warning`
- non-Docker SSH, Workspace, capability, and affected harness suites: 264 passed
- native macOS coverage for cancellation, timeout, pre-commit connection loss, atomic visibility, symlinks, metadata, cleanup, and umask

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core workspace filesystem and SSH client behavior on POSIX; mitigated by atomic-write contracts, explicit failures when sftp-server is missing, and broad test coverage including macOS CI.
> 
> **Overview**
> POSIX **SSH file I/O** no longer streams writes through shell exec (`cat >`), which could truncate or empty an existing file on timeout, cancel, or disconnect. **`SSHClient`** now uses an advertised SFTP subsystem for `read_text`, `write_text`, and `listdir` on non-Windows shells; POSIX **`write_text`** stages full content to a `.hud-write.*` file and commits with **`posix_rename`**, preserving metadata and symlink targets. Endpoints without SFTP cannot perform atomic POSIX writes and fail explicitly.
> 
> **Workspace** on Linux/macOS requires **`openssh-sftp-server`**, advertises subsystem **`hud-sftp`**, and launches the real **`sftp-server`** inside the same bwrap/session boundary as shell commands (not AsyncSSH’s in-process SFTP). **`Capability.ssh`** adds **`sftp_subsystem`**; **`hud init`** Dockerfile and Ubuntu CI install the package. New **native macOS** workspace write-contract tests and updated agent/capability tests align fakes with SFTP-style writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23bd3425ba8749d657060485c23ceed43584c8ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->