### PR TITLE
Remove the hidden SSH tool timeout

### DIFF
--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -155,13 +155,14 @@ class ClaudeSDKAgent(Agent):
         completed = await self._ssh.run(full_cmd, check=False)
         stdout = completed.stdout if isinstance(completed.stdout, str) else ""
         stderr = completed.stderr if isinstance(completed.stderr, str) else ""
+        returncode = completed.returncode
 
-        logger.info("exit=%s stdout=%d stderr=%d", completed.exit_status, len(stdout), len(stderr))
+        logger.info("returncode=%s stdout=%d stderr=%d", returncode, len(stdout), len(stderr))
 
-        if completed.exit_status != 0 and not stdout.strip():
-            error = stderr or f"claude CLI exited with status {completed.exit_status}"
+        if returncode != 0 and not stdout.strip():
+            error = stderr or f"claude CLI exited with return code {returncode}"
             run.trace.status = "error"
-            run.trace.extra.update({"exit_status": completed.exit_status, "stderr": stderr})
+            run.trace.extra.update({"returncode": returncode, "stderr": stderr})
             run.record(Step(source="system", error=error))
             return
 

--- a/hud/agents/openai/tools/coding.py
+++ b/hud/agents/openai/tools/coding.py
@@ -73,16 +73,13 @@ class OpenAIShellTool(SSHTool):
         outputs: list[dict[str, Any]] = []
         display_outputs: list[str] = []
         is_error = False
-        env_arguments: dict[str, Any] = {}
+        timeout_seconds: float | None = None
         timeout_ms = arguments.get("timeout_ms")
         if isinstance(timeout_ms, int):
-            env_arguments["timeout_seconds"] = timeout_ms / 1000.0
+            timeout_seconds = timeout_ms / 1000.0
 
         for command in command_list:
-            if env_arguments.get("timeout_seconds"):
-                full_cmd = f"timeout {int(env_arguments['timeout_seconds'])} {command}"
-            else:
-                full_cmd = command
+            full_cmd = f"timeout {timeout_seconds:g}s {command}" if timeout_seconds else command
             completed = await self.client.run(full_cmd, check=False)
             stdout = completed.stdout if isinstance(completed.stdout, str) else ""
             stderr = completed.stderr if isinstance(completed.stderr, str) else ""

--- a/hud/agents/openai/tools/coding.py
+++ b/hud/agents/openai/tools/coding.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shlex
 from typing import Any, cast
 
 import mcp.types as mcp_types
@@ -79,7 +80,11 @@ class OpenAIShellTool(SSHTool):
             timeout_seconds = timeout_ms / 1000.0
 
         for command in command_list:
-            full_cmd = f"timeout {timeout_seconds:g}s {command}" if timeout_seconds else command
+            full_cmd = (
+                f"timeout {timeout_seconds:g}s bash -lc {shlex.quote(command)}"
+                if timeout_seconds
+                else command
+            )
             completed = await self.client.run(full_cmd, check=False)
             stdout = completed.stdout if isinstance(completed.stdout, str) else ""
             stderr = completed.stderr if isinstance(completed.stderr, str) else ""

--- a/hud/agents/openai/tools/coding.py
+++ b/hud/agents/openai/tools/coding.py
@@ -7,12 +7,7 @@ from typing import Any, cast
 import mcp.types as mcp_types
 
 from hud.agents.tools import SSHTool
-from hud.agents.tools.ssh import (
-    DEFAULT_SSH_COMMAND_TIMEOUT_S,
-    MAX_SHELL_OUTPUT_LENGTH,
-    SSHInfrastructureErrorResult,
-    bound_shell_output,
-)
+from hud.agents.tools.ssh import MAX_SHELL_OUTPUT_LENGTH, bound_shell_output
 from hud.types import MCPToolResult
 
 from .base import OpenAIToolSpec
@@ -88,28 +83,11 @@ class OpenAIShellTool(SSHTool):
                 full_cmd = f"timeout {int(env_arguments['timeout_seconds'])} {command}"
             else:
                 full_cmd = command
-            try:
-                completed = await self.client.run(
-                    full_cmd,
-                    check=False,
-                    timeout=self._remaining_timeout(),
-                )
-            except TimeoutError:
-                text = f"tool error: command timed out after {DEFAULT_SSH_COMMAND_TIMEOUT_S:g}s"
-                outputs.append(shell_output("", text, 1))
-                display_outputs.append(text)
-                return _shell_result(
-                    display_outputs,
-                    is_error=True,
-                    infrastructure_error=True,
-                    structured={
-                        "output": outputs,
-                        "max_output_length": max_output_length,
-                    },
-                )
+            completed = await self.client.run(full_cmd, check=False)
             stdout = completed.stdout if isinstance(completed.stdout, str) else ""
             stderr = completed.stderr if isinstance(completed.stderr, str) else ""
-            exit_code = completed.exit_status if completed.exit_status is not None else 1
+            exit_code = completed.returncode
+            assert exit_code is not None
             stdout, stderr = bound_shell_output(stdout, stderr, max_output_length)
             outputs.append(shell_output(stdout, stderr, exit_code))
             display_outputs.append(stdout + stderr)
@@ -129,12 +107,10 @@ def _shell_result(
     texts: list[str],
     *,
     is_error: bool = False,
-    infrastructure_error: bool = False,
     structured: dict[str, Any] | None = None,
 ) -> MCPToolResult:
     payload = {"provider_tool": "shell", **(structured or {})}
-    result_type = SSHInfrastructureErrorResult if infrastructure_error else MCPToolResult
-    return result_type(
+    return MCPToolResult(
         content=[mcp_types.TextContent(type="text", text=text) for text in texts if text],
         isError=is_error,
         structuredContent=payload,

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -86,6 +86,28 @@ class _FakeConn:
         self.ran.append(cmd)
         return self._result
 
+    async def create_process(self, cmd: str, **kwargs: Any) -> _FakeProcess:
+        return _FakeProcess(await self.run(cmd, **kwargs))
+
+
+class _FakeProcess:
+    def __init__(self, result: Any) -> None:
+        self._result = result
+
+    async def wait(self, *, check: bool, **kwargs: Any) -> Any:
+        del check
+        assert kwargs == {"timeout": None}
+        return self._result
+
+    def terminate(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def wait_closed(self) -> None:
+        pass
+
 
 def _fake_run() -> Any:
     trace = SimpleNamespace(status="", content="", extra={})

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -86,28 +86,6 @@ class _FakeConn:
         self.ran.append(cmd)
         return self._result
 
-    async def create_process(self, cmd: str, **kwargs: Any) -> _FakeProcess:
-        return _FakeProcess(await self.run(cmd, **kwargs))
-
-
-class _FakeProcess:
-    def __init__(self, result: Any) -> None:
-        self._result = result
-
-    async def wait(self, *, check: bool, **kwargs: Any) -> Any:
-        del check
-        assert kwargs == {"timeout": None}
-        return self._result
-
-    def terminate(self) -> None:
-        pass
-
-    def close(self) -> None:
-        pass
-
-    async def wait_closed(self) -> None:
-        pass
-
 
 def _fake_run() -> Any:
     trace = SimpleNamespace(status="", content="", extra={})

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -82,9 +82,31 @@ class _FakeConn:
                 self._sink[name] += base64.b64decode(match.group(1))
             else:
                 self._sink[name] = b""
-            return SimpleNamespace(stdout="", stderr="", exit_status=0)
+            return SimpleNamespace(stdout="", stderr="", exit_status=0, returncode=0)
         self.ran.append(cmd)
         return self._result
+
+    async def create_process(self, cmd: str, **kwargs: Any) -> _FakeProcess:
+        return _FakeProcess(await self.run(cmd, **kwargs))
+
+
+class _FakeProcess:
+    def __init__(self, result: Any) -> None:
+        self._result = result
+
+    async def wait(self, *, check: bool, **kwargs: Any) -> Any:
+        del check
+        assert kwargs == {"timeout": None}
+        return self._result
+
+    def terminate(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    async def wait_closed(self) -> None:
+        pass
 
 
 def _fake_run() -> Any:
@@ -115,7 +137,10 @@ def _agent_with_conn(shell: str, conn: _FakeConn) -> ClaudeSDKAgent:
 
 async def test_exec_on_windows_writes_batch_and_execs_via_cmd() -> None:
     sink: dict[str, bytes] = {}
-    conn = _FakeConn(sink, SimpleNamespace(stdout=_STREAM_JSON, stderr="", exit_status=0))
+    conn = _FakeConn(
+        sink,
+        SimpleNamespace(stdout=_STREAM_JSON, stderr="", exit_status=0, returncode=0),
+    )
     agent = _agent_with_conn("cmd", conn)
 
     run = _fake_run()
@@ -131,7 +156,10 @@ async def test_exec_on_windows_writes_batch_and_execs_via_cmd() -> None:
 
 async def test_exec_on_bash_runs_inline_without_batch() -> None:
     sink: dict[str, bytes] = {}
-    conn = _FakeConn(sink, SimpleNamespace(stdout=_STREAM_JSON, stderr="", exit_status=0))
+    conn = _FakeConn(
+        sink,
+        SimpleNamespace(stdout=_STREAM_JSON, stderr="", exit_status=0, returncode=0),
+    )
     agent = _agent_with_conn("bash", conn)
 
     run = _fake_run()
@@ -147,15 +175,34 @@ async def test_exec_on_bash_runs_inline_without_batch() -> None:
 
 async def test_exec_nonzero_exit_with_no_stdout_records_system_error() -> None:
     sink: dict[str, bytes] = {}
-    conn = _FakeConn(sink, SimpleNamespace(stdout="", stderr="boom", exit_status=1))
+    conn = _FakeConn(
+        sink,
+        SimpleNamespace(stdout="", stderr="boom", exit_status=1, returncode=1),
+    )
     agent = _agent_with_conn("cmd", conn)
 
     run = _fake_run()
     await agent._exec(run, prompt="x", max_steps=1)
 
     assert run.trace.status == "error"
-    assert run.trace.extra["exit_status"] == 1
+    assert run.trace.extra["returncode"] == 1
     assert run.steps[0].error == "boom"
+
+
+async def test_exec_signal_exit_records_the_returncode() -> None:
+    sink: dict[str, bytes] = {}
+    conn = _FakeConn(
+        sink,
+        SimpleNamespace(stdout="", stderr="", exit_status=None, returncode=-15),
+    )
+    agent = _agent_with_conn("bash", conn)
+
+    run = _fake_run()
+    await agent._exec(run, prompt="x", max_steps=1)
+
+    assert run.trace.status == "error"
+    assert run.trace.extra["returncode"] == -15
+    assert run.steps[0].error == "claude CLI exited with return code -15"
 
 
 @pytest.mark.parametrize(

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -175,12 +175,19 @@ class _OpenAIChatAgentForTest(OpenAIChatAgent):
 # ─── OpenAI shell ─────────────────────────────────────────────────────
 
 
-async def test_openai_shell_wraps_command_with_timeout() -> None:
+@pytest.mark.parametrize(
+    ("timeout_ms", "expected"),
+    [(2500, "timeout 2.5s pwd"), (500, "timeout 0.5s pwd")],
+)
+async def test_openai_shell_preserves_requested_timeout(
+    timeout_ms: int,
+    expected: str,
+) -> None:
     tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
 
-    result = await tool.execute({"commands": ["pwd"], "timeout_ms": 2500})
+    result = await tool.execute({"commands": ["pwd"], "timeout_ms": timeout_ms})
 
-    assert _commands(tool) == ["timeout 2 pwd"]
+    assert _commands(tool) == [expected]
     assert result.isError is False
     assert result.structuredContent is not None
     assert result.structuredContent["provider_tool"] == "shell"

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -176,16 +176,25 @@ class _OpenAIChatAgentForTest(OpenAIChatAgent):
 
 
 @pytest.mark.parametrize(
-    ("timeout_ms", "expected"),
-    [(2500, "timeout 2.5s pwd"), (500, "timeout 0.5s pwd")],
+    ("command", "timeout_ms", "expected"),
+    [
+        ("pwd", 2500, "timeout 2.5s bash -lc pwd"),
+        ("pwd", 500, "timeout 0.5s bash -lc pwd"),
+        (
+            "echo ready; sleep infinity",
+            500,
+            "timeout 0.5s bash -lc 'echo ready; sleep infinity'",
+        ),
+    ],
 )
-async def test_openai_shell_preserves_requested_timeout(
+async def test_openai_shell_applies_requested_timeout_to_entire_command(
+    command: str,
     timeout_ms: int,
     expected: str,
 ) -> None:
     tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
 
-    result = await tool.execute({"commands": ["pwd"], "timeout_ms": timeout_ms})
+    result = await tool.execute({"commands": [command], "timeout_ms": timeout_ms})
 
     assert _commands(tool) == [expected]
     assert result.isError is False

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -7,7 +7,6 @@ client and assert the command translation + result shape, fully offline.
 
 from __future__ import annotations
 
-import asyncio
 import shlex
 from types import SimpleNamespace
 from typing import Any, cast
@@ -23,7 +22,7 @@ from hud.agents.openai_compatible.agent import OpenAIChatAgent
 from hud.agents.openai_compatible.tools import BashTool, EditTool, ReadTool, WriteTool
 from hud.agents.tool_agent import RunState
 from hud.agents.tools.base import result_text
-from hud.agents.tools.ssh import SSHInfrastructureErrorResult, bound_shell_output
+from hud.agents.tools.ssh import bound_shell_output
 from hud.agents.types import OpenAIChatConfig
 from hud.capabilities import Capability, SSHClient
 from hud.types import MCPToolCall
@@ -160,20 +159,6 @@ class _FakeSSH(SSHClient):
         )
 
 
-class _TimedSSH:
-    def __init__(self) -> None:
-        self.timeouts: list[float] = []
-
-    async def run(self, command: str, **kwargs: Any) -> _Completed:
-        self.timeouts.append(kwargs["timeout"])
-        await asyncio.sleep(0.01)
-        return _Completed(exit_status=1 if command.startswith("test ") else 0)
-
-    async def write_text(self, path: str, content: str, *, timeout_s: float) -> None:
-        del path, content
-        self.timeouts.append(timeout_s)
-
-
 def _ssh(**kwargs: Any) -> SSHClient:
     return cast("SSHClient", _FakeSSH(**kwargs))
 
@@ -210,18 +195,15 @@ async def test_openai_shell_runs_each_command_without_timeout() -> None:
     assert _commands(tool) == ["echo a", "echo b"]
 
 
-async def test_openai_shell_shares_timeout_across_command_batch(
+async def test_openai_shell_has_no_hidden_timeout_across_command_batch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
-    timeouts: list[float] = []
+    calls: list[dict[str, Any]] = []
 
     async def run(*args: object, **kwargs: Any) -> _Completed:
         del args
-        timeout = kwargs["timeout"]
-        assert isinstance(timeout, float)
-        timeouts.append(timeout)
-        await asyncio.sleep(0.01)
+        calls.append(kwargs)
         return _Completed()
 
     monkeypatch.setattr(tool.client, "run", run)
@@ -234,8 +216,8 @@ async def test_openai_shell_shares_timeout_across_command_batch(
         RunState(tools={"shell": tool}),
     )
 
-    assert len(timeouts) == 2
-    assert timeouts[0] > timeouts[1]
+    assert len(calls) == 2
+    assert all("timeout" not in kwargs for kwargs in calls)
 
 
 async def test_openai_shell_applies_limit_independently_to_each_command() -> None:
@@ -345,23 +327,24 @@ async def test_openai_compatible_bash_uses_workdir_and_timeout() -> None:
     assert _commands(tool) == ["cd '/tmp/my dir' && timeout 3s bash -lc 'echo hi'"]
 
 
-async def test_shared_ssh_timeout_returns_infrastructure_error(
+async def test_shared_ssh_tool_has_no_hidden_command_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     ssh = _ssh()
+    seen_kwargs: dict[str, Any] = {}
 
-    async def timeout(*args: object, **kwargs: Any) -> _Completed:
-        del args, kwargs
-        raise TimeoutError
+    async def run(*args: object, **kwargs: Any) -> _Completed:
+        del args
+        seen_kwargs.update(kwargs)
+        return _Completed()
 
-    monkeypatch.setattr(ssh, "run", timeout)
+    monkeypatch.setattr(ssh, "run", run)
     tool = BashTool(spec=BashTool.default_spec("qwen"), client=ssh)
 
     result = await tool.execute({"command": "sleep forever"})
 
-    assert result.isError is True
-    assert isinstance(result, SSHInfrastructureErrorResult)
-    assert result_text(result) == "tool error: command timed out after 300s"
+    assert result.isError is False
+    assert "timeout" not in seen_kwargs
 
 
 async def test_shared_ssh_tool_reports_a_signal_returncode(
@@ -385,47 +368,6 @@ async def test_shared_ssh_tool_reports_a_signal_returncode(
 
     assert result.isError is True
     assert result_text(result).endswith("(exit -15)")
-
-
-async def test_openai_shell_uses_the_same_ssh_timeout(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    ssh = _ssh()
-
-    async def timeout(*args: object, **kwargs: Any) -> _Completed:
-        del args, kwargs
-        raise TimeoutError
-
-    monkeypatch.setattr(ssh, "run", timeout)
-    tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=ssh)
-
-    result = await tool.execute({"commands": ["sleep forever"]})
-
-    assert isinstance(result, SSHInfrastructureErrorResult)
-    assert result.structuredContent is not None
-    assert result.structuredContent["output"][0]["stderr"] == (
-        "tool error: command timed out after 300s"
-    )
-
-
-async def test_composite_ssh_tool_shares_one_operation_deadline() -> None:
-    ssh = _TimedSSH()
-    tool = EditTool(spec=EditTool.default_spec("test"), client=cast("SSHClient", ssh))
-    agent = _OpenAIChatAgentForTest(
-        OpenAIChatConfig(model="test", model_client=cast("Any", object()))
-    )
-
-    result = await agent._dispatch_call(
-        MCPToolCall(
-            name="edit",
-            arguments={"filePath": "/work/f.txt", "oldString": "", "newString": "new"},
-        ),
-        RunState(tools={"edit": tool}),
-    )
-
-    assert result.isError is False
-    assert len(ssh.timeouts) == 3
-    assert ssh.timeouts[0] > ssh.timeouts[1] > ssh.timeouts[2]
 
 
 async def test_shared_ssh_tool_bounds_combined_output(

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import shlex
+from types import SimpleNamespace
 from typing import Any, cast
 
 import asyncssh
@@ -33,6 +34,7 @@ class _Completed:
         self.stdout = stdout
         self.stderr = stderr
         self.exit_status = exit_status
+        self.returncode = exit_status
 
 
 class _Conn:
@@ -123,6 +125,9 @@ class _Process:
         return self.completed
 
     def close(self) -> None:
+        self.closed = True
+
+    def terminate(self) -> None:
         self.closed = True
 
     async def wait_closed(self) -> None:
@@ -357,6 +362,29 @@ async def test_shared_ssh_timeout_returns_infrastructure_error(
     assert result.isError is True
     assert isinstance(result, SSHInfrastructureErrorResult)
     assert result_text(result) == "tool error: command timed out after 300s"
+
+
+async def test_shared_ssh_tool_reports_a_signal_returncode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ssh = _ssh()
+
+    async def signaled(*args: object, **kwargs: Any) -> SimpleNamespace:
+        del args, kwargs
+        return SimpleNamespace(
+            stdout="",
+            stderr="terminated",
+            exit_status=None,
+            returncode=-15,
+        )
+
+    monkeypatch.setattr(ssh, "run", signaled)
+    tool = BashTool(spec=BashTool.default_spec("qwen"), client=ssh)
+
+    result = await tool.execute({"command": "sleep forever"})
+
+    assert result.isError is True
+    assert result_text(result).endswith("(exit -15)")
 
 
 async def test_openai_shell_uses_the_same_ssh_timeout(

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -30,7 +30,7 @@ from hud.agents.misc import auto_respond
 from hud.agents.tools.base import AgentTool, provider_tool_name
 from hud.agents.tools.mcp import MCPTool
 from hud.agents.tools.rfb import RFBTool
-from hud.agents.tools.ssh import SSHInfrastructureErrorResult, SSHTool
+from hud.agents.tools.ssh import SSHInfrastructureErrorResult
 from hud.agents.types import AgentStep, ToolStep
 from hud.capabilities import MCPClient, RFBClient
 from hud.capabilities.ssh import SSHConnectionError
@@ -339,8 +339,6 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
             )
         args = call.arguments or {}
         try:
-            if isinstance(tool, SSHTool):
-                return await tool.execute_with_deadline(args)
             return await tool.execute(args)
         except (TimeoutError, asyncio.CancelledError):
             raise

--- a/hud/agents/tools/ssh.py
+++ b/hud/agents/tools/ssh.py
@@ -73,10 +73,10 @@ class SSHTool(AgentTool[SSHClient]):
         body = f"$ {command}\n{stdout}"
         if stderr:
             body += f"\nstderr:\n{stderr}"
-        body += f"\n(exit {completed.exit_status})"
+        body += f"\n(exit {completed.returncode})"
         return MCPToolResult(
             content=[mcp_types.TextContent(type="text", text=body)],
-            isError=bool(completed.exit_status),
+            isError=completed.returncode != 0,
         )
 
     async def file_read(self, path: str) -> MCPToolResult:

--- a/hud/agents/tools/ssh.py
+++ b/hud/agents/tools/ssh.py
@@ -7,10 +7,6 @@ differs between providers.
 
 from __future__ import annotations
 
-import asyncio
-from contextvars import ContextVar
-from typing import Any
-
 import asyncssh
 import mcp.types as mcp_types
 
@@ -18,10 +14,8 @@ from hud.agents.tools.base import AgentTool, tool_err, tool_ok
 from hud.capabilities import SSHClient
 from hud.types import MCPToolResult
 
-DEFAULT_SSH_COMMAND_TIMEOUT_S = 300.0
 MAX_SHELL_OUTPUT_LENGTH = 10 * 1024 * 1024
 TRUNCATION_MARKER = "[truncated]"
-_OPERATION_DEADLINE: ContextVar[float | None] = ContextVar("ssh_operation_deadline", default=None)
 
 
 class SSHInfrastructureErrorResult(MCPToolResult):
@@ -43,30 +37,9 @@ class SSHTool(AgentTool[SSHClient]):
 
     # ─── action helpers ───────────────────────────────────────────────
 
-    async def execute_with_deadline(self, arguments: dict[str, Any]) -> MCPToolResult:
-        deadline = asyncio.get_running_loop().time() + DEFAULT_SSH_COMMAND_TIMEOUT_S
-        token = _OPERATION_DEADLINE.set(deadline)
-        try:
-            return await self.execute(arguments)
-        finally:
-            _OPERATION_DEADLINE.reset(token)
-
-    def _remaining_timeout(self) -> float:
-        deadline = _OPERATION_DEADLINE.get()
-        if deadline is None:
-            return DEFAULT_SSH_COMMAND_TIMEOUT_S
-        return max(0.0, deadline - asyncio.get_running_loop().time())
-
     async def bash(self, command: str) -> MCPToolResult:
         """Run a shell command. Returns combined stdout/stderr + exit code."""
-        try:
-            completed = await self.client.run(
-                command,
-                check=False,
-                timeout=self._remaining_timeout(),
-            )
-        except TimeoutError:
-            return _timeout_error(f"command timed out after {DEFAULT_SSH_COMMAND_TIMEOUT_S:g}s")
+        completed = await self.client.run(command, check=False)
         stdout = completed.stdout if isinstance(completed.stdout, str) else ""
         stderr = completed.stderr if isinstance(completed.stderr, str) else ""
         stdout, stderr = bound_shell_output(stdout, stderr, MAX_SHELL_OUTPUT_LENGTH)
@@ -82,27 +55,14 @@ class SSHTool(AgentTool[SSHClient]):
     async def file_read(self, path: str) -> MCPToolResult:
         """Read a text file through SSH exec."""
         try:
-            return tool_ok(
-                await self.client.read_text(
-                    path,
-                    timeout_s=self._remaining_timeout(),
-                )
-            )
-        except TimeoutError:
-            return _timeout_error(f"reading {path} timed out")
+            return tool_ok(await self.client.read_text(path))
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
 
     async def file_write(self, path: str, content: str) -> MCPToolResult:
         """Write a text file through SSH exec."""
         try:
-            await self.client.write_text(
-                path,
-                content,
-                timeout_s=self._remaining_timeout(),
-            )
-        except TimeoutError:
-            return _timeout_error(f"writing {path} timed out")
+            await self.client.write_text(path, content)
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
         return tool_ok(f"wrote {len(content)} bytes to {path}")
@@ -110,22 +70,10 @@ class SSHTool(AgentTool[SSHClient]):
     async def file_list(self, path: str = "/") -> MCPToolResult:
         """List directory entries through SSH exec."""
         try:
-            names = await self.client.listdir(
-                path,
-                timeout_s=self._remaining_timeout(),
-            )
-        except TimeoutError:
-            return _timeout_error(f"listing {path} timed out")
+            names = await self.client.listdir(path)
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
         return tool_ok("\n".join(names) if names else "(empty)")
-
-
-def _timeout_error(detail: str) -> SSHInfrastructureErrorResult:
-    return SSHInfrastructureErrorResult(
-        content=[mcp_types.TextContent(type="text", text=f"tool error: {detail}")],
-        isError=True,
-    )
 
 
 def bound_shell_output(stdout: str, stderr: str, limit: int) -> tuple[str, str]:

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -80,22 +80,37 @@ class SSHClient(CapabilityClient):
         try:
             if timeout is None:
                 conn = await self._connection()
-                return await conn.run(*args, check=check, **run_kwargs)
-            async with asyncio.timeout(timeout):
-                conn = await self._connection()
-                process = await conn.create_process(*args, **run_kwargs)
-                return await process.wait(check=check, timeout=None)
+                completed = await conn.run(*args, check=check, **run_kwargs)
+            else:
+                async with asyncio.timeout(timeout):
+                    conn = await self._connection()
+                    process = await conn.create_process(*args, **run_kwargs)
+                    completed = await process.wait(check=check, timeout=None)
+            if completed.returncode is None:
+                conn.close()
+                raise SSHConnectionError("SSH command ended without an exit status")
+            return completed
         except (TimeoutError, asyncio.CancelledError):
             if process is not None:
-                process.close()
-                with contextlib.suppress(OSError, TimeoutError, asyncssh.Error):
+                try:
+                    process.terminate()
+                except (OSError, asyncssh.Error):
+                    process.close()
+                try:
                     async with asyncio.timeout(SSH_SESSION_CLOSE_TIMEOUT_S):
                         await process.wait_closed()
+                except (OSError, TimeoutError, asyncssh.Error):
+                    process.close()
+                    with contextlib.suppress(OSError, TimeoutError, asyncssh.Error):
+                        async with asyncio.timeout(SSH_SESSION_CLOSE_TIMEOUT_S):
+                            await process.wait_closed()
             raise
         except asyncssh.ChannelOpenError as exc:
             raise SSHConnectionError("SSH server rejected the session") from exc
         except asyncssh.ConnectionLost as exc:
             raise SSHConnectionError("SSH connection lost during operation") from exc
+        except SSHConnectionError:
+            raise
         except (OSError, asyncssh.Error) as exc:
             if conn is not None and _is_closed(conn):
                 raise SSHConnectionError("SSH connection lost during operation") from exc

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -80,8 +80,7 @@ class SSHClient(CapabilityClient):
         try:
             if timeout is None:
                 conn = await self._connection()
-                process = await conn.create_process(*args, **run_kwargs)
-                completed = await process.wait(check=check, timeout=None)
+                completed = await conn.run(*args, check=check, **run_kwargs)
             else:
                 async with asyncio.timeout(timeout):
                     conn = await self._connection()

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -78,14 +78,10 @@ class SSHClient(CapabilityClient):
         conn: asyncssh.SSHClientConnection | None = None
         process = None
         try:
-            if timeout is None:
+            async with asyncio.timeout(timeout):
                 conn = await self._connection()
-                completed = await conn.run(*args, check=check, **run_kwargs)
-            else:
-                async with asyncio.timeout(timeout):
-                    conn = await self._connection()
-                    process = await conn.create_process(*args, **run_kwargs)
-                    completed = await process.wait(check=check, timeout=None)
+                process = await conn.create_process(*args, **run_kwargs)
+                completed = await process.wait(check=check, timeout=None)
             if completed.returncode is None:
                 conn.close()
                 raise SSHConnectionError("SSH command ended without an exit status")

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -80,7 +80,8 @@ class SSHClient(CapabilityClient):
         try:
             if timeout is None:
                 conn = await self._connection()
-                completed = await conn.run(*args, check=check, **run_kwargs)
+                process = await conn.create_process(*args, **run_kwargs)
+                completed = await process.wait(check=check, timeout=None)
             else:
                 async with asyncio.timeout(timeout):
                     conn = await self._connection()

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -18,15 +18,24 @@ class _Completed:
     stdout = "ok"
     stderr = ""
     exit_status = 0
+    returncode: int | None = 0
 
 
 class _Process:
-    def __init__(self, *, wait_error: BaseException | None = None, block: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        completed: _Completed | None = None,
+        wait_error: BaseException | None = None,
+        block: bool = False,
+    ) -> None:
+        self.completed = completed or _Completed()
         self.wait_error = wait_error
         self.block = block
         self.on_wait: Callable[[], None] | None = None
         self.started = asyncio.Event()
         self.closed = False
+        self.terminated = False
         self.waited_closed = False
 
     async def wait(self, *, check: bool, **kwargs: Any) -> _Completed:
@@ -39,10 +48,13 @@ class _Process:
             await asyncio.Event().wait()
         if self.wait_error is not None:
             raise self.wait_error
-        return _Completed()
+        return self.completed
 
     def close(self) -> None:
         self.closed = True
+
+    def terminate(self) -> None:
+        self.terminated = True
 
     async def wait_closed(self) -> None:
         self.waited_closed = True
@@ -208,7 +220,7 @@ async def test_run_preserves_timeout_when_the_connection_closes() -> None:
         await client.run("echo never", timeout=1)
 
 
-async def test_run_cancellation_closes_the_remote_process() -> None:
+async def test_run_cancellation_terminates_the_remote_process() -> None:
     connection = _Connection(process=_Process(block=True))
     client = _client(connection)
     run = asyncio.create_task(client.run("echo never", timeout=300))
@@ -218,8 +230,21 @@ async def test_run_cancellation_closes_the_remote_process() -> None:
 
     with pytest.raises(asyncio.CancelledError):
         await run
-    assert connection.process.closed is True
+    assert connection.process.terminated is True
+    assert connection.process.closed is False
     assert connection.process.waited_closed is True
+
+
+async def test_run_rejects_a_completed_process_without_a_returncode() -> None:
+    completed = _Completed()
+    completed.returncode = None
+    connection = _Connection(process=_Process(completed=completed))
+    client = _client(connection)
+
+    with pytest.raises(SSHConnectionError, match="without an exit status"):
+        await client.run("echo incomplete", timeout=1)
+
+    assert connection.closed is True
 
 
 async def test_windows_write_uses_one_timeout_budget(

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -97,8 +97,7 @@ class _Connection:
         return _Completed()
 
     async def create_process(self, *args: object, **kwargs: Any) -> _Process:
-        del kwargs
-        self.commands.append(str(args[0]))
+        del args, kwargs
         if self.stall_open:
             try:
                 await asyncio.Event().wait()
@@ -107,10 +106,6 @@ class _Connection:
                 raise
         if self.open_error is not None:
             raise self.open_error
-        if self.run_error is not None:
-            if isinstance(self.run_error, asyncssh.ConnectionLost):
-                self.closed = True
-            raise self.run_error
         return self.process
 
 
@@ -225,13 +220,10 @@ async def test_run_preserves_timeout_when_the_connection_closes() -> None:
         await client.run("echo never", timeout=1)
 
 
-@pytest.mark.parametrize("command_timeout", [None, 300])
-async def test_run_cancellation_terminates_the_remote_process(
-    command_timeout: float | None,
-) -> None:
+async def test_run_cancellation_terminates_the_remote_process() -> None:
     connection = _Connection(process=_Process(block=True))
     client = _client(connection)
-    run = asyncio.create_task(client.run("echo never", timeout=command_timeout))
+    run = asyncio.create_task(client.run("echo never", timeout=300))
     await connection.process.started.wait()
 
     run.cancel()

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -97,7 +97,8 @@ class _Connection:
         return _Completed()
 
     async def create_process(self, *args: object, **kwargs: Any) -> _Process:
-        del args, kwargs
+        del kwargs
+        self.commands.append(str(args[0]))
         if self.stall_open:
             try:
                 await asyncio.Event().wait()
@@ -106,6 +107,10 @@ class _Connection:
                 raise
         if self.open_error is not None:
             raise self.open_error
+        if self.run_error is not None:
+            if isinstance(self.run_error, asyncssh.ConnectionLost):
+                self.closed = True
+            raise self.run_error
         return self.process
 
 
@@ -220,10 +225,13 @@ async def test_run_preserves_timeout_when_the_connection_closes() -> None:
         await client.run("echo never", timeout=1)
 
 
-async def test_run_cancellation_terminates_the_remote_process() -> None:
+@pytest.mark.parametrize("command_timeout", [None, 300])
+async def test_run_cancellation_terminates_the_remote_process(
+    command_timeout: float | None,
+) -> None:
     connection = _Connection(process=_Process(block=True))
     client = _client(connection)
-    run = asyncio.create_task(client.run("echo never", timeout=300))
+    run = asyncio.create_task(client.run("echo never", timeout=command_timeout))
     await connection.process.started.wait()
 
     run.cancel()

--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -251,6 +251,23 @@ async def test_workspace_channel_close_during_teardown_keeps_connection_usable(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group regression")
+async def test_workspace_client_timeout_keeps_connection_usable(tmp_path: Path) -> None:
+    env = Environment("ws-env")
+    env.workspace(tmp_path / "root", track_files=False)
+
+    async with served(env) as client:
+        ssh = cast("SSHClient", await client.open("shell"))
+        started = asyncio.get_running_loop().time()
+
+        with pytest.raises(TimeoutError):
+            await ssh.run("sleep 120", timeout=0.1)
+
+        assert asyncio.get_running_loop().time() - started < 2.0
+        completed = await ssh.run("printf healthy", check=True, timeout=5.0)
+        assert completed.stdout == "healthy"
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group regression")
 async def test_workspace_timeout_reports_exit_after_child_teardown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -1600,6 +1600,8 @@ class Workspace:
                         break
                     stdin_writer.write(chunk)
                     await stdin_writer.drain()
+            except asyncssh.SignalReceived:
+                await sub.terminate()
             except (asyncssh.Error, BrokenPipeError, ConnectionResetError, OSError):
                 pass
             finally:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -584,6 +584,57 @@ async def test_openai_compatible_write_reaches_workspace_grader(tmp_path: Path) 
     ]
 
 
+async def test_tool_agent_timeout_stops_running_workspace_command_before_grading(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    started = workspace / "started"
+    late = workspace / "late"
+    env = Environment("timeout_cleanup")
+    env.workspace(workspace, guest_path=str(workspace))
+
+    @env.initialize
+    async def seed() -> None:
+        workspace.mkdir(parents=True, exist_ok=True)
+        started.unlink(missing_ok=True)
+        late.unlink(missing_ok=True)
+
+    @env.template()
+    async def wait_for_cleanup():
+        yield "Start the requested command."
+        await asyncio.sleep(1.2)
+        yield 1.0 if started.exists() and not late.exists() else 0.0
+
+    model_client = _FakeOpenAI(
+        [
+            _chat_response(
+                "",
+                [_tool_call("bash", '{"command":"touch started; sleep 1; touch late"}')],
+            ),
+        ]
+    )
+    agent = OpenAIChatAgent(
+        OpenAIChatConfig(
+            model="qwen3.6-plus",
+            model_client=model_client,
+            max_steps=2,
+            timeout_seconds=0.5,
+        )
+    )
+
+    run = await rollout(
+        Task(env="timeout_cleanup", id="wait_for_cleanup"),
+        agent,
+        runtime=lambda _task: _local(env),
+    )
+
+    assert run.trace.status == "error"
+    assert run.trace.stop_reason == "timeout"
+    assert run.reward == 1.0
+    assert started.exists()
+    assert not late.exists()
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group regression")
 async def test_local_runtime_startup_failure_kills_spawned_children(tmp_path: Path) -> None:
     env_file = tmp_path / "env.py"


### PR DESCRIPTION
## Summary

- remove the implicit 300-second deadline applied to every SSH-backed tool operation
- leave timeout ownership with `agent_config.timeout_seconds` and the rollout/runtime deadline; provider tools which explicitly request a command timeout still enforce it in the remote command
- reject SSH completions without a return code as infrastructure failures instead of rendering `(exit None)` as success
- use `returncode` for shared shell, OpenAI shell, and Claude SDK agent outcomes
- when a caller explicitly supplies an `SSHClient.run(..., timeout=...)`, terminate only that command process group and preserve the workspace session

## Root cause

Closing the timed-out exec channel could then race workspace teardown. Later commands completed without an exit status, and the shared tool classified `bool(None)` as success. This produced `(exit None)`, reset the existing infrastructure-error circuit breaker, and allowed retries until the step budget was exhausted without producing `final_model`.

The Claude SDK agent does not use the hidden per-tool deadline, so the timeout bug did not apply there. It did share the exit reporting issue: signal termination has `exit_status=None` and a negative `returncode`. Claude SDK traces now record the actual return code.

## Impact

Long-running commands are bounded only by the configured agent or rollout policy instead of an undocumented shorter SSH deadline. Explicit command timeouts remain available where requested. Transport failures with no return code are surfaced honestly, allowing the existing three-strike circuit breaker to stop retry storms.

## Validation

- `uv run --extra dev pytest hud/capabilities/tests hud/environment/tests/test_capability_backing.py hud/environment/tests/test_workspace.py hud/agents/tests/test_provider_native_tools.py hud/agents/tests/test_tool_agent.py hud/agents/tests/test_claude_sdk_agent.py -q` (`161 passed`)
- `uv run --extra dev ruff format . --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ty check hud/capabilities/ssh.py hud/capabilities/tests/test_ssh.py hud/environment/workspace.py hud/environment/tests/test_capability_backing.py hud/agents/tool_agent.py hud/agents/tools/ssh.py hud/agents/openai/tools/coding.py hud/agents/claude/sdk/agent.py hud/agents/tests/test_provider_native_tools.py hud/agents/tests/test_claude_sdk_agent.py --error-on-warning`
- `git diff --check`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core SSH execution, timeout, and exit-status handling used by all SSH-backed agent tools. Incorrect cleanup or returncode handling could affect tool reliability and retry/circuit-breaker behavior.
> 
> **Overview**
> Removes the implicit **300s per-tool SSH deadline**, so long-running commands are bounded only by agent/rollout timeouts. Explicit provider timeouts (e.g. OpenAI `timeout_ms`) still wrap the remote command.
> 
> Switches shell outcome reporting to **`returncode`** (including negative signal exits) and treats completions with no return code as infrastructure failures, so the circuit breaker can stop retry storms instead of treating `(exit None)` as success.
> 
> On cancel/timeout, `SSHClient.run` now **terminates the command process** and keeps the workspace session usable, with regression coverage for cleanup before grading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40e11fc710fa439475b211218638a2ab0f23fa0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->