### PR TITLE
fix(environment): harden workspace egress lifetimes

### DIFF
--- a/hud/environment/egress.py
+++ b/hud/environment/egress.py
@@ -121,18 +121,24 @@ VISITOR_PORT = 3129
 _BRIDGE = """
 import asyncio, json, sys
 
-async def splice(reader, writer):
+async def pump(reader, writer):
+    while chunk := await reader.read(65536):
+        writer.write(chunk)
+        await writer.drain()
+    if writer.can_write_eof():
+        try:
+            writer.write_eof()
+        except OSError:
+            pass
+
+async def splice(a, b):
     try:
-        while chunk := await reader.read(65536):
-            writer.write(chunk)
-            await writer.drain()
-    except Exception:
+        await asyncio.gather(pump(a[0], b[1]), pump(b[0], a[1]))
+    except OSError:
         pass
     finally:
-        try:
-            writer.close()
-        except Exception:
-            pass
+        a[1].close()
+        b[1].close()
 
 def bridged(path):
     async def handle(reader, writer):
@@ -141,7 +147,7 @@ def bridged(path):
         except OSError:
             writer.close()
             return
-        await asyncio.gather(splice(reader, up_writer), splice(up_reader, writer))
+        await splice((reader, writer), (up_reader, up_writer))
     return handle
 
 async def main():
@@ -304,17 +310,24 @@ def _connect_public(host: str, port: int, timeout: float) -> socket.socket:
 
 
 def _relay(one: socket.socket, other: socket.socket, timeout: float = 300.0) -> None:
-    """Copy bytes between two connected sockets until either end is done."""
-    while True:
-        ready, _, _ = select.select([one, other], [], [], timeout)
+    """Copy bytes until both directions reach EOF, error, or the connection stalls."""
+    readers = [one, other]
+    while readers:
+        ready, _, _ = select.select(readers, [], [], timeout)
         if not ready:
             return
         for source in ready:
             target = other if source is one else one
             try:
                 data = source.recv(65536)
-                if not data:
-                    return
+            except OSError:
+                return
+            if not data:
+                readers.remove(source)
+                with contextlib.suppress(OSError):
+                    target.shutdown(socket.SHUT_WR)
+                continue
+            try:
                 target.sendall(data)
             except OSError:
                 return

--- a/hud/environment/egress.py
+++ b/hud/environment/egress.py
@@ -120,19 +120,7 @@ VISITOR_PORT = 3129
 #: the port refused.
 _BRIDGE = """
 import asyncio, json, sys
-
-async def splice(reader, writer):
-    try:
-        while chunk := await reader.read(65536):
-            writer.write(chunk)
-            await writer.drain()
-    except Exception:
-        pass
-    finally:
-        try:
-            writer.close()
-        except Exception:
-            pass
+from hud.environment.utils import splice
 
 def bridged(path):
     async def handle(reader, writer):
@@ -141,7 +129,7 @@ def bridged(path):
         except OSError:
             writer.close()
             return
-        await asyncio.gather(splice(reader, up_writer), splice(up_reader, writer))
+        await splice((reader, writer), (up_reader, up_writer))
     return handle
 
 async def main():
@@ -304,9 +292,10 @@ def _connect_public(host: str, port: int, timeout: float) -> socket.socket:
 
 
 def _relay(one: socket.socket, other: socket.socket, timeout: float = 300.0) -> None:
-    """Copy bytes between two connected sockets until either end is done."""
-    while True:
-        ready, _, _ = select.select([one, other], [], [], timeout)
+    """Copy bytes until both directions reach EOF, error, or the connection stalls."""
+    readers = [one, other]
+    while readers:
+        ready, _, _ = select.select(readers, [], [], timeout)
         if not ready:
             return
         for source in ready:
@@ -314,7 +303,9 @@ def _relay(one: socket.socket, other: socket.socket, timeout: float = 300.0) -> 
             try:
                 data = source.recv(65536)
                 if not data:
-                    return
+                    readers.remove(source)
+                    target.shutdown(socket.SHUT_WR)
+                    continue
                 target.sendall(data)
             except OSError:
                 return

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -3,19 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import itertools
 import json
 import os
 import shutil
 import socket
+import struct
+import subprocess
 import sys
 import tempfile
 import threading
 import time
+import urllib.parse
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
@@ -28,6 +32,9 @@ from hud.environment import workspace as workspace_mod
 from hud.environment.egress import Peer, _field, _Unrelayable
 from hud.environment.workspace import Bubblewrap, Mount, Workspace
 from hud.utils.process import ProcessResult
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX workspace semantics")
 
@@ -498,6 +505,105 @@ async def test_visiting_uses_the_reserved_workspace_bridge(
 
 
 @pytest.mark.asyncio
+async def test_overlapping_runs_keep_their_visitor_policies_and_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hud.environment import egress as egress_mod
+
+    credentials = Path(tempfile.mkdtemp(prefix="hud-visitors-", dir="/tmp"))
+    ws = Workspace(tmp_path / "root", credentials_dir=credentials)
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
+    monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=7))
+
+    def unavailable(*_args: object, **_kwargs: object) -> socket.socket:
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(egress_mod, "_connect_public", unavailable)
+    started = {host: asyncio.Event() for host in ("first.example", "second.example")}
+    release = {host: asyncio.Event() for host in started}
+    environments: dict[str, Mapping[str, str]] = {}
+
+    class VisitorProcess:
+        def __init__(self, host: str, environment: Mapping[str, str]) -> None:
+            self.host = host
+            self.environment = environment
+
+        async def complete(self, *, max_wait: float | None = None) -> ProcessResult:
+            environments[self.host] = self.environment
+            started[self.host].set()
+            await release[self.host].wait()
+            return ProcessResult(0, b"", b"")
+
+    async def launch(
+        command: list[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        **_kwargs: object,
+    ) -> VisitorProcess:
+        assert env is not None
+        return VisitorProcess(command[0], env)
+
+    def proxy_response(
+        environment: Mapping[str, str],
+        host: str,
+        *,
+        credentials_from: Mapping[str, str] | None = None,
+    ) -> bytes:
+        proxy = urllib.parse.urlsplit((credentials_from or environment)["http_proxy"])
+        assert proxy.username == "hud" and proxy.password is not None
+        token = urllib.parse.unquote(proxy.password)
+        authorization = base64.b64encode(f"hud:{token}".encode()).decode()
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(str(credentials / "visitor" / "egress.sock"))
+        try:
+            client.sendall(
+                (
+                    f"GET http://{host}/ HTTP/1.1\r\n"
+                    f"Host: {host}\r\n"
+                    f"Proxy-Authorization: Basic {authorization}\r\n\r\n"
+                ).encode()
+            )
+            return client.recv(4096)
+        finally:
+            client.close()
+
+    monkeypatch.setattr(ws, "launch", launch)
+    tasks = [
+        asyncio.create_task(
+            ws.run(["first.example"], allowed_hosts={"first.example"}, identity=None)
+        )
+    ]
+    try:
+        await asyncio.wait_for(started["first.example"].wait(), 1)
+        tasks.append(
+            asyncio.create_task(
+                ws.run(["second.example"], allowed_hosts={"second.example"}, identity=None)
+            )
+        )
+        await asyncio.sleep(0)
+        assert not started["second.example"].is_set()
+
+        first = environments["first.example"]
+        assert b"502" in proxy_response(first, "first.example")
+        assert b"403" in proxy_response(first, "second.example")
+        release["first.example"].set()
+        assert (await tasks[0]).returncode == 0
+
+        await asyncio.wait_for(started["second.example"].wait(), 1)
+        second = environments["second.example"]
+        assert first["http_proxy"] != second["http_proxy"]
+        assert b"502" in proxy_response(second, "second.example")
+        assert b"403" in proxy_response(second, "first.example")
+        assert b"407" in proxy_response(second, "second.example", credentials_from=first)
+    finally:
+        for event in release.values():
+            event.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        shutil.rmtree(credentials, ignore_errors=True)
+
+
+@pytest.mark.asyncio
 async def test_staged_verifier_is_launched_by_the_namespace_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -859,6 +965,254 @@ def test_bridge_socket_paths_are_configuration_not_process_arguments() -> None:
     routes = json.loads(config)
     assert ["127.0.0.1", 3129, str(visitor)] in routes
     assert ["127.0.0.2", 5432, "/media/hud/session-keys/peer-0.sock"] in routes
+
+
+def test_bridge_ignores_workspace_imports_and_closes_reset_connections(tmp_path: Path) -> None:
+    from hud.environment.egress import Egress
+
+    workspace = tmp_path / "workspace"
+    package = workspace / "hud" / "environment"
+    package.mkdir(parents=True)
+    (workspace / "hud" / "__init__.py").write_text("")
+    (package / "__init__.py").write_text("")
+    marker = workspace / "imported"
+    (package / "utils.py").write_text(
+        f"from pathlib import Path\nPath({str(marker)!r}).write_text('imported')\n"
+    )
+
+    sockets = Path(tempfile.mkdtemp(dir="/tmp"))
+    egress = Egress(sockets, {"example.com"})
+    upstream_listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    upstream_listener.bind(str(egress.socket_path))
+    upstream_listener.listen()
+    upstream_listener.settimeout(5)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as port_holder:
+        port_holder.bind(("127.0.0.1", 0))
+        port = port_holder.getsockname()[1]
+    argv, config = egress.bridge_command(port=port)
+    process = subprocess.Popen(
+        argv,
+        cwd=workspace,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    client: socket.socket | None = None
+    upstream: socket.socket | None = None
+    try:
+        assert process.stdin is not None and process.stdout is not None
+        process.stdin.write(config)
+        process.stdin.flush()
+        assert process.stdout.readline() == b"ready\n"
+        assert not marker.exists()
+
+        client = socket.create_connection(("127.0.0.1", port), timeout=5)
+        upstream, _ = upstream_listener.accept()
+        upstream.settimeout(1)
+        client.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, struct.pack("ii", 1, 0))
+        client.close()
+        client = None
+
+        assert upstream.recv(1) == b""
+    finally:
+        if client is not None:
+            client.close()
+        if upstream is not None:
+            upstream.close()
+        upstream_listener.close()
+        if process.poll() is None:
+            process.terminate()
+        process.wait(timeout=5)
+        shutil.rmtree(sockets, ignore_errors=True)
+
+
+def test_bridge_drains_reverse_direction_after_half_close(tmp_path: Path) -> None:
+    from hud.environment.egress import Egress
+
+    sockets = Path(tempfile.mkdtemp(dir="/tmp"))
+    egress = Egress(sockets, {"example.com"})
+    upstream_listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    upstream_listener.bind(str(egress.socket_path))
+    upstream_listener.listen()
+    upstream_listener.settimeout(5)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as port_holder:
+        port_holder.bind(("127.0.0.1", 0))
+        port = port_holder.getsockname()[1]
+    argv, config = egress.bridge_command(port=port)
+    process = subprocess.Popen(
+        argv,
+        cwd=tmp_path,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    client: socket.socket | None = None
+    upstream: socket.socket | None = None
+    try:
+        assert process.stdin is not None and process.stdout is not None
+        process.stdin.write(config)
+        process.stdin.flush()
+        assert process.stdout.readline() == b"ready\n"
+
+        client = socket.create_connection(("127.0.0.1", port), timeout=5)
+        client.settimeout(5)
+        upstream, _ = upstream_listener.accept()
+        upstream.settimeout(5)
+
+        request = b"complete request"
+        client.sendall(request)
+        client.shutdown(socket.SHUT_WR)
+        assert upstream.recv(65536) == request
+        assert upstream.recv(1) == b""
+
+        response = b"complete response" * 4096
+        upstream.sendall(response)
+        upstream.shutdown(socket.SHUT_WR)
+        received = bytearray()
+        while chunk := client.recv(65536):
+            received.extend(chunk)
+        assert received == response
+    finally:
+        if client is not None:
+            client.close()
+        if upstream is not None:
+            upstream.close()
+        upstream_listener.close()
+        if process.poll() is None:
+            process.terminate()
+        process.wait(timeout=5)
+        shutil.rmtree(sockets, ignore_errors=True)
+
+
+def _half_close_backend(
+    response: bytes,
+) -> tuple[socket.socket, threading.Thread, int, list[bytes]]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    listener.settimeout(5)
+    port = listener.getsockname()[1]
+    requests: list[bytes] = []
+
+    def serve() -> None:
+        with listener:
+            connection, _ = listener.accept()
+            with connection:
+                chunks: list[bytes] = []
+                while chunk := connection.recv(65536):
+                    chunks.append(chunk)
+                requests.append(b"".join(chunks))
+                connection.sendall(response)
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    return listener, thread, port, requests
+
+
+def test_relay_drains_reverse_direction_when_write_shutdown_fails() -> None:
+    from hud.environment.egress import _relay
+
+    class ShutdownErrorSocket(socket.socket):
+        def shutdown(self, how: int) -> None:
+            raise OSError("injected shutdown failure")
+
+    one, one_peer = socket.socketpair()
+    other_socket, other_peer = socket.socketpair()
+    other = ShutdownErrorSocket(fileno=other_socket.detach())
+    one_peer.settimeout(5)
+    relay_thread = threading.Thread(target=_relay, args=(one, other, 1.0))
+    relay_thread.start()
+    try:
+        one_peer.shutdown(socket.SHUT_WR)
+        response = b"complete response" * 64
+        other_peer.sendall(response)
+        other_peer.shutdown(socket.SHUT_WR)
+
+        received = bytearray()
+        while len(received) < len(response):
+            received.extend(one_peer.recv(65536))
+        assert received == response
+    finally:
+        one.close()
+        one_peer.close()
+        other.close()
+        other_peer.close()
+        relay_thread.join(5)
+    assert not relay_thread.is_alive()
+
+
+def test_connect_tunnel_drains_response_after_client_half_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.environment import egress as egress_mod
+    from hud.environment.egress import Egress
+
+    response = b"complete response" * 32768
+    listener, thread, port, requests = _half_close_backend(response)
+
+    def connect(_host: str, _port: int, timeout: float) -> socket.socket:
+        return socket.create_connection(("127.0.0.1", port), timeout)
+
+    monkeypatch.setattr(egress_mod, "_connect_public", connect)
+    sockets = Path(tempfile.mkdtemp(dir="/tmp"))
+    egress = Egress(sockets, {"example.com"})
+    egress.start()
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(str(egress.socket_path))
+        client.sendall(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+        established = b""
+        while b"\r\n\r\n" not in established:
+            established += client.recv(4096)
+        assert b"200 Connection established" in established
+
+        request = b"request body"
+        client.sendall(request)
+        client.shutdown(socket.SHUT_WR)
+        received = b""
+        while chunk := client.recv(65536):
+            received += chunk
+        client.close()
+    finally:
+        egress.stop()
+        listener.close()
+        shutil.rmtree(sockets, ignore_errors=True)
+
+    thread.join(5)
+    assert not thread.is_alive()
+    assert requests == [request]
+    assert received == response
+
+
+def test_peer_forward_drains_response_after_client_half_close() -> None:
+    from hud.environment.egress import Egress
+
+    response = b"complete response" * 32768
+    listener, thread, port, requests = _half_close_backend(response)
+    sockets = Path(tempfile.mkdtemp(dir="/tmp"))
+    egress = Egress(sockets, set(), [Peer("service", port)])
+    egress.start()
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(str(sockets / "peer-0.sock"))
+        request = b"request body"
+        client.sendall(request)
+        client.shutdown(socket.SHUT_WR)
+        received = b""
+        while chunk := client.recv(65536):
+            received += chunk
+        client.close()
+    finally:
+        egress.stop()
+        listener.close()
+        shutil.rmtree(sockets, ignore_errors=True)
+
+    thread.join(5)
+    assert not thread.is_alive()
+    assert requests == [request]
+    assert received == response
 
 
 def test_the_proxy_normalizes_http_framing_in_both_directions(

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import itertools
 import json
@@ -13,9 +14,10 @@ import sys
 import tempfile
 import threading
 import time
+import urllib.parse
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest import mock
 from unittest.mock import AsyncMock, Mock
 
@@ -28,6 +30,9 @@ from hud.environment import workspace as workspace_mod
 from hud.environment.egress import Peer, _field, _Unrelayable
 from hud.environment.workspace import Bubblewrap, Mount, Workspace
 from hud.utils.process import ProcessResult
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="POSIX workspace semantics")
 
@@ -488,6 +493,105 @@ async def test_visiting_uses_the_reserved_workspace_bridge(
 
 
 @pytest.mark.asyncio
+async def test_overlapping_runs_keep_their_visitor_policies_and_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from hud.environment import egress as egress_mod
+
+    credentials = Path(tempfile.mkdtemp(prefix="hud-visitors-", dir="/tmp"))
+    ws = Workspace(tmp_path / "root", credentials_dir=credentials)
+    monkeypatch.setattr(ws, "_bwrap", Bubblewrap("/usr/bin/bwrap"))
+    monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=7))
+
+    def unavailable(*_args: object, **_kwargs: object) -> socket.socket:
+        raise ConnectionRefusedError
+
+    monkeypatch.setattr(egress_mod, "_connect_public", unavailable)
+    started = {host: asyncio.Event() for host in ("first.example", "second.example")}
+    release = {host: asyncio.Event() for host in started}
+    environments: dict[str, Mapping[str, str]] = {}
+
+    class VisitorProcess:
+        def __init__(self, host: str, environment: Mapping[str, str]) -> None:
+            self.host = host
+            self.environment = environment
+
+        async def complete(self, *, max_wait: float | None = None) -> ProcessResult:
+            environments[self.host] = self.environment
+            started[self.host].set()
+            await release[self.host].wait()
+            return ProcessResult(0, b"", b"")
+
+    async def launch(
+        command: list[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        **_kwargs: object,
+    ) -> VisitorProcess:
+        assert env is not None
+        return VisitorProcess(command[0], env)
+
+    def proxy_response(
+        environment: Mapping[str, str],
+        host: str,
+        *,
+        credentials_from: Mapping[str, str] | None = None,
+    ) -> bytes:
+        proxy = urllib.parse.urlsplit((credentials_from or environment)["http_proxy"])
+        assert proxy.username == "hud" and proxy.password is not None
+        token = urllib.parse.unquote(proxy.password)
+        authorization = base64.b64encode(f"hud:{token}".encode()).decode()
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(str(credentials / "visitor" / "egress.sock"))
+        try:
+            client.sendall(
+                (
+                    f"GET http://{host}/ HTTP/1.1\r\n"
+                    f"Host: {host}\r\n"
+                    f"Proxy-Authorization: Basic {authorization}\r\n\r\n"
+                ).encode()
+            )
+            return client.recv(4096)
+        finally:
+            client.close()
+
+    monkeypatch.setattr(ws, "launch", launch)
+    tasks = [
+        asyncio.create_task(
+            ws.run(["first.example"], allowed_hosts={"first.example"}, identity=None)
+        )
+    ]
+    try:
+        await asyncio.wait_for(started["first.example"].wait(), 1)
+        tasks.append(
+            asyncio.create_task(
+                ws.run(["second.example"], allowed_hosts={"second.example"}, identity=None)
+            )
+        )
+        await asyncio.sleep(0)
+        assert not started["second.example"].is_set()
+
+        first = environments["first.example"]
+        assert b"502" in proxy_response(first, "first.example")
+        assert b"403" in proxy_response(first, "second.example")
+        release["first.example"].set()
+        assert (await tasks[0]).returncode == 0
+
+        await asyncio.wait_for(started["second.example"].wait(), 1)
+        second = environments["second.example"]
+        assert first["http_proxy"] != second["http_proxy"]
+        assert b"502" in proxy_response(second, "second.example")
+        assert b"403" in proxy_response(second, "first.example")
+        assert b"407" in proxy_response(second, "second.example", credentials_from=first)
+    finally:
+        for event in release.values():
+            event.set()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        shutil.rmtree(credentials, ignore_errors=True)
+
+
+@pytest.mark.asyncio
 async def test_staged_verifier_is_launched_by_the_namespace_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -849,6 +953,105 @@ def test_bridge_socket_paths_are_configuration_not_process_arguments() -> None:
     routes = json.loads(config)
     assert ["127.0.0.1", 3129, str(visitor)] in routes
     assert ["127.0.0.2", 5432, "/media/hud/session-keys/peer-0.sock"] in routes
+
+
+def _half_close_backend(
+    response: bytes,
+) -> tuple[socket.socket, threading.Thread, int, list[bytes]]:
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    listener.settimeout(5)
+    port = listener.getsockname()[1]
+    requests: list[bytes] = []
+
+    def serve() -> None:
+        with listener:
+            connection, _ = listener.accept()
+            with connection:
+                chunks: list[bytes] = []
+                while chunk := connection.recv(65536):
+                    chunks.append(chunk)
+                requests.append(b"".join(chunks))
+                connection.sendall(response)
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    return listener, thread, port, requests
+
+
+def test_connect_tunnel_drains_response_after_client_half_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.environment import egress as egress_mod
+    from hud.environment.egress import Egress
+
+    response = b"complete response" * 32768
+    listener, thread, port, requests = _half_close_backend(response)
+
+    def connect(_host: str, _port: int, timeout: float) -> socket.socket:
+        return socket.create_connection(("127.0.0.1", port), timeout)
+
+    monkeypatch.setattr(egress_mod, "_connect_public", connect)
+    sockets = Path(tempfile.mkdtemp(dir="/tmp"))
+    egress = Egress(sockets, {"example.com"})
+    egress.start()
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(str(egress.socket_path))
+        client.sendall(b"CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n")
+        established = b""
+        while b"\r\n\r\n" not in established:
+            established += client.recv(4096)
+        assert b"200 Connection established" in established
+
+        request = b"request body"
+        client.sendall(request)
+        client.shutdown(socket.SHUT_WR)
+        received = b""
+        while chunk := client.recv(65536):
+            received += chunk
+        client.close()
+    finally:
+        egress.stop()
+        listener.close()
+        shutil.rmtree(sockets, ignore_errors=True)
+
+    thread.join(5)
+    assert not thread.is_alive()
+    assert requests == [request]
+    assert received == response
+
+
+def test_peer_forward_drains_response_after_client_half_close() -> None:
+    from hud.environment.egress import Egress
+
+    response = b"complete response" * 32768
+    listener, thread, port, requests = _half_close_backend(response)
+    sockets = Path(tempfile.mkdtemp(dir="/tmp"))
+    egress = Egress(sockets, set(), [Peer("service", port)])
+    egress.start()
+    try:
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.settimeout(5)
+        client.connect(str(sockets / "peer-0.sock"))
+        request = b"request body"
+        client.sendall(request)
+        client.shutdown(socket.SHUT_WR)
+        received = b""
+        while chunk := client.recv(65536):
+            received += chunk
+        client.close()
+    finally:
+        egress.stop()
+        listener.close()
+        shutil.rmtree(sockets, ignore_errors=True)
+
+    thread.join(5)
+    assert not thread.is_alive()
+    assert requests == [request]
+    assert received == response
 
 
 def test_the_proxy_normalizes_http_framing_in_both_directions(

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -576,6 +576,9 @@ class Workspace:
         # Sessions start concurrently (an agent can issue parallel tool calls),
         # and two that each started a sandbox would not share one.
         self._sandbox_lock = asyncio.Lock()
+        # The bridge has one fixed visitor route, so its socket and policy have
+        # one owner for the full lifetime of each visiting command.
+        self._visitor_lock = asyncio.Lock()
 
     @contextlib.asynccontextmanager
     async def visiting(self, allowed: Collection[str] | None) -> AsyncIterator[dict[str, str]]:
@@ -602,21 +605,22 @@ class Workspace:
         if not allowed:
             yield {}
             return
-        token = secrets.token_urlsafe(32)
-        egress = Egress(self._credentials_dir() / "visitor", allowed, token=token)
-        egress.start()
-        try:
-            # The peers are the workspace's, bound by its own bridge: a visitor
-            # reaches them at those addresses, so they stay out of its proxy.
-            yield proxy_environment(
-                VISITOR_PORT,
-                self.peers,
-                local_aliases=self.local_aliases,
-                reserved_ports=self.ports,
-                token=token,
-            )
-        finally:
-            egress.stop()
+        async with self._visitor_lock:
+            token = secrets.token_urlsafe(32)
+            egress = Egress(self._credentials_dir() / "visitor", allowed, token=token)
+            egress.start()
+            try:
+                # The peers are the workspace's, bound by its own bridge: a visitor
+                # reaches them at those addresses, so they stay out of its proxy.
+                yield proxy_environment(
+                    VISITOR_PORT,
+                    self.peers,
+                    local_aliases=self.local_aliases,
+                    reserved_ports=self.ports,
+                    token=token,
+                )
+            finally:
+                egress.stop()
 
     @property
     def owns_netns(self) -> bool:

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -430,6 +430,9 @@ class Workspace:
         # Sessions start concurrently (an agent can issue parallel tool calls),
         # and two that each started a sandbox would not share one.
         self._sandbox_lock = asyncio.Lock()
+        # The bridge has one fixed visitor route, so its socket and policy have
+        # one owner for the full lifetime of each visiting command.
+        self._visitor_lock = asyncio.Lock()
 
     @contextlib.asynccontextmanager
     async def visiting(self, allowed: Collection[str] | None) -> AsyncIterator[dict[str, str]]:
@@ -456,21 +459,22 @@ class Workspace:
         if not allowed:
             yield {}
             return
-        token = secrets.token_urlsafe(32)
-        egress = Egress(self._credentials_dir() / "visitor", allowed, token=token)
-        egress.start()
-        try:
-            # The peers are the workspace's, bound by its own bridge: a visitor
-            # reaches them at those addresses, so they stay out of its proxy.
-            yield proxy_environment(
-                VISITOR_PORT,
-                self.peers,
-                local_aliases=self.local_aliases,
-                reserved_ports=self.ports,
-                token=token,
-            )
-        finally:
-            egress.stop()
+        async with self._visitor_lock:
+            token = secrets.token_urlsafe(32)
+            egress = Egress(self._credentials_dir() / "visitor", allowed, token=token)
+            egress.start()
+            try:
+                # The peers are the workspace's, bound by its own bridge: a visitor
+                # reaches them at those addresses, so they stay out of its proxy.
+                yield proxy_environment(
+                    VISITOR_PORT,
+                    self.peers,
+                    local_aliases=self.local_aliases,
+                    reserved_ports=self.ports,
+                    token=token,
+                )
+            finally:
+                egress.stop()
 
     @property
     def owns_netns(self) -> bool:


### PR DESCRIPTION
Egress relays now propagate EOF as a write-side shutdown and drain the reverse direction until EOF, error, or idle timeout, so CONNECT tunnels and peer forwards keep response bytes already in flight after one endpoint half-closes. A failed write-side shutdown does not abort the still-readable reverse direction. The namespace bridge implements the same half-close semantics without importing from the agent-writable working directory: reset and forwarding errors close both transports promptly, while a clean EOF shutdown race does not abort the reverse pump.

Workspace visitor egress serializes the fixed visitor route across run lifetimes: each command owns its proxy socket, allowlist, and auth token until completion, and an overlapping run waits instead of unlinking the live route. Serialization is the cleaner invariant because the namespace bridge exposes one fixed visitor port and socket path; independent routes would require allocating and securely publishing per-run network endpoints to the visitor process.

Regression coverage: CONNECT, peer, and namespace-bridge half-closes still receive complete responses; injected write-shutdown failure preserves reverse delivery; the bridge rejects workspace module shadowing and closes reset connections promptly; two overlapping visitor runs complete with their own policies and tokens intact.

Verification: 159 non-Docker environment tests, ruff, strict ty on touched files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on workspace network egress and connection relay paths used by agents and verifiers; incorrect half-close or visitor lifetime handling could truncate responses or break concurrent grading, but scope is bounded to egress/workspace with substantial new tests.
> 
> **Overview**
> **Egress relays and the namespace bridge** now treat TCP half-close correctly: when one side hits EOF, the other direction keeps draining until EOF, error, or idle timeout. `_relay` shuts down the peer write side on read EOF instead of exiting immediately; the embedded asyncio bridge uses bidirectional `pump`/`splice` with optional `write_eof` propagation.
> 
> **Visitor egress** is serialized with `_visitor_lock` so concurrent `visiting()` / verifier runs cannot tear down the fixed visitor socket and credentials while another run still holds the bridge route on port 3129.
> 
> Regression tests cover full responses after client half-close on CONNECT, peer forwards, and the bridge; relay behavior when `shutdown(SHUT_WR)` fails; bridge startup without importing agent-writable `hud` from CWD; and overlapping visitor runs with distinct tokens and allowlists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dc8ee50bc4c0c190af2fea968b3447070bc00a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->