### PR TITLE
Fix SSH and Claude agent lifecycles

### DIFF
--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -63,9 +63,10 @@ agent = ClaudeAgent(ClaudeConfig(model="claude-sonnet-4-5", max_steps=30))
 
 Each config lives in `hud.agents.types`. `OpenAIChatAgent` speaks the OpenAI Chat Completions API, so it
 points at any compatible server (vLLM, a local model) via `base_url`; `ClaudeSDKAgent` runs the `claude`
-CLI over an `ssh` capability, against the env's filesystem. Every knob (`model`, `max_steps`,
-`timeout_seconds`, `system_prompt`, `citations_enabled`, `stop_on`) lives on the config; `__call__(run)`
-takes only the run.
+CLI over an `ssh` capability, against the env's filesystem. SSH-only runs support POSIX and Windows
+workspaces; computer use over an `rfb` capability currently requires a POSIX workspace. Every knob
+(`model`, `max_steps`, `timeout_seconds`, `system_prompt`, `citations_enabled`, `stop_on`) lives on the
+config; `__call__(run)` takes only the run.
 
 ## create_agent {#create-agent}
 

--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import shlex
+from contextlib import AsyncExitStack
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -71,8 +72,8 @@ class ClaudeSDKAgent(Agent):
     """Runs ``claude`` CLI over SSH inside the env workspace.
 
     Stateless w.r.t. the env: driven by ``await agent(run)``. SSH is opened
-    live off the run; MCP and RFB servers are read as raw bindings and written
-    into the CLI's MCP config so remote child processes own those connections.
+    live off the run. Environment MCP bindings are used directly; computer MCP
+    servers are bridged over the run's SSH connection.
     """
 
     config: ClaudeSDKConfig
@@ -91,42 +92,46 @@ class ClaudeSDKAgent(Agent):
         ssh = cast("SSHClient", await run.client.open("ssh"))
         shell = ssh.capability.params.get("shell", "bash")
 
-        for cap in bindings:
-            family = cap.protocol.split("/", 1)[0]
-            if family == "mcp":
-                token = cap.params.get("auth_token")
-                transport = "http" if cap.params["transport"] == "streamable-http" else "sse"
-                server_config: dict[str, Any] = {"type": transport, "url": cap.url}
-                if token:
-                    server_config["headers"] = {"Authorization": f"Bearer {token}"}
-                mcp_servers[cap.name] = server_config
-            elif family == "rfb":
-                from hud.agents.claude.sdk.computer_mcp import (
-                    RFB_CAPABILITY_ENV,
-                    SCREENSHOT_ENCODING_ENV,
-                )
+        rfb_bindings = [cap for cap in bindings if cap.protocol.split("/", 1)[0] == "rfb"]
+        async with AsyncExitStack() as resources:
+            for cap in bindings:
+                family = cap.protocol.split("/", 1)[0]
+                if family == "mcp":
+                    token = cap.params.get("auth_token")
+                    transport = "http" if cap.params["transport"] == "streamable-http" else "sse"
+                    server_config: dict[str, Any] = {"type": transport, "url": cap.url}
+                    if token:
+                        server_config["headers"] = {"Authorization": f"Bearer {token}"}
+                    if cap.name in mcp_servers:
+                        raise RuntimeError(f"duplicate MCP server name {cap.name!r}")
+                    mcp_servers[cap.name] = server_config
+                elif family == "rfb":
+                    from hud.agents.claude.sdk.computer_mcp import bridge_computer_mcp
 
-                mcp_servers["computer-use"] = {
-                    "type": "stdio",
-                    "command": "python",
-                    "args": ["-m", "hud.agents.claude.sdk.computer_mcp"],
-                    "env": {
-                        RFB_CAPABILITY_ENV: json.dumps(cap.to_manifest(), separators=(",", ":")),
-                        SCREENSHOT_ENCODING_ENV: (
-                            self.config.screenshot_encoding.model_dump_json()
-                        ),
-                    },
-                }
+                    server_name = (
+                        "computer-use" if len(rfb_bindings) == 1 else f"computer-use-{cap.name}"
+                    )
+                    if server_name in mcp_servers:
+                        raise RuntimeError(f"duplicate MCP server name {server_name!r}")
+                    routed = run.client.binding(cap.name)
+                    mcp_servers[server_name] = await resources.enter_async_context(
+                        bridge_computer_mcp(
+                            ssh,
+                            routed,
+                            self.config.screenshot_encoding,
+                            shell=shell,
+                        )
+                    )
 
-        await self._exec(
-            run,
-            ssh=ssh,
-            shell=shell,
-            mcp_servers=mcp_servers,
-            prompt=run.prompt_text,
-            max_steps=self.config.max_steps,
-            system_prompt=self.config.system_prompt,
-        )
+            await self._exec(
+                run,
+                ssh=ssh,
+                shell=shell,
+                mcp_servers=mcp_servers,
+                prompt=run.prompt_text,
+                max_steps=self.config.max_steps,
+                system_prompt=self.config.system_prompt,
+            )
 
     async def _exec(
         self,

--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -22,7 +22,7 @@ from hud.settings import settings
 from hud.types import Step
 
 if TYPE_CHECKING:
-    from hud.capabilities import RFBClient, SSHClient
+    from hud.capabilities import SSHClient
     from hud.eval.run import Run
 
 logger = logging.getLogger(__name__)
@@ -70,30 +70,26 @@ def build_remote_invocation(shell: str, run_cmd: str) -> RemoteInvocation:
 class ClaudeSDKAgent(Agent):
     """Runs ``claude`` CLI over SSH inside the env workspace.
 
-    Stateless w.r.t. the env: driven by ``await agent(run)``. SSH and RFB are
-    opened live off the run (we
-    drive them); MCP servers are read as raw bindings and written into the CLI's
-    MCP config (the CLI connects to them itself).
+    Stateless w.r.t. the env: driven by ``await agent(run)``. SSH is opened
+    live off the run; MCP and RFB servers are read as raw bindings and written
+    into the CLI's MCP config so remote child processes own those connections.
     """
 
     config: ClaudeSDKConfig
 
     def __init__(self, config: ClaudeSDKConfig | None = None) -> None:
         self.config = config or ClaudeSDKConfig()
-        self._ssh: SSHClient | None = None
-        self._mcp_servers: dict[str, dict[str, Any]] = {}
-        self._shell = "bash"
 
     async def __call__(self, run: Run) -> None:
-        self._mcp_servers = {}
+        mcp_servers: dict[str, dict[str, Any]] = {}
         manifest = run.client.manifest
         bindings = manifest.bindings if manifest is not None else []
         families = {c.protocol.split("/", 1)[0] for c in bindings}
 
         if "ssh" not in families:
             raise RuntimeError("ClaudeSDKAgent requires an SSH capability")
-        self._ssh = cast("SSHClient", await run.client.open("ssh"))
-        self._shell = self._ssh.capability.params.get("shell", "bash")
+        ssh = cast("SSHClient", await run.client.open("ssh"))
+        shell = ssh.capability.params.get("shell", "bash")
 
         for cap in bindings:
             family = cap.protocol.split("/", 1)[0]
@@ -103,19 +99,30 @@ class ClaudeSDKAgent(Agent):
                 server_config: dict[str, Any] = {"type": transport, "url": cap.url}
                 if token:
                     server_config["headers"] = {"Authorization": f"Bearer {token}"}
-                self._mcp_servers[cap.name] = server_config
+                mcp_servers[cap.name] = server_config
             elif family == "rfb":
-                from hud.agents.claude.sdk.computer_mcp import serve_computer_mcp
+                from hud.agents.claude.sdk.computer_mcp import (
+                    RFB_CAPABILITY_ENV,
+                    SCREENSHOT_ENCODING_ENV,
+                )
 
-                rfb = cast("RFBClient", await run.client.open("rfb"))
-                port = await serve_computer_mcp(rfb, self.config.screenshot_encoding)
-                self._mcp_servers["computer-use"] = {
-                    "type": "http",
-                    "url": f"http://127.0.0.1:{port}/mcp",
+                mcp_servers["computer-use"] = {
+                    "type": "stdio",
+                    "command": "python",
+                    "args": ["-m", "hud.agents.claude.sdk.computer_mcp"],
+                    "env": {
+                        RFB_CAPABILITY_ENV: json.dumps(cap.to_manifest(), separators=(",", ":")),
+                        SCREENSHOT_ENCODING_ENV: (
+                            self.config.screenshot_encoding.model_dump_json()
+                        ),
+                    },
                 }
 
         await self._exec(
             run,
+            ssh=ssh,
+            shell=shell,
+            mcp_servers=mcp_servers,
             prompt=run.prompt_text,
             max_steps=self.config.max_steps,
             system_prompt=self.config.system_prompt,
@@ -125,34 +132,36 @@ class ClaudeSDKAgent(Agent):
         self,
         run: Run,
         *,
+        ssh: SSHClient,
+        shell: str,
+        mcp_servers: dict[str, dict[str, Any]],
         prompt: str,
         max_steps: int = -1,
         system_prompt: str | None = None,
     ) -> None:
-        assert self._ssh is not None
+        mcp_config_path = await self._write_mcp_config(ssh, mcp_servers)
 
-        mcp_config_path = await self._write_mcp_config()
-
-        await self._ssh.write_text(".hud_prompt.txt", prompt)
+        await ssh.write_text(".hud_prompt.txt", prompt)
 
         run_cmd = self._build_cli_command(
+            shell=shell,
             prompt=prompt,
             max_steps=max_steps,
             system_prompt=system_prompt,
             mcp_config_path=mcp_config_path,
         )
 
-        invocation = build_remote_invocation(self._shell, run_cmd)
+        invocation = build_remote_invocation(shell, run_cmd)
         if invocation.script_name is not None:
             assert invocation.script_body is not None
             # cmd.exe mangles inline quotes, so the command rides a batch file.
-            await self._ssh.write_text(invocation.script_name, invocation.script_body)
+            await ssh.write_text(invocation.script_name, invocation.script_body)
 
         full_cmd = invocation.command
         logger.info("SSH exec claude CLI (%d chars)", len(full_cmd))
         logger.info("Full command: %s", full_cmd)
 
-        completed = await self._ssh.run(full_cmd, check=False)
+        completed = await ssh.run(full_cmd, check=False)
         stdout = completed.stdout if isinstance(completed.stdout, str) else ""
         stderr = completed.stderr if isinstance(completed.stderr, str) else ""
         returncode = completed.returncode
@@ -193,27 +202,31 @@ class ClaudeSDKAgent(Agent):
 
         return env
 
-    async def _write_mcp_config(self) -> str | None:
+    async def _write_mcp_config(
+        self,
+        ssh: SSHClient,
+        mcp_servers: dict[str, dict[str, Any]],
+    ) -> str | None:
         """Write MCP config into the workspace and return its path."""
-        if not self._mcp_servers or self._ssh is None:
+        if not mcp_servers:
             return None
-        mcp_json = json.dumps({"mcpServers": self._mcp_servers}, indent=2)
+        mcp_json = json.dumps({"mcpServers": mcp_servers}, indent=2)
         path = ".hud_mcp_config.json"
-        await self._ssh.write_text(path, mcp_json)
+        await ssh.write_text(path, mcp_json)
         logger.info("Wrote MCP config")
         return path
 
     def _build_cli_command(
         self,
         *,
+        shell: str,
         prompt: str,
         max_steps: int,
         system_prompt: str | None,
         mcp_config_path: str | None = None,
     ) -> str:
         env_vars = self._build_env_vars()
-        is_win = self._shell in WINDOWS_SHELLS
-        self._win_redirect = False
+        is_win = shell in WINDOWS_SHELLS
 
         # Raw args list (no shell quoting) — used directly for Windows Python launcher.
         base_args: list[str] = [

--- a/hud/agents/claude/sdk/computer_mcp.py
+++ b/hud/agents/claude/sdk/computer_mcp.py
@@ -173,10 +173,7 @@ async def bridge_computer_mcp(
     token = secrets.token_hex(16)
     request_path = str(_REMOTE_TMP / f"hud-computer-{token}.request")
     response_path = str(_REMOTE_TMP / f"hud-computer-{token}.response")
-    bridge = await ssh.conn.create_process(
-        _bridge_command(request_path, response_path),
-        encoding=None,
-    )
+    bridge = await ssh.create_process(_bridge_command(request_path, response_path))
     local: asyncio.subprocess.Process | None = None
     tasks: list[asyncio.Task[None]] = []
     try:

--- a/hud/agents/claude/sdk/computer_mcp.py
+++ b/hud/agents/claude/sdk/computer_mcp.py
@@ -7,21 +7,21 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 import fastmcp
+from pydantic import TypeAdapter
 
-from hud.capabilities.rfb import ScreenshotEncoding, WebPScreenshotEncoding
+from hud.capabilities import Capability
+from hud.capabilities.rfb import RFBClient, ScreenshotEncoding, WebPScreenshotEncoding
 
 if TYPE_CHECKING:
-    from hud.capabilities.rfb import RFBClient
+    from collections.abc import Mapping
 
-logger = logging.getLogger(__name__)
-
-#: Keep references to background server tasks so they aren't garbage-collected.
-_BACKGROUND_TASKS: set[asyncio.Task[None]] = set()
 _DEFAULT_SCREENSHOT_ENCODING = WebPScreenshotEncoding()
+RFB_CAPABILITY_ENV = "HUD_RFB_CAPABILITY"
+SCREENSHOT_ENCODING_ENV = "HUD_SCREENSHOT_ENCODING"
 
 
 def create_computer_mcp(
@@ -114,34 +114,42 @@ def create_computer_mcp(
     return mcp
 
 
-async def serve_computer_mcp(
-    rfb: RFBClient,
-    screenshot_encoding: ScreenshotEncoding = _DEFAULT_SCREENSHOT_ENCODING,
-    host: str = "127.0.0.1",
-    port: int = 0,
-) -> int:
-    """Start the computer-use MCP server in the background, return the port."""
-    if port == 0:
-        srv = await asyncio.get_event_loop().create_server(lambda: asyncio.Protocol(), host, 0)
-        port = srv.sockets[0].getsockname()[1]
-        srv.close()
-
-    mcp = create_computer_mcp(rfb, screenshot_encoding)
-    task = asyncio.create_task(_run(mcp, host, port))
-    _BACKGROUND_TASKS.add(task)
-    task.add_done_callback(_BACKGROUND_TASKS.discard)
-    await asyncio.sleep(0.5)
-    logger.info("computer-use MCP server on %s:%d", host, port)
-    return port
-
-
-async def _run(mcp: fastmcp.FastMCP, host: str, port: int) -> None:
+def _required_env(environ: Mapping[str, str], name: str) -> str:
     try:
-        await mcp.run_http_async(host=host, port=port)
-    except asyncio.CancelledError:
-        pass
-    except Exception:
-        logger.exception("computer-use MCP server crashed")
+        return environ[name]
+    except KeyError as exc:
+        raise RuntimeError(f"missing required environment variable {name}") from exc
 
 
-__all__ = ["create_computer_mcp", "serve_computer_mcp"]
+async def run_computer_mcp(environ: Mapping[str, str] = os.environ) -> None:
+    """Run computer-use over stdio for the lifetime of the invoking Claude CLI."""
+    raw_manifest = json.loads(_required_env(environ, RFB_CAPABILITY_ENV))
+    if not isinstance(raw_manifest, dict):
+        raise ValueError(f"{RFB_CAPABILITY_ENV} must contain a JSON object")
+    capability = Capability.from_manifest(raw_manifest)
+    if capability.protocol.split("/", 1)[0] != "rfb":
+        raise ValueError(f"{RFB_CAPABILITY_ENV} must describe an RFB capability")
+    screenshot_encoding = TypeAdapter(ScreenshotEncoding).validate_json(
+        _required_env(environ, SCREENSHOT_ENCODING_ENV)
+    )
+
+    rfb = await RFBClient.connect(capability)
+    try:
+        await create_computer_mcp(rfb, screenshot_encoding).run_async(
+            transport="stdio",
+            show_banner=False,
+        )
+    finally:
+        await rfb.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_computer_mcp())
+
+
+__all__ = [
+    "RFB_CAPABILITY_ENV",
+    "SCREENSHOT_ENCODING_ENV",
+    "create_computer_mcp",
+    "run_computer_mcp",
+]

--- a/hud/agents/claude/sdk/computer_mcp.py
+++ b/hud/agents/claude/sdk/computer_mcp.py
@@ -6,10 +6,18 @@ Single tool ``computer`` backed by ``ClaudeComputerTool`` / ``RFBTool``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
+import logging
 import os
+import secrets
+import shlex
+import sys
+from contextlib import asynccontextmanager
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+import asyncssh
 import fastmcp
 from pydantic import TypeAdapter
 
@@ -17,11 +25,18 @@ from hud.capabilities import Capability
 from hud.capabilities.rfb import RFBClient, ScreenshotEncoding, WebPScreenshotEncoding
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import AsyncIterator, Mapping
+
+    from hud.capabilities import SSHClient
 
 _DEFAULT_SCREENSHOT_ENCODING = WebPScreenshotEncoding()
 RFB_CAPABILITY_ENV = "HUD_RFB_CAPABILITY"
 SCREENSHOT_ENCODING_ENV = "HUD_SCREENSHOT_ENCODING"
+_PROCESS_CLOSE_TIMEOUT_S = 5.0
+_BRIDGE_READY_TIMEOUT_S = 5.0
+_REMOTE_TMP = PurePosixPath("/") / "tmp"
+
+logger = logging.getLogger(__name__)
 
 
 def create_computer_mcp(
@@ -122,7 +137,7 @@ def _required_env(environ: Mapping[str, str], name: str) -> str:
 
 
 async def run_computer_mcp(environ: Mapping[str, str] = os.environ) -> None:
-    """Run computer-use over stdio for the lifetime of the invoking Claude CLI."""
+    """Run computer-use over stdio in a controller-side child process."""
     raw_manifest = json.loads(_required_env(environ, RFB_CAPABILITY_ENV))
     if not isinstance(raw_manifest, dict):
         raise ValueError(f"{RFB_CAPABILITY_ENV} must contain a JSON object")
@@ -143,6 +158,120 @@ async def run_computer_mcp(environ: Mapping[str, str] = os.environ) -> None:
         await rfb.close()
 
 
+@asynccontextmanager
+async def bridge_computer_mcp(
+    ssh: SSHClient,
+    capability: Capability,
+    screenshot_encoding: ScreenshotEncoding = _DEFAULT_SCREENSHOT_ENCODING,
+    *,
+    shell: str,
+) -> AsyncIterator[dict[str, Any]]:
+    """Bridge a controller-side computer MCP process into a remote POSIX shell."""
+    if shell in {"cmd", "powershell"}:
+        raise RuntimeError("ClaudeSDKAgent computer use requires a POSIX workspace")
+
+    token = secrets.token_hex(16)
+    request_path = str(_REMOTE_TMP / f"hud-computer-{token}.request")
+    response_path = str(_REMOTE_TMP / f"hud-computer-{token}.response")
+    bridge = await ssh.conn.create_process(
+        _bridge_command(request_path, response_path),
+        encoding=None,
+    )
+    local: asyncio.subprocess.Process | None = None
+    tasks: list[asyncio.Task[None]] = []
+    try:
+        ready = await asyncio.wait_for(bridge.stderr.readline(), _BRIDGE_READY_TIMEOUT_S)
+        if ready != b"ready\n":
+            detail = ready.decode("utf-8", "replace").strip()
+            raise RuntimeError(detail or "computer MCP SSH bridge did not become ready")
+
+        environ = {
+            **os.environ,
+            RFB_CAPABILITY_ENV: json.dumps(capability.to_manifest(), separators=(",", ":")),
+            SCREENSHOT_ENCODING_ENV: screenshot_encoding.model_dump_json(),
+        }
+        local = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "hud.agents.claude.sdk.computer_mcp",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=environ,
+        )
+        assert local.stdin is not None
+        assert local.stdout is not None
+        assert local.stderr is not None
+        tasks = [
+            asyncio.create_task(_copy_stream(bridge.stdout, local.stdin)),
+            asyncio.create_task(_copy_stream(local.stdout, bridge.stdin)),
+            asyncio.create_task(_log_stream(bridge.stderr, "SSH bridge")),
+            asyncio.create_task(_log_stream(local.stderr, "computer MCP")),
+        ]
+        yield _relay_config(request_path, response_path)
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        bridge.stdin.close()
+        bridge.channel.close()
+        with contextlib.suppress(OSError, TimeoutError, asyncssh.Error):
+            await asyncio.wait_for(bridge.wait_closed(), _PROCESS_CLOSE_TIMEOUT_S)
+        if local is not None:
+            if local.stdin is not None:
+                local.stdin.close()
+            if local.returncode is None:
+                with contextlib.suppress(ProcessLookupError):
+                    local.terminate()
+            try:
+                await asyncio.wait_for(local.wait(), _PROCESS_CLOSE_TIMEOUT_S)
+            except TimeoutError:
+                with contextlib.suppress(ProcessLookupError):
+                    local.kill()
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(local.wait(), _PROCESS_CLOSE_TIMEOUT_S)
+
+
+def _bridge_command(request_path: str, response_path: str) -> str:
+    request = shlex.quote(request_path)
+    response = shlex.quote(response_path)
+    cleanup = shlex.quote(f"rm -f -- {request} {response}")
+    return (
+        "set -eu; umask 077; "
+        f"rm -f -- {request} {response}; mkfifo -- {request} {response}; "
+        f"trap {cleanup} EXIT HUP INT TERM; "
+        "printf 'ready\\n' >&2; "
+        f"cat {request} & reader=$!; cat > {response}; wait $reader"
+    )
+
+
+def _relay_config(request_path: str, response_path: str) -> dict[str, Any]:
+    request = shlex.quote(request_path)
+    response = shlex.quote(response_path)
+    script = f"cat {response} & reader=$!; cat > {request}; wait $reader"
+    return {"type": "stdio", "command": "sh", "args": ["-c", script]}
+
+
+async def _copy_stream(
+    reader: asyncio.StreamReader | asyncssh.SSHReader[bytes],
+    writer: asyncio.StreamWriter | asyncssh.SSHWriter[bytes],
+) -> None:
+    try:
+        while chunk := await reader.read(65536):
+            writer.write(chunk)
+            await writer.drain()
+    finally:
+        writer.close()
+
+
+async def _log_stream(
+    reader: asyncio.StreamReader | asyncssh.SSHReader[bytes],
+    source: str,
+) -> None:
+    while line := await reader.readline():
+        logger.warning("%s: %s", source, line.decode("utf-8", "replace").rstrip())
+
+
 if __name__ == "__main__":
     asyncio.run(run_computer_mcp())
 
@@ -150,6 +279,7 @@ if __name__ == "__main__":
 __all__ = [
     "RFB_CAPABILITY_ENV",
     "SCREENSHOT_ENCODING_ENV",
+    "bridge_computer_mcp",
     "create_computer_mcp",
     "run_computer_mcp",
 ]

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -576,9 +576,7 @@ async def test_computer_mcp_fifo_relay_is_bidirectional(tmp_path: Path) -> None:
 
         relay.stdin.write(b'{"method":"tools/list"}\n')
         await relay.stdin.drain()
-        assert await asyncio.wait_for(bridge.stdout.readline(), 2) == (
-            b'{"method":"tools/list"}\n'
-        )
+        assert await asyncio.wait_for(bridge.stdout.readline(), 2) == (b'{"method":"tools/list"}\n')
 
         bridge.stdin.write(b'{"result":{"tools":[]}}\n')
         await bridge.stdin.drain()

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -13,8 +13,10 @@ import asyncio
 import base64
 import json
 import re
+import sys
+from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -24,6 +26,9 @@ from hud.agents.claude.sdk.agent import ClaudeSDKAgent, build_remote_invocation
 from hud.agents.types import ClaudeSDKConfig
 from hud.capabilities import Capability, SSHClient
 from hud.capabilities.rfb import WebPScreenshotEncoding
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # ─── build_remote_invocation (pure) ───────────────────────────────────
 
@@ -266,8 +271,10 @@ async def test_remote_claude_passes_screenshot_encoding_to_computer_mcp(
         params={"shell": "bash"},
     )
     screen = Capability.rfb(name="screen", url="rfb://localhost:5900", display=0)
+    routed = Capability.rfb(name="screen", url="rfb://127.0.0.1:41000", display=0)
     ssh = SSHClient(shell, cast("Any", object()))
     opened: list[str] = []
+    bridge_active = False
 
     class Client:
         manifest = SimpleNamespace(bindings=[shell, screen])
@@ -277,10 +284,38 @@ async def test_remote_claude_passes_screenshot_encoding_to_computer_mcp(
             assert ref == "ssh"
             return ssh
 
+        def binding(self, ref: str) -> Capability:
+            assert ref == "screen"
+            return routed
+
+    @asynccontextmanager
+    async def bridge(
+        bridge_ssh: SSHClient,
+        capability: Capability,
+        screenshot_encoding: WebPScreenshotEncoding,
+        *,
+        shell: str,
+    ) -> Any:
+        nonlocal bridge_active
+        assert bridge_ssh is ssh
+        assert capability == routed
+        assert screenshot_encoding == encoding
+        assert shell == "bash"
+        bridge_active = True
+        try:
+            yield {"type": "stdio", "command": "sh", "args": ["-c", "relay"]}
+        finally:
+            bridge_active = False
+
     encoding = WebPScreenshotEncoding(quality=42)
     agent = ClaudeSDKAgent(ClaudeSDKConfig(screenshot_encoding=encoding))
-    execute = AsyncMock()
-    monkeypatch.setattr(agent, "_exec", execute)
+
+    async def execute(*_args: Any, **_kwargs: Any) -> None:
+        assert bridge_active
+
+    execute_mock = AsyncMock(side_effect=execute)
+    monkeypatch.setattr(computer_mcp, "bridge_computer_mcp", bridge)
+    monkeypatch.setattr(agent, "_exec", execute_mock)
 
     await agent(
         cast(
@@ -290,20 +325,88 @@ async def test_remote_claude_passes_screenshot_encoding_to_computer_mcp(
     )
 
     assert opened == ["ssh"]
-    await_args = execute.await_args
+    await_args = execute_mock.await_args
     assert await_args is not None
     server = await_args.kwargs["mcp_servers"]["computer-use"]
     assert server == {
         "type": "stdio",
-        "command": "python",
-        "args": ["-m", "hud.agents.claude.sdk.computer_mcp"],
-        "env": {
-            computer_mcp.RFB_CAPABILITY_ENV: json.dumps(
-                screen.to_manifest(), separators=(",", ":")
-            ),
-            computer_mcp.SCREENSHOT_ENCODING_ENV: encoding.model_dump_json(),
-        },
+        "command": "sh",
+        "args": ["-c", "relay"],
     }
+    assert not bridge_active
+
+
+async def test_remote_claude_preserves_multiple_rfb_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shell = Capability(
+        name="shell",
+        protocol="ssh/2",
+        url="ssh://localhost:22",
+        params={"shell": "bash"},
+    )
+    screens = [
+        Capability.rfb(name="screen-0", url="rfb://display-0:5900", display=0),
+        Capability.rfb(name="screen-1", url="rfb://display-1:5901", display=1),
+    ]
+    routed = {
+        cap.name: Capability.rfb(
+            name=cap.name,
+            url=f"rfb://127.0.0.1:{41000 + index}",
+            display=index,
+        )
+        for index, cap in enumerate(screens)
+    }
+    ssh = SSHClient(shell, cast("Any", object()))
+    bridged: list[str] = []
+
+    class Client:
+        manifest = SimpleNamespace(bindings=[shell, *screens])
+
+        async def open(self, ref: str) -> SSHClient:
+            assert ref == "ssh"
+            return ssh
+
+        def binding(self, ref: str) -> Capability:
+            return routed[ref]
+
+    @asynccontextmanager
+    async def bridge(
+        _ssh: SSHClient,
+        capability: Capability,
+        _encoding: WebPScreenshotEncoding,
+        *,
+        shell: str,
+    ) -> Any:
+        assert shell == "bash"
+        bridged.append(capability.name)
+        try:
+            yield {"type": "stdio", "command": "sh", "args": ["-c", capability.name]}
+        finally:
+            bridged.remove(capability.name)
+
+    async def execute(*_args: Any, **kwargs: Any) -> None:
+        assert bridged == ["screen-0", "screen-1"]
+        assert kwargs["mcp_servers"] == {
+            "computer-use-screen-0": {
+                "type": "stdio",
+                "command": "sh",
+                "args": ["-c", "screen-0"],
+            },
+            "computer-use-screen-1": {
+                "type": "stdio",
+                "command": "sh",
+                "args": ["-c", "screen-1"],
+            },
+        }
+
+    agent = ClaudeSDKAgent()
+    monkeypatch.setattr(computer_mcp, "bridge_computer_mcp", bridge)
+    monkeypatch.setattr(agent, "_exec", execute)
+
+    await agent(cast("Any", SimpleNamespace(client=Client(), prompt_text="use both screens")))
+
+    assert bridged == []
 
 
 async def test_computer_mcp_stdio_owns_rfb_lifetime(
@@ -329,6 +432,173 @@ async def test_computer_mcp_stdio_owns_rfb_lifetime(
     create.assert_called_once_with(rfb, encoding)
     server.run_async.assert_awaited_once_with(transport="stdio", show_banner=False)
     rfb.close.assert_awaited_once()
+
+
+class _ByteWriter:
+    def __init__(self) -> None:
+        self.closed = False
+        self.data = bytearray()
+
+    def write(self, data: bytes) -> None:
+        self.data.extend(data)
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _LocalComputerProcess:
+    def __init__(self) -> None:
+        self.stdin = _ByteWriter()
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.returncode: int | None = None
+        self.terminated = False
+        self.killed = False
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    async def wait(self) -> int:
+        assert self.returncode is not None
+        return self.returncode
+
+
+async def test_computer_mcp_bridge_uses_controller_python_and_owns_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_stdout = asyncio.StreamReader()
+    bridge_stderr = asyncio.StreamReader()
+    bridge_stderr.feed_data(b"ready\n")
+    bridge_stdin = _ByteWriter()
+    bridge = SimpleNamespace(
+        stdin=bridge_stdin,
+        stdout=bridge_stdout,
+        stderr=bridge_stderr,
+        channel=SimpleNamespace(close=Mock()),
+        wait_closed=AsyncMock(),
+    )
+    connection = SimpleNamespace(create_process=AsyncMock(return_value=bridge))
+    ssh = SimpleNamespace(conn=connection)
+    local = _LocalComputerProcess()
+    spawn = AsyncMock(return_value=local)
+    monkeypatch.setattr(computer_mcp.asyncio, "create_subprocess_exec", spawn)
+    monkeypatch.setattr(computer_mcp.secrets, "token_hex", lambda _length: "bridge-token")
+    screen = Capability.rfb(name="screen", url="rfb://127.0.0.1:41000", display=0)
+    encoding = WebPScreenshotEncoding(quality=42)
+
+    async with computer_mcp.bridge_computer_mcp(
+        cast("Any", ssh),
+        screen,
+        encoding,
+        shell="bash",
+    ) as config:
+        assert config == {
+            "type": "stdio",
+            "command": "sh",
+            "args": [
+                "-c",
+                "cat /tmp/hud-computer-bridge-token.response & reader=$!; "
+                "cat > /tmp/hud-computer-bridge-token.request; wait $reader",
+            ],
+        }
+        assert not bridge_stdin.closed
+        assert not local.stdin.closed
+
+    bridge_command = connection.create_process.await_args.args[0]
+    assert "mkfifo -- /tmp/hud-computer-bridge-token.request" in bridge_command
+    assert "printf 'ready\\n' >&2" in bridge_command
+    spawn.assert_awaited_once()
+    spawn_call = spawn.await_args
+    assert spawn_call is not None
+    spawn_args = spawn_call.args
+    assert spawn_args[:3] == (
+        sys.executable,
+        "-m",
+        "hud.agents.claude.sdk.computer_mcp",
+    )
+    environ = spawn_call.kwargs["env"]
+    assert json.loads(environ[computer_mcp.RFB_CAPABILITY_ENV]) == screen.to_manifest()
+    assert environ[computer_mcp.SCREENSHOT_ENCODING_ENV] == encoding.model_dump_json()
+    bridge.channel.close.assert_called_once()
+    bridge.wait_closed.assert_awaited_once()
+    assert bridge_stdin.closed
+    assert local.stdin.closed
+    assert local.terminated
+    assert not local.killed
+
+
+async def test_computer_mcp_bridge_rejects_windows_before_starting_resources() -> None:
+    screen = Capability.rfb(name="screen", url="rfb://127.0.0.1:41000", display=0)
+    ssh = SimpleNamespace(conn=SimpleNamespace(create_process=AsyncMock()))
+
+    with pytest.raises(RuntimeError, match="requires a POSIX workspace"):
+        async with computer_mcp.bridge_computer_mcp(
+            cast("Any", ssh),
+            screen,
+            shell="powershell",
+        ):
+            pass
+
+    ssh.conn.create_process.assert_not_awaited()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX FIFO relay")
+async def test_computer_mcp_fifo_relay_is_bidirectional(tmp_path: Path) -> None:
+    request_path = str(tmp_path / "request")
+    response_path = str(tmp_path / "response")
+    bridge = await asyncio.create_subprocess_shell(
+        computer_mcp._bridge_command(request_path, response_path),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    relay: asyncio.subprocess.Process | None = None
+    try:
+        assert bridge.stderr is not None
+        assert await asyncio.wait_for(bridge.stderr.readline(), 2) == b"ready\n"
+        config = computer_mcp._relay_config(request_path, response_path)
+        relay = await asyncio.create_subprocess_exec(
+            config["command"],
+            *config["args"],
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+        )
+        assert relay.stdin is not None and relay.stdout is not None
+        assert bridge.stdin is not None and bridge.stdout is not None
+
+        relay.stdin.write(b'{"method":"tools/list"}\n')
+        await relay.stdin.drain()
+        assert await asyncio.wait_for(bridge.stdout.readline(), 2) == (
+            b'{"method":"tools/list"}\n'
+        )
+
+        bridge.stdin.write(b'{"result":{"tools":[]}}\n')
+        await bridge.stdin.drain()
+        assert await asyncio.wait_for(relay.stdout.readline(), 2) == b'{"result":{"tools":[]}}\n'
+    finally:
+        for process in (relay, bridge):
+            if process is not None and process.stdin is not None:
+                process.stdin.close()
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(
+                    *(process.wait() for process in (relay, bridge) if process is not None),
+                    return_exceptions=True,
+                ),
+                2,
+            )
+        except TimeoutError:
+            for process in (relay, bridge):
+                if process is not None and process.returncode is None:
+                    process.kill()
 
 
 async def test_concurrent_runs_keep_their_ssh_state_isolated(

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -248,7 +248,9 @@ async def test_manifest_mcp_capability_is_written_for_remote_claude(
         )
     )
 
-    assert execute.await_args.kwargs["mcp_servers"] == {
+    await_args = execute.await_args
+    assert await_args is not None
+    assert await_args.kwargs["mcp_servers"] == {
         "database": {"type": claude_type, "url": "http://database:8000/mcp"}
     }
     execute.assert_awaited_once()
@@ -288,7 +290,9 @@ async def test_remote_claude_passes_screenshot_encoding_to_computer_mcp(
     )
 
     assert opened == ["ssh"]
-    server = execute.await_args.kwargs["mcp_servers"]["computer-use"]
+    await_args = execute.await_args
+    assert await_args is not None
+    server = await_args.kwargs["mcp_servers"]["computer-use"]
     assert server == {
         "type": "stdio",
         "command": "python",

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -486,7 +486,7 @@ async def test_computer_mcp_bridge_uses_controller_python_and_owns_resources(
         wait_closed=AsyncMock(),
     )
     connection = SimpleNamespace(create_process=AsyncMock(return_value=bridge))
-    ssh = SimpleNamespace(conn=connection)
+    ssh = SimpleNamespace(create_process=connection.create_process)
     local = _LocalComputerProcess()
     spawn = AsyncMock(return_value=local)
     monkeypatch.setattr(computer_mcp.asyncio, "create_subprocess_exec", spawn)
@@ -537,7 +537,7 @@ async def test_computer_mcp_bridge_uses_controller_python_and_owns_resources(
 
 async def test_computer_mcp_bridge_rejects_windows_before_starting_resources() -> None:
     screen = Capability.rfb(name="screen", url="rfb://127.0.0.1:41000", display=0)
-    ssh = SimpleNamespace(conn=SimpleNamespace(create_process=AsyncMock()))
+    ssh = SimpleNamespace(create_process=AsyncMock())
 
     with pytest.raises(RuntimeError, match="requires a POSIX workspace"):
         async with computer_mcp.bridge_computer_mcp(
@@ -547,7 +547,7 @@ async def test_computer_mcp_bridge_rejects_windows_before_starting_resources() -
         ):
             pass
 
-    ssh.conn.create_process.assert_not_awaited()
+    ssh.create_process.assert_not_awaited()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX FIFO relay")

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -9,18 +9,20 @@ rejected by the remote shell (and silently fails under PowerShell), so the
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import json
 import re
 from types import SimpleNamespace
 from typing import Any, Literal, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from hud.agents.claude.sdk import computer_mcp
 from hud.agents.claude.sdk.agent import ClaudeSDKAgent, build_remote_invocation
 from hud.agents.types import ClaudeSDKConfig
-from hud.capabilities import Capability, RFBClient, SSHClient
+from hud.capabilities import Capability, SSHClient
 from hud.capabilities.rfb import WebPScreenshotEncoding
 
 # ─── build_remote_invocation (pure) ───────────────────────────────────
@@ -122,17 +124,14 @@ _STREAM_JSON = (
 )
 
 
-def _agent_with_conn(shell: str, conn: _FakeConn) -> ClaudeSDKAgent:
-    agent = ClaudeSDKAgent()
+def _ssh_with_conn(shell: str, conn: _FakeConn) -> SSHClient:
     capability = Capability(
         name="shell",
         protocol="ssh/2",
         url="ssh://localhost:22",
         params={"shell": shell},
     )
-    agent._ssh = SSHClient(capability, cast("Any", conn))
-    agent._shell = shell
-    return agent
+    return SSHClient(capability, cast("Any", conn))
 
 
 async def test_exec_on_windows_writes_batch_and_execs_via_cmd() -> None:
@@ -141,10 +140,11 @@ async def test_exec_on_windows_writes_batch_and_execs_via_cmd() -> None:
         sink,
         SimpleNamespace(stdout=_STREAM_JSON, stderr="", exit_status=0, returncode=0),
     )
-    agent = _agent_with_conn("cmd", conn)
+    agent = ClaudeSDKAgent()
+    ssh = _ssh_with_conn("cmd", conn)
 
     run = _fake_run()
-    await agent._exec(run, prompt="build it", max_steps=5)
+    await agent._exec(run, ssh=ssh, shell="cmd", mcp_servers={}, prompt="build it", max_steps=5)
 
     assert conn.ran == ["cmd /c .hud_run.bat"]
     assert all(command.startswith("powershell ") for command in conn.write_commands)
@@ -160,10 +160,11 @@ async def test_exec_on_bash_runs_inline_without_batch() -> None:
         sink,
         SimpleNamespace(stdout=_STREAM_JSON, stderr="", exit_status=0, returncode=0),
     )
-    agent = _agent_with_conn("bash", conn)
+    agent = ClaudeSDKAgent()
+    ssh = _ssh_with_conn("bash", conn)
 
     run = _fake_run()
-    await agent._exec(run, prompt="build it", max_steps=5)
+    await agent._exec(run, ssh=ssh, shell="bash", mcp_servers={}, prompt="build it", max_steps=5)
 
     assert ".hud_run.bat" not in sink
     assert conn.write_commands == ["cat > .hud_prompt.txt"]
@@ -179,10 +180,11 @@ async def test_exec_nonzero_exit_with_no_stdout_records_system_error() -> None:
         sink,
         SimpleNamespace(stdout="", stderr="boom", exit_status=1, returncode=1),
     )
-    agent = _agent_with_conn("cmd", conn)
+    agent = ClaudeSDKAgent()
+    ssh = _ssh_with_conn("cmd", conn)
 
     run = _fake_run()
-    await agent._exec(run, prompt="x", max_steps=1)
+    await agent._exec(run, ssh=ssh, shell="cmd", mcp_servers={}, prompt="x", max_steps=1)
 
     assert run.trace.status == "error"
     assert run.trace.extra["returncode"] == 1
@@ -195,10 +197,11 @@ async def test_exec_signal_exit_records_the_returncode() -> None:
         sink,
         SimpleNamespace(stdout="", stderr="", exit_status=None, returncode=-15),
     )
-    agent = _agent_with_conn("bash", conn)
+    agent = ClaudeSDKAgent()
+    ssh = _ssh_with_conn("bash", conn)
 
     run = _fake_run()
-    await agent._exec(run, prompt="x", max_steps=1)
+    await agent._exec(run, ssh=ssh, shell="bash", mcp_servers={}, prompt="x", max_steps=1)
 
     assert run.trace.status == "error"
     assert run.trace.extra["returncode"] == -15
@@ -245,7 +248,7 @@ async def test_manifest_mcp_capability_is_written_for_remote_claude(
         )
     )
 
-    assert agent._mcp_servers == {
+    assert execute.await_args.kwargs["mcp_servers"] == {
         "database": {"type": claude_type, "url": "http://database:8000/mcp"}
     }
     execute.assert_awaited_once()
@@ -262,20 +265,20 @@ async def test_remote_claude_passes_screenshot_encoding_to_computer_mcp(
     )
     screen = Capability.rfb(name="screen", url="rfb://localhost:5900", display=0)
     ssh = SSHClient(shell, cast("Any", object()))
-    rfb = object.__new__(RFBClient)
+    opened: list[str] = []
 
     class Client:
         manifest = SimpleNamespace(bindings=[shell, screen])
 
-        async def open(self, ref: str) -> Any:
-            return ssh if ref == "ssh" else rfb
+        async def open(self, ref: str) -> SSHClient:
+            opened.append(ref)
+            assert ref == "ssh"
+            return ssh
 
     encoding = WebPScreenshotEncoding(quality=42)
     agent = ClaudeSDKAgent(ClaudeSDKConfig(screenshot_encoding=encoding))
     execute = AsyncMock()
-    serve = AsyncMock(return_value=8765)
     monkeypatch.setattr(agent, "_exec", execute)
-    monkeypatch.setattr(computer_mcp, "serve_computer_mcp", serve)
 
     await agent(
         cast(
@@ -284,8 +287,100 @@ async def test_remote_claude_passes_screenshot_encoding_to_computer_mcp(
         )
     )
 
-    serve.assert_awaited_once_with(rfb, encoding)
-    assert agent._mcp_servers["computer-use"] == {
-        "type": "http",
-        "url": "http://127.0.0.1:8765/mcp",
+    assert opened == ["ssh"]
+    server = execute.await_args.kwargs["mcp_servers"]["computer-use"]
+    assert server == {
+        "type": "stdio",
+        "command": "python",
+        "args": ["-m", "hud.agents.claude.sdk.computer_mcp"],
+        "env": {
+            computer_mcp.RFB_CAPABILITY_ENV: json.dumps(
+                screen.to_manifest(), separators=(",", ":")
+            ),
+            computer_mcp.SCREENSHOT_ENCODING_ENV: encoding.model_dump_json(),
+        },
     }
+
+
+async def test_computer_mcp_stdio_owns_rfb_lifetime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    screen = Capability.rfb(name="screen", url="rfb://localhost:5900", display=0)
+    encoding = WebPScreenshotEncoding(quality=42)
+    rfb = SimpleNamespace(close=AsyncMock())
+    connect = AsyncMock(return_value=rfb)
+    server = SimpleNamespace(run_async=AsyncMock())
+    create = Mock(return_value=server)
+    monkeypatch.setattr(computer_mcp.RFBClient, "connect", connect)
+    monkeypatch.setattr(computer_mcp, "create_computer_mcp", create)
+
+    await computer_mcp.run_computer_mcp(
+        {
+            computer_mcp.RFB_CAPABILITY_ENV: json.dumps(screen.to_manifest()),
+            computer_mcp.SCREENSHOT_ENCODING_ENV: encoding.model_dump_json(),
+        }
+    )
+
+    connect.assert_awaited_once_with(screen)
+    create.assert_called_once_with(rfb, encoding)
+    server.run_async.assert_awaited_once_with(transport="stdio", show_banner=False)
+    rfb.close.assert_awaited_once()
+
+
+async def test_concurrent_runs_keep_their_ssh_state_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shell_a = Capability(
+        name="shell-a",
+        protocol="ssh/2",
+        url="ssh://a:22",
+        params={"shell": "bash"},
+    )
+    shell_b = Capability(
+        name="shell-b",
+        protocol="ssh/2",
+        url="ssh://b:22",
+        params={"shell": "powershell"},
+    )
+    ssh_a = SSHClient(shell_a, cast("Any", object()))
+    ssh_b = SSHClient(shell_b, cast("Any", object()))
+
+    class Client:
+        def __init__(self, shell: Capability, ssh: SSHClient) -> None:
+            self.manifest = SimpleNamespace(bindings=[shell])
+            self.ssh = ssh
+
+        async def open(self, ref: str) -> SSHClient:
+            assert ref == "ssh"
+            return self.ssh
+
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    seen: list[tuple[Any, SSHClient, str]] = []
+
+    async def execute(
+        run: Any,
+        *,
+        ssh: SSHClient,
+        shell: str,
+        mcp_servers: dict[str, dict[str, Any]],
+        **_: Any,
+    ) -> None:
+        assert mcp_servers == {}
+        seen.append((run, ssh, shell))
+        if run.prompt_text == "first":
+            first_entered.set()
+            await release_first.wait()
+
+    agent = ClaudeSDKAgent()
+    monkeypatch.setattr(agent, "_exec", execute)
+    run_a = SimpleNamespace(client=Client(shell_a, ssh_a), prompt_text="first")
+    run_b = SimpleNamespace(client=Client(shell_b, ssh_b), prompt_text="second")
+
+    first = asyncio.create_task(agent(cast("Any", run_a)))
+    await first_entered.wait()
+    await agent(cast("Any", run_b))
+    release_first.set()
+    await first
+
+    assert seen == [(run_a, ssh_a, "bash"), (run_b, ssh_b, "powershell")]

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -71,6 +71,20 @@ class SSHClient(CapabilityClient):
         """Raw asyncssh connection for commands and port forwarding."""
         return self._conn
 
+    async def create_process(self, command: str) -> asyncssh.SSHClientProcess[bytes]:
+        """Open a binary exec channel after restoring a dropped SSH transport."""
+        try:
+            conn = await self._connection()
+            return await conn.create_process(command, encoding=None)
+        except asyncssh.ChannelOpenError as exc:
+            raise SSHConnectionError("SSH server rejected the session") from exc
+        except asyncssh.ConnectionLost as exc:
+            raise SSHConnectionError("SSH connection lost while opening the session") from exc
+        except (OSError, asyncssh.Error) as exc:
+            if _is_closed(self._conn):
+                raise SSHConnectionError("SSH connection lost while opening the session") from exc
+            raise
+
     async def run(self, *args: object, **kwargs: Any) -> asyncssh.SSHCompletedProcess:
         """Run one command, reconnecting first when the transport is closed."""
         run_kwargs = dict(kwargs)

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -61,6 +61,7 @@ class SSHClient(CapabilityClient):
             username=cap.params.get("user", "agent"),
             client_keys=client_keys,
             known_hosts=None,
+            errors="replace",
             keepalive_interval=15,
             keepalive_count_max=4,
         )

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -80,6 +80,8 @@ class SSHClient(CapabilityClient):
             raise SSHConnectionError("SSH server rejected the session") from exc
         except asyncssh.ConnectionLost as exc:
             raise SSHConnectionError("SSH connection lost while opening the session") from exc
+        except SSHConnectionError:
+            raise
         except (OSError, asyncssh.Error) as exc:
             if _is_closed(self._conn):
                 raise SSHConnectionError("SSH connection lost while opening the session") from exc

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -186,6 +186,18 @@ async def test_create_process_reconnects_before_opening_channel(
     assert replacement.commands == ["bridge"]
 
 
+async def test_create_process_preserves_reconnect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client(_Connection(closed=True))
+    reconnect = AsyncMock(side_effect=OSError("unreachable"))
+    monkeypatch.setattr(client, "_connect", reconnect)
+    monkeypatch.setattr("hud.capabilities.ssh.asyncio.sleep", AsyncMock())
+
+    with pytest.raises(SSHConnectionError, match="reconnect failed after 3 attempts"):
+        await client.create_process("bridge")
+
+
 async def test_run_classifies_rejected_session_as_connection_error() -> None:
     connection = _Connection(
         open_error=asyncssh.ChannelOpenError(asyncssh.OPEN_RESOURCE_SHORTAGE, "busy")

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -143,6 +143,7 @@ async def test_connect_keeps_tunneled_connection_active(monkeypatch: pytest.Monk
         username="agent",
         client_keys=None,
         known_hosts=None,
+        errors="replace",
         keepalive_interval=15,
         keepalive_count_max=4,
     )

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -169,6 +169,23 @@ async def test_run_does_not_replay_a_command_lost_in_flight(
     assert replacement.commands == ["next-command"]
 
 
+async def test_create_process_reconnects_before_opening_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dropped = _Connection(closed=True)
+    replacement = _Connection()
+    client = _client(dropped)
+    reconnect = AsyncMock(return_value=replacement)
+    monkeypatch.setattr(client, "_connect", reconnect)
+
+    process = await client.create_process("bridge")
+
+    assert process is replacement.process
+    reconnect.assert_awaited_once_with(client.capability)
+    assert dropped.commands == []
+    assert replacement.commands == ["bridge"]
+
+
 async def test_run_classifies_rejected_session_as_connection_error() -> None:
     connection = _Connection(
         open_error=asyncssh.ChannelOpenError(asyncssh.OPEN_RESOURCE_SHORTAGE, "busy")

--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -268,44 +268,22 @@ async def test_workspace_client_timeout_keeps_connection_usable(tmp_path: Path) 
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group regression")
-async def test_workspace_timeout_reports_exit_after_child_teardown(
+async def test_workspace_shell_replaces_invalid_utf8_without_losing_transport(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(workspace_module, "_COMMAND_TIMEOUT", 0.5)
     env = Environment("ws-env")
     env.workspace(tmp_path / "root", track_files=False)
-    pid: int | None = None
 
-    try:
-        async with served(env) as client:
-            ssh = cast("SSHClient", await client.open("shell"))
-            remote = await ssh.conn.create_process(
-                "trap '' TERM; sleep 120 & echo $! > timeout-child.pid; wait"
-            )
-            try:
-                result = await asyncio.wait_for(
-                    ssh.conn.run(
-                        "while [ ! -s timeout-child.pid ]; do sleep 0.01; done; "
-                        "cat timeout-child.pid",
-                        check=True,
-                    ),
-                    5.0,
-                )
-                assert isinstance(result.stdout, str)
-                pid = int(result.stdout)
-                assert _pid_is_running(pid)
+    async with served(env) as client:
+        ssh = cast("SSHClient", await client.open("shell"))
+        connection = ssh.conn
 
-                completed = await remote.wait(timeout=5.0)
-                assert completed.exit_status == 1
-                assert not _pid_is_running(pid)
-            finally:
-                remote.close()
-                await asyncio.wait_for(remote.wait_closed(), 5.0)
-    finally:
-        if pid is not None and _pid_is_running(pid):
-            with contextlib.suppress(ProcessLookupError):
-                os.kill(pid, signal.SIGKILL)
+        completed = await ssh.run("printf '\\226\\214 split-utf8'", check=True)
+
+        assert completed.stdout == "�� split-utf8"
+        assert completed.returncode == 0
+        assert ssh.conn is connection
+        assert not connection.is_closed()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="requires POSIX setsid")

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -1237,6 +1237,83 @@ def test_usable_bwrap_reports_unusable_installs(monkeypatch) -> None:
     assert ws.usable_bwrap() is None
 
 
+def test_windows_job_owns_the_process_tree() -> None:
+    kernel32 = SimpleNamespace(
+        CreateJobObjectW=Mock(return_value=42),
+        SetInformationJobObject=Mock(return_value=True),
+        AssignProcessToJobObject=Mock(return_value=True),
+        CloseHandle=Mock(return_value=True),
+        GetLastError=Mock(return_value=0),
+    )
+    job = workspace_mod._WindowsJob(kernel32)
+    child = SimpleNamespace(_handle=99)
+
+    job.assign(cast("Any", child))
+    job.close()
+    job.close()
+
+    set_limits = kernel32.SetInformationJobObject.call_args.args
+    assert set_limits[1] == workspace_mod._JOB_OBJECT_EXTENDED_LIMIT_INFORMATION
+    assert (
+        set_limits[2]._obj.basic_limit_information.limit_flags
+        == workspace_mod._JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    )
+    kernel32.AssignProcessToJobObject.assert_called_once_with(42, 99)
+    kernel32.CloseHandle.assert_called_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_windows_channel_close_terminates_the_process_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exited = threading.Event()
+
+    class Child:
+        _handle = 99
+        stdout = None
+        stderr = None
+        returncode: int | None = None
+
+        def communicate(self) -> tuple[bytes, bytes]:
+            assert exited.wait(1)
+            self.returncode = -1
+            return b"", b""
+
+        def kill(self) -> None:
+            self.returncode = -9
+            exited.set()
+
+    child = Child()
+    job = SimpleNamespace(
+        assign=Mock(),
+        close=Mock(side_effect=exited.set),
+    )
+    channel = SimpleNamespace(
+        wait_closed=AsyncMock(),
+        is_closing=Mock(return_value=True),
+    )
+    process = SimpleNamespace(
+        term_type=None,
+        command="cmd /c echo hello",
+        channel=channel,
+        stdout=SimpleNamespace(write=Mock()),
+        stderr=SimpleNamespace(write=Mock()),
+        exit=Mock(),
+    )
+    ws = Workspace(tmp_path / "root")
+    monkeypatch.setattr(workspace_mod.sys, "platform", "win32")
+    monkeypatch.setattr(workspace_mod, "_WindowsJob", Mock(return_value=job))
+    monkeypatch.setattr(workspace_mod.subprocess, "Popen", Mock(return_value=child))
+    monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=None))
+
+    await ws._handle_process(cast("Any", process))
+
+    job.assign.assert_called_once_with(child)
+    job.close.assert_called_once()
+    process.exit.assert_not_called()
+
+
 def test_usable_bwrap_stages_pid_creation_when_direct_mounting_is_blocked(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -1238,17 +1238,28 @@ def test_usable_bwrap_reports_unusable_installs(monkeypatch) -> None:
 
 
 def test_windows_job_owns_the_process_tree() -> None:
+    def first_thread(_snapshot: int, entry_pointer: Any) -> bool:
+        entry_pointer._obj.owner_process_id = 123
+        entry_pointer._obj.thread_id = 456
+        return True
+
     kernel32 = SimpleNamespace(
         CreateJobObjectW=Mock(return_value=42),
         SetInformationJobObject=Mock(return_value=True),
         AssignProcessToJobObject=Mock(return_value=True),
+        CreateToolhelp32Snapshot=Mock(return_value=43),
+        Thread32First=Mock(side_effect=first_thread),
+        Thread32Next=Mock(return_value=False),
+        OpenThread=Mock(return_value=44),
+        ResumeThread=Mock(return_value=1),
         CloseHandle=Mock(return_value=True),
         GetLastError=Mock(return_value=0),
     )
     job = workspace_mod._WindowsJob(kernel32)
-    child = SimpleNamespace(_handle=99)
+    child = SimpleNamespace(_handle=99, pid=123)
 
     job.assign(cast("Any", child))
+    job.resume(cast("Any", child))
     job.close()
     job.close()
 
@@ -1259,7 +1270,10 @@ def test_windows_job_owns_the_process_tree() -> None:
         == workspace_mod._JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
     )
     kernel32.AssignProcessToJobObject.assert_called_once_with(42, 99)
-    kernel32.CloseHandle.assert_called_once_with(42)
+    kernel32.CreateToolhelp32Snapshot.assert_called_once_with(workspace_mod._TH32CS_SNAPTHREAD, 0)
+    kernel32.OpenThread.assert_called_once_with(workspace_mod._THREAD_SUSPEND_RESUME, False, 456)
+    kernel32.ResumeThread.assert_called_once_with(44)
+    assert [call.args[0] for call in kernel32.CloseHandle.call_args_list] == [44, 43, 42]
 
 
 @pytest.mark.asyncio
@@ -1287,6 +1301,7 @@ async def test_windows_channel_close_terminates_the_process_job(
     child = Child()
     job = SimpleNamespace(
         assign=Mock(),
+        resume=Mock(),
         close=Mock(side_effect=exited.set),
     )
     channel = SimpleNamespace(
@@ -1302,15 +1317,18 @@ async def test_windows_channel_close_terminates_the_process_job(
         exit=Mock(),
     )
     ws = Workspace(tmp_path / "root")
+    popen = Mock(return_value=child)
     monkeypatch.setattr(workspace_mod.sys, "platform", "win32")
     monkeypatch.setattr(workspace_mod, "_WindowsJob", Mock(return_value=job))
-    monkeypatch.setattr(workspace_mod.subprocess, "Popen", Mock(return_value=child))
+    monkeypatch.setattr(workspace_mod.subprocess, "Popen", popen)
     monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=None))
 
     await ws._handle_process(cast("Any", process))
 
     job.assign.assert_called_once_with(child)
+    job.resume.assert_called_once_with(child)
     job.close.assert_called_once()
+    assert popen.call_args.kwargs["creationflags"] == workspace_mod._CREATE_SUSPENDED
     process.exit.assert_not_called()
 
 

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -167,26 +167,6 @@ async def test_a_resize_does_not_cost_the_session_its_keyboard(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_a_timed_out_command_keeps_what_it_printed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The output is the evidence of how far it got — reporting only that the
-    deadline passed throws that away."""
-    monkeypatch.setattr(workspace_mod, "_COMMAND_TIMEOUT", 1.0)
-    ws = Workspace(tmp_path / "root")
-    await ws.start()
-    try:
-        async with await _connect(ws) as conn:
-            result = await conn.run("echo progress-so-far; sleep 30", check=False)
-    finally:
-        await ws.stop()
-
-    assert "progress-so-far" in str(result.stdout)
-    assert "timed out" in str(result.stderr)
-    assert result.exit_status == 1
-
-
-@pytest.mark.asyncio
 async def test_session_setup_failure_is_reported_to_the_client(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1169,6 +1149,52 @@ async def test_session_wrapper_environment_contains_no_server_secrets(
         await ws._handle_process(cast("Any", process))
 
     assert captured.value.env == {"PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")}
+
+
+@pytest.mark.asyncio
+async def test_namespace_wait_status_is_forwarded_to_ssh_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def wait_until_cancelled() -> None:
+        await asyncio.Event().wait()
+
+    def empty_reader() -> asyncio.StreamReader:
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+        return reader
+
+    child_channel = SimpleNamespace(close=Mock(), wait_closed=AsyncMock())
+    child_process = SimpleNamespace(
+        stdin=SimpleNamespace(write_eof=Mock()),
+        stdout=empty_reader(),
+        stderr=empty_reader(),
+        wait=AsyncMock(return_value=SimpleNamespace(returncode=None)),
+        returncode=None,
+        channel=child_channel,
+    )
+    child = namespace_mod.NamespaceProcess(cast("Any", child_process))
+    namespace = SimpleNamespace(spawn=AsyncMock(return_value=child))
+    channel = SimpleNamespace(
+        wait_closed=wait_until_cancelled,
+        is_closing=Mock(return_value=False),
+    )
+    process = SimpleNamespace(
+        term_type=None,
+        command="true",
+        stdin=SimpleNamespace(read=AsyncMock(return_value=b"")),
+        stdout=SimpleNamespace(write=Mock(), drain=AsyncMock()),
+        stderr=SimpleNamespace(write=Mock(), drain=AsyncMock()),
+        channel=channel,
+        exit=Mock(),
+    )
+    ws = Workspace(tmp_path / "root")
+    monkeypatch.setattr(ws, "sandbox_pid", AsyncMock(return_value=7))
+    ws._namespace = cast("Any", namespace)
+
+    await ws._handle_process(cast("Any", process))
+
+    process.exit.assert_called_once_with(255)
+    child_channel.close.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger("hud.environment.workspace")
 
-_COMMAND_TIMEOUT = 3600.0
+_PROCESS_CLOSE_TIMEOUT_S = 5.0
 
 
 @dataclass(slots=True, frozen=True)
@@ -1454,7 +1454,7 @@ class Workspace:
             # after the subprocess coroutine has already returned (a race that can
             # happen even when communicate() calls wait() internally), it corrupts
             # asyncssh's IOCP state and permanently breaks the SSH session.
-            # Running subprocess.run() in a thread-pool executor sidesteps IOCP
+            # Running a blocking subprocess in a worker thread sidesteps IOCP
             # entirely: the blocking WaitForSingleObject in the worker thread drains
             # the process exit before the Future resolves, leaving no pending events.
             #
@@ -1489,36 +1489,55 @@ class Workspace:
 
             try:
                 loop = asyncio.get_running_loop()
-                result = await asyncio.wait_for(
-                    loop.run_in_executor(
-                        None,
-                        functools.partial(
-                            _subprocess.run,
-                            win_argv,
-                            stdin=_subprocess.DEVNULL,
-                            stdout=_subprocess.PIPE,
-                            stderr=_subprocess.PIPE,
-                            cwd=str(self.root),
-                            env=proc_env,
-                            timeout=3600,
-                        ),
+                child = await loop.run_in_executor(
+                    None,
+                    functools.partial(
+                        _subprocess.Popen,
+                        win_argv,
+                        stdin=_subprocess.DEVNULL,
+                        stdout=_subprocess.PIPE,
+                        stderr=_subprocess.PIPE,
+                        cwd=str(self.root),
+                        env=proc_env,
                     ),
-                    timeout=3660.0,
                 )
             except FileNotFoundError as exc:
                 process.stderr.write(f"workspace: cannot spawn shell: {exc}\n".encode())
                 process.exit(127)
                 return
-            except (TimeoutError, _subprocess.TimeoutExpired):
-                process.stderr.write(b"workspace: command timed out after 3600s\n")
-                process.exit(1)
-                return
 
-            if result.stdout:
-                process.stdout.write(result.stdout)
-            if result.stderr:
-                process.stderr.write(result.stderr)
-            process.exit(result.returncode)
+            communicate_task = asyncio.create_task(asyncio.to_thread(child.communicate))
+            channel_closed_task = asyncio.create_task(process.channel.wait_closed())
+            try:
+                done, _ = await asyncio.wait(
+                    (communicate_task, channel_closed_task),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if channel_closed_task in done and not communicate_task.done():
+                    return
+                stdout, stderr = await communicate_task
+            finally:
+                if not communicate_task.done():
+                    with contextlib.suppress(OSError):
+                        child.terminate()
+                    try:
+                        async with asyncio.timeout(_PROCESS_CLOSE_TIMEOUT_S):
+                            await asyncio.shield(communicate_task)
+                    except TimeoutError:
+                        with contextlib.suppress(OSError):
+                            child.kill()
+                        await communicate_task
+                channel_closed_task.cancel()
+                await asyncio.gather(channel_closed_task, return_exceptions=True)
+
+            if process.channel.is_closing():
+                return
+            if stdout:
+                process.stdout.write(stdout)
+            if stderr:
+                process.stderr.write(stderr)
+            assert child.returncode is not None
+            process.exit(child.returncode)
             return
 
         pty_pair = _open_pty(process) if wants_tty and pid is None else None
@@ -1618,9 +1637,8 @@ class Workspace:
             """Forward the child's output as it is produced.
 
             Streamed, not accumulated: an agent watching a build wants the
-            lines while it runs, a session that never exits would otherwise
-            say nothing at all, and a command killed at the timeout still
-            keeps whatever it managed to print.
+            lines while it runs, and a session that never exits would otherwise
+            say nothing at all.
             """
             try:
                 while chunk := await reader.read(65536):
@@ -1638,18 +1656,15 @@ class Workspace:
             output_tasks.append(asyncio.create_task(relay_output(stderr_reader, process.stderr)))
         wait_task = asyncio.create_task(sub.wait())
         channel_closed_task = asyncio.create_task(process.channel.wait_closed())
-        timed_out = False
+        returncode: int | None = None
         try:
-            async with asyncio.timeout(_COMMAND_TIMEOUT):
-                done, _ = await asyncio.wait(
-                    (wait_task, channel_closed_task),
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                if channel_closed_task in done and not wait_task.done():
-                    return
-                await wait_task
-        except TimeoutError:
-            timed_out = True
+            done, _ = await asyncio.wait(
+                (wait_task, channel_closed_task),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if channel_closed_task in done and not wait_task.done():
+                return
+            returncode = await wait_task
         finally:
             # A command that ran to completion inside the sandbox keeps its
             # process group: `some-server &` is how an agent starts something
@@ -1657,11 +1672,10 @@ class Workspace:
             # here would take it down with the shell that launched it. The
             # sandbox is the lifetime boundary instead — discarding it at the
             # end of the rollout collapses the pid namespace and everything
-            # left in it. Nothing bounds a command that timed out, was
-            # abandoned mid-flight, or ran with no sandbox at all, so those
-            # are still torn down as a group.
+            # left in it. An abandoned command or one running without a
+            # sandbox is still torn down as a group.
             completed = wait_task.done() and not wait_task.cancelled()
-            if pid is None or timed_out or not completed:
+            if pid is None or not completed:
                 await sub.terminate()
             stdin_task.cancel()
             wait_task.cancel()
@@ -1679,15 +1693,8 @@ class Workspace:
 
         if process.channel.is_closing():
             return
-        if timed_out:
-            # Whatever ran before the deadline has already been relayed; this
-            # only says why it stopped.
-            process.stderr.write(
-                f"workspace: command timed out after {_COMMAND_TIMEOUT:g}s\n".encode()
-            )
-            process.exit(1)
-            return
-        process.exit(sub.returncode if sub.returncode is not None else 0)
+        assert returncode is not None
+        process.exit(returncode)
 
 
 __all__ = [

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ctypes
 import json
 import logging
 import os
@@ -39,6 +40,82 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("hud.environment.workspace")
 
 _PROCESS_CLOSE_TIMEOUT_S = 5.0
+_JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
+_JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+
+
+class _WindowsJob:
+    """Windows Job Object which owns a subprocess and all of its descendants."""
+
+    def __init__(self, kernel32: Any | None = None) -> None:
+        from ctypes import wintypes
+
+        class BasicLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("per_process_user_time_limit", ctypes.c_longlong),
+                ("per_job_user_time_limit", ctypes.c_longlong),
+                ("limit_flags", wintypes.DWORD),
+                ("minimum_working_set_size", ctypes.c_size_t),
+                ("maximum_working_set_size", ctypes.c_size_t),
+                ("active_process_limit", wintypes.DWORD),
+                ("affinity", ctypes.c_size_t),
+                ("priority_class", wintypes.DWORD),
+                ("scheduling_class", wintypes.DWORD),
+            ]
+
+        class IoCounters(ctypes.Structure):
+            _fields_ = [
+                ("read_operation_count", ctypes.c_ulonglong),
+                ("write_operation_count", ctypes.c_ulonglong),
+                ("other_operation_count", ctypes.c_ulonglong),
+                ("read_transfer_count", ctypes.c_ulonglong),
+                ("write_transfer_count", ctypes.c_ulonglong),
+                ("other_transfer_count", ctypes.c_ulonglong),
+            ]
+
+        class ExtendedLimitInformation(ctypes.Structure):
+            _fields_ = [
+                ("basic_limit_information", BasicLimitInformation),
+                ("io_info", IoCounters),
+                ("process_memory_limit", ctypes.c_size_t),
+                ("job_memory_limit", ctypes.c_size_t),
+                ("peak_process_memory_used", ctypes.c_size_t),
+                ("peak_job_memory_used", ctypes.c_size_t),
+            ]
+
+        if kernel32 is None:
+            win_dll = ctypes.__dict__["WinDLL"]
+            kernel32 = win_dll("kernel32")
+        self._kernel32 = kernel32
+        handle = kernel32.CreateJobObjectW(None, None)
+        if not handle:
+            raise OSError(int(kernel32.GetLastError()), "CreateJobObjectW failed")
+        self._handle: Any | None = handle
+        limits = ExtendedLimitInformation()
+        limits.basic_limit_information.limit_flags = _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if not kernel32.SetInformationJobObject(
+            handle,
+            _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION,
+            ctypes.byref(limits),
+            ctypes.sizeof(limits),
+        ):
+            self.close()
+            raise OSError(int(kernel32.GetLastError()), "SetInformationJobObject failed")
+
+    def assign(self, process: subprocess.Popen[bytes]) -> None:
+        if self._handle is None:
+            raise RuntimeError("Windows Job Object is closed")
+        process_handle = getattr(process, "_handle", None)
+        if process_handle is None or not self._kernel32.AssignProcessToJobObject(
+            self._handle,
+            process_handle,
+        ):
+            raise OSError(int(self._kernel32.GetLastError()), "AssignProcessToJobObject failed")
+
+    def close(self) -> None:
+        handle, self._handle = self._handle, None
+        if handle is not None:
+            self._kernel32.CloseHandle(handle)
 
 
 @dataclass(slots=True, frozen=True)
@@ -1465,7 +1542,6 @@ class Workspace:
             # Additionally, cmd.exe launched via CreateProcess does NOT search the
             # CWD for batch files (only PATH), so relative .bat paths are resolved
             # to absolute below.
-            import functools
             import shlex
             import subprocess as _subprocess
 
@@ -1487,23 +1563,38 @@ class Workspace:
             else:
                 win_argv = ["cmd.exe"]
 
-            try:
-                loop = asyncio.get_running_loop()
-                child = await loop.run_in_executor(
-                    None,
-                    functools.partial(
-                        _subprocess.Popen,
+            def spawn() -> tuple[_subprocess.Popen[bytes], _WindowsJob]:
+                job = _WindowsJob()
+                try:
+                    child = _subprocess.Popen(
                         win_argv,
                         stdin=_subprocess.DEVNULL,
                         stdout=_subprocess.PIPE,
                         stderr=_subprocess.PIPE,
                         cwd=str(self.root),
                         env=proc_env,
-                    ),
-                )
+                    )
+                    try:
+                        job.assign(child)
+                    except BaseException:
+                        child.kill()
+                        child.wait()
+                        raise
+                except BaseException:
+                    job.close()
+                    raise
+                return child, job
+
+            try:
+                loop = asyncio.get_running_loop()
+                child, job = await loop.run_in_executor(None, spawn)
             except FileNotFoundError as exc:
                 process.stderr.write(f"workspace: cannot spawn shell: {exc}\n".encode())
                 process.exit(127)
+                return
+            except OSError as exc:
+                process.stderr.write(f"workspace: cannot own shell process tree: {exc}\n".encode())
+                process.exit(1)
                 return
 
             communicate_task = asyncio.create_task(asyncio.to_thread(child.communicate))
@@ -1518,15 +1609,23 @@ class Workspace:
                 stdout, stderr = await communicate_task
             finally:
                 if not communicate_task.done():
-                    with contextlib.suppress(OSError):
-                        child.terminate()
+                    job.close()
                     try:
                         async with asyncio.timeout(_PROCESS_CLOSE_TIMEOUT_S):
                             await asyncio.shield(communicate_task)
                     except TimeoutError:
-                        with contextlib.suppress(OSError):
-                            child.kill()
-                        await communicate_task
+                        for pipe in (child.stdout, child.stderr):
+                            if pipe is not None:
+                                with contextlib.suppress(OSError):
+                                    pipe.close()
+                        communicate_task.cancel()
+                        with contextlib.suppress(TimeoutError):
+                            await asyncio.wait_for(
+                                asyncio.gather(communicate_task, return_exceptions=True),
+                                _PROCESS_CLOSE_TIMEOUT_S,
+                            )
+                else:
+                    job.close()
                 channel_closed_task.cancel()
                 await asyncio.gather(channel_closed_task, return_exceptions=True)
 

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -40,8 +40,12 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("hud.environment.workspace")
 
 _PROCESS_CLOSE_TIMEOUT_S = 5.0
+_CREATE_SUSPENDED = 0x00000004
 _JOB_OBJECT_EXTENDED_LIMIT_INFORMATION = 9
 _JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000
+_THREAD_SUSPEND_RESUME = 0x0002
+_TH32CS_SNAPTHREAD = 0x00000004
+_INVALID_DWORD = 0xFFFFFFFF
 
 
 class _WindowsJob:
@@ -83,10 +87,45 @@ class _WindowsJob:
                 ("peak_job_memory_used", ctypes.c_size_t),
             ]
 
+        class ThreadEntry(ctypes.Structure):
+            _fields_ = [
+                ("size", wintypes.DWORD),
+                ("usage_count", wintypes.DWORD),
+                ("thread_id", wintypes.DWORD),
+                ("owner_process_id", wintypes.DWORD),
+                ("base_priority", wintypes.LONG),
+                ("priority_delta", wintypes.LONG),
+                ("flags", wintypes.DWORD),
+            ]
+
         if kernel32 is None:
             win_dll = ctypes.__dict__["WinDLL"]
             kernel32 = win_dll("kernel32")
+        kernel32.CreateJobObjectW.argtypes = [ctypes.c_void_p, wintypes.LPCWSTR]
+        kernel32.CreateJobObjectW.restype = wintypes.HANDLE
+        kernel32.SetInformationJobObject.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            wintypes.DWORD,
+        ]
+        kernel32.SetInformationJobObject.restype = wintypes.BOOL
+        kernel32.AssignProcessToJobObject.argtypes = [wintypes.HANDLE, wintypes.HANDLE]
+        kernel32.AssignProcessToJobObject.restype = wintypes.BOOL
+        kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+        kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+        kernel32.Thread32First.argtypes = [wintypes.HANDLE, ctypes.POINTER(ThreadEntry)]
+        kernel32.Thread32First.restype = wintypes.BOOL
+        kernel32.Thread32Next.argtypes = [wintypes.HANDLE, ctypes.POINTER(ThreadEntry)]
+        kernel32.Thread32Next.restype = wintypes.BOOL
+        kernel32.OpenThread.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.OpenThread.restype = wintypes.HANDLE
+        kernel32.ResumeThread.argtypes = [wintypes.HANDLE]
+        kernel32.ResumeThread.restype = wintypes.DWORD
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
         self._kernel32 = kernel32
+        self._thread_entry_type = ThreadEntry
         handle = kernel32.CreateJobObjectW(None, None)
         if not handle:
             raise OSError(int(kernel32.GetLastError()), "CreateJobObjectW failed")
@@ -111,6 +150,37 @@ class _WindowsJob:
             process_handle,
         ):
             raise OSError(int(self._kernel32.GetLastError()), "AssignProcessToJobObject failed")
+
+    def resume(self, process: subprocess.Popen[bytes]) -> None:
+        """Resume the primary thread of a process created with CREATE_SUSPENDED."""
+        snapshot = self._kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPTHREAD, 0)
+        if snapshot == ctypes.c_void_p(-1).value:
+            raise OSError(int(self._kernel32.GetLastError()), "thread snapshot failed")
+        thread_handle: Any | None = None
+        try:
+            entry = self._thread_entry_type()
+            entry.size = ctypes.sizeof(entry)
+            if not self._kernel32.Thread32First(snapshot, ctypes.byref(entry)):
+                raise OSError(int(self._kernel32.GetLastError()), "thread enumeration failed")
+            while True:
+                if entry.owner_process_id == process.pid:
+                    thread_handle = self._kernel32.OpenThread(
+                        _THREAD_SUSPEND_RESUME,
+                        False,
+                        entry.thread_id,
+                    )
+                    if not thread_handle:
+                        raise OSError(int(self._kernel32.GetLastError()), "OpenThread failed")
+                    break
+                if not self._kernel32.Thread32Next(snapshot, ctypes.byref(entry)):
+                    raise OSError(0, f"no thread found for suspended process {process.pid}")
+
+            if self._kernel32.ResumeThread(thread_handle) == _INVALID_DWORD:
+                raise OSError(int(self._kernel32.GetLastError()), "ResumeThread failed")
+        finally:
+            if thread_handle is not None:
+                self._kernel32.CloseHandle(thread_handle)
+            self._kernel32.CloseHandle(snapshot)
 
     def close(self) -> None:
         handle, self._handle = self._handle, None
@@ -1573,9 +1643,11 @@ class Workspace:
                         stderr=_subprocess.PIPE,
                         cwd=str(self.root),
                         env=proc_env,
+                        creationflags=_CREATE_SUSPENDED,
                     )
                     try:
                         job.assign(child)
+                        job.resume(child)
                     except BaseException:
                         child.kill()
                         child.wait()


### PR DESCRIPTION
## What changed

- Decode SSH text output with replacement semantics so arbitrary byte boundaries cannot tear down the connection.
- Remove the workspace server's hidden one-hour command deadline and preserve the actual namespace wait status.
- Keep Claude SDK SSH, shell, and MCP configuration local to each run so concurrent taskset runs cannot overwrite one another.
- Run each Claude computer-use MCP server in an owned controller-side subprocess, bridge its stdio through a reconnect-aware SSH channel, and preserve every RFB/display binding with a distinct MCP name.
- Create Windows shell commands suspended, assign them to kill-on-close Job Objects, then resume them; final pipe draining remains bounded.

## Root cause

AsyncSSH's connection-wide strict UTF-8 decoder could close an otherwise healthy transport when a command such as `tail -c` began inside a multibyte character. The workspace also imposed its own deadline below the rollout/agent/client ownership layers and could turn a missing nested exit status into success.

Separately, `ClaudeSDKAgent` described itself as stateless while storing live per-run clients on the shared agent instance. Its computer MCP server also lacked a valid ownership and reachability boundary: a controller-local HTTP task was unreachable from isolated workspaces, while moving the HUD MCP process into the guest assumed the task image contained HUD.

## Impact

Command output remains text-oriented, with malformed byte fragments represented by replacement characters instead of destroying the SSH transport. Deadlines remain explicit caller policy, nested failures remain failures, concurrent Claude runs are isolated, and every Windows process tree and computer-use resource ends with its owning SSH/agent run.

The computer MCP stays in the controller environment where HUD and the routed RFB binding exist. A run-scoped SSH/FIFO bridge carries MCP stdio into POSIX workspaces without opening a port or installing HUD in the task image. SSH-only Claude SDK runs continue to support Windows; RFB computer use currently requires a POSIX workspace.

## Validation

- `uv run --extra dev -- pytest -q hud/capabilities/tests/test_ssh.py hud/environment/tests/test_capability_backing.py hud/environment/tests/test_workspace.py hud/agents/tests/test_claude_sdk_agent.py` (107 passed)
- `uv run --extra dev --extra train -- ty check --error-on-warning`
- `uv run --extra dev -- ruff format . --check`
- `uv run --extra dev -- ruff check .`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core SSH transport decoding, workspace process ownership (including Windows Job Objects), and Claude computer-use MCP bridging—areas where regressions can break remote runs or leak processes.
> 
> **Overview**
> Hardens SSH and Claude SDK run lifecycles so concurrent runs stay isolated and process/MCP resources are owned by the run that created them.
> 
> **SSH / workspace:** Decode SSH text with `errors="replace"` so invalid UTF-8 no longer tears down the transport. Remove the workspace's hidden one-hour command deadline and forward the real namespace wait status. On Windows, spawn shells suspended into kill-on-close Job Objects so the full process tree is cleaned up when the SSH channel closes.
> 
> **Claude SDK:** Keep SSH, shell, and MCP config local to each `__call__(run)` instead of on the shared agent instance. Replace the controller-local HTTP computer MCP with a controller-side stdio subprocess bridged into the guest over SSH FIFOs, with distinct MCP names for multiple RFB displays. Computer use now requires a POSIX workspace; SSH-only runs still support Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d183b15a483f6ed4c7552ffe6130077906c7091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->