### PR TITLE
Fix capability connection readiness

### DIFF
--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -41,7 +41,11 @@ class SSHClient(CapabilityClient):
 
     @classmethod
     async def connect(cls, cap: Capability) -> Self:
-        return cls(cap, await cls._connect(cap))
+        try:
+            connection = await cls._connect(cap)
+        except (ConnectionError, asyncssh.ConnectionLost) as exc:
+            raise SSHConnectionError("SSH connection failed during handshake") from exc
+        return cls(cap, connection)
 
     @staticmethod
     async def _connect(cap: Capability) -> asyncssh.SSHClientConnection:

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -149,6 +149,16 @@ async def test_connect_keeps_tunneled_connection_active(monkeypatch: pytest.Monk
     )
 
 
+async def test_connect_classifies_a_lost_handshake_as_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connect = AsyncMock(side_effect=asyncssh.ConnectionLost("dropped"))
+    monkeypatch.setattr(SSHClient, "_connect", connect)
+
+    with pytest.raises(SSHConnectionError, match="failed during handshake"):
+        await SSHClient.connect(_capability())
+
+
 async def test_run_does_not_replay_a_command_lost_in_flight(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -37,11 +37,27 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger("hud.clients")
 _CONTROL_HEARTBEAT_INTERVAL_SECONDS = 120.0
 _CONTROL_HEARTBEAT_TIMEOUT_SECONDS = 5.0
+_CAPABILITY_CONNECT_ATTEMPTS = 3
+_CAPABILITY_CONNECT_BASE_DELAY_SECONDS = 0.25
 
 #: protocol -> CapabilityClient subclass, for ``HudClient.open``.
 _CLIENT_REGISTRY: dict[str, type[CapabilityClient]] = {
     cls.protocol: cls for cls in (SSHClient, RFBClient, MCPClient, CDPClient)
 }
+
+
+async def _connect_capability(
+    client_cls: type[CapabilityClient],
+    capability: Capability,
+) -> CapabilityClient:
+    for attempt in range(_CAPABILITY_CONNECT_ATTEMPTS):
+        try:
+            return await client_cls.connect(capability)
+        except ConnectionError:
+            if attempt + 1 == _CAPABILITY_CONNECT_ATTEMPTS:
+                raise
+            await asyncio.sleep(_CAPABILITY_CONNECT_BASE_DELAY_SECONDS * 2**attempt)
+    raise RuntimeError("capability connect attempts must be positive")
 
 
 class HudProtocolError(RuntimeError):
@@ -277,7 +293,7 @@ class HudClient:
                     f"no client registered for protocol {cap.protocol!r}; "
                     f"use binding({ref!r}) for raw access",
                 )
-            cap_client = await client_cls.connect(cap)
+            cap_client = await _connect_capability(client_cls, cap)
             self._opened[cap.name] = cap_client
         return cap_client
 

--- a/hud/clients/tests/test_connect.py
+++ b/hud/clients/tests/test_connect.py
@@ -11,16 +11,76 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import ClassVar
 from urllib.parse import urlsplit
 
 import pytest
 
 import hud.clients.client as client_module
+from hud.capabilities import Capability, CapabilityClient
 from hud.clients import connect
 from hud.environment.utils import read_frame, send_frame
 from hud.eval.runtime import Runtime
 
 HELLO_RESULT = {"session_id": "s-1", "env": {"name": "stub", "version": "1.0"}, "bindings": []}
+
+
+async def test_open_retries_transient_capability_connection_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RetryingClient(CapabilityClient):
+        protocol: ClassVar[str] = "test/1"
+        attempts = 0
+
+        @classmethod
+        async def connect(cls, cap: Capability) -> RetryingClient:
+            del cap
+            cls.attempts += 1
+            if cls.attempts < 3:
+                raise ConnectionError("connection reset")
+            return cls()
+
+        async def close(self) -> None:
+            pass
+
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            hello = await read_frame(reader)
+            assert hello is not None
+            await send_frame(
+                writer,
+                {
+                    "jsonrpc": "2.0",
+                    "id": hello["id"],
+                    "result": {
+                        **HELLO_RESULT,
+                        "bindings": [
+                            {
+                                "name": "test",
+                                "protocol": RetryingClient.protocol,
+                                "url": "tcp://environment:1234",
+                            }
+                        ],
+                    },
+                },
+            )
+            await read_frame(reader)
+        finally:
+            writer.close()
+
+    monkeypatch.setitem(client_module._CLIENT_REGISTRY, RetryingClient.protocol, RetryingClient)
+    monkeypatch.setattr(client_module, "_CAPABILITY_CONNECT_BASE_DELAY_SECONDS", 0)
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        async with connect(Runtime(f"tcp://127.0.0.1:{port}")) as client:
+            opened = await client.open("test")
+            assert await client.open("test") is opened
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert RetryingClient.attempts == 3
 
 
 async def test_connect_retries_through_accept_then_eof_until_the_env_serves() -> None:

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -46,6 +46,36 @@ async def _connect(ws: Workspace) -> asyncssh.SSHClientConnection:
 
 
 @pytest.mark.asyncio
+async def test_start_waits_until_the_ssh_acceptor_is_ready(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    listen_started = asyncio.Event()
+    allow_listen = asyncio.Event()
+    listen = asyncssh.listen
+
+    async def delayed_listen(*args: Any, **kwargs: Any) -> asyncssh.SSHAcceptor:
+        listen_started.set()
+        await allow_listen.wait()
+        return await listen(*args, **kwargs)
+
+    monkeypatch.setattr(asyncssh, "listen", delayed_listen)
+    ws = Workspace(tmp_path / "root", track_files=False)
+    start = asyncio.create_task(ws.start())
+    await asyncio.wait_for(listen_started.wait(), 1.0)
+
+    assert not start.done()
+
+    allow_listen.set()
+    await start
+    try:
+        async with await _connect(ws) as conn:
+            assert (await conn.run("echo ready")).stdout == "ready\n"
+    finally:
+        await ws.stop()
+
+
+@pytest.mark.asyncio
 async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
     """The agent's shell root must not contain its SSH key material."""
     ws = Workspace(tmp_path / "root")

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -552,7 +552,6 @@ class Workspace:
         self._ssh_host_key_path = host_key_path
         self._ssh_authorized_client_keys = list(authorized_client_keys or [])
         self._acceptor: asyncssh.SSHAcceptor | None = None
-        self._serve_task: asyncio.Task[None] | None = None
         self._client_key_path: Path | None = None
         self._host_key: asyncssh.SSHKey | None = None
         self._host_pubkey_str: str | None = None
@@ -709,35 +708,31 @@ class Workspace:
 
     # ─── lifecycle ────────────────────────────────────────────────────
 
-    async def _serve(self) -> None:
-        """Run the asyncssh accept loop on the pre-bound socket."""
-        self._prepare_runtime()
-        assert self._sock is not None
-        assert self._host_key is not None
-        assert self._authorized_keys_path is not None
-        self._acceptor = await asyncssh.listen(
-            sock=self._sock,
-            server_host_keys=[self._host_key],
-            authorized_client_keys=str(self._authorized_keys_path),
-            process_factory=self._handle_process,
-            line_editor=False,
-            keepalive_interval=30,
-            encoding=None,
-        )
-
     async def start(self) -> None:
         """Ensure the SSH accept loop is running. Idempotent.
 
-        The first start prepares credentials and binds the socket, then ensures
-        the async acceptor exists.
+        Returns only after every published workspace service is accepting clients.
         """
-        self._prepare_runtime()
-        if self._serve_task is None and self._acceptor is None:
-            self._serve_task = asyncio.get_event_loop().create_task(self._serve())
-        # Yield so the acceptor binds before first use.
-        await asyncio.sleep(0)
-        if self._track_files and self._ft_server is None:
-            await self._start_file_tracking()
+        try:
+            self._prepare_runtime()
+            if self._acceptor is None:
+                assert self._sock is not None
+                assert self._host_key is not None
+                assert self._authorized_keys_path is not None
+                self._acceptor = await asyncssh.listen(
+                    sock=self._sock,
+                    server_host_keys=[self._host_key],
+                    authorized_client_keys=str(self._authorized_keys_path),
+                    process_factory=self._handle_process,
+                    line_editor=False,
+                    keepalive_interval=30,
+                    encoding=None,
+                )
+            if self._track_files and self._ft_server is None:
+                await self._start_file_tracking()
+        except BaseException:
+            await self.stop()
+            raise
 
     async def _start_file_tracking(self) -> None:
         """Take the baseline snapshot and bind the filetracking/1 server."""
@@ -764,11 +759,6 @@ class Workspace:
             self._ft_server = None
             self._ft_host = self._ft_port = None
             self._file_tracker = None
-        if self._serve_task is not None:
-            self._serve_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._serve_task
-            self._serve_task = None
         if self._acceptor is not None:
             self._acceptor.close()
             # close() initiates shutdown; wait_closed() can hang on Windows when a


### PR DESCRIPTION
## Summary

- wait for the workspace SSH acceptor before publishing the capability
- retry transient initial capability connection failures centrally in `HudClient.open()`
- classify an initial AsyncSSH connection loss as retryable without replaying operations

## Root cause

`Workspace.start()` scheduled `asyncssh.listen()` in a background task and yielded once instead of awaiting listener initialization. A capability could therefore be published while its SSH acceptor was still starting. If the first SSH handshake was reset in that window, `HudClient.open()` treated the transient connection loss as terminal.

## Impact

Cold-start capability connections now wait for server readiness and absorb bounded transient handshake failures. Retry remains limited to initial connection establishment; commands or other operations with uncertain outcomes are never replayed.

## Validation

- `uv run --extra dev pytest -q hud/clients/tests/test_connect.py hud/capabilities/tests/test_ssh.py hud/environment/tests/test_workspace.py hud/environment/tests/test_capability_backing.py hud/environment/tests/test_tunnel.py` — 106 passed
- `uv run --extra dev pytest -q hud/capabilities/tests hud/clients/tests hud/agents/tests/test_tool_agent.py` — 48 passed
- focused Ruff format and lint checks
- focused `ty check`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connection establishment and workspace lifecycle timing for SSH capabilities; bounded retries limit blast radius, but readiness ordering affects deploy/cold-start behavior.
> 
> **Overview**
> Fixes cold-start races where capabilities were published before SSH was listening and the first handshake could fail permanently.
> 
> **Workspace** `start()` now **awaits** `asyncssh.listen()` instead of scheduling it in a background task and yielding once. Startup failures trigger `stop()` for cleanup. `stop()` no longer cancels a separate serve task.
> 
> **HudClient.open()** uses **`_connect_capability`** with three attempts and exponential backoff (0.25s base) on **`ConnectionError`**, including SSH handshake failures wrapped as **`SSHConnectionError`**.
> 
> **SSHClient.connect()** maps **`ConnectionError`** and **`asyncssh.ConnectionLost`** during handshake to **`SSHConnectionError`** (“failed during handshake”) so the central retry path can absorb transient drops without changing mid-operation behavior (commands still are not replayed after loss in flight).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 504df48c0aefe27cf35e3bbf425116f71155ce56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->