### PR TITLE
fix(harbor): accept artifact destination and exclude from Harbor task.toml

### DIFF
--- a/hud/integrations/harbor/adapt.py
+++ b/hud/integrations/harbor/adapt.py
@@ -49,6 +49,8 @@ class Artifact(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     source: str = Field(pattern=r"^/")
+    destination: str | None = None
+    exclude: list[str] = Field(default_factory=list)
     service: str = Field(default="main", min_length=1)
 
     @model_validator(mode="before")
@@ -63,6 +65,21 @@ class Artifact(BaseModel):
         if len(path.parts) == 1 or ".." in path.parts:
             raise ValueError("artifact source must name a path beneath /")
         return str(path)
+
+    @field_validator("destination")
+    @classmethod
+    def normalize_destination(cls, value: str | None) -> str | None:
+        """Harbor host placement: a relative path beneath the trial's artifacts dir."""
+        if not value:
+            return None
+        if "\\" in value:
+            raise ValueError("artifact destination must use forward slashes")
+        path = PurePosixPath(value)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("artifact destination must be a relative path without '..'")
+        if value.rstrip("/") == "manifest.json":
+            raise ValueError("artifact destination 'manifest.json' is reserved by Harbor")
+        return value
 
 
 class Collect(BaseModel):

--- a/hud/integrations/harbor/env.py
+++ b/hud/integrations/harbor/env.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import fnmatch
 import grp
 import json
 import math
@@ -352,6 +353,31 @@ def copy_artifact(source: Path, target: Path) -> None:
         shutil.copy2(source, target, follow_symlinks=False)
 
 
+def prune_excluded(target: Path, patterns: list[str]) -> None:
+    """Drop staged entries matching Harbor exclude patterns (GNU tar semantics).
+
+    A pattern excludes an entry when it matches any run of trailing path
+    components; matching a directory prunes its whole subtree.
+    """
+
+    def excluded(entry: Path) -> bool:
+        parts = entry.relative_to(target).as_posix().split("/")
+        return any(
+            fnmatch.fnmatch("/".join(parts[start:]), pattern)
+            for pattern in patterns
+            for start in range(len(parts))
+        )
+
+    for root, directories, files in os.walk(target, topdown=True):
+        for name in list(directories):
+            if excluded(Path(root, name)):
+                shutil.rmtree(Path(root, name))
+                directories.remove(name)
+        for name in files:
+            if excluded(Path(root, name)):
+                Path(root, name).unlink()
+
+
 async def collect(task: dict[str, Any]) -> None:
     clear(ARTIFACTS)
     services: dict[str, str] = {}
@@ -442,6 +468,8 @@ async def collect(task: dict[str, Any]) -> None:
             copy_artifact(Path(source), target)
         if target.is_symlink() or any(path.is_symlink() for path in target.rglob("*")):
             raise RuntimeError(f"artifact {source} contains a symbolic link")
+        if artifact["exclude"] and target.is_dir():
+            prune_excluded(target, artifact["exclude"])
 
 
 @env.template(id="run", description="Run a Harbor task")

--- a/hud/integrations/harbor/env.py
+++ b/hud/integrations/harbor/env.py
@@ -343,12 +343,7 @@ def copy_artifact(source: Path, target: Path) -> None:
         raise RuntimeError(f"artifact {source} has a symbolic link in its path")
     target.parent.mkdir(parents=True, exist_ok=True)
     if source.is_dir():
-        for root, directories, files in os.walk(source, followlinks=False):
-            for name in (*directories, *files):
-                entry = Path(root, name)
-                if entry.is_symlink():
-                    raise RuntimeError(f"artifact {source} contains symbolic link {entry}")
-        shutil.copytree(source, target)
+        shutil.copytree(source, target, symlinks=True)
     elif source.exists() or source.is_symlink():
         shutil.copy2(source, target, follow_symlinks=False)
 
@@ -370,8 +365,12 @@ def prune_excluded(target: Path, patterns: list[str]) -> None:
 
     for root, directories, files in os.walk(target, topdown=True):
         for name in list(directories):
-            if excluded(Path(root, name)):
-                shutil.rmtree(Path(root, name))
+            entry = Path(root, name)
+            if excluded(entry):
+                if entry.is_symlink():
+                    entry.unlink()
+                else:
+                    shutil.rmtree(entry)
                 directories.remove(name)
         for name in files:
             if excluded(Path(root, name)):
@@ -466,10 +465,10 @@ async def collect(task: dict[str, Any]) -> None:
                 continue
         else:
             copy_artifact(Path(source), target)
-        if target.is_symlink() or any(path.is_symlink() for path in target.rglob("*")):
-            raise RuntimeError(f"artifact {source} contains a symbolic link")
         if artifact["exclude"] and target.is_dir():
             prune_excluded(target, artifact["exclude"])
+        if target.is_symlink() or any(path.is_symlink() for path in target.rglob("*")):
+            raise RuntimeError(f"artifact {source} contains a symbolic link")
 
 
 @env.template(id="run", description="Run a Harbor task")

--- a/hud/integrations/harbor/env.py
+++ b/hud/integrations/harbor/env.py
@@ -465,9 +465,11 @@ async def collect(task: dict[str, Any]) -> None:
                 continue
         else:
             copy_artifact(Path(source), target)
+        if target.is_symlink():
+            raise RuntimeError(f"artifact {source} contains a symbolic link")
         if artifact["exclude"] and target.is_dir():
             prune_excluded(target, artifact["exclude"])
-        if target.is_symlink() or any(path.is_symlink() for path in target.rglob("*")):
+        if any(path.is_symlink() for path in target.rglob("*")):
             raise RuntimeError(f"artifact {source} contains a symbolic link")
 
 

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -595,7 +595,7 @@ timeout_sec = 30
     assert taskset["build-pmars"].agent_config == {"timeout_seconds": 45.0}
     assert taskset["build-pmars"].args["task"]["verifier_timeout"] == 30.0
     assert taskset["build-pmars"].args["task"]["artifacts"] == [
-        {"service": "main", "source": "/tmp/result"}
+        {"service": "main", "source": "/tmp/result", "destination": None, "exclude": []}
     ]
 
 
@@ -883,7 +883,9 @@ timeout_sec = 10
     }
     assert "tasks" not in manifest
     assert row.args["task"] == {
-        "artifacts": [{"service": "main", "source": "/tmp/agent.patch"}],
+        "artifacts": [
+            {"service": "main", "source": "/tmp/agent.patch", "destination": None, "exclude": []}
+        ],
         "collect": [{"command": "redis-cli save", "service": "redis", "timeout_sec": 10.0}],
         "description": "",
         "id": "separate",
@@ -992,6 +994,52 @@ def test_artifacts_must_name_normalized_paths_beneath_root(
     (task / "task.toml").write_text(f'artifacts = ["{source}"]\n', encoding="utf-8")
 
     with pytest.raises(ValueError, match="artifact source must name a path beneath /"):
+        harbor.adapt(tmp_path)
+
+
+def test_artifacts_keep_harbor_destination_and_exclude(tmp_path: Path) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "task.toml").write_text(
+        """\
+[[artifacts]]
+source = "/app/outputs"
+destination = "results/outputs"
+exclude = ["*.tmp", "cache"]
+""",
+        encoding="utf-8",
+    )
+
+    taskset = harbor.adapt(tmp_path)
+
+    assert taskset["task-a"].args["task"]["artifacts"] == [
+        {
+            "service": "main",
+            "source": "/app/outputs",
+            "destination": "results/outputs",
+            "exclude": ["*.tmp", "cache"],
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "destination",
+    ["/absolute/path", "results/../../escape", "results\\\\windows", "manifest.json"],
+)
+def test_artifact_destinations_harbor_rejects_fail_adaptation(
+    tmp_path: Path,
+    destination: str,
+) -> None:
+    task = make_harbor_task(tmp_path, "task-a")
+    (task / "task.toml").write_text(
+        f"""\
+[[artifacts]]
+source = "/app/out.json"
+destination = "{destination}"
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="not a valid Harbor task"):
         harbor.adapt(tmp_path)
 
 

--- a/hud/integrations/harbor/tests/test_integration.py
+++ b/hud/integrations/harbor/tests/test_integration.py
@@ -241,6 +241,63 @@ def test_separate_verifier_rejects_artifact_symlinks(
     assert "artifact /app/main.html is a symbolic link" in (run.trace.error or "")
 
 
+def test_separate_verifier_sees_directory_artifacts_without_excluded_entries(
+    tmp_path_factory: pytest.TempPathFactory, wheel: Path
+) -> None:
+    dataset = tmp_path_factory.mktemp("harbor-artifact-exclude") / "harbor-harness"
+    task = dataset / "sidecar-reachability"
+    shutil.copytree(TASKS / "sidecar-reachability", task)
+    (task / "task.toml").write_text(
+        """\
+artifacts = [
+  { source = "/app/outputs", destination = "results", exclude = ["*.tmp", "cache"] },
+]
+
+[task]
+name = "sidecar-reachability"
+
+[verifier]
+environment_mode = "separate"
+timeout_sec = 30
+""",
+        encoding="utf-8",
+    )
+    (task / "solution" / "solve.sh").write_text(
+        """\
+#!/bin/sh
+set -eu
+mkdir -p /app/outputs/cache/nested /app/outputs/logs
+echo keep > /app/outputs/keep.txt
+echo junk > /app/outputs/junk.tmp
+echo junk > /app/outputs/logs/nested.tmp
+echo junk > /app/outputs/cache/nested/blob
+""",
+        encoding="utf-8",
+    )
+    (task / "tests" / "test.sh").write_text(
+        """\
+#!/bin/sh
+set -u
+mkdir -p /logs/verifier
+if [ "$(cat /app/outputs/keep.txt 2>/dev/null)" = "keep" ] \\
+  && [ -d /app/outputs/logs ] \\
+  && [ ! -e /app/outputs/junk.tmp ] \\
+  && [ ! -e /app/outputs/logs/nested.tmp ] \\
+  && [ ! -e /app/outputs/cache ]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo "excluded artifact entries leaked into the verifier" >&2
+  echo 0 > /logs/verifier/reward.txt
+fi
+""",
+        encoding="utf-8",
+    )
+
+    run = asyncio.run(_grade_every_task(dataset, wheel))["sidecar-reachability"]
+
+    assert run.reward == 1.0, run.trace.error
+
+
 def test_separate_verifier_rejects_artifacts_beneath_symlinks(
     tmp_path_factory: pytest.TempPathFactory, wheel: Path
 ) -> None:

--- a/hud/integrations/harbor/tests/test_integration.py
+++ b/hud/integrations/harbor/tests/test_integration.py
@@ -241,6 +241,38 @@ def test_separate_verifier_rejects_artifact_symlinks(
     assert "artifact /app/main.html is a symbolic link" in (run.trace.error or "")
 
 
+def test_separate_verifier_rejects_sidecar_symlink_artifact_roots(
+    tmp_path_factory: pytest.TempPathFactory, wheel: Path
+) -> None:
+    dataset = tmp_path_factory.mktemp("harbor-sidecar-symlink") / "harbor-harness"
+    task = dataset / "sidecar-reachability"
+    shutil.copytree(TASKS / "sidecar-reachability", task)
+    (task / "task.toml").write_text(
+        """\
+artifacts = [{ source = "/link", service = "web", exclude = ["main.html"] }]
+
+[task]
+name = "sidecar-reachability"
+
+[verifier]
+environment_mode = "separate"
+timeout_sec = 30
+
+[[verifier.collect]]
+service = "web"
+command = "ln -sfn /app /link"
+timeout_sec = 10
+""",
+        encoding="utf-8",
+    )
+    (task / "solution" / "solve.sh").write_text("true\n", encoding="utf-8")
+
+    run = asyncio.run(_grade_every_task(dataset, wheel))["sidecar-reachability"]
+
+    assert run.reward == 0.0
+    assert "artifact /link contains a symbolic link" in (run.trace.error or "")
+
+
 def test_separate_verifier_sees_directory_artifacts_without_excluded_entries(
     tmp_path_factory: pytest.TempPathFactory, wheel: Path
 ) -> None:

--- a/hud/integrations/harbor/tests/test_integration.py
+++ b/hud/integrations/harbor/tests/test_integration.py
@@ -271,6 +271,8 @@ echo keep > /app/outputs/keep.txt
 echo junk > /app/outputs/junk.tmp
 echo junk > /app/outputs/logs/nested.tmp
 echo junk > /app/outputs/cache/nested/blob
+ln -s /etc/passwd /app/outputs/cache/link
+ln -s missing /app/outputs/logs/dangling.tmp
 """,
         encoding="utf-8",
     )
@@ -283,6 +285,7 @@ if [ "$(cat /app/outputs/keep.txt 2>/dev/null)" = "keep" ] \\
   && [ -d /app/outputs/logs ] \\
   && [ ! -e /app/outputs/junk.tmp ] \\
   && [ ! -e /app/outputs/logs/nested.tmp ] \\
+  && [ ! -L /app/outputs/logs/dangling.tmp ] \\
   && [ ! -e /app/outputs/cache ]; then
   echo 1 > /logs/verifier/reward.txt
 else


### PR DESCRIPTION
## Problem

`harbor.adapt()` rejects Harbor tasks that Harbor itself accepts. Harbor's `ArtifactConfig` (harbor 0.20.0, `harbor/models/task/config.py`) has two fields the adapter's `Artifact` model forbids:

```toml
[[artifacts]]
source = "/app/outputs"
destination = "results/outputs"   # extra_forbidden -> "not a valid Harbor task"
exclude = ["*.tmp", "cache"]      # extra_forbidden -> "not a valid Harbor task"
```

Any task directory using either field fails adaptation outright.

## Fix

**`destination`** — accepted and preserved through the task args. No runtime behavior change: Harbor documents that verifier-side placement never depends on `destination` (it only controls host placement under the trial's artifacts dir), and this runtime already re-mounts artifacts at their source path, which matches Harbor's verifier-side contract. Validation mirrors Harbor's: relative, forward slashes, no `..`, `manifest.json` reserved — so tasks Harbor would reject still fail adaptation loudly.

**`exclude`** — implemented, not just accepted. Harbor applies these as `tar --exclude` flags when downloading directory artifacts, so silently ignoring them would hand the verifier files Harbor's verifier never sees. `env.py` now prunes matching entries after staging a directory artifact, following GNU tar exclusion semantics (unanchored: a pattern matches any run of trailing path components; a matched directory prunes its subtree).

Artifact `source` intentionally still requires an absolute path: this runtime mounts artifacts back at their source path for the verifier, which needs an absolute anchor. Harbor itself requires absolute sources for sidecar services; relative sources for the main container are a separate discussion.

## Testing

- `uv run pytest hud/integrations/harbor/tests/test_contract.py hud/integrations/harbor/tests/test_harbor.py` — 67 passed (new: destination/exclude round-trip into task args; Harbor-invalid destinations fail adaptation)
- `uv run pytest -m integration -k "artifact or restores_image_paths or excluded_entries"` — 5 passed, including a new end-to-end test: a directory artifact with `exclude = ["*.tmp", "cache"]` is staged for a separate verifier without the excluded entries (nested matches included), reward 1.0
- `ruff format --check`, `ruff check`, `ty check` — clean

The exclusion matcher follows GNU tar's documented `--exclude` behavior (unanchored glob over component boundaries + subtree pruning); byte-for-byte parity with every tar edge case is not claimed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes artifact staging and symlink handling in the verifier collect path; incorrect exclude semantics could hide or leak files to graders, but scope is limited to Harbor integration.
> 
> **Overview**
> Harbor tasks that declare `destination` or `exclude` on artifacts no longer fail `harbor.adapt()`; those fields are modeled on `Artifact` with Harbor-aligned validation (relative `destination`, no `..`, reserved `manifest.json`).
> 
> At collect time, directory artifacts are staged with `copytree(..., symlinks=True)`, then **`exclude` patterns prune matching paths** via new `prune_excluded` (GNU tar–style unanchored globs and subtree removal). Symlink checks still reject symlink roots and any symlinks left in the staged tree after pruning.
> 
> Contract and Docker integration tests cover round-trip args, invalid destinations, sidecar symlink roots, and end-to-end grading when `exclude` drops `*.tmp` and `cache` from verifier-visible artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a537e065d48175161cc223f19d604c0017ed692a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->