### PR TITLE
Deflake workspace timeout and teardown timing tests

### DIFF
--- a/hud/environment/tests/test_capability_backing.py
+++ b/hud/environment/tests/test_capability_backing.py
@@ -218,10 +218,15 @@ async def test_workspace_channel_close_during_teardown_keeps_connection_usable(
     try:
         async with served(env) as client:
             ssh = cast("SSHClient", await client.open("shell"))
+            # The pid file doubles as the child's readiness signal: it is
+            # written after the TERM trap is installed, and teardown's TERM
+            # only fires once the foreground command exits. Exiting before
+            # the child is ready would kill it while still untrapped.
             remote = await ssh.conn.create_process(
                 "sh -c 'trap \"echo started > teardown-started; "
                 'while :; do sleep 1; done" TERM; '
                 "echo $$ > close-race-child.pid; while :; do sleep 1; done' & "
+                "while [ ! -s close-race-child.pid ]; do sleep 0.01; done; "
                 "printf output"
             )
             try:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -599,17 +599,21 @@ async def test_tool_agent_timeout_stops_running_workspace_command_before_grading
         started.unlink(missing_ok=True)
         late.unlink(missing_ok=True)
 
+    # Timing contract, sized to survive loaded CI: the command must start
+    # within the 2s agent budget, still be running when that budget expires
+    # (it sleeps 3s), and the grading delay must outlast the sleep so a
+    # command that survived the timeout provably leaves `late` behind.
     @env.template()
     async def wait_for_cleanup():
         yield "Start the requested command."
-        await asyncio.sleep(1.2)
+        await asyncio.sleep(4.0)
         yield 1.0 if started.exists() and not late.exists() else 0.0
 
     model_client = _FakeOpenAI(
         [
             _chat_response(
                 "",
-                [_tool_call("bash", '{"command":"touch started; sleep 1; touch late"}')],
+                [_tool_call("bash", '{"command":"touch started; sleep 3; touch late"}')],
             ),
         ]
     )
@@ -618,7 +622,7 @@ async def test_tool_agent_timeout_stops_running_workspace_command_before_grading
             model="qwen3.6-plus",
             model_client=model_client,
             max_steps=2,
-            timeout_seconds=0.5,
+            timeout_seconds=2.0,
         )
     )
 
@@ -630,9 +634,9 @@ async def test_tool_agent_timeout_stops_running_workspace_command_before_grading
 
     assert run.trace.status == "error"
     assert run.trace.stop_reason == "timeout"
-    assert run.reward == 1.0
     assert started.exists()
     assert not late.exists()
+    assert run.reward == 1.0
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group regression")


### PR DESCRIPTION
## Problem

Two recent regression tests fail intermittently under CPU load (reproduced locally by running each in a loop with all cores saturated):

- `test_tool_agent_timeout_stops_running_workspace_command_before_grading` (added in 4b828adb) — 1/25 failures: `run.reward == 0.0` with `agent timed out after 0.5s`.
- `test_workspace_channel_close_during_teardown_keeps_connection_usable` (added in 244f5bf1) — 3/25 failures: the first `wait_for(..., 5.0)` expires waiting for `teardown-started`.

Both pass reliably in isolation, so each failure was root-caused with a diagnostic twin of the test that reports the hidden state on failure.

## Root causes

**Timeout test — spawn latency races a 0.5s wall.** On the failing runs the diagnostic showed `started=False late=False`: under load, the 0.5s agent budget expired before `touch started` ever executed, so the (correctly working) group kill landed before the first `touch`. The product invariant held — `late` never appeared; the test's spawn budget was just too tight. The kill path is sound: cancellation reaches `ProcessGroup.complete`, whose `finally` awaits `terminate()` (TERM → poll → KILL on the group) before the timeout resumes the template.

**Teardown test — TERM beats the child's `trap`.** On the failing runs the diagnostic showed the workspace empty: no pid file, no marker. The background child is forked, but nothing orders its `trap ... TERM` before the foreground `printf output; exit` — and the leader's exit is what triggers the server's group TERM. Under load the child's first scheduling slice can come after the whole exit-detection path, so it dies untrapped, the marker never appears, and the 5s wait always burns out. This is an ordering race, not a budget problem; no timeout is large enough to fix it.

## Fixes

- **Timeout test**: widen only the load-sensitive constraint — agent budget 0.5s → 2s — and rescale the other two so the contract is preserved: the command sleeps 3s (still running when the budget expires for any spawn < 2s), and grading waits 4s (past the latest moment `late` could land, spawn < 2s + sleep 3s < resume 2s + wait 4s). Asserts reordered so a failure names the broken invariant (`started` missing vs `late` present) instead of hiding behind `reward`.
- **Teardown test**: the child's pid file is written immediately after its trap is installed, so it doubles as a readiness signal — the foreground command now waits for it before exiting. TERM can no longer reach an untrapped child, regardless of scheduling. The 5s budgets are unchanged and now only cover operations with bounded latency.

Neither change touches what the tests guard: the timeout test still requires the workspace command to be provably started and provably stopped before grading; the teardown test still exercises TERM-surviving-child teardown, channel close during it, and connection reuse after it.

## Testing

- Reproduction and fix verified under full-core CPU saturation (`yes` per core): before — 1/25 and 3/25 failures respectively; after — 0/40 and 0/40.
- Regression power spot-checked: with the process-group kill neutered, the timeout test fails via `late.exists()`.
- `uv run pytest -q` (full suite), `ruff format --check`, `ruff check`, `ty check` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test timing, shell snippets, and assertion order; no runtime or grading logic changes.
> 
> **Overview**
> **Deflakes two POSIX regression tests** that failed under CPU load while still checking the same product behavior.
> 
> In **`test_workspace_channel_close_during_teardown_keeps_connection_usable`**, the foreground shell now **waits until `close-race-child.pid` exists** before `printf output` exits. That pid is written after the child installs its TERM trap, so teardown cannot send TERM to an untrapped child when scheduling is slow.
> 
> In **`test_tool_agent_timeout_stops_running_workspace_command_before_grading`**, timings are widened for loaded CI: agent **`timeout_seconds` 0.5 → 2**, workspace command **`sleep 1 → 3`**, template grading wait **1.2s → 4s**, with a short comment describing the contract. Assertions on **`started` / `late`** now run **before** `run.reward` so failures point at the invariant instead of a misleading reward check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1121d6556e0816f0199857d51ecb8477f8544cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->