### PR TITLE
ci(release): point the docs branch at every published release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -23,3 +25,8 @@ jobs:
         run: |
           uv build
           uv publish
+
+      # docs.hud.ai builds the SDK tab from the docs branch.
+      - name: Point docs at this release
+        run: |
+          git push --force origin "${GITHUB_SHA}:refs/heads/docs"


### PR DESCRIPTION
docs.hud.ai builds its SDK tab from the `docs` branch: normally the latest release, optionally plus docs-only commits shipped between releases. The release workflow force-pushes the released commit to `docs` after publishing to PyPI, so the pointer needs no manual maintenance; docs-only commits on the branch are contained in the released main by construction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a release workflow; the force-push to `docs` is intentional and scoped to the release commit SHA.
> 
> **Overview**
> After each published release, the **Release** workflow now updates the `docs` branch so docs.hud.ai’s SDK tab builds from the same commit that was shipped to PyPI.
> 
> The deploy job gains **`contents: write`** permissions and a new step **Point docs at this release** that runs `git push --force origin "${GITHUB_SHA}:refs/heads/docs"` after `uv publish`. PyPI publishing is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 616f90b72bdfe68bb668e208b36e35326473f257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->