### PR TITLE
Fix Modal runtime environment injection

### DIFF
--- a/hud/eval/runtime.py
+++ b/hud/eval/runtime.py
@@ -825,13 +825,12 @@ class ModalRuntime:
                         await self._image.build.aio(app=app)
                         self._resolved = self._image
             image = self._resolved
-        if self.env_vars and compose is None:
-            image = image.env(self.env_vars)
-
         if app is None:
             app = await modal.App.lookup.aio(self.app_name, create_if_missing=True)
 
         sandbox_kwargs: dict[str, Any] = {}
+        if self.env_vars and compose is None:
+            sandbox_kwargs["env"] = self.env_vars
         resources = config.resources
         if compose is not None:
             sandbox_kwargs["cpu"] = max(

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -863,6 +863,7 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     assert kwargs["cpu"] == 4
     assert kwargs["memory"] == 8192
     assert kwargs["image"] == _ModalImageRef("registry", "docker:28.3.3-dind")
+    assert "env" not in kwargs
     assert calls["uploads"] == [
         ("project.tar.gz", "/hud/project.tar.gz"),
         ("override.json", "/hud/override.json"),
@@ -967,7 +968,7 @@ async def test_modal_runtime_can_override_workdir(
     assert sandbox_kwargs["workdir"] == "/app"
 
 
-async def test_modal_runtime_applies_env_vars_to_image(
+async def test_modal_runtime_passes_env_vars_to_sandbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls = _install_fake_modal(monkeypatch)
@@ -979,11 +980,8 @@ async def test_modal_runtime_applies_env_vars_to_image(
 
     sandbox_kwargs = calls["sandbox_kwargs"]
     assert isinstance(sandbox_kwargs, dict)
-    assert sandbox_kwargs["image"] == _ModalImageRef(
-        "registry",
-        "img:tag",
-        {"TOKEN": "secret"},
-    )
+    assert sandbox_kwargs["image"] == _ModalImageRef("registry", "img:tag")
+    assert sandbox_kwargs["env"] == {"TOKEN": "secret"}
 
 
 async def test_daytona_runtime_config_flows_into_daytona_sdk(


### PR DESCRIPTION
## Summary

Pass environment variables to `modal.Sandbox.create` for image-based Modal runtimes instead of deriving a new image with `Image.env`.

Compose retains its existing behavior: runtime variables are injected into the inner `main` service and are not added to the outer DinD sandbox.

## Root cause

Hosted rollouts resolve deployed environments by Modal image ID. Calling `Image.env` on that resolved image creates another image layer and caused sandbox startup to fail during Modal's Python runtime setup. The build-validation path already passed environment variables directly to the sandbox and started the same image successfully.

## Impact

Hosted Modal rollouts can start deployed image environments with member or registry environment variables without rebuilding the image.

## Validation

- `uv run pytest hud/eval/tests/test_docker_provider.py -q` — 40 passed
- `uv run ruff check hud/eval/runtime.py hud/eval/tests/test_docker_provider.py`
- `uv run ruff format --check hud/eval/runtime.py hud/eval/tests/test_docker_provider.py`
- `uv run ty check hud/eval/runtime.py`
- started deployed image `modal://im-97vUZPBX8kK08VPPEsGrpV` with runtime variables and completed a full rollout: https://hud.ai/jobs/7bfabf2c9feb4c72b33f0fd91cd900d5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Modal sandbox startup for image-based hosted rollouts; scope is narrow (env injection path) but affects production rollout provisioning.
> 
> **Overview**
> **Modal image-based runtimes** now inject member/registry environment variables through `sandbox_kwargs["env"]` on `modal.Sandbox.create`, instead of calling `Image.env` on the resolved deployed image.
> 
> That avoids adding another image layer when rollouts start from a hosted `modal://` image ID—a path that was failing during Modal’s Python runtime setup while the build-validation flow (which already passed env to the sandbox) worked.
> 
> **Compose on Modal** is unchanged: runtime vars still go into the inner `main` service via compose staging, and the outer DinD sandbox does not receive `env` in sandbox kwargs (covered by tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 587c234fd2a2a1ffc4e683aab2e393dd75a175ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->