### PR TITLE
docs: send docs analytics to PostHog

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -126,9 +126,9 @@
     "discord": "https://discord.gg/wkjtmHYYjm",
     "x": "https://x.com/hud_evals"
   },
-  "analytics": {
-    "ga4": {
-      "measurementId": "G-XXXXXXXXXX"
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_Y0O4R6an6XCDwoGLKvGiazyd1C1UdYQKCXFYSrqVzDJ"
     }
   },
   "seo": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Configuration-only change for public docs analytics; no SDK, auth, or runtime behavior is affected. The PostHog key is a public client key typical for browser analytics.
> 
> **Overview**
> **Docs site analytics** switches from a placeholder Google Analytics 4 config to **Mintlify PostHog integration** in `docs/docs.json`.
> 
> The removed `analytics.ga4` block only had a dummy measurement ID (`G-XXXXXXXXXX`). The new `integrations.posthog` section wires the published docs to PostHog using the configured project API key so page views and related Mintlify analytics go to PostHog instead of GA4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774ea095a347e0a0e9d527aae88882285c4971bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->