### PR TITLE
Allow ModalRuntime to use caller-owned Modal apps

### DIFF
--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -138,14 +138,16 @@ security override are documented in
 ### `ModalRuntime`
 
 ```python
-ModalRuntime(image_name=None, *, image=None, command=None, app_name="hud-envs", workdir=None, port=8765, runtime_config=None, env_vars=None)
+ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=None, workdir=None, port=8765, runtime_config=None, env_vars=None)
 ```
 
 - **`image_name`** - published Modal image name (the preferred durable handle), e.g. `ModalRuntime("hud-libero-env")`.
 - **`image`** - an `Image` to build lazily on first use, as an escape hatch.
 - **`command`** - override the serving command (defaults to the scaffolded `hud serve` entrypoint).
 - **`workdir`** - working directory inside the sandbox. Left unset, Modal keeps the image's `WORKDIR`.
-- **`app_name`** / **`port`** / **`env_vars`** - Modal app name, in-sandbox serving port, and extra environment variables.
+- **`app`** - an already-running, caller-owned Modal app. `ModalRuntime` does not manage its lifecycle.
+- **`app_name`** - a Modal app to look up. Defaults to `hud-envs` when `app` is not supplied; `app` and `app_name` are mutually exclusive.
+- **`port`** / **`env_vars`** - in-sandbox serving port and extra environment variables.
 
 For Compose input, `ModalRuntime` runs the project in a Docker-in-Docker
 sandbox in your Modal account and merges `env_vars` into `main` at acquisition

--- a/hud/eval/runtime/modal.py
+++ b/hud/eval/runtime/modal.py
@@ -140,12 +140,15 @@ class ModalRuntime:
         *,
         image: modal.Image | None = None,
         command: Sequence[str] | None = None,
-        app_name: str = "hud-envs",
+        app: modal.App | None = None,
+        app_name: str | None = None,
         workdir: str | None = None,
         port: int = 8765,
         runtime_config: RuntimeConfig | dict[str, Any] | None = None,
         env_vars: Mapping[str, str] | None = None,
     ) -> None:
+        if app is not None and app_name is not None:
+            raise ValueError("ModalRuntime accepts either app or app_name, not both")
         self.image_name = image_name
         self.port = port
         self.env_vars = dict(env_vars or {})
@@ -165,7 +168,8 @@ class ModalRuntime:
                 str(port),
             )
         )
-        self.app_name = app_name
+        self.app = app
+        self.app_name = "hud-envs" if app_name is None else app_name
         config = None
         if runtime_config is not None:
             config = RuntimeConfig.model_validate(runtime_config)
@@ -199,7 +203,6 @@ class ModalRuntime:
                 "use a materialized image or omit runtime_config.compose"
             )
         port_service = ComposeConfig.from_file(compose).network_owner("main") if compose else "main"
-        app = None
         if compose is not None:
             image = modal.Image.from_registry("docker:28.3.3-dind")
         elif config.image is not None:
@@ -216,18 +219,19 @@ class ModalRuntime:
                 "or runtime_config.compose"
             )
         else:
+            image = self._resolved
+
+        app = self.app
+        if app is None:
+            app = await modal.App.lookup.aio(self.app_name, create_if_missing=True)
+        if image is None:
+            assert self._image is not None
             if self._resolved is None:
                 async with self._image_lock:
                     if self._resolved is None:
-                        app = await modal.App.lookup.aio(
-                            self.app_name,
-                            create_if_missing=True,
-                        )
                         await self._image.build.aio(app=app)
                         self._resolved = self._image
-            image = self._resolved
-        if app is None:
-            app = await modal.App.lookup.aio(self.app_name, create_if_missing=True)
+            image = self._image
 
         sandbox_kwargs: dict[str, Any] = {}
         if compose is not None:

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -1025,6 +1025,31 @@ async def test_modal_runtime_config_flows_into_modal_sdk(
     assert calls["terminated"] is True
 
 
+async def test_modal_runtime_uses_caller_owned_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    app = object()
+
+    async def build(*, app: object) -> None:
+        calls["image_build_app"] = app
+
+    image = SimpleNamespace(build=SimpleNamespace(aio=build))
+    provider = ModalRuntime(app=cast("Any", app), image=cast("Any", image))
+
+    async with provider(_row()):
+        pass
+
+    assert "app_lookup" not in calls
+    assert calls["image_build_app"] is app
+    assert calls["sandbox_kwargs"]["app"] is app
+
+
+def test_modal_runtime_rejects_app_and_app_name() -> None:
+    with pytest.raises(ValueError, match="either app or app_name"):
+        ModalRuntime(app=cast("Any", object()), app_name="hud-envs")
+
+
 async def test_modal_runtime_rejects_gpu_alternatives() -> None:
     provider = ModalRuntime(
         runtime_config=RuntimeConfig(


### PR DESCRIPTION
## Summary

- accept an already-running `modal.App` as an alternative to `app_name`
- use the caller-owned app for both lazy image builds and sandbox creation without managing its lifecycle
- preserve the existing `hud-envs` lookup default and document the ownership contract

## Why

`ModalRuntime` previously resolved every acquisition through a persistent app name, even when the caller already owned an explicit Modal app lifecycle. Accepting the app directly enables ephemeral apps, scoped log ownership, and intentional sharing across sandboxes without another lifecycle abstraction.

## Validation

- `uv run pytest -q hud/eval/tests` — 208 passed
- `uv run ty check`
- `uv run ruff check .`
- `uv run ruff format . --check`

## Uncertain

- None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped API extension to Modal runtime acquisition with validation and tests; no auth, data, or core eval path changes beyond optional Modal app wiring.
> 
> **Overview**
> **`ModalRuntime`** can now take a caller-owned **`modal.App`** via **`app=`**, so lazy image builds and sandbox creation use that app without **`ModalRuntime`** starting or stopping it.
> 
> When **`app`** is omitted, behavior stays the same: **`app_name`** resolves through **`modal.App.lookup`** (default **`hud-envs`**). Passing both **`app`** and **`app_name`** raises **`ValueError`**. The runtime reference documents the ownership contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657f8ce2dd3a01f76b03c83a4c7999847b1168c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->