### PR TITLE
Make rollout timeout the canonical SDK deadline

### DIFF
--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -26,7 +26,7 @@ await taskset.run(agent, runtime=LocalRuntime("env.py"))   # serve env.py locall
 | `Runtime("tcp://host:8765")` | A substrate you already started | Attaching to a long-lived container or sandbox you own |
 | `Shared(provider, width=N)` | One substrate from `provider`, shared by up to N concurrent connections | Multi-agent evals - agents that share, compete, or coordinate over one live environment |
 | `HUDRuntime()` | A HUD-hosted env, leased by name and tunneled | Local agent loop against a deployed env |
-| `HostedRuntime()` | The whole rollout on a HUD-leased box | Agent and env run together off your machine |
+| `HostedRuntime()` | The whole rollout managed by HUD | Agent and env execute remotely together |
 
 Most runtimes are on the top-level package (`from hud import LocalRuntime, DockerRuntime, HUDRuntime,
 HostedRuntime, Runtime`); `ModalRuntime` and `DaytonaRuntime` import from `hud.eval`.
@@ -83,6 +83,14 @@ enough whole GiB, while providers without disk sizing proceed with their default
 Daytona accepts a list of GPU alternatives; Modal accepts one GPU type. Docker ignores `limits`;
 Daytona rejects `run_timeout_s` and resource overrides when booting from an already-built snapshot.
 `LocalRuntime` rejects a per-task `runtime_config`.
+
+`run_timeout_s` bounds the lifetime of the provisioned environment, not the complete rollout.
+The optional `rollout_timeout` passed to `Task.run` or `Taskset.run` bounds submission, queueing,
+provisioning, the agent, and grading together. When both are set, `run_timeout_s` and other known
+phase limits must be less than `rollout_timeout`; an agent timeout must also be less than the
+actor environment's `run_timeout_s`. Contradictory values fail before execution. When
+`rollout_timeout` is omitted, the SDK adds no overall deadline; configured phase limits and limits
+imposed by the selected runtime still apply.
 
 ## Runtime directory
 
@@ -178,11 +186,11 @@ Compose authoring conventions are documented in
 ### `HUDRuntime`
 
 ```python
-HUDRuntime(*, run_timeout=3600.0, runtime_url=None)
+HUDRuntime(*, run_timeout=None, runtime_url=None)
 ```
 
-- **`run_timeout`** - hard deadline for the full rollout lifecycle. A timeout
-  returns an errored `Run` with `stop_reason="timeout"` while teardown completes.
+- **`run_timeout`** - deprecated alias for the `rollout_timeout` passed to `Task.run` or
+  `Taskset.run`.
 - **`runtime_url`** - override the runtime endpoint the tunnel connects to.
 
 The SDK leases your deployed env by name and tunnels to its control channel; the agent loop runs local.
@@ -190,17 +198,21 @@ The SDK leases your deployed env by name and tunnels to its control channel; the
 ### `HostedRuntime`
 
 ```python
-HostedRuntime(*, poll_interval=5.0, run_timeout=3600.0)
+HostedRuntime(*, poll_interval=5.0, run_timeout=None)
 ```
 
 - **`poll_interval`** - seconds between trace-status polls while the rollout runs remotely.
-- **`run_timeout`** - hard deadline including submission, provisioning, queueing,
-  and execution. A timeout requests cancellation and returns an errored `Run`.
+- **`run_timeout`** - deprecated alias for the `rollout_timeout` passed to `Task.run` or
+  `Taskset.run`.
+
+For example, a task with `RuntimeLimits(run_timeout_s=18_000)` can omit `rollout_timeout` to avoid
+adding an SDK-wide cap. To add one, pass a larger value such as
+`task.run(agent, runtime=HostedRuntime(), rollout_timeout=18_600)`, leaving time for queueing and
+provisioning.
 
 Where `HUDRuntime` runs the agent loop locally against a tunneled env, `HostedRuntime` runs the
-**whole rollout** off-box: the platform leases an instance, brings the env's container up on it, and
-runs the agent right next to it. This process only submits the rollout and polls its trace to
-completion. It supports gateway agents from
+**whole rollout** remotely, with the agent running alongside the task environment. This process
+only submits the rollout and polls its trace to completion. It supports gateway agents from
 [`create_agent`](/v6/reference/agents#create-agent); agents with a custom `model_client` must use
 `HUDRuntime` or `LocalRuntime`.
 

--- a/docs/v6/reference/tasks.mdx
+++ b/docs/v6/reference/tasks.mdx
@@ -162,11 +162,15 @@ job = await ts.run(agent, runtime=LocalRuntime("env.py"), group=8, max_concurren
 | `group` | `int \| None` | Repeats each task N times for GRPO. |
 | `max_concurrent` | `int \| None` | Caps how many rollouts run in parallel. |
 | `job` | `Job \| None` | An open [`Job`](/v6/reference/types#job) to accumulate into; defaults to a fresh job per call. |
-| `rollout_timeout` | `float \| None` | Hard deadline (seconds) for the full local rollout lifecycle; a breach returns a failed run. |
+| `rollout_timeout` | `float \| None` | Optional hard deadline (seconds) for the full rollout lifecycle in every placement; omitted means no SDK-wide deadline. |
 
 `agent_config.timeout_seconds` bounds only the agent phase. If it expires, the
 run is marked as timed out but grading still runs against any completed work.
-`rollout_timeout` instead bounds startup, the agent, grading, and cleanup together.
+`rollout_timeout` instead bounds startup, the agent, and grading together; runtime cleanup may
+finish in the background after a timeout. When both are set, the agent timeout must be less than
+the rollout timeout and any explicit actor `run_timeout_s`. Limits imposed by the selected runtime
+still apply when `rollout_timeout` is omitted. Grader-specific limits, such as
+`BashGrader.timeout_seconds`, remain local to that grader.
 
 A crashed rollout comes back as a failed [`Run`](/v6/reference/types#run) inside the job rather than
 raising, so one bad rollout never collapses a batch. For the end-to-end workflow see

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -8,9 +8,8 @@ grades, and tears down, filling a :class:`Run` along the way::
     run = await rollout(task, agent, runtime=LocalRuntime("env.py"))
 
 It is the *client-here* path: the agent loop runs in this process against a
-:class:`~hud.eval.runtime.Provider`'s channel. The same driver runs on the
-daemon (the leased box's agent loop is just ``rollout`` over a
-``DockerRuntime``), in ``Chat`` per turn, and in ``AgentTool`` per invocation.
+:class:`~hud.eval.runtime.Provider`'s channel. The same driver handles hosted
+execution once delegated, each ``Chat`` turn, and each ``AgentTool`` invocation.
 Delegated hosted execution is a different act — see
 :class:`hud.eval.runtime.HostedRuntime` — and the scheduler (:meth:`Taskset.run`)
 chooses between them; the atom itself never branches on placement.
@@ -47,10 +46,62 @@ if TYPE_CHECKING:
     from hud.clients.client import HudClient
 
     from .runtime import Provider
-    from .runtime.core import RuntimeSession
+    from .runtime.core import RuntimeConfig, RuntimeSession
     from .task import Task
 
 logger = logging.getLogger("hud.eval.run")
+
+
+def validate_rollout_timeouts(
+    task: Task,
+    agent: Agent,
+    rollout_timeout: float | None,
+    *,
+    actor_runtime_config: RuntimeConfig | None,
+    verifier_runtime_config: RuntimeConfig | None,
+) -> float | None:
+    """Validate configured phase limits and return the effective agent timeout."""
+    from hud.agents.tool_agent import ToolAgent
+
+    agent_timeout = agent.config.timeout_seconds if isinstance(agent, ToolAgent) else None
+    if task.agent_config is not None:
+        agent_timeout = task.agent_config.get("timeout_seconds", agent_timeout)
+
+    actor_limits = actor_runtime_config.limits if actor_runtime_config is not None else None
+    actor_run_timeout = actor_limits.run_timeout_s if actor_limits is not None else None
+    if (
+        agent_timeout is not None
+        and actor_run_timeout is not None
+        and agent_timeout >= actor_run_timeout
+    ):
+        raise ValueError(
+            f"agent timeout ({agent_timeout:g}s) must be less than "
+            f"runtime_config.limits.run_timeout_s ({actor_run_timeout}s)"
+        )
+
+    if rollout_timeout is None:
+        return agent_timeout
+    if rollout_timeout <= 0:
+        raise ValueError("rollout_timeout must be greater than 0")
+
+    if agent_timeout is not None and agent_timeout >= rollout_timeout:
+        raise ValueError(
+            f"agent timeout ({agent_timeout:g}s) must be less than "
+            f"rollout_timeout ({rollout_timeout:g}s)"
+        )
+
+    configs = (("actor", actor_runtime_config), ("verifier", verifier_runtime_config))
+    for phase, config in configs:
+        if config is None or config.limits is None:
+            continue
+        for limit_name in ("startup_timeout_s", "run_timeout_s"):
+            value = getattr(config.limits, limit_name)
+            if value is not None and value >= rollout_timeout:
+                raise ValueError(
+                    f"{phase} runtime_config.limits.{limit_name} ({value}s) must be less than "
+                    f"rollout_timeout ({rollout_timeout:g}s)"
+                )
+    return agent_timeout
 
 
 def _prompt_message(item: Any) -> mcp_types.PromptMessage:
@@ -418,10 +469,21 @@ async def rollout(
     ``cleanup``) so
     callers can tell where the failure landed without reading the trace.
 
-    ``rollout_timeout`` bounds the entire lifecycle, including grading and
-    provider cleanup. A timeout aborts the control transport, lets provider
-    teardown finish in the background, and returns an errored run immediately.
+    ``rollout_timeout`` bounds execution through grading. A timeout aborts the
+    control transport, lets provider teardown finish in the background, and
+    returns an errored run immediately.
     """
+    from .runtime.core import resolve_runtime_config
+
+    agent_timeout = validate_rollout_timeouts(
+        task,
+        agent,
+        rollout_timeout,
+        actor_runtime_config=resolve_runtime_config(runtime, task),
+        verifier_runtime_config=(
+            resolve_runtime_config(runtime, task.verifier) if task.verifier is not None else None
+        ),
+    )
     if job_id is None:  # no standalone traces: a lone rollout is a job of one
         job_id = uuid.uuid4().hex
         await job_enter(job_id, name=task.id, group=1)
@@ -433,9 +495,6 @@ async def rollout(
     from hud.agents.tool_agent import ToolAgent
 
     agent_model = agent.config.model if isinstance(agent, ToolAgent) else None
-    agent_timeout = agent.config.timeout_seconds if isinstance(agent, ToolAgent) else None
-    if task.agent_config is not None:
-        agent_timeout = task.agent_config.get("timeout_seconds", agent_timeout)
     with set_trace_context(trace_id):
         await trace_enter(
             trace_id,

--- a/hud/eval/runtime/core.py
+++ b/hud/eval/runtime/core.py
@@ -7,7 +7,7 @@ import contextlib
 import json
 from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcontext
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Protocol, Self
+from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -120,6 +120,11 @@ class Provider(Protocol):
     """
 
     def __call__(self, task: Task, /) -> AbstractAsyncContextManager[Runtime]: ...
+
+
+@runtime_checkable
+class _ConfiguredProvider(Protocol):
+    runtime_config: RuntimeConfig | None
 
 
 @dataclass(frozen=True)
@@ -240,3 +245,16 @@ class Shared:
                     self._addresses[key] = await self._stack.enter_async_context(self.inner(task))
                 addr = self._addresses[key]
             yield addr
+
+
+def resolve_runtime_config(provider: Provider, task: Task) -> RuntimeConfig | None:
+    """Return the runtime configuration a provider will apply to a task."""
+    if isinstance(provider, Shared):
+        return resolve_runtime_config(provider.inner, task)
+    if isinstance(provider, Runtime):
+        return provider.config if provider.config is not None else task.runtime_config
+    if isinstance(provider, _ConfiguredProvider) and provider.runtime_config is not None:
+        base = provider.runtime_config
+        config = base.with_overrides(task.runtime_config)
+        return config if config.model_dump(exclude_none=True) else None
+    return task.runtime_config

--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+import warnings
 from typing import TYPE_CHECKING, Any
 
-from hud.eval.run import Grade, Run
+from hud.eval.run import Grade, Run, validate_rollout_timeouts
 from hud.types import Step
 from hud.utils.platform import PlatformClient
 
@@ -21,29 +22,32 @@ _TERMINAL_TRACE_STATUSES = frozenset({"completed", "error", "cancelled"})
 
 
 class HostedRuntime:
-    """HUD-hosted placement: runs the rollout on a leased box and returns its ``Run``.
+    """HUD-hosted placement: runs the rollout remotely and returns its ``Run``.
 
     The *client-elsewhere* placement. Where a :class:`Provider` yields a channel
-    this process drives, ``HostedRuntime`` runs the whole rollout off-box: the
-    platform leases an instance, brings the env's container up on it, and runs
-    the agent right next to it (the instance-side driver is just
-    :func:`hud.eval.run.rollout` over a ``DockerRuntime`` — co-location all the
-    way down). This process only submits the rollout and polls the trace to
-    completion, folding the result into a :class:`~hud.eval.run.Run`. Because
-    the agent runs remotely, its identity travels via :func:`_agent_spec`.
+    this process drives, ``HostedRuntime`` runs the whole rollout remotely: the
+    agent runs alongside the task environment. This process only submits the
+    rollout and polls the trace to completion, folding the result into a
+    :class:`~hud.eval.run.Run`. Because the agent runs remotely, its identity
+    travels via :func:`_agent_spec`.
 
-    ``run_timeout`` bounds one rollout end to end, including instance
-    provisioning (a cold EC2 boot plus image pull), queueing, and the agent
-    run itself. A local cancel (Ctrl-C) requests a platform-side cancel before
-    propagating, so abandoned rollouts do not hold instances open.
+    ``run_timeout`` is a deprecated constructor alias for ``rollout_timeout``.
+    A local cancel (Ctrl-C) requests remote cancellation before propagating.
     """
 
     def __init__(
         self,
         *,
         poll_interval: float = 5.0,
-        run_timeout: float = 3600.0,
+        run_timeout: float | None = None,
     ) -> None:
+        if run_timeout is not None:
+            warnings.warn(
+                "HostedRuntime(run_timeout=...) is deprecated; pass "
+                "rollout_timeout=... to Task.run or Taskset.run",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.poll_interval = poll_interval
         self.run_timeout = run_timeout
         self._cancellations: set[asyncio.Task[None]] = set()
@@ -56,17 +60,26 @@ class HostedRuntime:
         job_id: str,
         group_id: str | None = None,
         trace_id: str | None = None,
+        rollout_timeout: float | None = None,
     ) -> Run:
         """Submit one rollout, await its terminal trace, and fold it into a ``Run``.
 
-        The platform owns the trace lifecycle (the instance-side driver reports
-        enter/exit and streams telemetry), so this never double-reports.
+        The trace lifecycle is reported remotely, so this never double-reports.
         Failures isolating one rollout from its batch (submit rejected, the
         env/model unresolved) surface as :meth:`Run.failed`; a timeout or a
-        local cancel propagate, having first asked the platform to release the
-        lease.
+        local cancel propagate after requesting remote cancellation.
         """
         trace_id = trace_id or uuid.uuid4().hex
+        timeout = self.run_timeout if rollout_timeout is None else rollout_timeout
+        validate_rollout_timeouts(
+            task,
+            agent,
+            timeout,
+            actor_runtime_config=task.runtime_config,
+            verifier_runtime_config=(
+                task.verifier.runtime_config if task.verifier is not None else None
+            ),
+        )
         try:
             if task.verifier is not None and (
                 task.verifier.env != task.env or task.verifier.runtime_config is not None
@@ -75,16 +88,22 @@ class HostedRuntime:
                     "hosted verifier tasks must reuse the actor runtime: verifier.env must "
                     "match task.env and verifier.runtime_config must be omitted"
                 )
-            async with asyncio.timeout(self.run_timeout):
+            if timeout is None:
                 state = await self._submit_and_await(
                     task, agent, job_id=job_id, group_id=group_id, trace_id=trace_id
                 )
+            else:
+                async with asyncio.timeout(timeout):
+                    state = await self._submit_and_await(
+                        task, agent, job_id=job_id, group_id=group_id, trace_id=trace_id
+                    )
         except asyncio.CancelledError:
             self._cancel_later(trace_id)
             raise
         except TimeoutError:
+            assert timeout is not None
             self._cancel_later(trace_id)
-            detail = f"hosted rollout {trace_id} did not finish within {self.run_timeout:g}s"
+            detail = f"hosted rollout {trace_id} did not finish within {timeout:g}s"
             logger.warning(detail)
             run = Run.failed(detail)
             run.trace.stop_reason = "timeout"

--- a/hud/eval/runtime/hud.py
+++ b/hud/eval/runtime/hud.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import logging
 import uuid
+import warnings
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
@@ -36,7 +37,19 @@ class HUDRuntime:
     atom drive it from this process.
     """
 
-    def __init__(self, *, run_timeout: float = 3600.0, runtime_url: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        run_timeout: float | None = None,
+        runtime_url: str | None = None,
+    ) -> None:
+        if run_timeout is not None:
+            warnings.warn(
+                "HUDRuntime(run_timeout=...) is deprecated; pass "
+                "rollout_timeout=... to Task.run or Taskset.run",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.run_timeout = run_timeout
         self.runtime_url = runtime_url
         self._warned_unsupported_config = False
@@ -49,6 +62,7 @@ class HUDRuntime:
         job_id: str,
         group_id: str | None = None,
         trace_id: str | None = None,
+        rollout_timeout: float | None = None,
     ) -> Run:
         return await rollout(
             task,
@@ -57,7 +71,7 @@ class HUDRuntime:
             trace_id=trace_id,
             job_id=job_id,
             group_id=group_id,
-            rollout_timeout=self.run_timeout,
+            rollout_timeout=(self.run_timeout if rollout_timeout is None else rollout_timeout),
         )
 
     def __call__(self, task: Task) -> AbstractAsyncContextManager[Runtime]:
@@ -126,7 +140,7 @@ class HUDRuntime:
                 params={
                     "session_id": session_id,
                     "gateway_url": runtime_url,
-                    "ready_timeout": min(self.run_timeout, _RUNTIME_READY_TIMEOUT),
+                    "ready_timeout": _RUNTIME_READY_TIMEOUT,
                 },
             )
         finally:

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -23,12 +23,13 @@ from hud.telemetry import flush
 from hud.utils.platform import PlatformClient
 
 from .job import Job, job_enter
-from .run import rollout
+from .run import rollout, validate_rollout_timeouts
 from .runtime import (
     HostedRuntime,
     HUDRuntime,
     LocalRuntime,
 )
+from .runtime.core import resolve_runtime_config
 from .sync import fetch_taskset_tasks, resolve_taskset_id
 
 if TYPE_CHECKING:
@@ -253,11 +254,11 @@ class Taskset:
         substrate (:class:`~hud.eval.runtime.Shared`) bounds its own occupancy
         and is scoped to this call when not already open.
 
-        ``rollout_timeout`` is a hard per-rollout wall-clock cap (seconds) for the
-        local (Provider) path: a rollout that exceeds it is cancelled and recorded
-        as a failed/errored run so one wedged rollout (e.g. a stuck sampling
-        stream) cannot stall the whole batch. ``HUDRuntime`` carries its own
-        ``run_timeout`` instead.
+        ``rollout_timeout`` is a hard per-rollout wall-clock cap (seconds) for
+        every placement: a rollout that exceeds it is cancelled and recorded as
+        a failed/errored run so one wedged rollout (e.g. a stuck sampling stream)
+        cannot stall the whole batch. When omitted, the SDK adds no overall
+        deadline; configured phase and runtime limits still apply.
         """
         if max_concurrent is not None and max_concurrent < 1:
             raise ValueError("max_concurrent must be >= 1")
@@ -267,6 +268,30 @@ class Taskset:
         group = group or (job.group if job else 1)
         if group < 1:
             raise ValueError("group must be >= 1")
+        timeout = rollout_timeout
+        if timeout is None and isinstance(placement, (HUDRuntime, HostedRuntime)):
+            timeout = placement.run_timeout
+        for task in task_list:
+            if isinstance(placement, HostedRuntime):
+                actor_runtime_config = task.runtime_config
+                verifier_runtime_config = (
+                    task.verifier.runtime_config if task.verifier is not None else None
+                )
+            else:
+                assert placement is not None
+                actor_runtime_config = resolve_runtime_config(placement, task)
+                verifier_runtime_config = (
+                    resolve_runtime_config(placement, task.verifier)
+                    if task.verifier is not None
+                    else None
+                )
+            validate_rollout_timeouts(
+                task,
+                agent,
+                timeout,
+                actor_runtime_config=actor_runtime_config,
+                verifier_runtime_config=verifier_runtime_config,
+            )
 
         # Tasks are pure rows, shared across rollouts; the ``group`` repeats of
         # one task share a group_id (the GRPO group).
@@ -285,16 +310,19 @@ class Taskset:
             await job_enter(job.id, name=job.name, group=group, taskset_id=self.taskset_id)
         job_id = job.id
         sem = asyncio.Semaphore(max_concurrent) if max_concurrent else None
-        timeout = (
-            placement.run_timeout
-            if rollout_timeout is None and isinstance(placement, HUDRuntime)
-            else rollout_timeout
-        )
 
         async def _run(task: Task, group_id: str) -> list[Run]:
             assert placement is not None  # only reached when tasks were expanded
             if isinstance(placement, HostedRuntime):
-                return [await placement.run(task, agent, job_id=job_id, group_id=group_id)]
+                return [
+                    await placement.run(
+                        task,
+                        agent,
+                        job_id=job_id,
+                        group_id=group_id,
+                        rollout_timeout=timeout,
+                    )
+                ]
             return [
                 await rollout(
                     task,

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -26,14 +26,17 @@ from hud.eval.runtime import (
     ComposeProject,
     HostedRuntime,
     HUDRuntime,
+    ModalRuntime,
     Runtime,
     RuntimeConfig,
     RuntimeGPU,
     RuntimeLimits,
     RuntimeResources,
 )
+from hud.eval.runtime.core import resolve_runtime_config
 from hud.eval.runtime.hud import _splice_websocket
 from hud.eval.task import Task
+from hud.eval.taskset import Taskset
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -78,6 +81,14 @@ def _agent() -> OpenAIChatAgent:
     return OpenAIChatAgent(
         OpenAIChatConfig(model="test-model", api_key="k", base_url="http://localhost")
     )
+
+
+@pytest.mark.parametrize("runtime_type", [HostedRuntime, HUDRuntime])
+def test_runtime_constructor_timeout_is_a_deprecated_alias(runtime_type: type[Any]) -> None:
+    with pytest.warns(DeprecationWarning, match="rollout_timeout"):
+        runtime = runtime_type(run_timeout=90.0)
+
+    assert runtime.run_timeout == 90.0
 
 
 def test_hosted_spec_serializes_full_config() -> None:
@@ -330,16 +341,218 @@ async def test_run_timeout_requests_platform_cancel(monkeypatch: pytest.MonkeyPa
         "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
     )
 
-    hosted = HostedRuntime(poll_interval=0.0, run_timeout=0.001)
+    hosted = HostedRuntime(poll_interval=0.0)
     task = Task(env="sums", id="add", args={})
 
-    run = await hosted.run(task, _agent(), job_id=uuid.uuid4().hex)
+    run = await hosted.run(
+        task,
+        _agent(),
+        job_id=uuid.uuid4().hex,
+        rollout_timeout=0.001,
+    )
     await asyncio.sleep(0)
 
     cancel_posts = [(p, b) for p, b in platform.posts if p == "/rollouts/cancel"]
     assert len(cancel_posts) == 1
     assert run.trace.status == "error"
     assert run.trace.stop_reason == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_omitted_rollout_timeout_allows_long_environment_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = _FakePlatform([{"status": "completed", "reward": 1.0}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+    task = Task(
+        env="sums",
+        id="add",
+        runtime_config=RuntimeConfig(limits=RuntimeLimits(run_timeout_s=18_000)),
+    )
+
+    run = await HostedRuntime(poll_interval=0.0).run(
+        task,
+        _agent(),
+        job_id=uuid.uuid4().hex,
+    )
+
+    assert run.trace.status == "completed"
+    assert platform.posts[0][0] == "/rollouts/submit"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("environment_timeout", [3_600, 18_000])
+async def test_explicit_rollout_timeout_rejects_environment_timeout_at_or_beyond_it(
+    monkeypatch: pytest.MonkeyPatch,
+    environment_timeout: int,
+) -> None:
+    platform = _FakePlatform([{"status": "completed", "reward": 1.0}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+    task = Task(
+        env="sums",
+        id="add",
+        runtime_config=RuntimeConfig(limits=RuntimeLimits(run_timeout_s=environment_timeout)),
+    )
+
+    with pytest.raises(ValueError, match=r"actor runtime_config\.limits\.run_timeout_s"):
+        await HostedRuntime().run(
+            task,
+            _agent(),
+            job_id=uuid.uuid4().hex,
+            rollout_timeout=3_600,
+        )
+
+    assert platform.posts == []
+
+
+@pytest.mark.asyncio
+async def test_taskset_rollout_timeout_reaches_hosted_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = _FakePlatform([{"status": "completed", "reward": 1.0}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+    task = Task(
+        env="sums",
+        id="add",
+        runtime_config=RuntimeConfig(limits=RuntimeLimits(run_timeout_s=18_000)),
+    )
+
+    job = await Taskset("sums", [task]).run(
+        _agent(),
+        runtime=HostedRuntime(poll_interval=0.0),
+        rollout_timeout=18_600,
+    )
+
+    assert job.runs[0].trace.status == "completed"
+    assert platform.posts[0][0] == "/rollouts/submit"
+
+
+@pytest.mark.asyncio
+async def test_agent_timeout_must_fit_explicit_environment_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = _FakePlatform([{"status": "completed", "reward": 1.0}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+    task = Task(
+        env="sums",
+        id="add",
+        agent_config={"timeout_seconds": 5_000},
+        runtime_config=RuntimeConfig(limits=RuntimeLimits(run_timeout_s=3_600)),
+    )
+
+    with pytest.raises(ValueError, match=r"agent timeout \(5000s\).+run_timeout_s \(3600s\)"):
+        await HostedRuntime().run(task, _agent(), job_id=uuid.uuid4().hex)
+
+    assert platform.posts == []
+
+
+@pytest.mark.asyncio
+async def test_agent_timeout_must_fit_explicit_rollout_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    platform = _FakePlatform([{"status": "completed", "reward": 1.0}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+    task = Task(
+        env="sums",
+        id="add",
+        agent_config={"timeout_seconds": 5_000},
+    )
+
+    with pytest.raises(ValueError, match=r"agent timeout \(5000s\).+rollout_timeout \(3600s\)"):
+        await HostedRuntime().run(
+            task,
+            _agent(),
+            job_id=uuid.uuid4().hex,
+            rollout_timeout=3_600,
+        )
+
+    assert platform.posts == []
+
+
+@pytest.mark.asyncio
+async def test_agent_timeout_must_fit_provider_runtime_timeout() -> None:
+    task = Task(
+        env="sums",
+        id="add",
+        agent_config={"timeout_seconds": 900},
+    )
+    runtime = ModalRuntime(runtime_config=RuntimeConfig(limits=RuntimeLimits(run_timeout_s=600)))
+
+    with pytest.raises(ValueError, match=r"agent timeout \(900s\).+run_timeout_s \(600s\)"):
+        await Taskset("sums", [task]).run(
+            _agent(),
+            runtime=runtime,
+            rollout_timeout=1_200,
+        )
+
+
+def test_task_runtime_timeout_overrides_provider_runtime_timeout() -> None:
+    runtime = ModalRuntime(runtime_config=RuntimeConfig(limits=RuntimeLimits(run_timeout_s=600)))
+    task = Task(
+        env="sums",
+        id="add",
+        runtime_config=RuntimeConfig(limits=RuntimeLimits(run_timeout_s=1_000)),
+    )
+
+    config = resolve_runtime_config(runtime, task)
+
+    assert config is not None
+    assert config.limits == RuntimeLimits(run_timeout_s=1_000)
+
+
+@pytest.mark.asyncio
+async def test_provider_startup_timeout_must_fit_rollout_timeout() -> None:
+    task = Task(
+        env="sums",
+        id="add",
+        agent_config={"timeout_seconds": 30},
+    )
+    runtime = ModalRuntime(
+        runtime_config=RuntimeConfig(limits=RuntimeLimits(startup_timeout_s=600))
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"actor runtime_config\.limits\.startup_timeout_s \(600s\)",
+    ):
+        await Taskset("sums", [task]).run(
+            _agent(),
+            runtime=runtime,
+            rollout_timeout=600,
+        )
+
+
+@pytest.mark.asyncio
+async def test_rollout_timeout_validates_separable_verifier_limits() -> None:
+    task = Task(
+        env="actor",
+        id="solve",
+        verifier=Task(
+            env="judge",
+            id="verify",
+            runtime_config=RuntimeConfig(limits=RuntimeLimits(startup_timeout_s=90)),
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"verifier runtime_config\.limits\.startup_timeout_s \(90s\)",
+    ):
+        await Taskset("separable", [task]).run(
+            _agent(),
+            runtime=Runtime("tcp://127.0.0.1:1"),
+            rollout_timeout=90,
+        )
 
 
 @pytest.mark.asyncio
@@ -358,10 +571,11 @@ async def test_submit_timeout_requests_platform_cancel(monkeypatch: pytest.Monke
         "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
     )
 
-    run = await HostedRuntime(run_timeout=0.001).run(
+    run = await HostedRuntime().run(
         Task(env="sums", id="add"),
         _agent(),
         job_id=uuid.uuid4().hex,
+        rollout_timeout=0.001,
     )
     await asyncio.sleep(0)
 
@@ -454,7 +668,6 @@ async def test_run_folds_ungraded_cancellation_as_an_error(
 async def test_scheduler_drives_provider_locally(monkeypatch: pytest.MonkeyPatch) -> None:
     """A Provider placement goes through the local rollout atom, not HostedRuntime."""
     import hud.eval.taskset as taskset_mod
-    from hud.eval.taskset import Taskset
 
     seen: dict[str, Any] = {}
 
@@ -478,8 +691,6 @@ async def test_scheduler_drives_provider_locally(monkeypatch: pytest.MonkeyPatch
 @pytest.mark.asyncio
 async def test_scheduler_delegates_hosted(monkeypatch: pytest.MonkeyPatch) -> None:
     """A HostedRuntime placement is delegated to via HostedRuntime.run, not the local atom."""
-    from hud.eval.taskset import Taskset
-
     seen: dict[str, Any] = {}
 
     class _RecordingHostedRuntime(HostedRuntime):
@@ -490,11 +701,12 @@ async def test_scheduler_delegates_hosted(monkeypatch: pytest.MonkeyPatch) -> No
             return run
 
     job = await Taskset("t", [Task(env="e", id="x")]).run(
-        _agent(), runtime=_RecordingHostedRuntime()
+        _agent(), runtime=_RecordingHostedRuntime(), rollout_timeout=90.0
     )
 
     assert len(job.runs) == 1
     assert "job_id" in seen and "group_id" in seen
+    assert seen["rollout_timeout"] == 90.0
 
 
 @pytest.mark.asyncio
@@ -509,7 +721,7 @@ async def test_hud_runtime_drives_local_rollout(monkeypatch: pytest.MonkeyPatch)
 
     monkeypatch.setattr("hud.eval.runtime.hud.rollout", fake_rollout)
 
-    runtime = HUDRuntime(run_timeout=90.0)
+    runtime = HUDRuntime()
     job_id = uuid.uuid4().hex
     trace_id = uuid.uuid4().hex
     run = await runtime.run(
@@ -518,6 +730,7 @@ async def test_hud_runtime_drives_local_rollout(monkeypatch: pytest.MonkeyPatch)
         job_id=job_id,
         group_id="g1",
         trace_id=trace_id,
+        rollout_timeout=90.0,
     )
 
     assert run.trace.status == "completed"
@@ -683,7 +896,8 @@ async def test_runtime_session_sets_runtime_connection_params(
     monkeypatch.setattr(HUDRuntime, "_create_runtime_session", fake_create_runtime_session)
     monkeypatch.setattr(HUDRuntime, "_delete_runtime_session", fake_delete_runtime_session)
 
-    cloud = HUDRuntime(runtime_url="https://mcp.hud.ai/", run_timeout=600.0)
+    with pytest.warns(DeprecationWarning, match="rollout_timeout"):
+        cloud = HUDRuntime(runtime_url="https://mcp.hud.ai/", run_timeout=30.0)
     async with cloud._runtime_session(Task(env="e", id="x")) as runtime:
         assert runtime.url == "tcp://127.0.0.1:4321"
         assert runtime.params == {

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -330,7 +330,7 @@ async def test_platform_taskset_defaults_to_hud_runtime(monkeypatch: pytest.Monk
     (run,) = job.runs
     assert run.trace.status == "completed"
     assert isinstance(seen["runtime"], HUDRuntime)
-    assert seen["rollout_timeout"] == 3600.0
+    assert seen["rollout_timeout"] is None
 
 
 # ─── taskset collection ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- make `rollout_timeout` the canonical optional SDK deadline across local, HUD, and hosted placements
- deprecate `HostedRuntime.run_timeout` and `HUDRuntime.run_timeout` as constructor aliases, removing the hidden one-hour SDK cap when neither is supplied
- fail fast when an explicit agent, actor, or separable-verifier timeout cannot fit inside its known containing deadline
- document the distinction between rollout, environment, agent, grader, provider, and platform limits

## Root cause

`HostedRuntime()` and `HUDRuntime()` silently supplied a 3600-second outer timeout. A longer `RuntimeLimits.run_timeout_s` therefore could not produce a longer rollout even though it configured a different boundary: the provisioned environment lifetime.

## Behavior

When `rollout_timeout` is omitted, the SDK adds no overall rollout deadline. Explicit phase limits and provider/platform limits still apply. When it is provided, known inner limits must be strictly shorter.

## Validation

- `uv run --extra dev pytest -q hud/eval/tests/test_hosted.py hud/eval/tests/test_task.py hud/eval/tests/test_rollout.py` — 99 passed
- `uv run --extra dev ruff format . --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev --extra train --extra modal --extra daytona ty check`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default timeout behavior for HUD/hosted runs (no implicit 3600s), which can lengthen rollouts or expose misconfigured limits; validation fails fast instead of silent truncation.
> 
> **Overview**
> **Makes `rollout_timeout` on `Task.run` / `Taskset.run` the optional SDK-wide deadline** for local provider rollouts, `HUDRuntime`, and `HostedRuntime`. Omitting it no longer applies a hidden one-hour cap from `HUDRuntime()` / `HostedRuntime()` constructors.
> 
> **Deprecates** `run_timeout` on `HUDRuntime` and `HostedRuntime` (warns and treats it as a fallback when `rollout_timeout` is unset). **`validate_rollout_timeouts`** runs before execution and rejects contradictory limits: agent timeout must be below actor `run_timeout_s` and below `rollout_timeout` when set; actor and separable verifier `startup_timeout_s` / `run_timeout_s` must be strictly below `rollout_timeout`.
> 
> **`resolve_runtime_config`** merges provider and per-task `runtime_config` so validation matches effective placement limits. **`rollout`** and docs clarify that `rollout_timeout` bounds through grading (cleanup may continue in the background) and that `run_timeout_s` bounds provisioned environment lifetime, not the full rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd51368b9907911e048f508c99d186add9c9a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->