### PR TITLE
fix(runtime): support hosted verifier placement

### DIFF
--- a/hud/eval/runtime/core.py
+++ b/hud/eval/runtime/core.py
@@ -9,7 +9,14 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager, nullcon
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, Self, runtime_checkable
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializationInfo,
+    field_serializer,
+    model_validator,
+)
 
 from .compose import ComposeProject
 
@@ -89,6 +96,21 @@ class RuntimeConfig(BaseModel):
     compose: ComposeProject | None = None
     resources: RuntimeResources | None = None
     limits: RuntimeLimits | None = None
+
+    @field_serializer("resources", "limits", when_used="json")
+    def _serialize_options(
+        self,
+        value: RuntimeResources | RuntimeLimits | None,
+        info: SerializationInfo,
+    ) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        return value.model_dump(
+            mode=info.mode,
+            exclude_none=True,
+            exclude_unset=True,
+            context=info.context,
+        )
 
     @model_validator(mode="after")
     def validate_source(self) -> Self:

--- a/hud/eval/runtime/core.py
+++ b/hud/eval/runtime/core.py
@@ -202,10 +202,11 @@ class Runtime:
 class Shared:
     """Lease provider: at most ``width`` rollouts share each task placement.
 
-    Each environment and runtime configuration boots lazily on its first lease
-    and lives for the enclosing ``async with`` scope. ``width`` is a substrate's
-    capacity (e.g. a vectorized sim's slot count): lease ``width + 1`` waits
-    for a slot instead of erroring, so the scheduler needs no pairing —
+    Each environment and runtime configuration boots lazily on its first lease.
+    It lives for the enclosing ``async with`` scope unless its run timeout
+    expires, in which case the next lease boots a fresh substrate. ``width`` is
+    a substrate's capacity (e.g. a vectorized sim's slot count): an excess lease
+    waits for a slot instead of erroring, so the scheduler needs no pairing —
     ``group`` and ``max_concurrent`` keep their ordinary meanings.
 
     ``Taskset.run`` scopes a context-manager placement to the call, so
@@ -224,7 +225,8 @@ class Shared:
         self._boot = asyncio.Lock()
         self._semaphores: dict[tuple[str, str], asyncio.Semaphore] = {}
         self._addresses: dict[tuple[str, str], Runtime] = {}
-        self._stack: contextlib.AsyncExitStack | None = None
+        self._contexts: dict[tuple[str, str], contextlib.AsyncExitStack] = {}
+        self._deadlines: dict[tuple[str, str], float] = {}
         self._opens = 0
 
     async def __aenter__(self) -> Self:
@@ -233,10 +235,14 @@ class Shared:
 
     async def __aexit__(self, *exc: object) -> None:
         self._opens -= 1
-        if self._opens == 0 and self._stack is not None:
-            stack, self._stack = self._stack, None
+        if self._opens == 0:
+            contexts, self._contexts = self._contexts, {}
             self._addresses.clear()
+            self._deadlines.clear()
             self._semaphores.clear()
+            stack = contextlib.AsyncExitStack()
+            for context in contexts.values():
+                stack.push_async_callback(context.aclose)
             await stack.aclose()
 
     @asynccontextmanager
@@ -259,12 +265,26 @@ class Shared:
         semaphore = self._semaphores.setdefault(key, asyncio.Semaphore(self.width))
         async with semaphore:
             async with self._boot:
+                deadline = self._deadlines.get(key)
+                if deadline is not None and deadline <= asyncio.get_running_loop().time():
+                    self._addresses.pop(key)
+                    self._deadlines.pop(key)
+                    await self._contexts.pop(key).aclose()
                 if key not in self._addresses:
                     # First leaseholder boots. A failed boot fails only its own
-                    # rollout (nothing entered the stack); the next lease retries.
-                    if self._stack is None:
-                        self._stack = contextlib.AsyncExitStack()
-                    self._addresses[key] = await self._stack.enter_async_context(self.inner(task))
+                    # rollout (nothing is retained); the next lease retries.
+                    config = resolve_runtime_config(self.inner, task)
+                    run_timeout = (
+                        config.limits.run_timeout_s
+                        if config is not None and config.limits is not None
+                        else None
+                    )
+                    context = contextlib.AsyncExitStack()
+                    address = await context.enter_async_context(self.inner(task))
+                    self._contexts[key] = context
+                    self._addresses[key] = address
+                    if run_timeout is not None:
+                        self._deadlines[key] = asyncio.get_running_loop().time() + run_timeout
                 addr = self._addresses[key]
             yield addr
 

--- a/hud/eval/runtime/docker.py
+++ b/hud/eval/runtime/docker.py
@@ -110,9 +110,8 @@ class DockerRuntime:
     @asynccontextmanager
     async def __call__(self, task: Task) -> AsyncIterator[Runtime]:
         config = (self.runtime_config or RuntimeConfig()).with_overrides(task.runtime_config)
-        if config.limits is not None and config.limits.run_timeout_s is not None:
-            raise ValueError("DockerRuntime does not support runtime_config.limits.run_timeout_s")
         startup_timeout = config.limits.startup_timeout_s if config.limits is not None else None
+        run_timeout = config.limits.run_timeout_s if config.limits is not None else None
         params = {"ready_timeout": startup_timeout} if startup_timeout is not None else {}
         resources = config.resources
         if resources is not None:
@@ -210,12 +209,13 @@ class DockerRuntime:
                         )
                     host_port = int(mapping.strip().splitlines()[0].rsplit(":", 1)[1])
                     container, _ = await _docker(*command, "ps", "--quiet", "main")
-                    yield _DockerEndpoint(
-                        f"tcp://127.0.0.1:{host_port}",
-                        params=params,
-                        config=config if config.model_dump(exclude_none=True) else None,
-                        container=container.strip(),
-                    )
+                    async with asyncio.timeout(run_timeout):
+                        yield _DockerEndpoint(
+                            f"tcp://127.0.0.1:{host_port}",
+                            params=params,
+                            config=config if config.model_dump(exclude_none=True) else None,
+                            container=container.strip(),
+                        )
                 finally:
                     await _docker(
                         *command,
@@ -275,12 +275,13 @@ class DockerRuntime:
                     f"{self.port}:\n{(logs_err or logs_out).strip()}",
                 )
             host_port = int(mapping.strip().splitlines()[0].rsplit(":", 1)[1])
-            yield _DockerEndpoint(
-                f"tcp://127.0.0.1:{host_port}",
-                params=params,
-                config=config,
-                container=container,
-            )
+            async with asyncio.timeout(run_timeout):
+                yield _DockerEndpoint(
+                    f"tcp://127.0.0.1:{host_port}",
+                    params=params,
+                    config=config,
+                    container=container,
+                )
         finally:
             # check=False: teardown must not shadow the run's own error, and
             # rm -f only fails when the daemon itself is broken.

--- a/hud/eval/runtime/docker.py
+++ b/hud/eval/runtime/docker.py
@@ -77,6 +77,27 @@ async def _prepare_compose_project(compose: Path, max_wait: float | None) -> boo
     return True
 
 
+@asynccontextmanager
+async def _docker_deadline(
+    seconds: float | None,
+    teardown: tuple[str, ...],
+) -> AsyncIterator[None]:
+    if seconds is None:
+        yield
+        return
+
+    async def expire() -> None:
+        await asyncio.sleep(seconds)
+        await _docker(*teardown, check=False)
+
+    expiry = asyncio.create_task(expire())
+    try:
+        yield
+    finally:
+        expiry.cancel()
+        await asyncio.gather(expiry, return_exceptions=True)
+
+
 class DockerRuntime:
     """Start a HUD environment from an image or a Docker Compose file.
 
@@ -183,6 +204,7 @@ class DockerRuntime:
                     "--file",
                     str(files.ports),
                 )
+                teardown = (*command, "down", "--volumes", "--remove-orphans")
                 try:
                     await _docker(
                         *command,
@@ -209,7 +231,7 @@ class DockerRuntime:
                         )
                     host_port = int(mapping.strip().splitlines()[0].rsplit(":", 1)[1])
                     container, _ = await _docker(*command, "ps", "--quiet", "main")
-                    async with asyncio.timeout(run_timeout):
+                    async with _docker_deadline(run_timeout, teardown):
                         yield _DockerEndpoint(
                             f"tcp://127.0.0.1:{host_port}",
                             params=params,
@@ -217,13 +239,7 @@ class DockerRuntime:
                             container=container.strip(),
                         )
                 finally:
-                    await _docker(
-                        *command,
-                        "down",
-                        "--volumes",
-                        "--remove-orphans",
-                        check=False,
-                    )
+                    await _docker(*teardown, check=False)
             return
         if config.image is None:
             raise ValueError(
@@ -263,6 +279,7 @@ class DockerRuntime:
             deadline=startup_timeout,
         )
         container = out.strip()
+        teardown = ("rm", "--force", container)
         try:
             if resources is not None and resources.storage_mb is not None:
                 free_disk, _ = await _docker("exec", container, "df", "-Pk", "/")
@@ -275,7 +292,7 @@ class DockerRuntime:
                     f"{self.port}:\n{(logs_err or logs_out).strip()}",
                 )
             host_port = int(mapping.strip().splitlines()[0].rsplit(":", 1)[1])
-            async with asyncio.timeout(run_timeout):
+            async with _docker_deadline(run_timeout, teardown):
                 yield _DockerEndpoint(
                     f"tcp://127.0.0.1:{host_port}",
                     params=params,
@@ -285,7 +302,7 @@ class DockerRuntime:
         finally:
             # check=False: teardown must not shadow the run's own error, and
             # rm -f only fails when the daemon itself is broken.
-            await _docker("rm", "--force", container, check=False)
+            await _docker(*teardown, check=False)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)

--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -81,11 +81,6 @@ class HostedRuntime:
             ),
         )
         try:
-            if task.verifier is not None and task.verifier.env != task.env:
-                raise ValueError(
-                    "hosted verifier tasks must use the actor environment: verifier.env must "
-                    "match task.env"
-                )
             if timeout is None:
                 state = await self._submit_and_await(
                     task, agent, job_id=job_id, group_id=group_id, trace_id=trace_id

--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -81,12 +81,10 @@ class HostedRuntime:
             ),
         )
         try:
-            if task.verifier is not None and (
-                task.verifier.env != task.env or task.verifier.runtime_config is not None
-            ):
+            if task.verifier is not None and task.verifier.env != task.env:
                 raise ValueError(
-                    "hosted verifier tasks must reuse the actor runtime: verifier.env must "
-                    "match task.env and verifier.runtime_config must be omitted"
+                    "hosted verifier tasks must use the actor environment: verifier.env must "
+                    "match task.env"
                 )
             if timeout is None:
                 state = await self._submit_and_await(

--- a/hud/eval/task.py
+++ b/hud/eval/task.py
@@ -84,7 +84,11 @@ class Task(BaseModel):
         info: SerializationInfo,
     ) -> dict[str, Any] | None:
         return (
-            config.model_dump(mode=info.mode, exclude_unset=True, context=info.context)
+            config.model_dump(
+                mode=info.mode,
+                exclude_unset=True,
+                context=info.context,
+            )
             if config is not None
             else None
         )

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -15,7 +15,6 @@ import logging
 import os
 import sys
 import tarfile
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -32,6 +31,7 @@ from hud.eval.runtime import (
     RuntimeGPU,
     RuntimeLimits,
     RuntimeResources,
+    Shared,
 )
 from hud.eval.runtime.compose import (
     ComposeConfig,
@@ -1720,24 +1720,53 @@ async def test_docker_honors_startup_timeout(
     assert calls[0][1]["deadline"] == 300
 
 
-async def test_docker_honors_run_timeout(
-    tmp_path: Path, docker_log: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize("compose", [False, True])
+async def test_docker_run_timeout_owns_shared_substrate_lifetime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    compose: bool,
 ) -> None:
-    _install_fake_docker(tmp_path, port_behavior="echo 127.0.0.1:43210", monkeypatch=monkeypatch)
-    config = RuntimeConfig(image="img:tag", limits=RuntimeLimits(run_timeout_s=300))
-    timeouts: list[float | None] = []
+    torn_down = asyncio.Event()
+    teardown_calls: list[tuple[str, ...]] = []
+    provisions = 0
 
-    @asynccontextmanager
-    async def timeout(delay: float | None):
-        timeouts.append(delay)
-        yield
+    async def fake_docker(*args: str, **kwargs: Any) -> tuple[str, str]:
+        nonlocal provisions
+        if args[0] == "run":
+            provisions += 1
+            return "cid-42\n", ""
+        if "up" in args:
+            provisions += 1
+        if args[0] == "port" or args[-3:] == ("port", "main", "8765"):
+            return "127.0.0.1:43210\n", ""
+        if args[-3:] == ("ps", "--quiet", "main"):
+            return "cid-42\n", ""
+        if args[:2] == ("rm", "--force") or "down" in args:
+            teardown_calls.append(args)
+            torn_down.set()
+        return "", ""
 
-    monkeypatch.setattr(runtime_module.asyncio, "timeout", timeout)
+    monkeypatch.setattr(runtime_module, "_docker", fake_docker)
 
-    async with DockerRuntime(runtime_config=config)(_row()):
-        pass
+    limits = RuntimeLimits(run_timeout_s=1)
+    if compose:
+        compose_file = tmp_path / "compose.yaml"
+        compose_file.write_text("services:\n  main:\n    image: img:tag\n")
+        source = RuntimeConfig(compose=ComposeProject(document=compose_file), limits=limits)
+    else:
+        source = RuntimeConfig(image="img:tag", limits=limits)
 
-    assert timeouts == [300]
+    async with Shared(DockerRuntime(runtime_config=source), width=2) as runtime:
+        async with runtime(_row()):
+            pass
+        async with runtime(_row()):
+            await asyncio.wait_for(torn_down.wait(), 2)
+        async with runtime(_row()):
+            pass
+
+    assert teardown_calls
+    assert provisions == 2
 
 
 async def test_daytona_names_a_sandbox_it_could_not_delete(

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sys
 import tarfile
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -671,7 +672,7 @@ def test_runtime_config_source_override_is_mutually_exclusive(tmp_path: Path) ->
     ) == RuntimeConfig(compose=ComposeProject(document=replacement))
 
 
-async def test_runtime_config_rejects_unsupported_docker_fields() -> None:
+async def test_runtime_config_rejects_typed_docker_gpu() -> None:
     with pytest.raises(ValueError, match="GPU"):
         async with DockerRuntime()(
             Task(
@@ -680,19 +681,6 @@ async def test_runtime_config_rejects_unsupported_docker_fields() -> None:
                 runtime_config=RuntimeConfig(
                     image="img",
                     resources=RuntimeResources(gpu=RuntimeGPU(type="L40S")),
-                ),
-            )
-        ):
-            pass
-
-    with pytest.raises(ValueError, match="limits"):
-        async with DockerRuntime()(
-            Task(
-                env="any-env",
-                id="t",
-                runtime_config=RuntimeConfig(
-                    image="img",
-                    limits=RuntimeLimits(run_timeout_s=60),
                 ),
             )
         ):
@@ -1732,15 +1720,24 @@ async def test_docker_honors_startup_timeout(
     assert calls[0][1]["deadline"] == 300
 
 
-async def test_docker_rejects_run_timeout(
+async def test_docker_honors_run_timeout(
     tmp_path: Path, docker_log: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _install_fake_docker(tmp_path, port_behavior="echo 127.0.0.1:43210", monkeypatch=monkeypatch)
     config = RuntimeConfig(image="img:tag", limits=RuntimeLimits(run_timeout_s=300))
+    timeouts: list[float | None] = []
 
-    with pytest.raises(ValueError, match=r"runtime_config\.limits\.run_timeout_s"):
-        async with DockerRuntime(runtime_config=config)(_row()):
-            pass
+    @asynccontextmanager
+    async def timeout(delay: float | None):
+        timeouts.append(delay)
+        yield
+
+    monkeypatch.setattr(runtime_module.asyncio, "timeout", timeout)
+
+    async with DockerRuntime(runtime_config=config)(_row()):
+        pass
+
+    assert timeouts == [300]
 
 
 async def test_daytona_names_a_sandbox_it_could_not_delete(

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -180,30 +180,19 @@ async def test_run_rejects_non_gateway_agent() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "verifier",
-    [
-        Task(env="judge", id="verify"),
-        Task(
-            env="actor",
-            id="verify",
-            runtime_config=RuntimeConfig(image="judge:latest"),
-        ),
-    ],
-)
-async def test_run_rejects_verifier_that_requires_another_runtime(verifier: Task) -> None:
+async def test_run_rejects_verifier_from_another_environment() -> None:
     run = await HostedRuntime(poll_interval=0.0).run(
         Task(
             env="actor",
             id="solve",
-            verifier=verifier,
+            verifier=Task(env="judge", id="verify"),
         ),
         _agent(),
         job_id="j",
     )
 
     assert run.trace.is_error
-    assert "must reuse the actor runtime" in (run.trace.error or "")
+    assert "must use the actor environment" in (run.trace.error or "")
 
 
 @pytest.mark.asyncio
@@ -237,6 +226,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
             env="sums",
             id="verify",
             args={"expected": 3},
+            runtime_config=RuntimeConfig(resources=RuntimeResources(memory_mb=4096)),
         ),
     )
 
@@ -267,6 +257,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
         "id": "verify",
         "args": {"expected": 3},
         "slug": "verify-5579a3e5",
+        "runtime_config": {"resources": {"memory_mb": 4096}},
     }
     assert payload["group_id"] == "g1"
     assert payload["agent"]["type"] == "openai_compatible"

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -180,22 +180,6 @@ async def test_run_rejects_non_gateway_agent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_rejects_verifier_from_another_environment() -> None:
-    run = await HostedRuntime(poll_interval=0.0).run(
-        Task(
-            env="actor",
-            id="solve",
-            verifier=Task(env="judge", id="verify"),
-        ),
-        _agent(),
-        job_id="j",
-    )
-
-    assert run.trace.is_error
-    assert "must use the actor environment" in (run.trace.error or "")
-
-
-@pytest.mark.asyncio
 async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch) -> None:
     platform = _FakePlatform(
         [
@@ -223,7 +207,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
             limits=RuntimeLimits(startup_timeout_s=120, run_timeout_s=900),
         ),
         verifier=Task(
-            env="sums",
+            env="judge",
             id="verify",
             args={"expected": 3},
             runtime_config=RuntimeConfig(resources=RuntimeResources(memory_mb=4096)),
@@ -253,7 +237,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
         "limits": {"startup_timeout_s": 120, "run_timeout_s": 900},
     }
     assert payload["verifier"] == {
-        "env": "sums",
+        "env": "judge",
         "id": "verify",
         "args": {"expected": 3},
         "slug": "verify-5579a3e5",

--- a/hud/eval/tests/test_task.py
+++ b/hud/eval/tests/test_task.py
@@ -203,6 +203,27 @@ def test_runtime_config_rejects_unknown_fields() -> None:
         RuntimeConfig.model_validate({"image": "img:tag", "provider_config": {}})
 
 
+def test_runtime_config_omits_null_resource_fields() -> None:
+    task = Task(
+        env="database",
+        id="cutover",
+        runtime_config=RuntimeConfig(
+            resources=RuntimeResources(
+                cpu=1,
+                memory_mb=None,
+                storage_mb=None,
+                gpu=None,
+                os=None,
+                tpu=None,
+            ),
+        ),
+    )
+
+    assert task.model_dump(mode="json", exclude_none=True)["runtime_config"] == {
+        "resources": {"cpu": 1.0}
+    }
+
+
 def test_compose_runtime_config_serializes_by_task_dump_mode(tmp_path: Path) -> None:
     compose = tmp_path / "compose.json"
     compose.write_text(

--- a/hud/integrations/harbor/adapt.py
+++ b/hud/integrations/harbor/adapt.py
@@ -1083,6 +1083,10 @@ fi
             needs_service_access = any(
                 item.service != "main" for item in (*config.verifier.collect, *config.artifacts)
             ) or bool(healthy_services)
+            runtime_limits = _runtime_limits(config.environment)
+            verifier_uses_actor = (
+                verifier_resources == task.resources and verifier_limits == runtime_limits
+            )
             columns = dict(config.metadata)
             if config.task.keywords:
                 columns.setdefault("keywords", config.task.keywords)
@@ -1107,7 +1111,7 @@ fi
                         service_access=(True if needs_service_access else None),
                     ),
                     resources=task.resources,
-                    limits=_runtime_limits(config.environment),
+                    limits=runtime_limits,
                 ),
                 verifier=(
                     Task(
@@ -1124,7 +1128,8 @@ fi
                                 resources=verifier_resources,
                                 limits=verifier_limits,
                             )
-                            if verifier_resources is not None or verifier_limits is not None
+                            if not verifier_uses_actor
+                            and (verifier_resources is not None or verifier_limits is not None)
                             else None
                         ),
                     )

--- a/hud/integrations/harbor/adapt.py
+++ b/hud/integrations/harbor/adapt.py
@@ -676,6 +676,7 @@ def adapt(
         (payload / "packages").mkdir(parents=True)
         if compose is not None:
             (payload / "peer-image-configs").mkdir()
+            (payload / "peer-image-configs" / ".keep").touch()
         shutil.copy2(ASSETS / "install.sh", payload / "install.sh")
         if compose is not None:
             shutil.copy2(ASSETS / "Dockerfile", payload / "Dockerfile")

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -1307,5 +1307,6 @@ def test_completed_compose_dependencies_are_not_routed_as_peers(tmp_path: Path) 
     manifest = _environment_config(context)
     assert manifest["peers"] == []
     assert manifest["peer_image_configs"] == {}
+    assert (context / "compose-project" / "main" / "peer-image-configs" / ".keep").is_file()
     script = (context / "compose-project" / "build.sh").read_text("utf-8")
     assert script.count("inspect_peer") == 1

--- a/hud/integrations/harbor/tests/test_contract.py
+++ b/hud/integrations/harbor/tests/test_contract.py
@@ -1072,7 +1072,24 @@ def test_image_task_keeps_only_the_verifier_as_a_build_service(
         encoding="utf-8",
     )
     (task / "task.toml").write_text(
-        '[environment]\nbuild_timeout_sec = 300\n\n[verifier]\nenvironment_mode = "separate"\n',
+        """
+[environment]
+build_timeout_sec = 300
+cpus = 4
+memory_mb = 14336
+gpus = 1
+gpu_types = ["H100"]
+
+[verifier]
+environment_mode = "separate"
+
+[verifier.environment]
+build_timeout_sec = 300
+cpus = 4
+memory_mb = 14336
+gpus = 1
+gpu_types = ["H100"]
+""",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## What

- allow tasks to carry a distinct verifier environment and runtime configuration
- omit unset runtime resource and limit values from task transport
- enforce Docker run limits across shared image and Compose acquisitions
- preserve empty Harbor peer build contexts required by Compose
- omit redundant Harbor verifier placement when actor and verifier requirements match

## Why

Task transport should preserve meaningful actor/verifier differences without creating a second placement when their requirements are identical. Shared Docker acquisitions must also enforce provider lifetime limits without cancelling rollout tasks or returning expired endpoints.

## Validation

- `uv run pytest hud/eval/tests -q` (220 passed)
- `uv run pytest hud/integrations/harbor/tests -q` (70 passed, 17 deselected)
- `uv run --with=".[dev]" ruff format . --check`
- `uv run --with=".[dev]" ruff check .`
- `uv run --extra dev --extra train --extra modal --extra daytona ty check --error-on-warning`

## Uncertain

- None.