### PR TITLE
Test example images against the checkout SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,12 @@ jobs:
       - name: Install example with the SDK from this checkout
         working-directory: ${{ runner.temp }}/${{ matrix.template }}
         run: |
+          uv build --wheel --no-create-gitignore --out-dir .hud-sdk "$GITHUB_WORKSPACE"
+          uv add --no-sync .hud-sdk/hud-*.whl
           uv sync --all-extras
-          uv pip install -e "$GITHUB_WORKSPACE"
+          sed -i '/^RUN .*uv sync/i COPY .hud-sdk .hud-sdk' Dockerfile.hud
+          echo '!.hud-sdk/' >> .dockerignore
+          echo '!.hud-sdk/**' >> .dockerignore
 
       - name: Run example checks
         working-directory: ${{ runner.temp }}/${{ matrix.template }}


### PR DESCRIPTION
## Summary
- build a wheel from the checked-out SDK for each generated example
- resolve the example against that relative wheel instead of replacing the host environment afterward
- include the wheel in the temporary Docker context so image startup exercises the PR SDK

Stacked on #604.

## Validation
- built blank, coding, and CUA images from generated contexts
- confirmed all three images installed HUD 0.6.13 from the generated wheel
- 13 focused init tests passed