### PR TITLE
fix(cli): preserve taskset_id when eval narrows a platform taskset

### DIFF
--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -813,22 +813,18 @@ async def _run_evaluation(cfg: EvalConfig) -> Any:
 
     if cfg.task_ids:
         wanted = set(cfg.task_ids)
-        taskset = Taskset(
-            taskset.name,
-            (
-                task
-                for index, (slug, task) in enumerate(taskset.items())
-                if slug in wanted or task.id in wanted or str(index) in wanted
-            ),
+        taskset = taskset.filter(
+            slug
+            for index, (slug, task) in enumerate(taskset.items())
+            if slug in wanted or task.id in wanted or str(index) in wanted
         )
         if not taskset:
             hud_console.error(f"No tasks matching: {', '.join(cfg.task_ids)}")
             raise typer.Exit(1)
         hud_console.info(f"Filtered to {len(taskset)} task(s)")
     elif not cfg.all:
-        tasks = list(taskset)
-        total = len(tasks)
-        taskset = Taskset(taskset.name, [tasks[0]])
+        total = len(taskset)
+        taskset = taskset.filter([next(iter(taskset.tasks))])
         if total > 1:
             hud_console.warning(
                 f"Running only 1 of {total} tasks (the first). "


### PR DESCRIPTION
## Summary

- `hud eval` loads a platform taskset via `Taskset.from_api`, which carries `taskset_id`, but both task-selection paths (`--task-ids` filtering and the default first-task truncation) rebuilt the `Taskset` through its constructor and dropped the id.
- The job then registered at job-enter with `taskset_id=null`, so the platform never resolved traces to the taskset's task versions — the job and its traces ended up unlinked from the taskset (invisible on the taskset's jobs page and excluded from coverage/overview aggregation).
- Route both paths through `Taskset.filter`, which already preserves `taskset_id`.

## Test plan

- [x] `ruff format --check` and `ruff check` on the changed file
- [x] `ty check` (only pre-existing optional-dependency diagnostics: daytona/modal)
- [x] `pytest hud/cli/tests/test_eval_config.py hud/eval/tests/test_task.py hud/eval/tests/test_job.py` — 69 passed