### PR TITLE
Fix web links for OpenTelemetry trace IDs

### DIFF
--- a/hud/cli/tests/test_trace.py
+++ b/hud/cli/tests/test_trace.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from hud.cli import trace
+from hud.settings import settings
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_trace_link_uses_web_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
+    trace_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
+    monkeypatch.setattr(settings, "api_key", "test-key")
+    monkeypatch.setattr(
+        trace,
+        "_load_remote",
+        lambda _: [{"kind": "agent_message", "text": "done"}],
+    )
+
+    result = CliRunner().invoke(trace.trace_app, [trace_id])
+
+    assert result.exit_code == 0
+    assert "https://hud.ai/trace/03dd2a73-d3df-4d10-a54a-e3d87c2d530d" in result.stdout

--- a/hud/cli/trace.py
+++ b/hud/cli/trace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import uuid
 from typing import Any
 
 import typer
@@ -77,7 +78,7 @@ def trace_command(
     _render_events(events)
 
     web = settings.hud_web_url.rstrip("/")
-    console.print(f"\n[dim]View: {web}/trace/{trace_id}[/dim]")
+    console.print(f"\n[dim]View: {web}/trace/{uuid.UUID(otel_id)}[/dim]")
 
 
 # ── local JSONL ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- format normalized OpenTelemetry trace IDs as UUIDs in hud trace web links
- add a regression test for 32-hex trace IDs

## Validation
- uv run --extra dev pytest -q hud/cli/tests (118 passed)
- uv run ruff check .
- uv run ruff format . --check
- uv run --extra dev --extra train --extra modal --extra daytona ty check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI output-formatting change plus a unit test; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes `hud trace` web links so 32-hex OpenTelemetry IDs are printed as hyphenated UUIDs (`uuid.UUID(otel_id)`), matching the `/trace/{uuid}` URL the site expects.
> 
> Adds a CLI regression test that stubs remote load and asserts the formatted `hud.ai/trace/...` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ff8abb79530908b25f37487f8ab2643a91bc63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->