### PR TITLE
feat(agents): add configurable tool timeouts

### DIFF
--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -65,8 +65,16 @@ Each config lives in `hud.agents.types`. `OpenAIChatAgent` speaks the OpenAI Cha
 points at any compatible server (vLLM, a local model) via `base_url`; `ClaudeSDKAgent` runs the `claude`
 CLI over an `ssh` capability, against the env's filesystem. SSH-only runs support POSIX and Windows
 workspaces; computer use over an `rfb` capability currently requires a POSIX workspace. Every knob
-(`model`, `max_steps`, `timeout_seconds`, `system_prompt`, `citations_enabled`, `stop_on`) lives on the
+(`model`, `max_steps`, `timeout_seconds`, `tool_timeout_seconds`, `system_prompt`, `citations_enabled`, `stop_on`) lives on the
 config; `__call__(run)` takes only the run.
+
+`timeout_seconds` bounds the complete agent phase. For provider tool agents, `tool_timeout_seconds` is an optional default for each SSH-backed tool or file operation; it is unset by default, and an operation-specific timeout takes precedence. `ClaudeSDKAgent` does not apply this setting because its SSH process is the complete Claude Code agent, not one tool call.
+
+```python
+agent = OpenAIChatAgent(
+    OpenAIChatConfig(tool_timeout_seconds=30 * 60)
+)
+```
 
 ## create_agent {#create-agent}
 

--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -68,7 +68,7 @@ workspaces; computer use over an `rfb` capability currently requires a POSIX wor
 (`model`, `max_steps`, `timeout_seconds`, `tool_timeout_seconds`, `system_prompt`, `citations_enabled`, `stop_on`) lives on the
 config; `__call__(run)` takes only the run.
 
-`timeout_seconds` bounds the complete agent phase. For provider tool agents, `tool_timeout_seconds` is an optional default for each SSH-backed tool or file operation; it is unset by default, and an operation-specific timeout takes precedence. `ClaudeSDKAgent` does not apply this setting because its SSH process is the complete Claude Code agent, not one tool call.
+`timeout_seconds` bounds the complete agent phase. For provider tool agents, `tool_timeout_seconds` bounds each complete SSH-backed tool call, including multi-operation editor calls. It is unset by default except on `ClaudeConfig`, where it defaults to 120 seconds. A timeout is returned to the model as a tool error so the agent can continue. `ClaudeSDKAgent` does not apply this setting because its SSH process is the complete Claude Code agent, not one tool call.
 
 ```python
 agent = OpenAIChatAgent(

--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -52,6 +52,12 @@ Capability.ssh(*, name="shell", url, user="agent", host_pubkey, client_key=None,
 
 The shell case is built in via [`Workspace`](#workspace), so you rarely call this factory directly. [`env.workspace(root)`](/v6/reference/environment#methods) starts a workspace, publishes its `ssh` capability, and stops it with the env.
 
+`SSHClient.connect(capability, default_timeout_s=None)` leaves operations unbounded by default. Set `default_timeout_s` to apply a client-owned deadline to commands and file operations; a timeout passed to an individual operation takes precedence:
+
+```python
+ssh = await SSHClient.connect(capability, default_timeout_s=30 * 60)
+```
+
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | `str` | Capability name. Default `"shell"`. |

--- a/docs/v6/reference/capabilities.mdx
+++ b/docs/v6/reference/capabilities.mdx
@@ -52,12 +52,6 @@ Capability.ssh(*, name="shell", url, user="agent", host_pubkey, client_key=None,
 
 The shell case is built in via [`Workspace`](#workspace), so you rarely call this factory directly. [`env.workspace(root)`](/v6/reference/environment#methods) starts a workspace, publishes its `ssh` capability, and stops it with the env.
 
-`SSHClient.connect(capability, default_timeout_s=None)` leaves operations unbounded by default. Set `default_timeout_s` to apply a client-owned deadline to commands and file operations; a timeout passed to an individual operation takes precedence:
-
-```python
-ssh = await SSHClient.connect(capability, default_timeout_s=30 * 60)
-```
-
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `name` | `str` | Capability name. Default `"shell"`. |

--- a/hud/agents/claude/tools/coding.py
+++ b/hud/agents/claude/tools/coding.py
@@ -48,9 +48,13 @@ class ClaudeBashTool(SSHTool):
 
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         if arguments.get("restart"):
-            # SSH session lives across calls; "restart" is a no-op for us.
             return MCPToolResult(
-                content=[mcp_types.TextContent(type="text", text="(restart acknowledged)")],
+                content=[
+                    mcp_types.TextContent(
+                        type="text",
+                        text="restart is unnecessary; each command runs in a fresh shell session",
+                    )
+                ],
             )
         command = arguments.get("command")
         if not command:

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -541,6 +541,9 @@ async def test_claude_bash_restart_is_a_noop() -> None:
     result = await tool.execute({"restart": True})
 
     assert result.isError is False
+    assert result_text(result) == (
+        "restart is unnecessary; each command runs in a fresh shell session"
+    )
     assert _commands(tool) == []  # restart never touches the shell
 
 

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -397,6 +397,22 @@ async def test_dispatch_marks_exhausted_ssh_reconnect_as_infrastructure_error() 
     assert isinstance(result, SSHInfrastructureErrorResult)
 
 
+async def test_dispatch_reraises_tool_timeout_before_deadline() -> None:
+    ssh = SimpleNamespace(run=AsyncMock(side_effect=TimeoutError("remote timed out")))
+    tool = ClaudeBashTool(
+        spec=ClaudeBashTool.default_spec("claude"),
+        client=cast("Any", ssh),
+    )
+    agent = DictAgent([], tool_timeout_seconds=120)
+    state: RunState[_Msg] = RunState(tools={"bash": tool})
+
+    with pytest.raises(TimeoutError, match="remote timed out"):
+        await agent._dispatch_call(
+            MCPToolCall(name="bash", arguments={"command": "sleep forever"}),
+            state,
+        )
+
+
 async def test_claude_bash_timeout_terminates_process_and_continues_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -6,19 +6,22 @@ scripted ``get_response`` so the loop, dispatch, and message formatting run offl
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import fastmcp
 import mcp.types as mcp_types
 import pytest
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
 
+from hud.agents.claude.agent import ClaudeAgent
+from hud.agents.claude.tools.coding import ClaudeBashTool, ClaudeTextEditorTool
 from hud.agents.openai.tools.coding import OpenAIShellTool
 from hud.agents.openai.tools.mcp_proxy import OpenAIMCPProxyTool
 from hud.agents.tool_agent import RunState, ToolAgent
-from hud.agents.tools.base import AgentToolSpec
+from hud.agents.tools.base import AgentToolSpec, result_text
 from hud.agents.tools.rfb import RFBTool
 from hud.agents.tools.ssh import SSHInfrastructureErrorResult
 from hud.agents.types import AgentConfig, AgentStep, ClaudeConfig, ClaudeSDKConfig, ToolStep
@@ -93,36 +96,14 @@ def test_claude_defaults_to_configurable_webp_screenshots() -> None:
         )
 
 
-async def test_agent_configures_ssh_client_tool_timeout() -> None:
-    capability = Capability.ssh(
-        name="shell",
-        url="ssh://workspace",
-        host_pubkey="key",
-    )
-    ssh = SSHClient(capability, cast("Any", object()))
+def test_only_claude_provider_has_a_default_tool_timeout() -> None:
+    config = ClaudeConfig(timeout_seconds=600)
 
-    class Client:
-        manifest = SimpleNamespace(bindings=[capability])
-
-        async def open(self, ref: str) -> CapabilityClient:
-            assert ref == "shell"
-            return ssh
-
-    class ShellAgent(DictAgent):
-        tool_catalog = (OpenAIShellTool,)
-
-    class LiveRun(_FakeRun):
-        def __init__(self) -> None:
-            super().__init__()
-            self.client = Client()
-            self.prompt_messages: list[Any] = []
-
-    await ShellAgent(
-        [AgentStep(content="done", done=True)],
-        tool_timeout_seconds=1800,
-    )(cast("Any", LiveRun()))
-
-    assert ssh.default_timeout_s == 1800
+    assert config.timeout_seconds == 600
+    assert config.tool_timeout_seconds == 120
+    assert ClaudeConfig(tool_timeout_seconds=None).tool_timeout_seconds is None
+    assert AgentConfig().tool_timeout_seconds is None
+    assert ClaudeSDKConfig().tool_timeout_seconds is None
 
 
 async def test_agent_passes_screenshot_encoding_to_rfb_tools() -> None:
@@ -414,6 +395,105 @@ async def test_dispatch_marks_exhausted_ssh_reconnect_as_infrastructure_error() 
 
     assert result.isError is True
     assert isinstance(result, SSHInfrastructureErrorResult)
+
+
+async def test_claude_bash_timeout_terminates_process_and_continues_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = asyncio.Event()
+
+    async def wait(*, check: bool, timeout: None) -> None:  # noqa: ASYNC109
+        del check, timeout
+        started.set()
+        await asyncio.Event().wait()
+
+    process = SimpleNamespace(
+        wait=AsyncMock(side_effect=wait),
+        terminate=Mock(),
+        close=Mock(side_effect=AssertionError("graceful termination should succeed")),
+        wait_closed=AsyncMock(),
+    )
+    connection = SimpleNamespace(
+        is_closed=Mock(return_value=False),
+        create_process=AsyncMock(return_value=process),
+    )
+    ssh = SSHClient(
+        Capability.ssh(url="ssh://workspace", host_pubkey="key"),
+        cast("Any", connection),
+    )
+    tool = ClaudeBashTool(spec=ClaudeBashTool.default_spec("claude"), client=ssh)
+    agent = ClaudeAgent(
+        ClaudeConfig(
+            model="claude-test",
+            model_client=cast("Any", object()),
+            tool_timeout_seconds=0.01,
+        )
+    )
+    responses = AsyncMock(
+        side_effect=[
+            AgentStep(
+                content="",
+                done=False,
+                tool_calls=[
+                    MCPToolCall(id="tool-1", name="bash", arguments={"command": "sleep forever"})
+                ],
+            ),
+            AgentStep(content="recovered", done=True),
+        ]
+    )
+    monkeypatch.setattr(agent, "get_response", responses)
+    state = RunState(messages=[], tools={"bash": tool})
+    run = cast("Run", _FakeRun())
+
+    await agent._loop(run, state, max_steps=3)
+
+    assert started.is_set()
+    process.terminate.assert_called_once_with()
+    process.wait_closed.assert_awaited_once_with()
+    assert responses.await_count == 2
+    assert run.trace.status == "completed"
+    assert run.trace.content == "recovered"
+    tool_result = cast("list[Any]", state.messages[0]["content"])[0]
+    error_block = cast("list[Any]", tool_result["content"])[0]
+    assert error_block["text"] == (
+        "Error: bash timed out after 0.01s; retry with a shorter command"
+    )
+
+
+async def test_composite_editor_uses_one_tool_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    deadline = Mock(wraps=asyncio.timeout)
+    monkeypatch.setattr(asyncio, "timeout", deadline)
+    ssh = SimpleNamespace(
+        read_text=AsyncMock(return_value="old"),
+        write_text=AsyncMock(),
+    )
+    tool = ClaudeTextEditorTool(
+        spec=ClaudeTextEditorTool.default_spec("claude"),
+        client=cast("Any", ssh),
+    )
+    agent = DictAgent([], tool_timeout_seconds=120)
+    state: RunState[_Msg] = RunState(tools={tool.provider_name: tool})
+
+    result = await agent._dispatch_call(
+        MCPToolCall(
+            name=tool.provider_name,
+            arguments={
+                "command": "str_replace",
+                "path": "/file.txt",
+                "old_str": "old",
+                "new_str": "new",
+            },
+        ),
+        state,
+    )
+
+    assert result.isError is False
+    assert result_text(result) == "wrote 3 bytes to /file.txt"
+    deadline.assert_called_once_with(120)
+    ssh.read_text.assert_awaited_once_with("/file.txt")
+    ssh.write_text.assert_awaited_once_with("/file.txt", "new")
 
 
 async def test_loop_finishes_on_done_response() -> None:

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -93,6 +93,38 @@ def test_claude_defaults_to_configurable_webp_screenshots() -> None:
         )
 
 
+async def test_agent_configures_ssh_client_tool_timeout() -> None:
+    capability = Capability.ssh(
+        name="shell",
+        url="ssh://workspace",
+        host_pubkey="key",
+    )
+    ssh = SSHClient(capability, cast("Any", object()))
+
+    class Client:
+        manifest = SimpleNamespace(bindings=[capability])
+
+        async def open(self, ref: str) -> CapabilityClient:
+            assert ref == "shell"
+            return ssh
+
+    class ShellAgent(DictAgent):
+        tool_catalog = (OpenAIShellTool,)
+
+    class LiveRun(_FakeRun):
+        def __init__(self) -> None:
+            super().__init__()
+            self.client = Client()
+            self.prompt_messages: list[Any] = []
+
+    await ShellAgent(
+        [AgentStep(content="done", done=True)],
+        tool_timeout_seconds=1800,
+    )(cast("Any", LiveRun()))
+
+    assert ssh.default_timeout_s == 1800
+
+
 async def test_agent_passes_screenshot_encoding_to_rfb_tools() -> None:
     class ScreenTool(RFBTool):
         name = "screen"

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -32,7 +32,7 @@ from hud.agents.tools.mcp import MCPTool
 from hud.agents.tools.rfb import RFBTool
 from hud.agents.tools.ssh import SSHInfrastructureErrorResult
 from hud.agents.types import AgentStep, ToolStep
-from hud.capabilities import MCPClient, RFBClient
+from hud.capabilities import MCPClient, RFBClient, SSHClient
 from hud.capabilities.ssh import SSHConnectionError
 from hud.types import AgentType, MCPToolCall, MCPToolResult, Step, StopCondition
 from hud.utils.time import now_iso
@@ -138,7 +138,10 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                     continue
                 if cap.protocol != MCPClient.protocol and cap.protocol in opened_protocols:
                     continue
-                connections[cap.name] = await run.client.open(cap.name)
+                client = await run.client.open(cap.name)
+                if isinstance(client, SSHClient):
+                    client.default_timeout_s = self.config.tool_timeout_seconds
+                connections[cap.name] = client
                 opened_protocols.add(cap.protocol)
         state = await self._initialize_state(prompt=run.prompt_messages)
         state.tools, state.params = await self._build_tools(connections)

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -30,9 +30,9 @@ from hud.agents.misc import auto_respond
 from hud.agents.tools.base import AgentTool, provider_tool_name
 from hud.agents.tools.mcp import MCPTool
 from hud.agents.tools.rfb import RFBTool
-from hud.agents.tools.ssh import SSHInfrastructureErrorResult
+from hud.agents.tools.ssh import SSHInfrastructureErrorResult, SSHTool
 from hud.agents.types import AgentStep, ToolStep
-from hud.capabilities import MCPClient, RFBClient, SSHClient
+from hud.capabilities import MCPClient, RFBClient
 from hud.capabilities.ssh import SSHConnectionError
 from hud.types import AgentType, MCPToolCall, MCPToolResult, Step, StopCondition
 from hud.utils.time import now_iso
@@ -138,10 +138,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                     continue
                 if cap.protocol != MCPClient.protocol and cap.protocol in opened_protocols:
                     continue
-                client = await run.client.open(cap.name)
-                if isinstance(client, SSHClient):
-                    client.default_timeout_s = self.config.tool_timeout_seconds
-                connections[cap.name] = client
+                connections[cap.name] = await run.client.open(cap.name)
                 opened_protocols.add(cap.protocol)
         state = await self._initialize_state(prompt=run.prompt_messages)
         state.tools, state.params = await self._build_tools(connections)
@@ -342,8 +339,29 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
             )
         args = call.arguments or {}
         try:
+            if isinstance(tool, SSHTool) and self.config.tool_timeout_seconds is not None:
+                timeout = self.config.tool_timeout_seconds
+                deadline = asyncio.timeout(timeout)
+                try:
+                    async with deadline:
+                        return await tool.execute(args)
+                except TimeoutError:
+                    if not deadline.expired():
+                        raise
+                    return MCPToolResult(
+                        content=[
+                            mcp_types.TextContent(
+                                type="text",
+                                text=(
+                                    f"{call.name} timed out after {timeout:g}s; "
+                                    "retry with a shorter command"
+                                ),
+                            )
+                        ],
+                        isError=True,
+                    )
             return await tool.execute(args)
-        except (TimeoutError, asyncio.CancelledError):
+        except asyncio.CancelledError:
             raise
         except SSHConnectionError as exc:
             logger.exception("tool %s lost its SSH connection", call.name)

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -361,7 +361,7 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
                         isError=True,
                     )
             return await tool.execute(args)
-        except asyncio.CancelledError:
+        except (TimeoutError, asyncio.CancelledError):
             raise
         except SSHConnectionError as exc:
             logger.exception("tool %s lost its SSH connection", call.name)

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -79,6 +79,7 @@ class AgentConfig(BaseModel):
 class ClaudeConfig(AgentConfig):
     model_name: str = "Claude"
     model: str = Field(default="claude-sonnet-4-6", validation_alias=_model_alias)
+    tool_timeout_seconds: float | None = Field(default=120, gt=0, allow_inf_nan=False)
     max_tokens: int = 16384
     use_computer_beta: bool = True
     screenshot_encoding: ScreenshotEncoding = Field(default_factory=WebPScreenshotEncoding)

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -55,6 +55,7 @@ class AgentConfig(BaseModel):
     auto_respond: bool = False
     max_steps: int = 10
     timeout_seconds: float | None = Field(default=None, gt=0, allow_inf_nan=False)
+    tool_timeout_seconds: float | None = Field(default=None, gt=0, allow_inf_nan=False)
     system_prompt: str | None = None
     citations_enabled: bool = False
     #: Conditions that end the rollout instead of being answered with an error

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -33,26 +33,19 @@ class SSHClient(CapabilityClient):
 
     protocol: ClassVar[str] = "ssh/2"
 
-    def __init__(
-        self,
-        capability: Capability,
-        conn: asyncssh.SSHClientConnection,
-        *,
-        default_timeout_s: float | None = None,
-    ) -> None:
+    def __init__(self, capability: Capability, conn: asyncssh.SSHClientConnection) -> None:
         self.capability = capability
         self._conn = conn
-        self.default_timeout_s = default_timeout_s
         self._reconnect_lock = asyncio.Lock()
         self._closing = False
 
     @classmethod
-    async def connect(cls, cap: Capability, *, default_timeout_s: float | None = None) -> Self:
+    async def connect(cls, cap: Capability) -> Self:
         try:
             connection = await cls._connect(cap)
         except (ConnectionError, asyncssh.ConnectionLost) as exc:
             raise SSHConnectionError("SSH connection failed during handshake") from exc
-        return cls(cap, connection, default_timeout_s=default_timeout_s)
+        return cls(cap, connection)
 
     @staticmethod
     async def _connect(cap: Capability) -> asyncssh.SSHClientConnection:
@@ -101,7 +94,7 @@ class SSHClient(CapabilityClient):
     async def run(self, *args: object, **kwargs: Any) -> asyncssh.SSHCompletedProcess:
         """Run one command, reconnecting first when the transport is closed."""
         run_kwargs = dict(kwargs)
-        timeout = self._effective_timeout(run_kwargs.pop("timeout", None))
+        timeout = run_kwargs.pop("timeout", None)
         check = bool(run_kwargs.pop("check", False))
         conn: asyncssh.SSHClientConnection | None = None
         process = None
@@ -177,7 +170,6 @@ class SSHClient(CapabilityClient):
 
     async def read_text(self, path: str, *, timeout_s: float | None = None) -> str:
         """Read a UTF-8 text file through the exec channel."""
-        timeout_s = self._effective_timeout(timeout_s)
         if self._is_windows:
             quoted = _powershell_quote(path)
             script = f"[Convert]::ToBase64String([IO.File]::ReadAllBytes({quoted}))"
@@ -201,7 +193,6 @@ class SSHClient(CapabilityClient):
         timeout_s: float | None = None,
     ) -> None:
         """Write UTF-8 text through the exec channel without command interpolation."""
-        timeout_s = self._effective_timeout(timeout_s)
         if self._is_windows:
             loop = asyncio.get_running_loop()
             deadline = loop.time() + timeout_s if timeout_s is not None else None
@@ -231,7 +222,6 @@ class SSHClient(CapabilityClient):
 
     async def listdir(self, path: str, *, timeout_s: float | None = None) -> list[str]:
         """List direct children through the exec channel."""
-        timeout_s = self._effective_timeout(timeout_s)
         if self._is_windows:
             script = f"Get-ChildItem -Force -Name -LiteralPath {_powershell_quote(path)}"
             result = await self.run(_powershell(script), check=True, timeout=timeout_s)
@@ -241,9 +231,6 @@ class SSHClient(CapabilityClient):
             result = await self.run(command, check=True, encoding=None, timeout=timeout_s)
             listing = _decode(result.stdout)
         return sorted(line for line in listing.splitlines() if line not in (".", ".."))
-
-    def _effective_timeout(self, timeout_s: float | None) -> float | None:
-        return self.default_timeout_s if timeout_s is None else timeout_s
 
     @property
     def _is_windows(self) -> bool:

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -33,19 +33,26 @@ class SSHClient(CapabilityClient):
 
     protocol: ClassVar[str] = "ssh/2"
 
-    def __init__(self, capability: Capability, conn: asyncssh.SSHClientConnection) -> None:
+    def __init__(
+        self,
+        capability: Capability,
+        conn: asyncssh.SSHClientConnection,
+        *,
+        default_timeout_s: float | None = None,
+    ) -> None:
         self.capability = capability
         self._conn = conn
+        self.default_timeout_s = default_timeout_s
         self._reconnect_lock = asyncio.Lock()
         self._closing = False
 
     @classmethod
-    async def connect(cls, cap: Capability) -> Self:
+    async def connect(cls, cap: Capability, *, default_timeout_s: float | None = None) -> Self:
         try:
             connection = await cls._connect(cap)
         except (ConnectionError, asyncssh.ConnectionLost) as exc:
             raise SSHConnectionError("SSH connection failed during handshake") from exc
-        return cls(cap, connection)
+        return cls(cap, connection, default_timeout_s=default_timeout_s)
 
     @staticmethod
     async def _connect(cap: Capability) -> asyncssh.SSHClientConnection:
@@ -94,7 +101,7 @@ class SSHClient(CapabilityClient):
     async def run(self, *args: object, **kwargs: Any) -> asyncssh.SSHCompletedProcess:
         """Run one command, reconnecting first when the transport is closed."""
         run_kwargs = dict(kwargs)
-        timeout = run_kwargs.pop("timeout", None)
+        timeout = self._effective_timeout(run_kwargs.pop("timeout", None))
         check = bool(run_kwargs.pop("check", False))
         conn: asyncssh.SSHClientConnection | None = None
         process = None
@@ -170,6 +177,7 @@ class SSHClient(CapabilityClient):
 
     async def read_text(self, path: str, *, timeout_s: float | None = None) -> str:
         """Read a UTF-8 text file through the exec channel."""
+        timeout_s = self._effective_timeout(timeout_s)
         if self._is_windows:
             quoted = _powershell_quote(path)
             script = f"[Convert]::ToBase64String([IO.File]::ReadAllBytes({quoted}))"
@@ -193,6 +201,7 @@ class SSHClient(CapabilityClient):
         timeout_s: float | None = None,
     ) -> None:
         """Write UTF-8 text through the exec channel without command interpolation."""
+        timeout_s = self._effective_timeout(timeout_s)
         if self._is_windows:
             loop = asyncio.get_running_loop()
             deadline = loop.time() + timeout_s if timeout_s is not None else None
@@ -214,15 +223,15 @@ class SSHClient(CapabilityClient):
                 )
                 await self.run(_powershell(script), check=True, timeout=remaining_timeout())
             return
-        await self.run(
-            f"cat > {shlex.quote(path)}",
-            input=content,
-            check=True,
-            timeout=timeout_s,
-        )
+        run_kwargs: dict[str, Any] = {"input": content}
+        if not content:
+            # AsyncSSH treats empty input as absent; DEVNULL still delivers EOF.
+            run_kwargs["stdin"] = asyncssh.DEVNULL
+        await self.run(f"cat > {shlex.quote(path)}", check=True, timeout=timeout_s, **run_kwargs)
 
     async def listdir(self, path: str, *, timeout_s: float | None = None) -> list[str]:
         """List direct children through the exec channel."""
+        timeout_s = self._effective_timeout(timeout_s)
         if self._is_windows:
             script = f"Get-ChildItem -Force -Name -LiteralPath {_powershell_quote(path)}"
             result = await self.run(_powershell(script), check=True, timeout=timeout_s)
@@ -232,6 +241,9 @@ class SSHClient(CapabilityClient):
             result = await self.run(command, check=True, encoding=None, timeout=timeout_s)
             listing = _decode(result.stdout)
         return sorted(line for line in listing.splitlines() if line not in (".", ".."))
+
+    def _effective_timeout(self, timeout_s: float | None) -> float | None:
+        return self.default_timeout_s if timeout_s is None else timeout_s
 
     @property
     def _is_windows(self) -> bool:

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -265,28 +265,6 @@ async def test_run_preserves_timeout_when_the_connection_closes() -> None:
         await client.run("echo never", timeout=1)
 
 
-@pytest.mark.parametrize(
-    ("default_timeout_s", "operation_timeout_s"),
-    [(0.01, None), (300, 0.01)],
-)
-async def test_run_uses_effective_timeout(
-    default_timeout_s: float,
-    operation_timeout_s: float | None,
-) -> None:
-    process = _Process(block=True)
-    connection = _Connection(process=process)
-    client = SSHClient(
-        _capability(),
-        cast("asyncssh.SSHClientConnection", connection),
-        default_timeout_s=default_timeout_s,
-    )
-
-    with pytest.raises(TimeoutError):
-        await client.run("echo never", timeout=operation_timeout_s)
-
-    assert process.terminated is True
-
-
 @pytest.mark.parametrize("command_timeout", [None, 300])
 async def test_run_cancellation_terminates_the_remote_process(
     command_timeout: float | None,

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -265,6 +265,28 @@ async def test_run_preserves_timeout_when_the_connection_closes() -> None:
         await client.run("echo never", timeout=1)
 
 
+@pytest.mark.parametrize(
+    ("default_timeout_s", "operation_timeout_s"),
+    [(0.01, None), (300, 0.01)],
+)
+async def test_run_uses_effective_timeout(
+    default_timeout_s: float,
+    operation_timeout_s: float | None,
+) -> None:
+    process = _Process(block=True)
+    connection = _Connection(process=process)
+    client = SSHClient(
+        _capability(),
+        cast("asyncssh.SSHClientConnection", connection),
+        default_timeout_s=default_timeout_s,
+    )
+
+    with pytest.raises(TimeoutError):
+        await client.run("echo never", timeout=operation_timeout_s)
+
+    assert process.terminated is True
+
+
 @pytest.mark.parametrize("command_timeout", [None, 300])
 async def test_run_cancellation_terminates_the_remote_process(
     command_timeout: float | None,
@@ -323,6 +345,22 @@ async def test_windows_write_uses_one_timeout_budget(
 
     assert len(timeouts) == 3
     assert timeouts[0] > timeouts[1] > timeouts[2]
+
+
+async def test_posix_empty_write_supplies_eof(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _client(_Connection())
+    run = AsyncMock(return_value=_Completed())
+    monkeypatch.setattr(client, "run", run)
+
+    await client.write_text("empty.txt", "")
+
+    run.assert_awaited_once_with(
+        "cat > empty.txt",
+        check=True,
+        timeout=None,
+        input="",
+        stdin=asyncssh.DEVNULL,
+    )
 
 
 async def test_close_during_reconnect_discards_the_replacement(

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -182,10 +182,12 @@ async def test_file_operations_use_the_exec_channel(tmp_path: Path) -> None:
     await ws.start()
     try:
         async with await _connect(ws) as conn:
-            client = SSHClient(ws.capability(), conn)
+            client = SSHClient(ws.capability(), conn, default_timeout_s=1)
             await client.write_text("hello world.txt", "héllo\n")
             assert await client.read_text("hello world.txt") == "héllo\n"
-            assert await client.listdir(".") == ["hello world.txt"]
+            await client.write_text("empty.txt", "")
+            assert await client.read_text("empty.txt") == ""
+            assert await client.listdir(".") == ["empty.txt", "hello world.txt"]
             # Absolute paths mean what they say in the session's namespace —
             # never re-anchored under the workspace.
             outside = tmp_path / "outside.txt"

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -182,7 +182,7 @@ async def test_file_operations_use_the_exec_channel(tmp_path: Path) -> None:
     await ws.start()
     try:
         async with await _connect(ws) as conn:
-            client = SSHClient(ws.capability(), conn, default_timeout_s=1)
+            client = SSHClient(ws.capability(), conn)
             await client.write_text("hello world.txt", "héllo\n")
             assert await client.read_text("hello world.txt") == "héllo\n"
             await client.write_text("empty.txt", "")

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -95,6 +95,7 @@ def test_hosted_spec_serializes_full_config() -> None:
     agent = _agent()
     agent.config.system_prompt = "be brief"
     agent.config.max_steps = 7
+    agent.config.tool_timeout_seconds = 1800
 
     spec = agent.hosted_spec()
 
@@ -104,6 +105,7 @@ def test_hosted_spec_serializes_full_config() -> None:
     assert config["model"] == "test-model"
     assert config["max_steps"] == 7
     assert config["system_prompt"] == "be brief"
+    assert config["tool_timeout_seconds"] == 1800
     # ...minus what can't or shouldn't cross the wire.
     assert "model_client" not in config
     assert "api_key" not in config

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -95,6 +95,7 @@ def test_hosted_spec_serializes_full_config() -> None:
     agent = _agent()
     agent.config.system_prompt = "be brief"
     agent.config.max_steps = 7
+    agent.config.timeout_seconds = 3600
     agent.config.tool_timeout_seconds = 1800
 
     spec = agent.hosted_spec()
@@ -105,6 +106,7 @@ def test_hosted_spec_serializes_full_config() -> None:
     assert config["model"] == "test-model"
     assert config["max_steps"] == 7
     assert config["system_prompt"] == "be brief"
+    assert config["timeout_seconds"] == 3600
     assert config["tool_timeout_seconds"] == 1800
     # ...minus what can't or shouldn't cross the wire.
     assert "model_client" not in config


### PR DESCRIPTION
## Summary
- add optional tool_timeout_seconds to agent configuration, defaulting to 120 seconds only for ClaudeConfig
- enforce one recoverable deadline around each SSH-backed logical tool dispatch, so composite editor operations share the same budget while timeout_seconds continues to govern the complete agent phase
- cancel timed-out SSH work so the active remote process is terminated, preserve the independent empty-file EOF fix, and report that Claude bash restart is unnecessary because commands use fresh shell sessions

ClaudeSDKAgent is unchanged. Persistent shell state and a real restart lifecycle remain out of scope for this incident fix.

## Testing
- 219 focused tests passed across SSH, workspace, tool dispatch, provider tools, hosted config, Claude, Claude SDK, and agent-phase timeout coverage
- uv run ruff format . --check
- uv run ruff check .
- focused uv run ty check passed

Full-repository ty currently reports one unrelated pre-existing diagnostic in hud/environment/robot/bridge.py:299; this branch does not touch that file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent tool dispatch and SSH process cancellation, which can change rollout behavior when tools hang. Defaults only apply to Claude; other providers remain unset unless configured.
> 
> **Overview**
> Adds optional `tool_timeout_seconds` so SSH-backed provider tools can time out independently of the overall agent-phase `timeout_seconds`. The setting is unset by default except on `ClaudeConfig` (120s). A deadline wraps each logical SSH tool dispatch (including multi-op editor calls); expiry is returned as a tool error so the loop can continue, while inner `TimeoutError`s that fire before the deadline still propagate. `ClaudeSDKAgent` is unchanged.
> 
> Also clarifies Claude bash `restart` as unnecessary (fresh shell per command), and POSIX empty-file writes now send EOF via `asyncssh.DEVNULL` so `cat > path` can create empty files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3721424f15296d36bc4c0a455b5e181bb3cd80ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->