### PR TITLE
ci: repoint docs only on stable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
           uv build
           uv publish
 
-      # docs.hud.ai builds the SDK tab from the docs branch.
+      # docs.hud.ai builds the SDK tab from the docs branch. Prereleases stay
+      # off it: the branch tracks the latest stable release.
       - name: Point docs at this release
+        if: ${{ !github.event.release.prerelease }}
         run: |
           git push --force origin "${GITHUB_SHA}:refs/heads/docs"


### PR DESCRIPTION
The release workflow force-pushes `docs` to every published release, including prereleases, so a dev release repoints docs.hud.ai's SDK tab source at a dev commit. Gate the step on `!github.event.release.prerelease` so `docs` tracks the latest stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI condition change only. No application, auth, or publish-path logic is modified.
> 
> **Overview**
> Stops the release workflow from force-pushing the `docs` branch on GitHub prereleases, so docs.hud.ai’s SDK tab stays on the latest **stable** release instead of a dev commit.
> 
> PyPI publish is unchanged; only the “Point docs at this release” step is gated with `!github.event.release.prerelease`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75e608f043aff1dd15fdffcf5e4a83b79f38b6c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->