### PR TITLE
fix(deploy): preserve empty build-context directories

### DIFF
--- a/hud/cli/utils/context.py
+++ b/hud/cli/utils/context.py
@@ -231,6 +231,14 @@ def create_build_context_tarball(
                     d for d in dirs if not should_ignore(root_path / d, directory, ignore_patterns)
                 ]
 
+                for child in dirs:
+                    dir_path = root_path / child
+                    tar.add(
+                        dir_path,
+                        arcname=str(dir_path.relative_to(directory)),
+                        recursive=False,
+                    )
+
                 for file in files:
                     file_path = root_path / file
 

--- a/hud/cli/utils/tests/test_context.py
+++ b/hud/cli/utils/tests/test_context.py
@@ -72,3 +72,21 @@ def test_create_build_context_tarball_excludes_secrets(tmp_path: Path) -> None:
         assert count == 1
     finally:
         tarball.unlink(missing_ok=True)
+
+
+def test_create_build_context_tarball_preserves_empty_directories(tmp_path: Path) -> None:
+    ctx = tmp_path / "ctx"
+    ctx.mkdir()
+    (ctx / "packages").mkdir()
+    (ctx / "ignored").mkdir()
+    (ctx / ".dockerignore").write_text("ignored/\n", encoding="utf-8")
+
+    tarball, _size, count, _duration = create_build_context_tarball(ctx)
+    try:
+        with tarfile.open(tarball) as tar:
+            members = {member.name: member for member in tar.getmembers()}
+        assert members["packages"].isdir()
+        assert "ignored" not in members
+        assert count == 1
+    finally:
+        tarball.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

- preserve empty directories in uploaded build-context archives
- continue excluding directories ignored by the context rules

## Tests

- `ruff format hud/cli/utils/context.py hud/cli/utils/tests/test_context.py --check`
- `ruff check hud/cli/utils/context.py hud/cli/utils/tests/test_context.py`
- `ty check --error-on-warning`
- `pytest hud/cli/utils/tests/test_context.py -q`

## Uncertain

- None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI packaging change with ignore rules unchanged; no auth, secrets, or runtime behavior is modified.
> 
> **Overview**
> Deploy build-context archives now include empty directories instead of dropping them when walking files only.
> 
> `create_build_context_tarball` adds each non-ignored directory with `recursive=False` after ignore filtering, so empty dirs like `packages/` survive upload while `.dockerignore` exclusions still apply. A regression test covers that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8de420d34669e012a4d595820c9cab94c7fcf63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->