### PR TITLE
feat(runtime): support Modal secrets and live output

### DIFF
--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -96,6 +96,12 @@ than `rollout_timeout`; an agent timeout must also be less than the actor enviro
 SDK adds no overall deadline; configured phase limits and limits imposed by the selected runtime
 still apply.
 
+When the SDK owns the environment process, its output is part of the local eval:
+`SubprocessRuntime`, Docker image and Compose runtimes, Modal image and Compose sandboxes,
+and Daytona sandboxes stream stdout and stderr directly to the terminal without
+reformatting them. `LocalRuntime` already shares the eval process's terminal. HUD-hosted
+runtimes retain environment output on the hosted trace instead.
+
 ## Runtime directory
 
 The constructor for each built-in runtime:
@@ -151,7 +157,7 @@ security override are documented in
 ### `ModalRuntime`
 
 ```python
-ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=None, workdir=None, port=8765, runtime_config=None, env_vars=None)
+ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=None, workdir=None, port=8765, runtime_config=None, env_vars=None, secrets=None)
 ```
 
 - **`image_name`** - published Modal image name (the preferred durable handle), e.g. `ModalRuntime("hud-libero-env")`.
@@ -161,6 +167,7 @@ ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=No
 - **`app`** - an already-running, caller-owned Modal app. `ModalRuntime` does not manage its lifecycle.
 - **`app_name`** - a Modal app to look up. Defaults to `hud-envs` when `app` is not supplied; `app` and `app_name` are mutually exclusive.
 - **`port`** / **`env_vars`** - in-sandbox serving port and extra environment variables.
+- **`secrets`** - Modal `Secret` objects to attach to the sandbox. Resolve named secrets with `modal.Secret.from_name(...)`; their values never pass through the local process. Secrets require an image runtime and are rejected for Docker-in-Docker Compose because attaching them to the outer sandbox would not expose them to `main`.
 
 For Compose input, `ModalRuntime` runs the project in a Docker-in-Docker
 sandbox in your Modal account and merges `env_vars` into `main` at acquisition
@@ -229,6 +236,11 @@ Runtime(url, params=..., config=...)
 
 - **`url`** - control-channel address of an already-running substrate (e.g. `tcp://host:8765`).
 - **`params`** - connection-time data a transport may need (auth token, sandbox id).
+
+Provisioned runtimes expose `snapshot_session(session_id)` and
+`restore_session(session_id, archive)` for transferring session files to an
+independent verifier. The base runtime is a no-op; providers such as Docker and
+Modal implement the transfer directly on their provisioned endpoint.
 
 ### `Shared`
 

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -593,9 +593,6 @@ async def rollout(
 
                 assert actor_session_id is not None
                 _phase = "snapshotting actor"
-                from .runtime.core import validate_session_id
-
-                validate_session_id(actor_session_id)
                 async with addr.snapshot_session(actor_session_id) as archive:
                     _phase = "actor cleanup"
                     await actor.aclose()
@@ -607,7 +604,6 @@ async def rollout(
                     verifier_client = await scope.enter_async_context(connect(verifier_addr))
                     if archive is not None:
                         assert verifier_client.manifest is not None
-                        validate_session_id(verifier_client.manifest.session_id)
                         await verifier_addr.restore_session(
                             verifier_client.manifest.session_id,
                             archive,

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     from hud.clients.client import HudClient
 
     from .runtime import Provider
-    from .runtime.core import RuntimeConfig, RuntimeSession
+    from .runtime.core import RuntimeConfig
     from .task import Task
 
 logger = logging.getLogger("hud.eval.run")
@@ -512,7 +512,7 @@ async def rollout(
         async def _drive() -> None:
             nonlocal client, run, _phase
             actor_result: dict[str, Any] = {}
-            actor_session: RuntimeSession | None = None
+            actor_session_id: str | None = None
             verifier = task.verifier
             shared_verifier = (
                 verifier is not None
@@ -572,7 +572,7 @@ async def rollout(
                     if verifier is not None:
                         actor_result = live.grade.raw
                         assert actor_client.manifest is not None
-                        actor_session = addr.session(actor_client.manifest.session_id)
+                        actor_session_id = actor_client.manifest.session_id
                         # The verifier is authoritative. Once its phase begins,
                         # an actor-side grade must not survive a verifier failure.
                         live.grade = Grade()
@@ -591,9 +591,9 @@ async def rollout(
                     _phase = "cleanup"
                     return
 
-                assert actor_session is not None
+                assert actor_session_id is not None
                 _phase = "snapshotting actor"
-                async with actor_session.snapshot() as archive:
+                async with addr.snapshot_session(actor_session_id) as archive:
                     _phase = "actor cleanup"
                     await actor.aclose()
                     client = None
@@ -604,8 +604,9 @@ async def rollout(
                     verifier_client = await scope.enter_async_context(connect(verifier_addr))
                     if archive is not None:
                         assert verifier_client.manifest is not None
-                        await verifier_addr.session(verifier_client.manifest.session_id).restore(
-                            archive
+                        await verifier_addr.restore_session(
+                            verifier_client.manifest.session_id,
+                            archive,
                         )
                     client = verifier_client
                     _phase = "verifying"

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -593,6 +593,9 @@ async def rollout(
 
                 assert actor_session_id is not None
                 _phase = "snapshotting actor"
+                from .runtime.core import validate_session_id
+
+                validate_session_id(actor_session_id)
                 async with addr.snapshot_session(actor_session_id) as archive:
                     _phase = "actor cleanup"
                     await actor.aclose()
@@ -604,6 +607,7 @@ async def rollout(
                     verifier_client = await scope.enter_async_context(connect(verifier_addr))
                     if archive is not None:
                         assert verifier_client.manifest is not None
+                        validate_session_id(verifier_client.manifest.session_id)
                         await verifier_addr.restore_session(
                             verifier_client.manifest.session_id,
                             archive,

--- a/hud/eval/runtime/__init__.py
+++ b/hud/eval/runtime/__init__.py
@@ -8,7 +8,6 @@ from .core import (
     RuntimeGPU,
     RuntimeLimits,
     RuntimeResources,
-    RuntimeSession,
     RuntimeTPU,
     Shared,
 )
@@ -33,7 +32,6 @@ __all__ = [
     "RuntimeGPU",
     "RuntimeLimits",
     "RuntimeResources",
-    "RuntimeSession",
     "RuntimeTPU",
     "Shared",
     "SubprocessRuntime",

--- a/hud/eval/runtime/core.py
+++ b/hud/eval/runtime/core.py
@@ -149,29 +149,9 @@ class _ConfiguredProvider(Protocol):
     runtime_config: RuntimeConfig | None
 
 
-@dataclass(frozen=True)
-class RuntimeSession:
-    """One control session in a provisioned runtime."""
-
-    session_id: str
-
-    def __post_init__(self) -> None:
-        if (
-            not self.session_id
-            or self.session_id in {".", ".."}
-            or "/" in self.session_id
-            or "\\" in self.session_id
-        ):
-            raise ValueError("runtime session id must be a single path component")
-
-    @asynccontextmanager
-    async def snapshot(self) -> AsyncIterator[Path | None]:
-        """Yield a portable archive of this session's files when present."""
-        yield None
-
-    async def restore(self, source: Path) -> None:
-        """Restore a portable session archive into this session."""
-        return
+def validate_session_id(session_id: str) -> None:
+    if not session_id or session_id in {".", ".."} or "/" in session_id or "\\" in session_id:
+        raise ValueError("runtime session id must be a single path component")
 
 
 @dataclass(frozen=True)
@@ -194,9 +174,15 @@ class Runtime:
     def __call__(self, task: Task) -> AbstractAsyncContextManager[Runtime]:
         return nullcontext(self)
 
-    def session(self, session_id: str) -> RuntimeSession:
-        """Bind a negotiated control session to this runtime."""
-        return RuntimeSession(session_id)
+    @asynccontextmanager
+    async def snapshot_session(self, session_id: str) -> AsyncIterator[Path | None]:
+        """Yield a portable archive of one control session's files when present."""
+        validate_session_id(session_id)
+        yield None
+
+    async def restore_session(self, session_id: str, source: Path) -> None:
+        """Restore a portable archive into one control session."""
+        validate_session_id(session_id)
 
 
 class Shared:

--- a/hud/eval/runtime/daytona.py
+++ b/hud/eval/runtime/daytona.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
-from hud.utils.process import finish_output, write_output
+from hud.utils.process import finish_output, output_writer
 
 from .core import Runtime, RuntimeConfig
 
@@ -265,12 +265,18 @@ class DaytonaRuntime:
                 )
 
                 async def follow_logs() -> None:
-                    await sandbox.process.get_session_command_logs_async(
-                        session,
-                        session_command.cmd_id,
-                        lambda chunk: write_output(sys.stdout, chunk),
-                        lambda chunk: write_output(sys.stderr, chunk),
-                    )
+                    write_stdout, finish_stdout = output_writer(sys.stdout)
+                    write_stderr, finish_stderr = output_writer(sys.stderr)
+                    try:
+                        await sandbox.process.get_session_command_logs_async(
+                            session,
+                            session_command.cmd_id,
+                            write_stdout,
+                            write_stderr,
+                        )
+                    finally:
+                        finish_stdout()
+                        finish_stderr()
 
                 output_task = asyncio.create_task(follow_logs())
                 ssh = await sandbox.create_ssh_access(expires_in_minutes=self.ssh_expires_minutes)

--- a/hud/eval/runtime/daytona.py
+++ b/hud/eval/runtime/daytona.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
+
+from hud.utils.process import write_output
 
 from .core import Runtime, RuntimeConfig
 
@@ -249,6 +252,7 @@ class DaytonaRuntime:
                 sandbox_params,
                 timeout=create_timeout,
             )
+            output_task: asyncio.Task[None] | None = None
             try:
                 # Start the env server in a background session (the snapshot's CMD is
                 # not the sandbox's main process). connect() retries the handshake,
@@ -259,6 +263,16 @@ class DaytonaRuntime:
                 session_command = await sandbox.process.execute_session_command(
                     session, SessionExecuteRequest(command=cmd, run_async=True)
                 )
+
+                async def follow_logs() -> None:
+                    await sandbox.process.get_session_command_logs_async(
+                        session,
+                        session_command.cmd_id,
+                        lambda chunk: write_output(sys.stdout, chunk),
+                        lambda chunk: write_output(sys.stderr, chunk),
+                    )
+
+                output_task = asyncio.create_task(follow_logs())
                 ssh = await sandbox.create_ssh_access(expires_in_minutes=self.ssh_expires_minutes)
                 async with asyncssh.connect(
                     self.ssh_host, username=ssh.token, known_hosts=None
@@ -288,8 +302,10 @@ class DaytonaRuntime:
                             )
                         raise
             finally:
+                deleted = False
                 try:
                     await daytona.delete(sandbox)
+                    deleted = True
                 except Exception:
                     # Swallowing this is how a billable sandbox outlives its process.
                     logger.warning(
@@ -297,3 +313,7 @@ class DaytonaRuntime:
                         sandbox.id,
                         exc_info=True,
                     )
+                if output_task is not None:
+                    if not deleted:
+                        output_task.cancel()
+                    await asyncio.gather(output_task, return_exceptions=True)

--- a/hud/eval/runtime/daytona.py
+++ b/hud/eval/runtime/daytona.py
@@ -8,7 +8,7 @@ import sys
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
-from hud.utils.process import write_output
+from hud.utils.process import finish_output, write_output
 
 from .core import Runtime, RuntimeConfig
 
@@ -302,10 +302,8 @@ class DaytonaRuntime:
                             )
                         raise
             finally:
-                deleted = False
                 try:
                     await daytona.delete(sandbox)
-                    deleted = True
                 except Exception:
                     # Swallowing this is how a billable sandbox outlives its process.
                     logger.warning(
@@ -314,6 +312,4 @@ class DaytonaRuntime:
                         exc_info=True,
                     )
                 if output_task is not None:
-                    if not deleted:
-                        output_task.cancel()
-                    await asyncio.gather(output_task, return_exceptions=True)
+                    await finish_output(output_task)

--- a/hud/eval/runtime/docker.py
+++ b/hud/eval/runtime/docker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import sys
 import tarfile
 import tempfile
 import uuid
@@ -15,10 +16,10 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 from hud.utils.docker import docker as _docker
-from hud.utils.process import create_process_group_exec
+from hud.utils.process import create_process_group_exec, stream_output
 
 from .compose import ComposeConfig
-from .core import Runtime, RuntimeConfig, RuntimeSession
+from .core import Runtime, RuntimeConfig, validate_session_id
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping, Sequence
@@ -96,6 +97,27 @@ async def _docker_deadline(
     finally:
         expiry.cancel()
         await asyncio.gather(expiry, return_exceptions=True)
+
+
+@asynccontextmanager
+async def _docker_output(*args: str) -> AsyncIterator[None]:
+    process = await create_process_group_exec(
+        "docker",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert process.stdout is not None
+    assert process.stderr is not None
+    tasks = (
+        asyncio.create_task(stream_output(process.stdout, sys.stdout)),
+        asyncio.create_task(stream_output(process.stderr, sys.stderr)),
+    )
+    try:
+        yield
+    finally:
+        await process.terminate()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 class DockerRuntime:
@@ -231,8 +253,16 @@ class DockerRuntime:
                         )
                     host_port = int(mapping.strip().splitlines()[0].rsplit(":", 1)[1])
                     container, _ = await _docker(*command, "ps", "--quiet", "main")
-                    async with _docker_deadline(run_timeout, teardown):
-                        yield _DockerEndpoint(
+                    async with (
+                        _docker_output(
+                            *command,
+                            "logs",
+                            "--follow",
+                            "--no-color",
+                        ),
+                        _docker_deadline(run_timeout, teardown),
+                    ):
+                        yield DockerEndpoint(
                             f"tcp://127.0.0.1:{host_port}",
                             params=params,
                             config=config if config.model_dump(exclude_none=True) else None,
@@ -292,8 +322,15 @@ class DockerRuntime:
                     f"{self.port}:\n{(logs_err or logs_out).strip()}",
                 )
             host_port = int(mapping.strip().splitlines()[0].rsplit(":", 1)[1])
-            async with _docker_deadline(run_timeout, teardown):
-                yield _DockerEndpoint(
+            async with (
+                _docker_output(
+                    "logs",
+                    "--follow",
+                    container,
+                ),
+                _docker_deadline(run_timeout, teardown),
+            ):
+                yield DockerEndpoint(
                     f"tcp://127.0.0.1:{host_port}",
                     params=params,
                     config=config,
@@ -306,22 +343,15 @@ class DockerRuntime:
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class _DockerEndpoint(Runtime):
-    container: str
-
-    def session(self, session_id: str) -> RuntimeSession:
-        return _DockerSession(session_id=session_id, container=self.container)
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class _DockerSession(RuntimeSession):
+class DockerEndpoint(Runtime):
     container: str
 
     @asynccontextmanager
-    async def snapshot(self) -> AsyncIterator[Path | None]:
+    async def snapshot_session(self, session_id: str) -> AsyncIterator[Path | None]:
+        validate_session_id(session_id)
         with tempfile.TemporaryDirectory(prefix="hud-session-") as directory:
             destination = Path(directory) / "session.tar.gz"
-            root = f"/media/hud/sessions/{self.session_id}"
+            root = f"/media/hud/sessions/{session_id}"
             exists, _ = await _docker(
                 "exec",
                 self.container,
@@ -369,8 +399,9 @@ with tarfile.open(sys.argv[2], "w:gz") as output:
                 )
             yield destination
 
-    async def restore(self, source: Path) -> None:
-        target = f"/media/hud/sessions/{self.session_id}"
+    async def restore_session(self, session_id: str, source: Path) -> None:
+        validate_session_id(session_id)
+        target = f"/media/hud/sessions/{session_id}"
         with tempfile.TemporaryDirectory(prefix="hud-session-import-") as directory:
             root = Path(directory)
             _extract_session_archive(source, root)

--- a/hud/eval/runtime/docker.py
+++ b/hud/eval/runtime/docker.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit
 
 from hud.utils.docker import docker as _docker
-from hud.utils.process import create_process_group_exec, stream_output
+from hud.utils.process import create_process_group_exec, finish_output, stream_output
 
 from .compose import ComposeConfig
 from .core import Runtime, RuntimeConfig, validate_session_id
@@ -117,7 +117,7 @@ async def _docker_output(*args: str) -> AsyncIterator[None]:
         yield
     finally:
         await process.terminate()
-        await asyncio.gather(*tasks, return_exceptions=True)
+        await finish_output(*tasks)
 
 
 class DockerRuntime:

--- a/hud/eval/runtime/local.py
+++ b/hud/eval/runtime/local.py
@@ -193,31 +193,49 @@ class SubprocessRuntime:
         stdout_drain: asyncio.Task[None] | None = None
 
         async def stream_stderr() -> None:
-            while line := await error.readline():
-                error_tail.append(line.decode("utf-8", "replace").strip())
-                write_output(sys.stderr, line)
+            while chunk := await error.read(65536):
+                error_tail.append(chunk.decode("utf-8", "replace").strip()[-1024:])
+                write_output(sys.stderr, chunk)
 
         stderr_drain = asyncio.create_task(stream_stderr())
         try:
             from hud.environment.server import PORT_ANNOUNCEMENT
 
             port = None
+            line_continues = False
             async with asyncio.timeout(self.ready_timeout):
-                while line := await output.readline():
+                while True:
+                    eof = False
+                    try:
+                        line = await output.readuntil()
+                    except asyncio.LimitOverrunError as exc:
+                        line = await output.read(exc.consumed)
+                        line_continues = True
+                    except asyncio.IncompleteReadError as exc:
+                        line = exc.partial
+                        eof = True
+                    if not line:
+                        break
                     text = line.decode("utf-8", "replace").strip()
-                    if text.startswith(PORT_ANNOUNCEMENT):
+                    if not line_continues and text.startswith(PORT_ANNOUNCEMENT):
                         port = int(text.removeprefix(PORT_ANNOUNCEMENT))
                         break
-                    output_tail.append(text)
+                    output_tail.append(text[-1024:])
                     write_output(sys.stdout, line)
+                    line_continues = not line.endswith(b"\n")
+                    if eof:
+                        break
             if port is None:
-                code = await proc.wait()
                 await finish_output(stderr_drain)
                 tail = "\n".join((*output_tail, *error_tail)).strip()
                 detail = f":\n{tail}" if tail else " (no output captured)"
+                status = (
+                    f"exited with code {proc.returncode}"
+                    if proc.returncode is not None
+                    else "closed stdout"
+                )
                 raise RuntimeError(
-                    f"spawned env exited with code {code} before serving "
-                    f"(source: {self.source}){detail}"
+                    f"spawned env {status} before serving (source: {self.source}){detail}"
                 )
 
             stdout_drain = asyncio.create_task(stream_output(output, sys.stdout))

--- a/hud/eval/runtime/local.py
+++ b/hud/eval/runtime/local.py
@@ -10,7 +10,11 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from hud.utils.process import create_process_group_exec
+from hud.utils.process import (
+    create_process_group_exec,
+    stream_output,
+    write_output,
+)
 
 from .core import Runtime
 
@@ -182,6 +186,7 @@ class SubprocessRuntime:
         assert proc.stdout is not None
         output = proc.stdout
         output_tail: deque[str] = deque(maxlen=50)
+        drain: asyncio.Task[None] | None = None
         try:
             from hud.environment.server import PORT_ANNOUNCEMENT
 
@@ -193,6 +198,7 @@ class SubprocessRuntime:
                         port = int(text.removeprefix(PORT_ANNOUNCEMENT))
                         break
                     output_tail.append(text)
+                    write_output(sys.stdout, line)
             if port is None:
                 code = await proc.wait()
                 tail = "\n".join(output_tail).strip()
@@ -202,16 +208,9 @@ class SubprocessRuntime:
                     f"(source: {self.source}){detail}"
                 )
 
-            async def discard_output() -> None:
-                while await output.read(65536):
-                    pass
-
-            drain = asyncio.create_task(discard_output())
-            try:
-                yield Runtime(f"tcp://127.0.0.1:{port}")
-            finally:
-                drain.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await drain
+            drain = asyncio.create_task(stream_output(output, sys.stdout))
+            yield Runtime(f"tcp://127.0.0.1:{port}")
         finally:
             await proc.terminate()
+            if drain is not None:
+                await asyncio.gather(drain, return_exceptions=True)

--- a/hud/eval/runtime/local.py
+++ b/hud/eval/runtime/local.py
@@ -181,13 +181,23 @@ class SubprocessRuntime:
             *cmd,
             term_timeout=10.0,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+            stderr=asyncio.subprocess.PIPE,
             cwd=self.source if self.source.is_dir() else self.source.parent,
         )
-        assert proc.stdout is not None
         output = proc.stdout
+        error = proc.stderr
+        assert output is not None
+        assert error is not None
         output_tail: deque[str] = deque(maxlen=50)
-        drain: asyncio.Task[None] | None = None
+        error_tail: deque[str] = deque(maxlen=50)
+        stdout_drain: asyncio.Task[None] | None = None
+
+        async def stream_stderr() -> None:
+            while line := await error.readline():
+                error_tail.append(line.decode("utf-8", "replace").strip())
+                write_output(sys.stderr, line)
+
+        stderr_drain = asyncio.create_task(stream_stderr())
         try:
             from hud.environment.server import PORT_ANNOUNCEMENT
 
@@ -202,16 +212,18 @@ class SubprocessRuntime:
                     write_output(sys.stdout, line)
             if port is None:
                 code = await proc.wait()
-                tail = "\n".join(output_tail).strip()
+                await finish_output(stderr_drain)
+                tail = "\n".join((*output_tail, *error_tail)).strip()
                 detail = f":\n{tail}" if tail else " (no output captured)"
                 raise RuntimeError(
                     f"spawned env exited with code {code} before serving "
                     f"(source: {self.source}){detail}"
                 )
 
-            drain = asyncio.create_task(stream_output(output, sys.stdout))
+            stdout_drain = asyncio.create_task(stream_output(output, sys.stdout))
             yield Runtime(f"tcp://127.0.0.1:{port}")
         finally:
             await proc.terminate()
-            if drain is not None:
-                await finish_output(drain)
+            await finish_output(
+                *(task for task in (stdout_drain, stderr_drain) if task is not None)
+            )

--- a/hud/eval/runtime/local.py
+++ b/hud/eval/runtime/local.py
@@ -13,8 +13,8 @@ from typing import TYPE_CHECKING
 from hud.utils.process import (
     create_process_group_exec,
     finish_output,
+    output_writer,
     stream_output,
-    write_output,
 )
 
 from .core import Runtime
@@ -192,39 +192,44 @@ class SubprocessRuntime:
         error_tail: deque[str] = deque(maxlen=50)
         stdout_drain: asyncio.Task[None] | None = None
 
-        async def stream_stderr() -> None:
-            while chunk := await error.read(65536):
-                error_tail.append(chunk.decode("utf-8", "replace").strip()[-1024:])
-                write_output(sys.stderr, chunk)
+        def capture_error(text: str) -> None:
+            error_tail.append(text.strip()[-1024:])
 
-        stderr_drain = asyncio.create_task(stream_stderr())
+        stderr_drain = asyncio.create_task(stream_output(error, sys.stderr, capture=capture_error))
         try:
             from hud.environment.server import PORT_ANNOUNCEMENT
 
             port = None
             line_continues = False
-            async with asyncio.timeout(self.ready_timeout):
-                while True:
-                    eof = False
-                    try:
-                        line = await output.readuntil()
-                    except asyncio.LimitOverrunError as exc:
-                        line = await output.read(exc.consumed)
-                        line_continues = True
-                    except asyncio.IncompleteReadError as exc:
-                        line = exc.partial
-                        eof = True
-                    if not line:
-                        break
-                    text = line.decode("utf-8", "replace").strip()
-                    if not line_continues and text.startswith(PORT_ANNOUNCEMENT):
-                        port = int(text.removeprefix(PORT_ANNOUNCEMENT))
-                        break
-                    output_tail.append(text[-1024:])
-                    write_output(sys.stdout, line)
-                    line_continues = not line.endswith(b"\n")
-                    if eof:
-                        break
+            write_stdout, finish_stdout = output_writer(
+                sys.stdout,
+                capture=lambda text: output_tail.append(text.strip()[-1024:]),
+            )
+            try:
+                async with asyncio.timeout(self.ready_timeout):
+                    while True:
+                        eof = False
+                        try:
+                            line = await output.readuntil()
+                        except asyncio.LimitOverrunError as exc:
+                            line = await output.read(exc.consumed)
+                            line_continues = True
+                        except asyncio.IncompleteReadError as exc:
+                            line = exc.partial
+                            eof = True
+                        if not line:
+                            break
+                        if not line_continues:
+                            text = line.decode("utf-8", "replace").strip()
+                            if text.startswith(PORT_ANNOUNCEMENT):
+                                port = int(text.removeprefix(PORT_ANNOUNCEMENT))
+                                break
+                        write_stdout(line)
+                        line_continues = not line.endswith(b"\n")
+                        if eof:
+                            break
+            finally:
+                finish_stdout()
             if port is None:
                 await finish_output(stderr_drain)
                 tail = "\n".join((*output_tail, *error_tail)).strip()

--- a/hud/eval/runtime/local.py
+++ b/hud/eval/runtime/local.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from hud.utils.process import (
     create_process_group_exec,
+    finish_output,
     stream_output,
     write_output,
 )
@@ -213,4 +214,4 @@ class SubprocessRuntime:
         finally:
             await proc.terminate()
             if drain is not None:
-                await asyncio.gather(drain, return_exceptions=True)
+                await finish_output(drain)

--- a/hud/eval/runtime/modal.py
+++ b/hud/eval/runtime/modal.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
-from hud.utils.process import stream_output
+from hud.utils.process import finish_output, stream_output
 
 from .compose import ComposeConfig
 from .core import Runtime, RuntimeConfig, validate_session_id
@@ -394,9 +394,6 @@ class ModalRuntime:
                         timeout=30,
                     )
                     await process.wait.aio()
-            try:
+            with contextlib.suppress(Exception):
                 await sb.terminate.aio()
-            except Exception:
-                for relay in output_tasks:
-                    relay.cancel()
-            await asyncio.gather(*output_tasks, return_exceptions=True)
+            await finish_output(*output_tasks)

--- a/hud/eval/runtime/modal.py
+++ b/hud/eval/runtime/modal.py
@@ -6,14 +6,17 @@ import asyncio
 import contextlib
 import logging
 import shlex
+import sys
 import tempfile
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
+from hud.utils.process import stream_output
+
 from .compose import ComposeConfig
-from .core import Runtime, RuntimeConfig, RuntimeSession
+from .core import Runtime, RuntimeConfig, validate_session_id
 from .docker import _DOCKER_SECCOMP_PROFILE
 
 if TYPE_CHECKING:
@@ -30,20 +33,7 @@ _MODAL_COMPOSE_MEMORY_MB = 8192
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
-class _ModalEndpoint(Runtime):
-    sandbox: modal.Sandbox
-    compose: str | None
-
-    def session(self, session_id: str) -> RuntimeSession:
-        return _ModalSession(
-            session_id=session_id,
-            sandbox=self.sandbox,
-            compose=self.compose,
-        )
-
-
-@dataclass(frozen=True, slots=True, kw_only=True)
-class _ModalSession(RuntimeSession):
+class ModalEndpoint(Runtime):
     sandbox: modal.Sandbox
     compose: str | None
 
@@ -67,10 +57,11 @@ class _ModalSession(RuntimeSession):
         return stdout
 
     @asynccontextmanager
-    async def snapshot(self) -> AsyncIterator[Path | None]:
+    async def snapshot_session(self, session_id: str) -> AsyncIterator[Path | None]:
+        validate_session_id(session_id)
         with tempfile.TemporaryDirectory(prefix="hud-session-") as directory:
             destination = Path(directory) / "session.tar.gz"
-            session = f"/media/hud/sessions/{self.session_id}"
+            session = f"/media/hud/sessions/{session_id}"
             if self.compose is None:
                 root = session
                 command = ""
@@ -100,8 +91,9 @@ class _ModalSession(RuntimeSession):
             )
             yield destination
 
-    async def restore(self, source: Path) -> None:
-        session = f"/media/hud/sessions/{self.session_id}"
+    async def restore_session(self, session_id: str, source: Path) -> None:
+        validate_session_id(session_id)
+        session = f"/media/hud/sessions/{session_id}"
         await self.sandbox.filesystem.copy_from_local.aio(source, "/media/hud/session.tar.gz")
         if self.compose is None:
             command = (
@@ -146,12 +138,14 @@ class ModalRuntime:
         port: int = 8765,
         runtime_config: RuntimeConfig | dict[str, Any] | None = None,
         env_vars: Mapping[str, str] | None = None,
+        secrets: Sequence[modal.Secret] | None = None,
     ) -> None:
         if app is not None and app_name is not None:
             raise ValueError("ModalRuntime accepts either app or app_name, not both")
         self.image_name = image_name
         self.port = port
         self.env_vars = dict(env_vars or {})
+        self.secrets = tuple(secrets or ())
         self.workdir = workdir
         # Default CMD mirrors the scaffolded Dockerfile.hud entrypoint. Leave
         # workdir unset by default so Modal preserves the image WORKDIR.
@@ -201,6 +195,11 @@ class ModalRuntime:
             raise ValueError(
                 "ModalRuntime cannot attach GPUs to services inside Docker-in-Docker; "
                 "use a materialized image or omit runtime_config.compose"
+            )
+        if compose is not None and self.secrets:
+            raise ValueError(
+                "ModalRuntime secrets require an image runtime; attaching them to "
+                "the outer Docker-in-Docker sandbox would not expose them to main"
             )
         port_service = ComposeConfig.from_file(compose).network_owner("main") if compose else "main"
         if compose is not None:
@@ -254,6 +253,8 @@ class ModalRuntime:
                 sandbox_kwargs["memory"] = resources.memory_mb
             if self.env_vars:
                 sandbox_kwargs["env"] = self.env_vars
+            if self.secrets:
+                sandbox_kwargs["secrets"] = self.secrets
         if resources is not None and resources.gpu is not None:
             gpu_types = resources.gpu.acceptable_types
             gpu_type = gpu_types[0] if gpu_types else "any"
@@ -278,6 +279,12 @@ class ModalRuntime:
             **({"experimental_options": {"vm_runtime": True}} if compose is not None else {}),
             **sandbox_kwargs,
         )
+        output_tasks: tuple[asyncio.Task[None], ...] = ()
+        if compose is None:
+            output_tasks = (
+                asyncio.create_task(stream_output(sb.stdout, sys.stdout)),
+                asyncio.create_task(stream_output(sb.stderr, sys.stderr)),
+            )
         compose_path: str | None = None
         try:
             if project is None:
@@ -335,8 +342,27 @@ class ModalRuntime:
                 if returncode != 0:
                     error = (await process.stderr.read.aio()).strip()
                     raise RuntimeError(f"Modal Compose startup failed: {error}")
+                logs = await sb.exec.aio(
+                    "docker",
+                    "compose",
+                    "--project-directory",
+                    project_directory,
+                    "--file",
+                    compose_path,
+                    "--file",
+                    "/hud/override.json",
+                    "--file",
+                    "/hud/ports.yaml",
+                    "logs",
+                    "--follow",
+                    "--no-color",
+                )
+                output_tasks = (
+                    asyncio.create_task(stream_output(logs.stdout, sys.stdout)),
+                    asyncio.create_task(stream_output(logs.stderr, sys.stderr)),
+                )
             host, port = (await sb.tunnels.aio())[self.port].tcp_socket
-            yield _ModalEndpoint(
+            yield ModalEndpoint(
                 url=f"tcp://{host}:{port}",
                 params={
                     "provider": "modal",
@@ -368,5 +394,9 @@ class ModalRuntime:
                         timeout=30,
                     )
                     await process.wait.aio()
-            with contextlib.suppress(Exception):
+            try:
                 await sb.terminate.aio()
+            except Exception:
+                for relay in output_tasks:
+                    relay.cancel()
+            await asyncio.gather(*output_tasks, return_exceptions=True)

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -42,6 +42,8 @@ from hud.eval.runtime.compose import (
 from hud.eval.task import Task
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from daytona import Image as DaytonaImage
 
 FAKE_DOCKER_SH = """\
@@ -154,6 +156,25 @@ class _ModalImageRef:
         return _ModalImageRef(self.kind, self.name, dict(vars))
 
 
+@dataclass(frozen=True)
+class _ModalSecretRef:
+    name: str
+
+
+class _FakeModalStream:
+    def __init__(self, calls: dict[str, Any], key: str) -> None:
+        self._calls = calls
+        self._key = key
+
+    def __aiter__(self) -> AsyncIterator[str]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[str]:
+        output = cast("str", self._calls.get(self._key, ""))
+        if output:
+            yield output
+
+
 class _FakeModalSandbox:
     object_id = "sb-1"
 
@@ -163,6 +184,8 @@ class _FakeModalSandbox:
         self.wait_until_ready = SimpleNamespace(aio=self._wait_until_ready)
         self.tunnels = SimpleNamespace(aio=self._tunnels)
         self.terminate = SimpleNamespace(aio=self._terminate)
+        self.stdout = _FakeModalStream(calls, "sandbox_stdout")
+        self.stderr = _FakeModalStream(calls, "sandbox_stderr")
         self.filesystem = SimpleNamespace(
             copy_from_local=SimpleNamespace(aio=self._copy_from_local),
             copy_to_local=SimpleNamespace(aio=self._copy_to_local),
@@ -212,6 +235,13 @@ class _FakeModalSandbox:
                 if "sessions/sess-actor" in command
                 and ("test -d" in command or "if [ -d" in command)
                 else ""
+            )
+
+        if "logs" in args:
+            return SimpleNamespace(
+                wait=SimpleNamespace(aio=wait),
+                stdout=_FakeModalStream(self._calls, "compose_stdout"),
+                stderr=_FakeModalStream(self._calls, "compose_stderr"),
             )
 
         return SimpleNamespace(
@@ -336,6 +366,17 @@ class _FakeDaytonaProcess:
     async def get_session_command_logs(self, session: str, cmd_id: str) -> SimpleNamespace:
         self._calls["logs"] = (session, cmd_id)
         return self.logs
+
+    async def get_session_command_logs_async(
+        self,
+        session: str,
+        cmd_id: str,
+        on_stdout: Any,
+        on_stderr: Any,
+    ) -> None:
+        self._calls["stream_logs"] = (session, cmd_id)
+        on_stdout(cast("str", self._calls.get("daytona_stdout", "")))
+        on_stderr(cast("str", self._calls.get("daytona_stderr", "")))
 
     async def exec(self, command: str, **kwargs: object) -> SimpleNamespace:
         commands = self._calls.setdefault("process_execs", [])
@@ -533,13 +574,17 @@ def _install_fake_daytona(monkeypatch: pytest.MonkeyPatch) -> _FakeDaytonaClient
 
 
 async def test_acquisition_publishes_ephemeral_port_and_removes_container(
-    tmp_path: Path, docker_log: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    docker_log: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     _install_fake_docker(tmp_path, port_behavior="echo 127.0.0.1:43210", monkeypatch=monkeypatch)
 
     provider = DockerRuntime("img:tag", run_args=("-e", "X=1"))
     async with provider(_row()) as runtime:
         assert runtime.url == "tcp://127.0.0.1:43210"
+        await asyncio.sleep(0.05)
         calls = await _docker_calls(docker_log)
         assert calls[0] == (
             f"run --detach -e X=1 {_docker_security_args()} --publish 127.0.0.1::8765 img:tag"
@@ -547,6 +592,7 @@ async def test_acquisition_publishes_ephemeral_port_and_removes_container(
         assert calls[1] == "port cid-42 8765"
 
     assert (await _docker_calls(docker_log))[-1] == "rm --force cid-42"
+    assert capsys.readouterr().out == "ImportError: boom\n"
 
 
 async def test_docker_session_archives_inside_the_container(
@@ -561,10 +607,10 @@ async def test_docker_session_archives_inside_the_container(
         return "", ""
 
     monkeypatch.setattr(runtime_module, "_docker", fake_docker)
-    async with runtime_module._DockerSession(
-        session_id="sess-actor",
+    async with runtime_module.DockerEndpoint(
+        url="tcp://127.0.0.1:8765",
         container="cid-42",
-    ).snapshot() as destination:
+    ).snapshot_session("sess-actor") as destination:
         assert destination is not None
 
     probe, export, copy, cleanup = calls
@@ -1054,8 +1100,11 @@ async def test_modal_runtime_rejects_gpu_alternatives() -> None:
 async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     calls = _install_fake_modal(monkeypatch)
+    calls["compose_stdout"] = "main  | server ready\n"
+    calls["compose_stderr"] = "grader | warning\n"
     project = tmp_path / "artifact"
     compose = project / "compose-project" / "compose.yaml"
     compose.parent.mkdir(parents=True)
@@ -1070,9 +1119,9 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     )(_row()) as runtime:
         assert runtime.url == "tcp://modal.host:4567"
         assert runtime.params == {"provider": "modal", "instance_id": "sb-1", "ready_timeout": 600}
-        async with runtime.session("sess-actor").snapshot() as archive:
+        async with runtime.snapshot_session("sess-actor") as archive:
             assert archive is not None
-            await runtime.session("sess-verifier").restore(archive)
+            await runtime.restore_session("sess-verifier", archive)
 
     assert calls["registry_image"] == "docker:28.3.3-dind"
     kwargs = calls["sandbox_kwargs"]
@@ -1108,6 +1157,8 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     assert "--file /hud/project/compose-project/compose.yaml" in startup
     assert "sh /hud/project/build.sh" in startup
     assert 'up --detach "$BUILD_FLAG" --remove-orphans' in startup
+    compose_logs = execs[1][0]
+    assert compose_logs[-3:] == ("logs", "--follow", "--no-color")
     session_commands = [
         call[0][-1]
         for call in execs[1:-1]
@@ -1126,6 +1177,9 @@ async def test_modal_runtime_runs_compose_inside_a_dind_vm(
     assert "down" in teardown
     assert execs[0][1]["timeout"] == 600
     assert calls["downloads"] == [("/media/hud/session.tar.gz", "session.tar.gz")]
+    captured = capsys.readouterr()
+    assert captured.out == "main  | server ready\n"
+    assert captured.err == "grader | warning\n"
 
 
 async def test_modal_runtime_bounds_compose_startup(
@@ -1260,6 +1314,56 @@ async def test_modal_runtime_passes_env_vars_to_sandbox(
     assert sandbox_kwargs["env"] == {"TOKEN": "secret"}
 
 
+async def test_modal_runtime_streams_sandbox_output_to_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    calls["sandbox_stdout"] = "server ready\nrequest complete"
+    calls["sandbox_stderr"] = "grader warning\n"
+    provider = ModalRuntime(runtime_config=RuntimeConfig(image="img:tag"))
+
+    async with provider(_row()):
+        pass
+
+    captured = capsys.readouterr()
+    assert captured.out == "server ready\nrequest complete"
+    assert captured.err == "grader warning\n"
+
+
+async def test_modal_runtime_attaches_secrets_to_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    secret = _ModalSecretRef("datacuration-cpu50-grader-auth")
+    provider = ModalRuntime(
+        runtime_config=RuntimeConfig(image="img:tag"),
+        secrets=[cast("Any", secret)],
+    )
+
+    async with provider(_row()):
+        pass
+
+    sandbox_kwargs = calls["sandbox_kwargs"]
+    assert isinstance(sandbox_kwargs, dict)
+    assert sandbox_kwargs["secrets"] == (secret,)
+
+
+async def test_modal_runtime_rejects_secrets_for_compose(
+    tmp_path: Path,
+) -> None:
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
+    provider = ModalRuntime(
+        runtime_config=RuntimeConfig(compose=ComposeProject(document=compose)),
+        secrets=[cast("Any", _ModalSecretRef("grader-auth"))],
+    )
+
+    with pytest.raises(ValueError, match="secrets require an image runtime"):
+        async with provider(_row()):
+            pass
+
+
 async def test_daytona_runtime_config_flows_into_daytona_sdk(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1312,6 +1416,23 @@ async def test_daytona_runtime_config_flows_into_daytona_sdk(
     )
     assert calls["forward"] == ("127.0.0.1", 0, "127.0.0.1", 8765)
     assert calls["delete"] == "sandbox-1"
+
+
+async def test_daytona_runtime_streams_sandbox_output_to_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls = _install_fake_daytona(monkeypatch).calls
+    calls["daytona_stdout"] = "server ready\n"
+    calls["daytona_stderr"] = "grader warning\n"
+
+    async with DaytonaRuntime("snapshot")(_row()):
+        pass
+
+    captured = capsys.readouterr()
+    assert captured.out == "server ready\n"
+    assert captured.err == "grader warning\n"
+    assert calls["stream_logs"] == ("hud-serve", "cmd-1")
 
 
 async def test_daytona_runtime_rejects_compose(

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, cast
 import pytest
 
 import hud.eval.runtime.docker as runtime_module
+import hud.utils.process as process_module
 from hud.eval.runtime import (
     DaytonaRuntime,
     DockerRuntime,
@@ -173,6 +174,9 @@ class _FakeModalStream:
         output = cast("str", self._calls.get(self._key, ""))
         if output:
             yield output
+        wait = self._calls.get(f"{self._key}_wait")
+        if isinstance(wait, asyncio.Event):
+            await wait.wait()
 
 
 class _FakeModalSandbox:
@@ -377,6 +381,9 @@ class _FakeDaytonaProcess:
         self._calls["stream_logs"] = (session, cmd_id)
         on_stdout(cast("str", self._calls.get("daytona_stdout", "")))
         on_stderr(cast("str", self._calls.get("daytona_stderr", "")))
+        wait = self._calls.get("daytona_log_wait")
+        if isinstance(wait, asyncio.Event):
+            await wait.wait()
 
     async def exec(self, command: str, **kwargs: object) -> SimpleNamespace:
         commands = self._calls.setdefault("process_execs", [])
@@ -1331,6 +1338,22 @@ async def test_modal_runtime_streams_sandbox_output_to_terminal(
     assert captured.err == "grader warning\n"
 
 
+async def test_modal_runtime_bounds_output_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    calls["sandbox_stdout_wait"] = asyncio.Event()
+    calls["sandbox_stderr_wait"] = asyncio.Event()
+    monkeypatch.setattr(process_module, "OUTPUT_DRAIN_TIMEOUT", 0.01)
+
+    async def run() -> None:
+        async with ModalRuntime(runtime_config=RuntimeConfig(image="img:tag"))(_row()):
+            pass
+
+    await asyncio.wait_for(run(), timeout=1)
+    assert calls["terminated"] is True
+
+
 async def test_modal_runtime_attaches_secrets_to_sandbox(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1433,6 +1456,21 @@ async def test_daytona_runtime_streams_sandbox_output_to_terminal(
     assert captured.out == "server ready\n"
     assert captured.err == "grader warning\n"
     assert calls["stream_logs"] == ("hud-serve", "cmd-1")
+
+
+async def test_daytona_runtime_bounds_output_teardown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_daytona(monkeypatch).calls
+    calls["daytona_log_wait"] = asyncio.Event()
+    monkeypatch.setattr(process_module, "OUTPUT_DRAIN_TIMEOUT", 0.01)
+
+    async def run() -> None:
+        async with DaytonaRuntime("snapshot")(_row()):
+            pass
+
+    await asyncio.wait_for(run(), timeout=1)
+    assert calls["delete"] == "sandbox-1"
 
 
 async def test_daytona_runtime_rejects_compose(

--- a/hud/eval/tests/test_local_runtime.py
+++ b/hud/eval/tests/test_local_runtime.py
@@ -11,7 +11,7 @@ import pytest
 
 from hud.agents.base import Agent
 from hud.environment import Environment
-from hud.eval import LocalRuntime, Task, Taskset
+from hud.eval import LocalRuntime, SubprocessRuntime, Task, Taskset
 
 _SUMS_ENV = """\
 from hud import Environment
@@ -81,6 +81,26 @@ async def test_source_path_serves_a_fresh_env_per_rollout(tmp_path) -> None:
     )
 
     assert [run.reward for run in job.runs] == [1.0, 1.0]
+
+
+async def test_subprocess_runtime_streams_environment_output(
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    source = tmp_path / "env.py"
+    source.write_text(
+        "from hud import Environment\n\n"
+        'env = Environment("sums")\n\n'
+        "@env.initialize\n"
+        "async def start():\n"
+        '    print("environment booted", flush=True)\n',
+        encoding="utf-8",
+    )
+
+    async with SubprocessRuntime(source)(Task(env="sums", id="add")):
+        pass
+
+    assert "environment booted" in capsys.readouterr().out
 
 
 async def test_constructor_builds_fresh_per_rollout_from_the_row() -> None:

--- a/hud/eval/tests/test_local_runtime.py
+++ b/hud/eval/tests/test_local_runtime.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 
 import pytest
 
+import hud.eval.runtime.local as local_runtime_module
 from hud.agents.base import Agent
 from hud.environment import Environment
 from hud.eval import LocalRuntime, SubprocessRuntime, Task, Taskset
@@ -111,29 +112,45 @@ async def test_subprocess_runtime_streams_environment_output(
     assert "environment warning" in captured.err
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group regression")
-async def test_subprocess_runtime_fails_when_stdout_closes_before_serving(tmp_path) -> None:
+async def test_subprocess_runtime_fails_when_stdout_closes_before_serving(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     source = tmp_path / "env.py"
-    source.write_text(
-        "import asyncio\n"
-        "import os\n"
-        "import sys\n\n"
-        "from hud import Environment\n\n"
-        'env = Environment("closed")\n\n'
-        "@env.initialize\n"
-        "async def start():\n"
-        "    os.close(sys.stdout.fileno())\n"
-        '    print("stdout closed", file=sys.stderr, flush=True)\n'
-        "    await asyncio.sleep(120)\n",
-        encoding="utf-8",
-    )
+    source.write_text("", encoding="utf-8")
+    output = asyncio.StreamReader()
+    output.feed_eof()
+    error = asyncio.StreamReader()
+    error.feed_data(b"stdout closed\n")
+    error.feed_eof()
+
+    class Process:
+        stdout = output
+        stderr = error
+        returncode = None
+        terminated = False
+
+        async def wait(self) -> int:
+            await asyncio.Event().wait()
+            return 0
+
+        async def terminate(self) -> None:
+            self.terminated = True
+
+    process = Process()
+
+    async def create_process(*args: Any, **kwargs: Any) -> Any:
+        return process
+
+    monkeypatch.setattr(local_runtime_module, "create_process_group_exec", create_process)
 
     async def run() -> None:
         async with SubprocessRuntime(source, ready_timeout=30)(Task(env="closed", id="noop")):
             pass
 
     with pytest.raises(RuntimeError, match=r"(?s)closed stdout.*stdout closed"):
-        await asyncio.wait_for(run(), timeout=3)
+        await asyncio.wait_for(run(), timeout=1)
+    assert process.terminated is True
 
 
 async def test_constructor_builds_fresh_per_rollout_from_the_row() -> None:

--- a/hud/eval/tests/test_local_runtime.py
+++ b/hud/eval/tests/test_local_runtime.py
@@ -89,18 +89,22 @@ async def test_subprocess_runtime_streams_environment_output(
 ) -> None:
     source = tmp_path / "env.py"
     source.write_text(
+        "import sys\n\n"
         "from hud import Environment\n\n"
         'env = Environment("sums")\n\n'
         "@env.initialize\n"
         "async def start():\n"
-        '    print("environment booted", flush=True)\n',
+        '    print("environment booted", flush=True)\n'
+        '    print("environment warning", file=sys.stderr, flush=True)\n',
         encoding="utf-8",
     )
 
     async with SubprocessRuntime(source)(Task(env="sums", id="add")):
         pass
 
-    assert "environment booted" in capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert "environment booted" in captured.out
+    assert "environment warning" in captured.err
 
 
 async def test_constructor_builds_fresh_per_rollout_from_the_row() -> None:

--- a/hud/eval/tests/test_local_runtime.py
+++ b/hud/eval/tests/test_local_runtime.py
@@ -94,7 +94,9 @@ async def test_subprocess_runtime_streams_environment_output(
         'env = Environment("sums")\n\n'
         "@env.initialize\n"
         "async def start():\n"
+        '    print("x" * 100_000, flush=True)\n'
         '    print("environment booted", flush=True)\n'
+        '    print("y" * 100_000, file=sys.stderr, flush=True)\n'
         '    print("environment warning", file=sys.stderr, flush=True)\n',
         encoding="utf-8",
     )
@@ -103,8 +105,35 @@ async def test_subprocess_runtime_streams_environment_output(
         pass
 
     captured = capsys.readouterr()
+    assert "x" * 100_000 in captured.out
     assert "environment booted" in captured.out
+    assert "y" * 100_000 in captured.err
     assert "environment warning" in captured.err
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX process-group regression")
+async def test_subprocess_runtime_fails_when_stdout_closes_before_serving(tmp_path) -> None:
+    source = tmp_path / "env.py"
+    source.write_text(
+        "import asyncio\n"
+        "import os\n"
+        "import sys\n\n"
+        "from hud import Environment\n\n"
+        'env = Environment("closed")\n\n'
+        "@env.initialize\n"
+        "async def start():\n"
+        "    os.close(sys.stdout.fileno())\n"
+        '    print("stdout closed", file=sys.stderr, flush=True)\n'
+        "    await asyncio.sleep(120)\n",
+        encoding="utf-8",
+    )
+
+    async def run() -> None:
+        async with SubprocessRuntime(source, ready_timeout=30)(Task(env="closed", id="noop")):
+            pass
+
+    with pytest.raises(RuntimeError, match=r"(?s)closed stdout.*stdout closed"):
+        await asyncio.wait_for(run(), timeout=3)
 
 
 async def test_constructor_builds_fresh_per_rollout_from_the_row() -> None:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -34,7 +34,6 @@ from hud.agents.types import OpenAIChatConfig
 from hud.environment import Answer, Environment
 from hud.eval import Job, LocalRuntime, Runtime, SubprocessRuntime, Task, Taskset
 from hud.eval.run import Run, rollout
-from hud.eval.runtime import RuntimeSession
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -284,27 +283,19 @@ async def test_independent_verifier_receives_runtime_session_files(tmp_path: Pat
         yield ""
         yield 1.0
 
-    class ActorSession(RuntimeSession):
+    class ActorRuntime(Runtime):
         @asynccontextmanager
-        async def snapshot(self) -> AsyncIterator[Path | None]:
+        async def snapshot_session(self, session_id: str) -> AsyncIterator[Path | None]:
             destination = tmp_path / "session.tar.gz"
-            await asyncio.to_thread(destination.write_text, self.session_id, encoding="utf-8")
-            transfers.append(("actor", self.session_id))
+            await asyncio.to_thread(destination.write_text, session_id, encoding="utf-8")
+            transfers.append(("actor", session_id))
             yield destination
 
-    class VerifierSession(RuntimeSession):
-        async def restore(self, source: Path) -> None:
+    class VerifierRuntime(Runtime):
+        async def restore_session(self, session_id: str, source: Path) -> None:
             content = await asyncio.to_thread(source.read_text, encoding="utf-8")
             assert content.startswith("sess-")
-            transfers.append(("verifier", self.session_id))
-
-    class ActorRuntime(Runtime):
-        def session(self, session_id: str) -> RuntimeSession:
-            return ActorSession(session_id)
-
-    class VerifierRuntime(Runtime):
-        def session(self, session_id: str) -> RuntimeSession:
-            return VerifierSession(session_id)
+            transfers.append(("verifier", session_id))
 
     @asynccontextmanager
     async def provider(row: TaskRow) -> AsyncIterator[Runtime]:
@@ -326,6 +317,16 @@ async def test_independent_verifier_receives_runtime_session_files(tmp_path: Pat
     assert transfers[0][1].startswith("sess-")
     assert transfers[1][1].startswith("sess-")
     assert transfers[0][1] != transfers[1][1]
+
+
+async def test_runtime_session_transfer_rejects_invalid_ids(tmp_path: Path) -> None:
+    runtime = Runtime("tcp://127.0.0.1:8765")
+
+    with pytest.raises(ValueError, match="single path component"):
+        async with runtime.snapshot_session("../actor"):
+            pass
+    with pytest.raises(ValueError, match="single path component"):
+        await runtime.restore_session("", tmp_path / "session.tar.gz")
 
 
 async def test_verifier_with_its_own_environment_is_placed_after_the_actor() -> None:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -34,6 +34,7 @@ from hud.agents.types import OpenAIChatConfig
 from hud.environment import Answer, Environment
 from hud.eval import Job, LocalRuntime, Runtime, SubprocessRuntime, Task, Taskset
 from hud.eval.run import Run, rollout
+from hud.eval.runtime.core import validate_session_id
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -268,10 +269,19 @@ async def test_malformed_subscores_fail_inside_the_rollout_boundary(
     assert reported == [{}]
 
 
-async def test_independent_verifier_receives_runtime_session_files(tmp_path: Path) -> None:
+async def test_independent_verifier_receives_runtime_session_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     actor_env = Environment("actor")
     verifier_env = Environment("judge")
     transfers: list[tuple[str, str]] = []
+
+    def record_validation(session_id: str) -> None:
+        validate_session_id(session_id)
+        transfers.append(("validate", session_id))
+
+    monkeypatch.setattr("hud.eval.runtime.core.validate_session_id", record_validation)
 
     @actor_env.template()
     async def solve():
@@ -313,10 +323,17 @@ async def test_independent_verifier_receives_runtime_session_files(tmp_path: Pat
     run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=provider)
 
     assert run.reward == 1.0
-    assert [runtime for runtime, _ in transfers] == ["actor", "verifier"]
+    assert [runtime for runtime, _ in transfers] == [
+        "validate",
+        "actor",
+        "validate",
+        "verifier",
+    ]
+    assert transfers[0][1] == transfers[1][1]
+    assert transfers[2][1] == transfers[3][1]
     assert transfers[0][1].startswith("sess-")
-    assert transfers[1][1].startswith("sess-")
-    assert transfers[0][1] != transfers[1][1]
+    assert transfers[2][1].startswith("sess-")
+    assert transfers[0][1] != transfers[2][1]
 
 
 async def test_runtime_session_transfer_rejects_invalid_ids(tmp_path: Path) -> None:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -34,7 +34,6 @@ from hud.agents.types import OpenAIChatConfig
 from hud.environment import Answer, Environment
 from hud.eval import Job, LocalRuntime, Runtime, SubprocessRuntime, Task, Taskset
 from hud.eval.run import Run, rollout
-from hud.eval.runtime.core import validate_session_id
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -269,19 +268,10 @@ async def test_malformed_subscores_fail_inside_the_rollout_boundary(
     assert reported == [{}]
 
 
-async def test_independent_verifier_receives_runtime_session_files(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+async def test_independent_verifier_receives_runtime_session_files(tmp_path: Path) -> None:
     actor_env = Environment("actor")
     verifier_env = Environment("judge")
     transfers: list[tuple[str, str]] = []
-
-    def record_validation(session_id: str) -> None:
-        validate_session_id(session_id)
-        transfers.append(("validate", session_id))
-
-    monkeypatch.setattr("hud.eval.runtime.core.validate_session_id", record_validation)
 
     @actor_env.template()
     async def solve():
@@ -323,17 +313,10 @@ async def test_independent_verifier_receives_runtime_session_files(
     run = await rollout(task, _FnAgent(lambda _prompt: "secret"), runtime=provider)
 
     assert run.reward == 1.0
-    assert [runtime for runtime, _ in transfers] == [
-        "validate",
-        "actor",
-        "validate",
-        "verifier",
-    ]
-    assert transfers[0][1] == transfers[1][1]
-    assert transfers[2][1] == transfers[3][1]
+    assert [runtime for runtime, _ in transfers] == ["actor", "verifier"]
     assert transfers[0][1].startswith("sess-")
-    assert transfers[2][1].startswith("sess-")
-    assert transfers[0][1] != transfers[2][1]
+    assert transfers[1][1].startswith("sess-")
+    assert transfers[0][1] != transfers[1][1]
 
 
 async def test_runtime_session_transfer_rejects_invalid_ids(tmp_path: Path) -> None:

--- a/hud/utils/process.py
+++ b/hud/utils/process.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import codecs
 import contextlib
+import io
 import os
 import signal
 from dataclasses import dataclass
@@ -18,6 +20,11 @@ OUTPUT_DRAIN_TIMEOUT = 1.0
 
 
 def write_output(output: TextIO, chunk: str | bytes) -> None:
+    if isinstance(chunk, bytes) and isinstance(output, io.TextIOWrapper):
+        output.flush()
+        output.buffer.write(chunk)
+        output.buffer.flush()
+        return
     output.write(chunk.decode("utf-8", "replace") if isinstance(chunk, bytes) else chunk)
     output.flush()
 
@@ -26,12 +33,28 @@ async def stream_output(
     source: AsyncIterable[str] | AsyncIterable[bytes],
     output: TextIO,
 ) -> None:
+    decoder = (
+        None
+        if isinstance(output, io.TextIOWrapper)
+        else codecs.getincrementaldecoder("utf-8")(errors="replace")
+    )
+
+    def relay(chunk: str | bytes) -> None:
+        if isinstance(chunk, bytes) and decoder is not None:
+            text = decoder.decode(chunk)
+            if text:
+                write_output(output, text)
+            return
+        write_output(output, chunk)
+
     if isinstance(source, asyncio.StreamReader):
         while chunk := await source.read(65536):
-            write_output(output, chunk)
-        return
-    async for chunk in source:
-        write_output(output, chunk)
+            relay(chunk)
+    else:
+        async for chunk in source:
+            relay(chunk)
+    if decoder is not None and (text := decoder.decode(b"", final=True)):
+        write_output(output, text)
 
 
 async def finish_output(*tasks: asyncio.Task[None]) -> None:

--- a/hud/utils/process.py
+++ b/hud/utils/process.py
@@ -12,49 +12,71 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterable
+    from collections.abc import AsyncIterable, Callable
     from typing import TextIO
 
 _PROCESS_EXIT_POLL_INTERVAL = 0.05
 OUTPUT_DRAIN_TIMEOUT = 1.0
 
 
-def write_output(output: TextIO, chunk: str | bytes) -> None:
-    if isinstance(chunk, bytes) and isinstance(output, io.TextIOWrapper):
-        output.flush()
-        output.buffer.write(chunk)
-        output.buffer.flush()
-        return
-    output.write(chunk.decode("utf-8", "replace") if isinstance(chunk, bytes) else chunk)
-    output.flush()
+def output_writer(
+    output: TextIO,
+    *,
+    capture: Callable[[str], None] | None = None,
+) -> tuple[Callable[[str | bytes], None], Callable[[], None]]:
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    sink_failed = False
+
+    def write(chunk: str | bytes) -> None:
+        nonlocal sink_failed
+        text = decoder.decode(chunk) if isinstance(chunk, bytes) else chunk
+        if capture is not None and text:
+            capture(text)
+        if sink_failed:
+            return
+        try:
+            if isinstance(chunk, bytes) and isinstance(output, io.TextIOWrapper):
+                output.flush()
+                output.buffer.write(chunk)
+                output.buffer.flush()
+            elif text:
+                output.write(text)
+                output.flush()
+        except Exception:
+            sink_failed = True
+
+    def finish() -> None:
+        nonlocal sink_failed
+        text = decoder.decode(b"", final=True)
+        if capture is not None and text:
+            capture(text)
+        if not text or isinstance(output, io.TextIOWrapper) or sink_failed:
+            return
+        try:
+            output.write(text)
+            output.flush()
+        except Exception:
+            sink_failed = True
+
+    return write, finish
 
 
 async def stream_output(
     source: AsyncIterable[str] | AsyncIterable[bytes],
     output: TextIO,
+    *,
+    capture: Callable[[str], None] | None = None,
 ) -> None:
-    decoder = (
-        None
-        if isinstance(output, io.TextIOWrapper)
-        else codecs.getincrementaldecoder("utf-8")(errors="replace")
-    )
-
-    def relay(chunk: str | bytes) -> None:
-        if isinstance(chunk, bytes) and decoder is not None:
-            text = decoder.decode(chunk)
-            if text:
-                write_output(output, text)
-            return
-        write_output(output, chunk)
-
-    if isinstance(source, asyncio.StreamReader):
-        while chunk := await source.read(65536):
-            relay(chunk)
-    else:
-        async for chunk in source:
-            relay(chunk)
-    if decoder is not None and (text := decoder.decode(b"", final=True)):
-        write_output(output, text)
+    write, finish = output_writer(output, capture=capture)
+    try:
+        if isinstance(source, asyncio.StreamReader):
+            while chunk := await source.read(65536):
+                write(chunk)
+        else:
+            async for chunk in source:
+                write(chunk)
+    finally:
+        finish()
 
 
 async def finish_output(*tasks: asyncio.Task[None]) -> None:

--- a/hud/utils/process.py
+++ b/hud/utils/process.py
@@ -26,6 +26,10 @@ async def stream_output(
     source: AsyncIterable[str] | AsyncIterable[bytes],
     output: TextIO,
 ) -> None:
+    if isinstance(source, asyncio.StreamReader):
+        while chunk := await source.read(65536):
+            write_output(output, chunk)
+        return
     async for chunk in source:
         write_output(output, chunk)
 

--- a/hud/utils/process.py
+++ b/hud/utils/process.py
@@ -7,9 +7,26 @@ import contextlib
 import os
 import signal
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterable
+    from typing import TextIO
 
 _PROCESS_EXIT_POLL_INTERVAL = 0.05
+
+
+def write_output(output: TextIO, chunk: str | bytes) -> None:
+    output.write(chunk.decode("utf-8", "replace") if isinstance(chunk, bytes) else chunk)
+    output.flush()
+
+
+async def stream_output(
+    source: AsyncIterable[str] | AsyncIterable[bytes],
+    output: TextIO,
+) -> None:
+    async for chunk in source:
+        write_output(output, chunk)
 
 
 @dataclass(frozen=True, slots=True)

--- a/hud/utils/process.py
+++ b/hud/utils/process.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from typing import TextIO
 
 _PROCESS_EXIT_POLL_INTERVAL = 0.05
+OUTPUT_DRAIN_TIMEOUT = 1.0
 
 
 def write_output(output: TextIO, chunk: str | bytes) -> None:
@@ -27,6 +28,15 @@ async def stream_output(
 ) -> None:
     async for chunk in source:
         write_output(output, chunk)
+
+
+async def finish_output(*tasks: asyncio.Task[None]) -> None:
+    if not tasks:
+        return
+    _, pending = await asyncio.wait(tasks, timeout=OUTPUT_DRAIN_TIMEOUT)
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
 
 
 @dataclass(frozen=True, slots=True)

--- a/hud/utils/tests/test_process.py
+++ b/hud/utils/tests/test_process.py
@@ -83,6 +83,20 @@ async def test_stream_output_preserves_utf8_split_across_chunks() -> None:
     assert output.getvalue() == "price: €10"
 
 
+async def test_stream_output_keeps_draining_after_sink_failure() -> None:
+    class FailedOutput(StringIO):
+        def write(self, value: str) -> int:
+            raise OSError("terminal closed")
+
+    source = asyncio.StreamReader()
+    source.feed_data(b"x" * 200_000)
+    source.feed_eof()
+
+    await stream_output(source, FailedOutput())
+
+    assert source.at_eof()
+
+
 async def test_a_child_outside_the_group_cannot_hold_completion_open() -> None:
     child = shlex.quote(sys.executable)
     result = await asyncio.wait_for(

--- a/hud/utils/tests/test_process.py
+++ b/hud/utils/tests/test_process.py
@@ -71,6 +71,18 @@ async def test_stream_output_drains_lines_larger_than_the_reader_limit() -> None
     assert output.getvalue() == "x" * 100_000
 
 
+async def test_stream_output_preserves_utf8_split_across_chunks() -> None:
+    async def chunks():
+        yield b"price: \xe2"
+        yield b"\x82\xac10"
+
+    output = StringIO()
+
+    await stream_output(chunks(), output)
+
+    assert output.getvalue() == "price: €10"
+
+
 async def test_a_child_outside_the_group_cannot_hold_completion_open() -> None:
     child = shlex.quote(sys.executable)
     result = await asyncio.wait_for(

--- a/hud/utils/tests/test_process.py
+++ b/hud/utils/tests/test_process.py
@@ -7,12 +7,13 @@ import os
 import shlex
 import signal
 import sys
+from io import StringIO
 from types import SimpleNamespace
 from typing import cast
 
 import pytest
 
-from hud.utils.process import ProcessGroup, ProcessResult, create_process_group_exec
+from hud.utils.process import ProcessGroup, ProcessResult, create_process_group_exec, stream_output
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -57,6 +58,17 @@ async def test_a_chatty_process_does_not_block_on_a_full_pipe() -> None:
 
     assert result.timed_out is False
     assert len(result.stdout) == 500000
+
+
+async def test_stream_output_drains_lines_larger_than_the_reader_limit() -> None:
+    source = asyncio.StreamReader()
+    source.feed_data(b"x" * 100_000)
+    source.feed_eof()
+    output = StringIO()
+
+    await stream_output(source, output)
+
+    assert output.getvalue() == "x" * 100_000
 
 
 async def test_a_child_outside_the_group_cannot_hold_completion_open() -> None:


### PR DESCRIPTION
## Summary

- attach native `modal.Secret` objects to direct Modal image runtimes
- stream raw environment stdout and stderr for SDK-owned Subprocess, Docker, Modal, and Daytona runtimes
- collapse runtime session transfer onto provisioned runtimes and remove the `RuntimeSession` wrapper

## Breaking change

`RuntimeSession` is removed. Custom provisioned runtimes should implement `snapshot_session(session_id)` and `restore_session(session_id, archive)` directly on `Runtime`.

## Validation

- `ruff check` on all modified Python files
- strict `ty check` on all modified Python files
- `pytest -q hud/eval/tests` — 226 passed
- `git diff --check`

A billable live Modal canary was not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public runtime API change for custom providers, plus new Modal secret attachment and live log streaming that can affect teardown and what appears on the local terminal. Not auth/payment-critical, but custom runtimes and secret handling need review.
> 
> **Overview**
> SDK-owned local evals now stream raw environment stdout/stderr to the terminal (Subprocess, Docker, Modal, Daytona). Hosted runtimes still keep that output on the trace.
> 
> `ModalRuntime` can attach native `modal.Secret` objects on image sandboxes so secret values never pass through the local process. Secrets are rejected for Docker-in-Docker Compose because they would not reach `main`.
> 
> **Breaking:** `RuntimeSession` is gone. Session file transfer lives on the provisioned `Runtime` as `snapshot_session` / `restore_session`. Rollout uses those methods when handing actor files to an independent verifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee355883589c0ed0471b2e50808097afad14cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->