### PR TITLE
Preserve taskset linkage when selecting eval tasks

### DIFF
--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -813,22 +813,20 @@ async def _run_evaluation(cfg: EvalConfig) -> Any:
 
     if cfg.task_ids:
         wanted = set(cfg.task_ids)
-        taskset = Taskset(
-            taskset.name,
-            (
-                task
-                for index, (slug, task) in enumerate(taskset.items())
-                if slug in wanted or task.id in wanted or str(index) in wanted
-            ),
-        )
+        selected_slugs = [
+            slug
+            for index, (slug, task) in enumerate(taskset.items())
+            if slug in wanted or task.id in wanted or str(index) in wanted
+        ]
+        taskset = taskset.filter(selected_slugs)
         if not taskset:
             hud_console.error(f"No tasks matching: {', '.join(cfg.task_ids)}")
             raise typer.Exit(1)
         hud_console.info(f"Filtered to {len(taskset)} task(s)")
     elif not cfg.all:
-        tasks = list(taskset)
-        total = len(tasks)
-        taskset = Taskset(taskset.name, [tasks[0]])
+        total = len(taskset)
+        first_slug, _ = next(taskset.items())
+        taskset = taskset.filter([first_slug])
         if total > 1:
             hud_console.warning(
                 f"Running only 1 of {total} tasks (the first). "

--- a/hud/cli/tests/test_eval_config.py
+++ b/hud/cli/tests/test_eval_config.py
@@ -291,6 +291,54 @@ async def test_python_task_source_loads_on_main_thread(
     assert marker.read_text(encoding="utf-8") == "True"
 
 
+@pytest.mark.parametrize(
+    ("task_ids", "expected_slug"),
+    [
+        (None, "first"),
+        (["second"], "second"),
+    ],
+)
+async def test_platform_task_selection_preserves_taskset_link(
+    monkeypatch: pytest.MonkeyPatch,
+    task_ids: list[str] | None,
+    expected_slug: str,
+) -> None:
+    from hud.eval import Job, Task, Taskset
+
+    platform_taskset = Taskset(
+        "Demo",
+        [
+            Task(env="demo", id="run", slug="first"),
+            Task(env="demo", id="run", slug="second"),
+        ],
+        taskset_id="taskset-123",
+    )
+    selected: Taskset | None = None
+
+    async def capture_run(self: Taskset, *_args: object, **_kwargs: object) -> Job:
+        nonlocal selected
+        selected = self
+        return Job(id="job-123", name=self.name)
+
+    monkeypatch.setattr(Taskset, "from_api", classmethod(lambda _cls, _name: platform_taskset))
+    monkeypatch.setattr(Taskset, "run", capture_run)
+    monkeypatch.setattr(eval_mod, "_build_agent", lambda _cfg: object())
+    monkeypatch.setattr(eval_mod, "_resolve_placement", lambda *_args: object())
+
+    await eval_mod._run_evaluation(
+        EvalConfig(
+            source="Demo",
+            agent_type="openai",
+            task_ids=task_ids,
+            remote=True,
+        )
+    )
+
+    assert selected is not None
+    assert selected.taskset_id == "taskset-123"
+    assert list(selected.tasks) == [expected_slug]
+
+
 def test_resolve_runtime_slug_defaults_to_remote() -> None:
     cfg = EvalConfig(source="My Tasks").resolve_runtime()
     assert cfg.runtime is None


### PR DESCRIPTION
## Summary

Preserve platform taskset identity when hud eval selects a subset of tasks.

## Issue

The CLI rebuilt a Taskset after --task-ids filtering or default first-task selection without carrying taskset_id. Hosted runs therefore became unlinked inline executions instead of traces associated with the synced task version.

## Solution

Use Taskset.filter for both selection paths so the existing taskset_id is retained. Add regression coverage for explicit task selection and the default first-task path.

## Impact

Remote evals launched from a platform taskset remain linked to that taskset and its persisted task version. Local task sources remain unchanged.

## Validation

- 119 CLI tests passed
- Ruff lint passed
- Ruff formatting check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI selection change with a regression test; it only affects how a subset of tasks is chosen, not auth or execution logic.
> 
> **Overview**
> Remote `hud eval` runs no longer drop platform taskset identity when selecting a subset of tasks.
> 
> `--task-ids` and the default first-task path now use `Taskset.filter` instead of reconstructing a new `Taskset`, so `taskset_id` is kept and hosted jobs stay linked to the synced taskset. A regression test covers both selection paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018f6a0f6fb4620309d9d3f5983ba385ed1d707e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->