### PR TITLE
docs(v6): add platform links to quickstart, intro, and eval guide

### DIFF
--- a/docs/v6/guides/running-an-eval.mdx
+++ b/docs/v6/guides/running-an-eval.mdx
@@ -34,7 +34,7 @@ hud eval "My Taskset" claude --all --group 3
 ```
 
 **From the platform**, open [hud.ai](https://hud.ai), pick the environment, choose a taskset and a model,
-and launch - no CLI required.
+and launch - no CLI required. See [evaluations on the platform](/platform/evaluations) for that flow.
 
 ### Choosing an agent
 

--- a/docs/v6/start/index.mdx
+++ b/docs/v6/start/index.mdx
@@ -68,6 +68,7 @@ that environment, and run any agent to perform those tasks, at any scale. Our SD
 - [**Advanced**](/v6/advanced/extending) - off the beaten path: bring your own harness, composing environments, subagents, and chat.
 - [**Cookbooks**](/v6/cookbooks/index) - worked examples and creative ways to use HUD.
 - [**More**](/v6/more/faq) - FAQ, migrating to v6, and contributing.
+- [**Platform**](/platform/introduction) - the hud.ai side of the workflow: deployed environments, tasksets, evaluations, and traces.
 
 {/* <CardGroup cols={2}>
 <Card title="Quickstart" icon="bolt" href="/v6/start/quickstart">

--- a/docs/v6/start/quickstart.mdx
+++ b/docs/v6/start/quickstart.mdx
@@ -61,4 +61,10 @@ tasks = [count_letter(word=w) for w in ("strawberry", "raspberry", "blueberry")]
 hud eval tasks.py claude
 ```
 
-`hud eval` spawns the environment locally, runs the `claude` agent, and grades it. Every rollout generates a replayable trace on [hud.ai](https://hud.ai). 
+`hud eval` spawns the environment locally, runs the `claude` agent, and grades it. Every rollout generates a replayable trace on [hud.ai](https://hud.ai).
+
+## 5. View your traces
+
+`hud eval` prints a job link. Open it on [hud.ai](https://hud.ai) to replay each trace step by
+step - every prompt, action, and the reward the grader returned. From the
+[platform](/platform/evaluations) you can run whole tasksets across models and compare the results.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only link and copy updates; no code, auth, or runtime behavior changes.
> 
> **Overview**
> Adds cross-links from v6 SDK docs into the hud.ai platform docs.
> 
> The intro now lists a **Platform** entry. The eval guide points platform-launched runs at `/platform/evaluations`. Quickstart adds a **View your traces** step covering job links, trace replay, and comparing tasksets on the platform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47d0ff63a7164af401726d53939621b656fea07b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->