### PR TITLE
fix(cli): use canonical environment names in hud init

### DIFF
--- a/hud/cli/init.py
+++ b/hud/cli/init.py
@@ -21,15 +21,10 @@ import httpx
 import typer
 
 from hud.utils.hud_console import HUDConsole
+from hud.utils.naming import normalize_environment_name
 
 from .presets import ENVIRONMENT_PRESETS, PRESETS_BY_ID, EnvironmentPreset, materialize_preset
 from .templates import DOCKERFILE_HUD, ENV_PY, PYPROJECT_TOML, TASKS_PY
-
-
-def _python_name(name: str) -> str:
-    """Normalize a package name into a Python-identifier-ish env name."""
-    name = name.replace("-", "_").replace(" ", "_")
-    return "".join(c if c.isalnum() or c == "_" else "_" for c in name)
 
 
 def _resolve_preset(preset: str | None, hud_console: HUDConsole) -> EnvironmentPreset | None:
@@ -157,7 +152,7 @@ def init_command(
             raise typer.Exit(1) from exc
         hud_console.status_item(f"{chosen.owner}/{chosen.repo}", "✓")
     else:
-        _write_local_scaffold(target, _python_name(target.name), hud_console)
+        _write_local_scaffold(target, normalize_environment_name(target.name), hud_console)
 
     hud_console.section_title("Next Steps")
     hud_console.info("")

--- a/hud/cli/tests/test_init.py
+++ b/hud/cli/tests/test_init.py
@@ -40,7 +40,7 @@ def test_init_scaffolds_a_runnable_package(tmp_path: Path) -> None:
     }
 
     env_py = (target / "env.py").read_text()
-    assert 'Environment(name="my_cool_env")' in env_py
+    assert 'Environment(name="my-cool-env")' in env_py
     assert (target / "tasks.py").read_text().startswith('"""')
     assert 'name = "my-cool-env"' in (target / "pyproject.toml").read_text()
 


### PR DESCRIPTION
## Issue

`hud init my-env` generated `Environment(name="my_env")` while the package and deployed registry used `my-env`. The mismatch caused tasks to reference a registry name that did not exist.

## Solution

Use the SDK's canonical environment-name normalization when generating `env.py`, so both names remain `my-env`.

## Tests

- `uv run --extra dev pytest -q hud/cli/tests/test_init.py`
- Ruff format and lint
- `ty check hud/cli/init.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only affects newly generated local scaffolds from `hud init`; no auth, sync, or runtime behavior changes in this diff.
> 
> **Overview**
> **`hud init`** no longer derives environment names with a local underscore slugifier. Local blank scaffolds now call shared **`normalize_environment_name`** on the target directory name, so generated **`env.py`** uses the same hyphenated, registry-style spelling (e.g. `my-cool-env` instead of `my_cool_env`).
> 
> The inline **`_python_name`** helper was removed in favor of that shared utility. **`test_init`** expectations were updated to match the hyphenated **`Environment(name=...)`** in the scaffold output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e975a123d02c0abfa5a1044ab0f65d889ad4b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->