### PR TITLE
docs(daytona): add cookbook walkthrough page and link the guide

### DIFF
--- a/cookbooks/daytona-rl/README.md
+++ b/cookbooks/daytona-rl/README.md
@@ -11,7 +11,7 @@ passes. Ten GRPO steps at 128 parallel rollouts took a Qwen3.5 4B fork from
 ![training curve](bench/train_curve.svg)
 
 The full measured walkthrough — spin-up ladders to 256 concurrent, warm pools,
-and sizing rules — is [the guide on Daytona's docs](DAYTONA_GUIDE_URL). The
+and sizing rules — is [the guide on Daytona's docs](https://www.daytona.io/docs/guides/reinforcement-learning/hud-rl-cookbook). The
 condensed HUD-side walkthrough is
 [on the HUD docs](https://docs.hud.ai/v6/cookbooks/daytona-rl).
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -72,7 +72,7 @@
             { "group": "Experimental", "expanded": false, "pages": ["v6/experimental/index", "v6/experimental/harbor", "v6/experimental/compose", "v6/experimental/verifier-environments"] }
           ] },
           { "group": "Cookbooks", "pages": [
-            { "group": "Cookbooks", "expanded": false, "pages": ["v6/cookbooks/index", "v6/cookbooks/fireworks-rl-training", "v6/cookbooks/coding-agent", "v6/cookbooks/ops-diagnostics", "v6/cookbooks/a2a-chat", "v6/cookbooks/robot-benchmark"] }
+            { "group": "Cookbooks", "expanded": false, "pages": ["v6/cookbooks/index", "v6/cookbooks/fireworks-rl-training", "v6/cookbooks/daytona-rl", "v6/cookbooks/coding-agent", "v6/cookbooks/ops-diagnostics", "v6/cookbooks/a2a-chat", "v6/cookbooks/robot-benchmark"] }
           ] },
           { "group": "Internals", "pages": [
             { "group": "Internals", "expanded": false, "pages": ["v6/internals/index", "v6/internals/walkthrough", "v6/internals/placement", "v6/internals/control-channel"] }

--- a/docs/logo/daytona.svg
+++ b/docs/logo/daytona.svg
@@ -1,0 +1,10 @@
+<svg width="69" height="72" viewBox="0 0 69 72" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3.63965" y="48.4343" width="24.9293" height="8.54716" fill="#9ca3af"/>
+<rect x="37.1162" y="18.5193" width="28.4906" height="8.54716" fill="#9ca3af"/>
+<rect width="29.9151" height="8.54717" transform="matrix(0.707107 -0.707106 0.707107 0.707106 22.1582 21.1531)" fill="#9ca3af"/>
+<rect width="22.9746" height="8.54717" transform="matrix(-0.707107 -0.707106 -0.707107 0.707106 22.2891 42.521)" fill="#9ca3af"/>
+<rect width="24.217" height="8.54717" transform="matrix(-0.707107 0.707106 -0.707107 -0.707106 43.6572 54.4778)" fill="#9ca3af"/>
+<rect width="27.066" height="8.54717" transform="matrix(0.707107 0.707106 0.707107 -0.707106 43.5264 33.1099)" fill="#9ca3af"/>
+<rect x="22.1582" y="12.1082" width="20.6556" height="8.54718" transform="rotate(90 22.1582 12.1082)" fill="#9ca3af"/>
+<rect x="52.0732" y="42.0237" width="25.6415" height="8.54718" transform="rotate(90 52.0732 42.0237)" fill="#9ca3af"/>
+</svg>

--- a/docs/v6/cookbooks/daytona-rl.mdx
+++ b/docs/v6/cookbooks/daytona-rl.mdx
@@ -1,0 +1,94 @@
+---
+title: "RL on Daytona sandboxes"
+description: "Run 256 parallel graded rollouts on Daytona and train on the results."
+icon: "/logo/daytona.svg"
+---
+
+Define one coding environment, run it 256 wide on Daytona sandboxes, and train a model on the graded rollouts. This page shows the HUD path. The full walkthrough, with the concurrency and warm-pool measurements, lives in [Daytona's guide](https://www.daytona.io/docs/guides/reinforcement-learning/hud-rl-cookbook).
+
+<Card title="Open the source" icon="github" href="https://github.com/hud-evals/hud-python/tree/main/cookbooks/daytona-rl">
+  The complete project: the environment, the training loop, and the benchmark receipts behind the numbers.
+</Card>
+
+## The environment
+
+One file. A workspace with a shell, a seeded bug in `calc.py`, and a pytest grader that pays 1.0 only when every test passes.
+
+```python
+from hud.environment import Environment
+
+env = Environment(name="smoke")
+ws = env.workspace(WORKSPACE, network=True)
+
+@env.template(id="fix_calc")
+async def fix_calc(variant: int = 0):
+    seed_bug(variant)
+    yield (
+        f"`pytest` fails in `{WORKSPACE}`. Fix `calc.py` so it passes. Don't edit `test_calc.py`."
+    )
+    passed, total = await run_pytest()
+    yield 1.0 if passed == total else 0.0
+```
+
+Run it locally first, no API key needed:
+
+```bash
+hud eval tasks.py claude
+```
+
+## Place rollouts on Daytona
+
+The environment travels as a Docker image. `DaytonaRuntime` builds it into a Daytona snapshot on first run and reuses it after.
+
+```python
+runtime = DaytonaRuntime(SNAPSHOT, image=Image.from_dockerfile("Dockerfile.hud"))
+```
+
+Same task, same agent, one argument changed. A fresh sandbox is usable in about 3 seconds at low concurrency and about 10 at 256 wide, and the full ladder to 256 ran 1,272 creates without a failure. For spin-up numbers, warm pools, and sizing rules, see [Daytona's guide](https://www.daytona.io/docs/guides/reinforcement-learning/hud-rl-cookbook).
+
+## Train on the graded rollouts
+
+Every rollout already carries what training needs, the tokens and the reward, so training is a few lines against the runs you just watched. No GPUs on your side.
+
+```python
+GROUP, WIDTH, CHUNK = 8, 128, 16
+
+agent = create_agent(MODEL, completion_kwargs={
+    "max_tokens": 2048,
+    "extra_body": {"return_token_ids": True},
+})
+trainer = TrainingClient(MODEL)
+taskset = Taskset("calc", [fix_calc(variant=v) for v in range(16)])
+
+session = await Job.start("calc-rl", group=GROUP)
+for step in range(10):
+    start = len(session.runs)
+    await taskset.run(agent, runtime=runtime, job=session,
+                      group=GROUP, max_concurrent=WIDTH)
+    batch = session.runs[start:]
+    for i in range(0, len(batch), CHUNK):
+        await trainer.forward_backward(batch[i:i + CHUNK],
+                                       loss_fn="importance_sampling", group_size=GROUP)
+    await trainer.optim_step(learning_rate=1e-5)
+```
+
+The `return_token_ids` flag is load-bearing, and chunks must not split groups. Ten steps took a Qwen3.5 4B fork from 35.9% to 81.2% pass rate on held-out bugs it never trained on.
+
+The same runs served three purposes. They tested the environment, measured the model, and became the training batch.
+
+## Run it
+
+<CardGroup cols={2}>
+  <Card title="Source code" icon="github" href="https://github.com/hud-evals/hud-python/tree/main/cookbooks/daytona-rl">
+    Runnable project, plus `bench/` with the concurrency and warm-pool receipts.
+  </Card>
+  <Card title="Training agents" icon="dumbbell" href="/v6/guides/training-agents">
+    How HUD turns tasksets, grouped rollouts, and rewards into a training loop.
+  </Card>
+  <Card title="Designing tasks for training" icon="signal" href="/v6/reference/advice">
+    Build rewards with enough signal to distinguish better trajectories.
+  </Card>
+  <Card title="Daytona sandboxes" icon={<svg className="size-6 m-0! shrink-0 bg-primary dark:bg-primary-light" aria-hidden="true" style={{ maskImage: "url(/logo/daytona.svg)", maskRepeat: "no-repeat", maskPosition: "center", maskSize: "contain", WebkitMaskImage: "url(/logo/daytona.svg)", WebkitMaskRepeat: "no-repeat", WebkitMaskPosition: "center", WebkitMaskSize: "contain" }} />} href="https://www.daytona.io/docs/guides/reinforcement-learning/hud-rl-cookbook">
+    Spin-up measurements to 256 concurrent, warm pools, and sizing rules.
+  </Card>
+</CardGroup>

--- a/docs/v6/cookbooks/index.mdx
+++ b/docs/v6/cookbooks/index.mdx
@@ -32,6 +32,10 @@ guide on this site; the rest are best read straight from their source.
     Train a Fireworks LoRA adapter on HUD environments, with grouped rewards,
     calibration, checkpoints, and evaluation.
   </Card>
+  <Card title="RL on Daytona sandboxes" icon={<svg className="size-6 m-0! shrink-0 bg-primary dark:bg-primary-light" aria-hidden="true" style={{ maskImage: "url(/logo/daytona.svg)", maskRepeat: "no-repeat", maskPosition: "center", maskSize: "contain", WebkitMaskImage: "url(/logo/daytona.svg)", WebkitMaskRepeat: "no-repeat", WebkitMaskPosition: "center", WebkitMaskSize: "contain" }} />} href="/v6/cookbooks/daytona-rl">
+    Evals and GRPO training at 256 parallel sandboxes: 35.9% to 81.2% held-out
+    on a bug-fixing task.
+  </Card>
 </CardGroup>
 
 ## More runnable examples

--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -195,6 +195,8 @@ as a linked sandbox. Sidecar images resolve to reusable Daytona snapshots.
 Compose authoring conventions are documented in
 [Compose environments](/v6/experimental/compose).
 
+Measured behavior at scale, up to 256 concurrent sandboxes with warm pools, is written up in the [Daytona cookbook](/v6/cookbooks/daytona-rl) and the [full guide on Daytona's docs](https://www.daytona.io/docs/guides/reinforcement-learning/hud-rl-cookbook).
+
 ### `HUDRuntime`
 
 ```python


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no SDK, runtime, or training code changes.
> 
> **Overview**
> Adds a **HUD docs walkthrough** for the existing `cookbooks/daytona-rl` project: new `v6/cookbooks/daytona-rl.mdx` (environment, `DaytonaRuntime`, GRPO training loop), a **Daytona logo** for nav/cards, and **Cookbooks nav + index** entries alongside the Fireworks RL page.
> 
> **Cross-links** replace the cookbook README placeholder with the live [Daytona RL guide](https://www.daytona.io/docs/guides/reinforcement-learning/hud-rl-cookbook) and point readers from the **`DaytonaRuntime`** reference section to the new cookbook page and that external guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cfadbdabcb17547fa5949e9e0a3c8b75bdf92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->