### PR TITLE
fix(environment): keep the package importable without unix sockets

### DIFF
--- a/hud/environment/egress.py
+++ b/hud/environment/egress.py
@@ -526,14 +526,16 @@ class _Forward(socketserver.BaseRequestHandler):
             _relay(self.request, upstream)
 
 
-class _UnixServer(socketserver.ThreadingUnixStreamServer):
-    daemon_threads = True
-    request_queue_size = socket.SOMAXCONN
+if sys.platform != "win32":  # the sockets this serves on have no Windows analogue
 
-    def get_request(self) -> tuple[socket.socket, tuple[str, int]]:
-        # A unix peer has no address; the handler wants one to log.
-        request, _ = super().get_request()
-        return request, ("workspace", 0)
+    class _UnixServer(socketserver.ThreadingUnixStreamServer):
+        daemon_threads = True
+        request_queue_size = socket.SOMAXCONN
+
+        def get_request(self) -> tuple[socket.socket, tuple[str, int]]:
+            # A unix peer has no address; the handler wants one to log.
+            request, _ = super().get_request()
+            return request, ("workspace", 0)
 
 
 class Egress:

--- a/hud/environment/namespace.py
+++ b/hud/environment/namespace.py
@@ -8,7 +8,6 @@ import contextlib
 import json
 import logging
 import os
-import pty
 import shutil
 import signal
 import socket
@@ -21,6 +20,9 @@ import asyncssh
 
 from hud.environment.utils import splice
 from hud.utils.process import ProcessGroup, ProcessResult, create_process_group_exec
+
+if sys.platform != "win32":  # the pty a session runs on has no Windows analogue
+    import pty
 
 _AF_NETLINK = getattr(socket, "AF_NETLINK", 16)
 _NETLINK_ROUTE = getattr(socket, "NETLINK_ROUTE", 0)

--- a/hud/environment/tests/test_platform.py
+++ b/hud/environment/tests/test_platform.py
@@ -1,0 +1,52 @@
+"""Regression test for importing the package where unix sockets do not exist.
+
+Both routes out of a workspace are served on unix sockets and a session runs on a pty,
+and each reached for its platform at module scope: a
+``socketserver.ThreadingUnixStreamServer`` subclass in :mod:`hud.environment.egress`,
+and a top-level ``import pty`` in :mod:`hud.environment.namespace`. Neither exists on
+Windows, so ``import hud`` raised there before any of it was used, taking down the
+commands that never go near a workspace with it. Both now sit behind the platform
+guard the rest of the package already applies.
+
+The breakage is at import time, so the check runs in a fresh interpreter. That
+interpreter imports the package once as the platform it really is, because the
+standard library and the dependencies settle their own platform at their first import
+and will not be told otherwise afterwards, and then imports it again with only the
+package's own modules dropped, the platform reported as Windows, and the unix pieces
+taken away.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_IMPORT_AS_WINDOWS = """
+import socketserver
+import sys
+
+import hud
+
+for name in [n for n in sys.modules if n == "hud" or n.startswith("hud.")]:
+    del sys.modules[name]
+
+sys.platform = "win32"
+sys.modules["pty"] = None  # a Windows interpreter has no pty module to import
+socketserver.__dict__.pop("ThreadingUnixStreamServer", None)  # nor this server
+
+import hud
+
+print("IMPORTED")
+"""
+
+
+def test_the_package_imports_where_unix_sockets_do_not_exist() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _IMPORT_AS_WINDOWS],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    assert "IMPORTED" in result.stdout

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -30,7 +30,7 @@ import pytest
 from hud.capabilities import SSHClient
 from hud.environment import namespace as namespace_mod
 from hud.environment import workspace as workspace_mod
-from hud.environment.egress import Peer, _field, _UnixServer, _Unrelayable
+from hud.environment.egress import Peer, _field, _Unrelayable
 from hud.environment.workspace import Bubblewrap, Mount, Workspace
 from hud.utils.process import ProcessGroup, ProcessResult
 
@@ -657,6 +657,8 @@ async def test_run_uses_a_disposable_writable_hosts_file(
 
 
 def test_peer_forwarders_use_the_substrate_listen_backlog() -> None:
+    from hud.environment.egress import _UnixServer  # unix-only, as this module is
+
     assert _UnixServer.request_queue_size == socket.SOMAXCONN
 
 


### PR DESCRIPTION
## Why

`import hud` fails on Windows, before any of the code involved is used:

```
File "hud\environment\egress.py", line 529, in <module>
    class _UnixServer(socketserver.ThreadingUnixStreamServer):
AttributeError: module 'socketserver' has no attribute 'ThreadingUnixStreamServer'
```

Two things run at module scope on a platform that has neither of them: the `_UnixServer` subclass in `hud/environment/egress.py`, and `import pty` in `hud/environment/namespace.py`. `hud/__init__.py` imports `clients`, which imports `environment`, so both run on any import of the package, and every command goes down with them. That includes the ones that never go near a workspace: `hud --version`, `hud set`, `hud jobs`.

This is a regression. `hud==0.6.12` imports on Windows and 0.6.13 onwards does not. `_UnixServer` arrived in 812ae12c, and the unguarded `import pty` in d62acaef, which moved namespace hosting out of `workspace.py`, where that same import had been behind a platform guard since 50b2acc9.

The package otherwise treats Windows as somewhere it runs. `workspace.py` guards `fcntl`, `pty` and `termios`, and has a `cmd.exe` session path; `hud/cli/__init__.py` rewraps the console so Rich can print on cp1252; six test modules carry `skipif(sys.platform == "win32")`. `hud/environment/tests/test_workspace.py` marks its whole module that way, but the marker never gets to apply: collecting the file imports `egress`, which raises first.

## What

Both now sit behind the `sys.platform != "win32"` guard `workspace.py` already uses.

This does not make workspaces run on Windows, and nothing about the unix machinery changes. `namespace.py` still opens `AF_UNIX` sockets, so starting an environment there still fails, at the point of use rather than at import. That is where the rest of the package's unix-only paths already fail.

It also lets the tests collect. `test_workspace.py` imports `_UnixServer` at module scope, which raised before this change and would have kept raising after it, so that module's own `skipif` never applied. The import now sits in the one test that uses it, and the whole suite collects on Windows: 1115 collected, 17 deselected, no collection errors. On `main` pytest fails while loading `hud/conftest.py`.

Left alone: `hud/integrations/harbor/env.py` imports `grp` and `pwd` at module scope. Nothing in the package imports that module, so it is off the `import hud` path and out of scope here.

## Tests

`hud/environment/tests/test_platform.py` imports the package in a fresh interpreter that reports itself as Windows and has the unix pieces taken away. Before the fix it fails on each of the two separately: `AttributeError` for the server, and `ModuleNotFoundError` for `pty` once the server is guarded.

It imports the package once as the real platform first, because the standard library settles its own platform on first import (`asyncio` picks `windows_events`, `shutil` reaches for `_winapi`) and will not be told otherwise afterwards. Only the package's own modules are then dropped and imported again as Windows.

## Validation

- `uv run pytest -q`
- `uv run ruff format . --check` and `uv run ruff check .`
- `uv run --extra dev --extra train --extra modal --extra daytona ty check --error-on-warning`
- Windows 11, CPython 3.12, the package installed from this branch: `import hud` and `hud --version` both work, and both fail on `main`.
