### PR TITLE
fix(eval): close incremental rollout submission

### DIFF
--- a/cookbooks/connect4-selfplay/train.py
+++ b/cookbooks/connect4-selfplay/train.py
@@ -153,6 +153,7 @@ async def main(
         print("\nvalidation curve:")
         for s, r in val_curve:
             print(f"  step {s:3d}: {r:.3f}  {'#' * int(r * 20)}")
+    await session.finish(failed=bool(session.errors))
 
 
 if __name__ == "__main__":

--- a/cookbooks/daytona-rl/bench/baseline.py
+++ b/cookbooks/daytona-rl/bench/baseline.py
@@ -39,10 +39,13 @@ async def main(*, variants: int, group: int, max_concurrent: int, start: int, mo
     print(
         f"model={model} variants={variant_ids} group={group} rollouts={len(variant_ids) * group} tests={bugs.test_count()}"
     )
-    session = await Job.start(f"calc-baseline-{start}-{start + variants - 1}", group=group)
-    t0 = time.perf_counter()
-    await taskset.run(agent, runtime=runtime, job=session, max_concurrent=max_concurrent)
-    wall = time.perf_counter() - t0
+    async with await Job.start(
+        f"calc-baseline-{start}-{start + variants - 1}",
+        group=group,
+    ) as session:
+        t0 = time.perf_counter()
+        await taskset.run(agent, runtime=runtime, job=session, max_concurrent=max_concurrent)
+        wall = time.perf_counter() - t0
 
     runs = session.runs
     rewards = [r.reward for r in runs]

--- a/cookbooks/daytona-rl/train.py
+++ b/cookbooks/daytona-rl/train.py
@@ -189,6 +189,7 @@ async def main(
                 )
             history.append(row)
             out.write_text(json.dumps(history, indent=1))
+        await session.finish(failed=bool(session.errors))
     finally:
         await pool.drop(SNAPSHOT)
         out.write_text(json.dumps(history, indent=1))

--- a/cookbooks/rl-training/ppo_custom_loss.py
+++ b/cookbooks/rl-training/ppo_custom_loss.py
@@ -124,6 +124,7 @@ async def main(*, steps: int, group: int, learning_rate: float, max_concurrent: 
             f"optim_step={result.step} -> {result.sampler_path}",
             flush=True,
         )
+    await session.finish(failed=bool(session.errors))
 
 
 if __name__ == "__main__":

--- a/cookbooks/rl-training/simple_train.py
+++ b/cookbooks/rl-training/simple_train.py
@@ -93,6 +93,7 @@ async def main(*, steps: int, group: int, learning_rate: float, max_concurrent: 
             f"| optim {result.step} datums {fb.num_datums}",
             flush=True,
         )
+    await session.finish(failed=bool(session.errors))
 
 
 if __name__ == "__main__":

--- a/cookbooks/rl-training/train_2048.py
+++ b/cookbooks/rl-training/train_2048.py
@@ -106,6 +106,7 @@ async def main(
             f"| optim {result.step} datums {fb.num_datums} failed {failed}/{len(batch)}",
             flush=True,
         )
+    await session.finish(failed=bool(session.errors))
 
 
 if __name__ == "__main__":

--- a/hud/eval/chat.py
+++ b/hud/eval/chat.py
@@ -14,6 +14,7 @@ Example::
     chat = Chat(assistant(messages=[]), create_agent("claude-sonnet-4-5"))
     r1 = await chat.send("Book me a flight")
     r2 = await chat.send("SFO to JFK")
+    await chat.close()
 
 ``Chat`` is protocol-agnostic: a web app, notebook, or wire protocol (A2A,
 etc.) is just a frontend calling ``await chat.send(...)``. The conversation
@@ -156,3 +157,8 @@ class Chat:
             ]
         self.messages.append(assistant_msg)
         return result
+
+    async def close(self, *, failed: bool = False) -> None:
+        """Close the platform job after the final conversation turn."""
+        if self.job is not None:
+            await self.job.finish(failed=failed)

--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -111,7 +111,7 @@ async def job_enter(
     name: str,
     group: int,
     taskset_id: str | None = None,
-    expected_trace_count: int | None = None,
+    is_open: bool = False,
 ) -> None:
     """Register a batch job with the platform.
 
@@ -127,12 +127,19 @@ async def job_enter(
             "name": name,
             "group": group,
             "taskset_id": taskset_id,
-            "expected_trace_count": expected_trace_count,
+            "is_open": is_open,
         },
     )
     from hud.settings import settings
 
     logger.info("job: %s/jobs/%s", settings.hud_web_url, job_id)
+
+
+async def job_exit(job_id: str, *, failed: bool = False) -> None:
+    """Report that an incrementally submitted job will receive no more traces."""
+    if not _reporting_enabled():
+        return
+    await _report(f"/trace/job/{job_id}/exit", {"failed": failed})
 
 
 async def trace_enter(

--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -7,10 +7,11 @@ registers when called bare.
 
 Backend reporting contract:
 - ``POST /trace/job/{job_id}/enter`` — register the batch job.
+- ``POST /trace/job/{job_id}/exit``  — close incremental submission.
 - ``POST /trace/{trace_id}/enter``   — a rollout started.
 - ``POST /trace/{trace_id}/exit``    — a rollout finished (reward / success).
 
-All three are best-effort no-ops without telemetry + an API key, so local runs
+All four are best-effort no-ops without telemetry + an API key, so local runs
 never depend on the platform.
 """
 

--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -105,7 +105,14 @@ def _reporting_enabled() -> bool:
     return bool(settings.telemetry_enabled and settings.api_key)
 
 
-async def job_enter(job_id: str, *, name: str, group: int, taskset_id: str | None = None) -> None:
+async def job_enter(
+    job_id: str,
+    *,
+    name: str,
+    group: int,
+    taskset_id: str | None = None,
+    expected_trace_count: int | None = None,
+) -> None:
     """Register a batch job with the platform.
 
     ``taskset_id`` links the job to a synced taskset (set when running
@@ -116,7 +123,12 @@ async def job_enter(job_id: str, *, name: str, group: int, taskset_id: str | Non
         return
     await _report(
         f"/trace/job/{job_id}/enter",
-        {"name": name, "group": group, "taskset_id": taskset_id},
+        {
+            "name": name,
+            "group": group,
+            "taskset_id": taskset_id,
+            "expected_trace_count": expected_trace_count,
+        },
     )
     from hud.settings import settings
 

--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -21,11 +21,13 @@ import asyncio
 import logging
 import uuid
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from hud.utils.platform import PlatformClient, canonical_record_id
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from .run import Run
 
 logger = logging.getLogger("hud.eval.job")
@@ -52,8 +54,29 @@ class Job:
         longer arc — a training session, a chat conversation — under one id.
         """
         job = cls(id=uuid.uuid4().hex, name=name, group=group, taskset_id=taskset_id)
-        await job_enter(job.id, name=name, group=group, taskset_id=taskset_id)
+        await job_enter(
+            job.id,
+            name=name,
+            group=group,
+            taskset_id=taskset_id,
+            is_open=True,
+        )
         return job
+
+    async def finish(self, *, failed: bool = False) -> None:
+        """Close this job after its final scheduler call."""
+        await job_exit(self.id, failed=failed)
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        _exc: BaseException | None,
+        _tb: TracebackType | None,
+    ) -> None:
+        await self.finish(failed=exc_type is not None)
 
     @property
     def reward(self) -> float:

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -301,19 +301,13 @@ class Taskset:
             expanded.extend((task, group_id) for _ in range(group))
 
         owns_job = job is None
+        submission_failed = False
         if owns_job:
             job = Job(
                 id=uuid.uuid4().hex,
                 name=_job_name(self.name, task_list, group),
                 group=group,
                 taskset_id=self.taskset_id,
-            )
-            await job_enter(
-                job.id,
-                name=job.name,
-                group=group,
-                taskset_id=self.taskset_id,
-                is_open=True,
             )
         assert job is not None
         job_id = job.id
@@ -355,8 +349,15 @@ class Taskset:
             group,
             f", max_concurrent={max_concurrent}" if max_concurrent else "",
         )
-        submission_failed = False
         try:
+            if owns_job:
+                await job_enter(
+                    job.id,
+                    name=job.name,
+                    group=group,
+                    taskset_id=self.taskset_id,
+                    is_open=True,
+                )
             async with contextlib.AsyncExitStack() as stack:
                 # A placement may own pooled resources across rollouts (e.g.
                 # Shared's one substrate for many leases); a context-manager
@@ -366,6 +367,9 @@ class Taskset:
                 parts = await asyncio.gather(*(_one(t, gid) for t, gid in expanded))
             job.runs.extend(run for part in parts for run in part)
             submission_failed = bool(job.errors)
+        except asyncio.CancelledError:
+            submission_failed = True
+            raise
         except Exception:
             submission_failed = True
             raise

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -307,7 +307,13 @@ class Taskset:
                 group=group,
                 taskset_id=self.taskset_id,
             )
-            await job_enter(job.id, name=job.name, group=group, taskset_id=self.taskset_id)
+            await job_enter(
+                job.id,
+                name=job.name,
+                group=group,
+                taskset_id=self.taskset_id,
+                expected_trace_count=len(expanded),
+            )
         job_id = job.id
         sem = asyncio.Semaphore(max_concurrent) if max_concurrent else None
 

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from hud.telemetry import flush
 from hud.utils.platform import PlatformClient
 
-from .job import Job, job_enter
+from .job import Job, job_enter, job_exit
 from .run import rollout, validate_rollout_timeouts
 from .runtime import (
     HostedRuntime,
@@ -300,7 +300,8 @@ class Taskset:
             group_id = uuid.uuid4().hex
             expanded.extend((task, group_id) for _ in range(group))
 
-        if job is None:
+        owns_job = job is None
+        if owns_job:
             job = Job(
                 id=uuid.uuid4().hex,
                 name=_job_name(self.name, task_list, group),
@@ -312,8 +313,9 @@ class Taskset:
                 name=job.name,
                 group=group,
                 taskset_id=self.taskset_id,
-                expected_trace_count=len(expanded),
+                is_open=True,
             )
+        assert job is not None
         job_id = job.id
         sem = asyncio.Semaphore(max_concurrent) if max_concurrent else None
 
@@ -353,20 +355,33 @@ class Taskset:
             group,
             f", max_concurrent={max_concurrent}" if max_concurrent else "",
         )
-        async with contextlib.AsyncExitStack() as stack:
-            # A placement may own pooled resources across rollouts (e.g.
-            # Shared's one substrate for many leases); a context-manager
-            # placement is scoped to this call unless already open.
-            if isinstance(placement, contextlib.AbstractAsyncContextManager):
-                await stack.enter_async_context(placement)
-            parts = await asyncio.gather(*(_one(t, gid) for t, gid in expanded))
-        job.runs.extend(run for part in parts for run in part)
-        # Drain telemetry before returning. The exporter uploads in parallel and
-        # flush is completion-based (waits for in-flight uploads, not a fixed
-        # sleep), so the timeout is only a safety cap for a wedged network.
-        if not await asyncio.to_thread(flush, timeout=120.0):
-            logger.warning("telemetry flush did not fully drain within 120s; some spans may lag")
-        return job
+        submission_failed = False
+        try:
+            async with contextlib.AsyncExitStack() as stack:
+                # A placement may own pooled resources across rollouts (e.g.
+                # Shared's one substrate for many leases); a context-manager
+                # placement is scoped to this call unless already open.
+                if isinstance(placement, contextlib.AbstractAsyncContextManager):
+                    await stack.enter_async_context(placement)
+                parts = await asyncio.gather(*(_one(t, gid) for t, gid in expanded))
+            job.runs.extend(run for part in parts for run in part)
+            submission_failed = bool(job.errors)
+            # Drain telemetry before returning. The exporter uploads in parallel and
+            # flush is completion-based (waits for in-flight uploads, not a fixed
+            # sleep), so the timeout is only a safety cap for a wedged network.
+            if not await asyncio.to_thread(flush, timeout=120.0):
+                logger.warning(
+                    "telemetry flush did not fully drain within 120s; some spans may lag"
+                )
+            return job
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            submission_failed = True
+            raise
+        finally:
+            if owns_job:
+                await job_exit(job_id, failed=submission_failed)
 
 
 __all__ = ["Job", "Taskset"]

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -366,22 +366,18 @@ class Taskset:
                 parts = await asyncio.gather(*(_one(t, gid) for t, gid in expanded))
             job.runs.extend(run for part in parts for run in part)
             submission_failed = bool(job.errors)
-            # Drain telemetry before returning. The exporter uploads in parallel and
-            # flush is completion-based (waits for in-flight uploads, not a fixed
-            # sleep), so the timeout is only a safety cap for a wedged network.
-            if not await asyncio.to_thread(flush, timeout=120.0):
-                logger.warning(
-                    "telemetry flush did not fully drain within 120s; some spans may lag"
-                )
-            return job
-        except asyncio.CancelledError:
-            raise
         except Exception:
             submission_failed = True
             raise
         finally:
             if owns_job:
                 await job_exit(job_id, failed=submission_failed)
+        # Drain telemetry before returning. The exporter uploads in parallel and
+        # flush is completion-based (waits for in-flight uploads, not a fixed
+        # sleep), so the timeout is only a safety cap for a wedged network.
+        if not await asyncio.to_thread(flush, timeout=120.0):
+            logger.warning("telemetry flush did not fully drain within 120s; some spans may lag")
+        return job
 
 
 __all__ = ["Job", "Taskset"]

--- a/hud/eval/taskset.py
+++ b/hud/eval/taskset.py
@@ -246,8 +246,9 @@ class Taskset:
         trace under it — or, given
         an open ``job`` (:meth:`Job.start`), accumulates this batch into it
         instead, so a longer arc (a training session) spans many calls under
-        one id. Returned ``job.runs`` preserves expansion order (task-major,
-        then group).
+        one id. Use the started job as an async context manager or call
+        :meth:`Job.finish` after the final batch. Returned ``job.runs``
+        preserves expansion order (task-major, then group).
 
         ``group`` is the statistical-repeat multiplier (one GRPO group_id per
         task's repeats), whatever the placement — a placement that pools a

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -47,16 +47,20 @@ def _run_with(trace_id: str, *, extra: dict[str, Any]) -> Run:
     return run
 
 
-async def test_open_job_reports_submission_lifecycle(recorder: _Recorder) -> None:
-    job_id = "00000000-0000-4000-a000-000000000001"
-    await job_mod.job_enter(
-        job_id,
-        name="benchmark",
+async def test_open_job_reports_submission_lifecycle(
+    recorder: _Recorder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated_id = job_mod.uuid.UUID("00000000-0000-4000-a000-000000000001")
+    job_id = generated_id.hex
+    monkeypatch.setattr(job_mod.uuid, "uuid4", lambda: generated_id)
+
+    async with await job_mod.Job.start(
+        "benchmark",
         group=2,
         taskset_id="taskset-1",
-        is_open=True,
-    )
-    await job_mod.job_exit(job_id)
+    ) as job:
+        assert job.id == job_id
 
     assert recorder.calls == [
         (
@@ -70,6 +74,21 @@ async def test_open_job_reports_submission_lifecycle(recorder: _Recorder) -> Non
         ),
         (f"/trace/job/{job_id}/exit", {"failed": False}),
     ]
+
+
+async def test_open_job_reports_failed_context_exit(
+    recorder: _Recorder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated_id = job_mod.uuid.UUID("00000000-0000-4000-a000-000000000002")
+    job_id = generated_id.hex
+    monkeypatch.setattr(job_mod.uuid, "uuid4", lambda: generated_id)
+
+    with pytest.raises(RuntimeError, match="submission failed"):
+        async with await job_mod.Job.start("benchmark"):
+            raise RuntimeError("submission failed")
+
+    assert recorder.calls[-1] == (f"/trace/job/{job_id}/exit", {"failed": True})
 
 
 async def test_trace_enter_reports_task_and_group_identity(recorder: _Recorder) -> None:

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -46,6 +46,28 @@ def _run_with(trace_id: str, *, extra: dict[str, Any]) -> Run:
     return run
 
 
+async def test_job_enter_reports_expected_trace_count(recorder: _Recorder) -> None:
+    await job_mod.job_enter(
+        "job-1",
+        name="benchmark",
+        group=2,
+        taskset_id="taskset-1",
+        expected_trace_count=6,
+    )
+
+    assert recorder.calls == [
+        (
+            "/trace/job/job-1/enter",
+            {
+                "name": "benchmark",
+                "group": 2,
+                "taskset_id": "taskset-1",
+                "expected_trace_count": 6,
+            },
+        )
+    ]
+
+
 async def test_trace_enter_reports_task_and_group_identity(recorder: _Recorder) -> None:
     await job_mod.trace_enter(
         "abc",

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -48,18 +48,19 @@ def _run_with(trace_id: str, *, extra: dict[str, Any]) -> Run:
 
 
 async def test_open_job_reports_submission_lifecycle(recorder: _Recorder) -> None:
+    job_id = "00000000-0000-4000-a000-000000000001"
     await job_mod.job_enter(
-        "job-1",
+        job_id,
         name="benchmark",
         group=2,
         taskset_id="taskset-1",
         is_open=True,
     )
-    await job_mod.job_exit("job-1")
+    await job_mod.job_exit(job_id)
 
     assert recorder.calls == [
         (
-            "/trace/job/job-1/enter",
+            f"/trace/job/{job_id}/enter",
             {
                 "name": "benchmark",
                 "group": 2,
@@ -67,7 +68,7 @@ async def test_open_job_reports_submission_lifecycle(recorder: _Recorder) -> Non
                 "is_open": True,
             },
         ),
-        ("/trace/job/job-1/exit", {"failed": False}),
+        (f"/trace/job/{job_id}/exit", {"failed": False}),
     ]
 
 

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -46,14 +46,15 @@ def _run_with(trace_id: str, *, extra: dict[str, Any]) -> Run:
     return run
 
 
-async def test_job_enter_reports_expected_trace_count(recorder: _Recorder) -> None:
+async def test_open_job_reports_submission_lifecycle(recorder: _Recorder) -> None:
     await job_mod.job_enter(
         "job-1",
         name="benchmark",
         group=2,
         taskset_id="taskset-1",
-        expected_trace_count=6,
+        is_open=True,
     )
+    await job_mod.job_exit("job-1")
 
     assert recorder.calls == [
         (
@@ -62,9 +63,10 @@ async def test_job_enter_reports_expected_trace_count(recorder: _Recorder) -> No
                 "name": "benchmark",
                 "group": 2,
                 "taskset_id": "taskset-1",
-                "expected_trace_count": 6,
+                "is_open": True,
             },
-        )
+        ),
+        ("/trace/job/job-1/exit", {"failed": False}),
     ]
 
 

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -1256,6 +1256,40 @@ async def test_task_run_closes_after_hosted_launch_failure(
     assert calls[-1] == (f"/trace/job/{job.id}/exit", {"failed": True})
 
 
+async def test_task_run_closes_as_failed_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.eval import job as job_mod
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+    launch_started = asyncio.Event()
+    runtime = HostedRuntime()
+
+    async def hang_launch(*args: Any, **kwargs: Any) -> Run:
+        launch_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def record(path: str, payload: dict[str, Any]) -> None:
+        calls.append((path, payload))
+
+    monkeypatch.setattr(runtime, "run", hang_launch)
+    monkeypatch.setattr(job_mod, "_reporting_enabled", lambda: True)
+    monkeypatch.setattr(job_mod, "_report", record)
+
+    run_task = asyncio.create_task(
+        _add_task(2, 3).run(_FnAgent(_solve_add), runtime=runtime),
+    )
+    await launch_started.wait()
+    run_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    job_id = calls[0][0].split("/")[-2]
+    assert calls[-1] == (f"/trace/job/{job_id}/exit", {"failed": True})
+
+
 async def test_task_run_has_taskset_scheduling_semantics(env_file: Path) -> None:
     job = await _add_task(1, 2).run(
         _FnAgent(_solve_add), runtime=SubprocessRuntime(env_file), group=2, max_concurrent=1

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -32,7 +32,7 @@ from hud.agents.base import Agent
 from hud.agents.openai_compatible import OpenAIChatAgent
 from hud.agents.types import OpenAIChatConfig
 from hud.environment import Answer, Environment
-from hud.eval import Job, LocalRuntime, Runtime, SubprocessRuntime, Task, Taskset
+from hud.eval import HostedRuntime, Job, LocalRuntime, Runtime, SubprocessRuntime, Task, Taskset
 from hud.eval.run import Run, rollout
 
 if TYPE_CHECKING:
@@ -1200,7 +1200,7 @@ async def test_task_run_schedules_a_single_task_job(env_file: Path) -> None:
     assert run.job_id == job.id  # the run's trace reports under the job
 
 
-async def test_task_run_declares_all_rollouts_before_submission(
+async def test_task_run_reports_its_submission_lifecycle(
     env_file: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1226,9 +1226,34 @@ async def test_task_run_declares_all_rollouts_before_submission(
             "name": "add (2 times)",
             "group": 2,
             "taskset_id": None,
-            "expected_trace_count": 2,
+            "is_open": True,
         },
     )
+    assert calls[-1] == (f"/trace/job/{job.id}/exit", {"failed": False})
+
+
+async def test_task_run_closes_after_hosted_launch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.eval import job as job_mod
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+    runtime = HostedRuntime()
+
+    async def fail_launch(*args: Any, **kwargs: Any) -> Run:
+        return Run.failed("submit rejected")
+
+    async def record(path: str, payload: dict[str, Any]) -> None:
+        calls.append((path, payload))
+
+    monkeypatch.setattr(runtime, "run", fail_launch)
+    monkeypatch.setattr(job_mod, "_reporting_enabled", lambda: True)
+    monkeypatch.setattr(job_mod, "_report", record)
+
+    job = await _add_task(2, 3).run(_FnAgent(_solve_add), runtime=runtime)
+
+    assert job.errors
+    assert calls[-1] == (f"/trace/job/{job.id}/exit", {"failed": True})
 
 
 async def test_task_run_has_taskset_scheduling_semantics(env_file: Path) -> None:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -1200,6 +1200,37 @@ async def test_task_run_schedules_a_single_task_job(env_file: Path) -> None:
     assert run.job_id == job.id  # the run's trace reports under the job
 
 
+async def test_task_run_declares_all_rollouts_before_submission(
+    env_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hud.eval import job as job_mod
+
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def record(path: str, payload: dict[str, Any]) -> None:
+        calls.append((path, payload))
+
+    monkeypatch.setattr(job_mod, "_reporting_enabled", lambda: True)
+    monkeypatch.setattr(job_mod, "_report", record)
+
+    job = await _add_task(2, 3).run(
+        _FnAgent(_solve_add),
+        runtime=SubprocessRuntime(env_file),
+        group=2,
+    )
+
+    assert calls[0] == (
+        f"/trace/job/{job.id}/enter",
+        {
+            "name": "add (2 times)",
+            "group": 2,
+            "taskset_id": None,
+            "expected_trace_count": 2,
+        },
+    )
+
+
 async def test_task_run_has_taskset_scheduling_semantics(env_file: Path) -> None:
     job = await _add_task(1, 2).run(
         _FnAgent(_solve_add), runtime=SubprocessRuntime(env_file), group=2, max_concurrent=1


### PR DESCRIPTION
## What changed

- Register auto-created `Taskset.run` jobs as open while rollouts are being submitted.
- Close submission in `finally`, including cancellation, hosted launch failures, and exceptional exits.
- Report submission failures that happen before a platform trace exists.
- Make manually started multi-call jobs explicitly open until `Job.finish()`, with async-context-manager support.
- Add `Chat.close()` and close long-running cookbook sessions after their final batch.
- Add lifecycle, hosted-failure, cancellation, and context-exit regression coverage.

## Why

The SDK submitted rollouts incrementally but did not tell the platform when submission was still in progress or definitively finished. An early terminal trace could therefore make a partial benchmark look complete, while pre-trace hosted failures could leave expected work unrepresented.

## Impact

Taskset jobs remain open until scheduling ends, failed submissions settle accurately, and multi-call jobs have an explicit safe completion lifecycle.

Depends on https://github.com/hud-evals/hud-monorepo/pull/1499

## Validation

- `54 passed` across `hud/eval/tests/test_job.py` and `hud/eval/tests/test_rollout.py`
- Ruff passed on changed implementation, tests, chat, and cookbook call sites
- `ty check` passed for `job.py`, `chat.py`, and `taskset.py`
- GitHub Python 3.11/3.12, Ruff, ty, and CodeQL checks passed on the latest SDK commit

HUD-2748