### PR TITLE
feat(cli): list and run trace QA agents

### DIFF
--- a/docs/v6/reference/cli.mdx
+++ b/docs/v6/reference/cli.mdx
@@ -137,8 +137,8 @@ experimental [Harbor integration](/v6/experimental/harbor).
 ### Platform QA
 
 ```bash
-hud qa scenarios
-hud qa create --name "Failure Analysis" --scenario <scenario-id> --model <model-id>
+hud qa templates
+hud qa create --name "Failure Analysis" --template <template-id> --model <model-id>
 hud qa agents
 hud qa run <agent-id> <trace-id>
 hud qa results <trace-id>

--- a/docs/v6/reference/cli.mdx
+++ b/docs/v6/reference/cli.mdx
@@ -137,21 +137,17 @@ experimental [Harbor integration](/v6/experimental/harbor).
 ### Platform QA
 
 ```bash
-hud qa templates
-hud qa create --name "Failure Analysis" --template <template-id> --model <model-id>
-hud qa agents
+hud qa
 hud qa run <agent-id> <trace-id>
 hud qa results <trace-id>
 ```
 
-`hud qa` authors and runs **trace** agents. Pass `--description`, `--max-steps`,
-`--args '{"threshold": 0.5}'`, or `--public` on create. `hud qa update` and
-`hud qa delete` take an agent id.
-
-`hud qa run` reuses matching evidence by default and waits for every requested
-trace. Pass `--overwrite` to create a fresh attempt, `--no-wait` to return
-after launch, or `--json` for machine-readable output. Exit code `1` means a
-completed QA result failed or the SDK could not complete the command.
+`hud qa` lists **trace** agents (name and UUID), including public ones.
+Copy an id into `hud qa run`. Reuses matching evidence by default and waits
+for every requested trace. Pass `--overwrite` to create a fresh attempt,
+`--no-wait` to return after launch, or `--json` for machine-readable output.
+Exit code `1` means a completed QA result failed or the SDK could not
+complete the command.
 
 ## Inspect
 

--- a/docs/v6/reference/cli.mdx
+++ b/docs/v6/reference/cli.mdx
@@ -134,18 +134,22 @@ hud sync env                   # sync environment metadata
 External benchmark formats can be adapted into runnable `Taskset`s through the
 experimental [Harbor integration](/v6/experimental/harbor).
 
-### Resource QA
-
-Use Platform QA agents with Environment, Taskset, or Task subjects:
+### Platform QA
 
 ```bash
-hud qa agents --subject-type environment
-hud qa run <agent-id> <resource-id>
-hud qa results environment <environment-id>
+hud qa scenarios
+hud qa create --name "Failure Analysis" --scenario <scenario-id> --model <model-id>
+hud qa agents
+hud qa run <agent-id> <trace-id>
+hud qa results <trace-id>
 ```
 
+`hud qa` authors and runs **trace** agents. Pass `--description`, `--max-steps`,
+`--args '{"threshold": 0.5}'`, or `--public` on create. `hud qa update` and
+`hud qa delete` take an agent id.
+
 `hud qa run` reuses matching evidence by default and waits for every requested
-subject. Pass `--overwrite` to create a fresh attempt, `--no-wait` to return
+trace. Pass `--overwrite` to create a fresh attempt, `--no-wait` to return
 after launch, or `--json` for machine-readable output. Exit code `1` means a
 completed QA result failed or the SDK could not complete the command.
 

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -1,4 +1,4 @@
-"""Author, run, and inspect trace-level platform QA agents."""
+"""List, run, and inspect trace-level platform QA agents."""
 
 from __future__ import annotations
 
@@ -8,7 +8,6 @@ from typing import Any, cast
 
 import typer
 
-from hud.cli.models import _resolve_model_id
 from hud.cli.utils.api import require_api_key
 from hud.utils.exceptions import HudTimeoutError
 from hud.utils.platform import PlatformClient
@@ -19,10 +18,10 @@ _TRACE_SUBJECT = "trace"
 
 qa_app = typer.Typer(
     name="qa",
-    help="Author, run, and inspect trace-level platform QA agents.",
+    help="List, run, and inspect trace-level platform QA agents.",
     add_completion=False,
     rich_markup_mode="rich",
-    no_args_is_help=True,
+    no_args_is_help=False,
 )
 
 
@@ -35,14 +34,8 @@ def _print_json(payload: Any) -> None:
     typer.echo(json.dumps(payload, indent=2, sort_keys=True, default=str))
 
 
-def _print_agent(agent: dict[str, Any], *, json_output: bool = False) -> None:
-    if json_output:
-        _print_json(agent)
-        return
-    typer.echo(
-        f"{agent.get('id', '-')}\t{agent.get('name', '-')}\t"
-        f"{agent.get('subject_type', '-')}\t{agent.get('model_name') or '-'}"
-    )
+def _print_agent(agent: dict[str, Any]) -> None:
+    typer.echo(f"{agent.get('name', '-')}\t{agent.get('id', '-')}")
 
 
 def _print_results(results: list[dict[str, Any]], *, json_output: bool) -> None:
@@ -61,19 +54,6 @@ def _print_results(results: list[dict[str, Any]], *, json_output: bool) -> None:
         stale = " stale" if result.get("stale") is True else ""
         line = f"{subject_id}\t{agent}\t{verdict}{stale}"
         typer.echo(f"{line}\t{summary}" if summary else line)
-
-
-def _parse_args(raw: str | None) -> dict[str, Any] | None:
-    if raw is None:
-        return None
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        parsed = None
-    if not isinstance(parsed, dict):
-        typer.echo("--args must be a JSON object.", err=True)
-        raise typer.Exit(1)
-    return parsed
 
 
 def _require_trace_agent(platform: PlatformClient, agent_id: str) -> None:
@@ -139,39 +119,16 @@ def _wait_for_results(
         time.sleep(_POLL_INTERVAL_SECONDS)
 
 
-@qa_app.command("templates")
-def list_templates(
-    json_output: bool = typer.Option(False, "--json", help="Output the machine-readable response."),
-    limit: int = typer.Option(500, "--limit", min=1, max=1000, help="Maximum templates to return."),
-) -> None:
-    """List templates that can be used to author a trace QA agent."""
-    templates = cast(
-        "list[dict[str, Any]]",
-        _platform().get(
-            "/qa-agents/scenarios",
-            params={"subject_type": _TRACE_SUBJECT, "limit": limit},
-        ),
-    )
-    if json_output:
-        _print_json(templates)
-        return
-    if not templates:
-        typer.echo("No trace QA templates found.")
-        return
-    for template in templates:
-        typer.echo(
-            f"{template.get('id', '-')}\t{template.get('name', '-')}\t"
-            f"{template.get('registry_display_name') or '-'}"
-        )
-
-
-@qa_app.command("agents")
+@qa_app.callback(invoke_without_command=True)
 def list_agents(
+    ctx: typer.Context,
     json_output: bool = typer.Option(False, "--json", help="Output the machine-readable response."),
     limit: int = typer.Option(50, "--limit", min=1, max=500, help="Maximum agents to return."),
     offset: int = typer.Option(0, "--offset", min=0, help="Number of agents to skip."),
 ) -> None:
     """List trace QA agents available to this team."""
+    if ctx.invoked_subcommand is not None:
+        return
     response = cast(
         "dict[str, Any]",
         _platform().get(
@@ -188,111 +145,6 @@ def list_agents(
         return
     for agent in agents:
         _print_agent(agent)
-
-
-@qa_app.command("create")
-def create_agent(
-    name: str = typer.Option(..., "--name", help="Display name for the agent."),
-    template: str = typer.Option(
-        ...,
-        "--template",
-        help="Template UUID from `hud qa templates`.",
-    ),
-    model: str = typer.Option(
-        ...,
-        "--model",
-        help="Model UUID or slug from `hud models list`.",
-    ),
-    description: str | None = typer.Option(
-        None,
-        "--description",
-        help="Optional agent description.",
-    ),
-    max_steps: int | None = typer.Option(
-        None,
-        "--max-steps",
-        min=1,
-        help="Maximum analysis steps.",
-    ),
-    args: str | None = typer.Option(None, "--args", help="JSON object of template partial args."),
-    public: bool = typer.Option(False, "--public", help="Make the agent visible to other teams."),
-    json_output: bool = typer.Option(False, "--json", help="Output the created agent as JSON."),
-) -> None:
-    """Create a trace QA agent."""
-    body: dict[str, Any] = {
-        "name": name,
-        "scenario_id": template,
-        "model_id": _resolve_model_id(model),
-        "subject_type": _TRACE_SUBJECT,
-    }
-    if description is not None:
-        body["description"] = description
-    if max_steps is not None:
-        body["max_steps"] = max_steps
-    if args is not None:
-        body["partial_args"] = _parse_args(args)
-    if public:
-        body["public"] = True
-    _print_agent(
-        cast("dict[str, Any]", _platform().post("/qa-agents", json=body)),
-        json_output=json_output,
-    )
-
-
-@qa_app.command("update")
-def update_agent(
-    agent_id: str = typer.Argument(..., help="QA agent UUID."),
-    name: str | None = typer.Option(None, "--name", help="New display name."),
-    model: str | None = typer.Option(None, "--model", help="Model UUID or slug."),
-    description: str | None = typer.Option(None, "--description", help="New description."),
-    max_steps: int | None = typer.Option(
-        None,
-        "--max-steps",
-        min=1,
-        help="Maximum analysis steps.",
-    ),
-    args: str | None = typer.Option(None, "--args", help="JSON object of template partial args."),
-    public: bool | None = typer.Option(
-        None,
-        "--public/--private",
-        help="Whether this agent is visible to other teams.",
-    ),
-    json_output: bool = typer.Option(False, "--json", help="Output the updated agent as JSON."),
-) -> None:
-    """Update a trace QA agent's configuration."""
-    platform = _platform()
-    _require_trace_agent(platform, agent_id)
-    body: dict[str, Any] = {}
-    if name is not None:
-        body["name"] = name
-    if model is not None:
-        body["model_id"] = _resolve_model_id(model)
-    if description is not None:
-        body["description"] = description
-    if max_steps is not None:
-        body["max_steps"] = max_steps
-    if args is not None:
-        body["partial_args"] = _parse_args(args)
-    if public is not None:
-        body["public"] = public
-    if not body:
-        typer.echo("Pass at least one field to update.", err=True)
-        raise typer.Exit(1)
-    _print_agent(
-        cast("dict[str, Any]", platform.patch(f"/qa-agents/{agent_id}", json=body)),
-        json_output=json_output,
-    )
-
-
-@qa_app.command("delete")
-def delete_agent(
-    agent_id: str = typer.Argument(..., help="QA agent UUID."),
-) -> None:
-    """Delete a trace QA agent."""
-    platform = _platform()
-    _require_trace_agent(platform, agent_id)
-    platform.delete(f"/qa-agents/{agent_id}")
-    typer.echo(f"Deleted {agent_id}.")
 
 
 @qa_app.command("run")

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -87,27 +87,53 @@ def _require_trace_agent(platform: PlatformClient, agent_id: str) -> None:
         raise typer.Exit(1)
 
 
+def _latest_agent_result(
+    results: list[dict[str, Any]],
+    *,
+    agent_id: str,
+    trace_id: str,
+) -> dict[str, Any] | None:
+    latest: dict[str, Any] | None = None
+    for result in results:
+        if (
+            result.get("qa_agent_id") == agent_id
+            and str(result.get("subject_trace_id")) == trace_id
+        ):
+            latest = result
+    return latest
+
+
 def _wait_for_results(
     platform: PlatformClient,
     timeout: float,
     *,
     trace_ids: list[str],
     agent_id: str,
+    launched: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
+    launched_id_by_trace = {str(run["subject_trace_id"]): str(run["id"]) for run in launched}
     deadline = time.monotonic() + timeout
     while True:
-        results = [
-            result
-            for result in cast(
-                "list[dict[str, Any]]",
-                platform.get("/qa-agents/results", params={"subject_trace_ids": trace_ids}),
+        listed = cast(
+            "list[dict[str, Any]]",
+            platform.get("/qa-agents/results", params={"subject_trace_ids": trace_ids}),
+        )
+        by_id = {str(result["id"]): result for result in listed}
+        selected: list[dict[str, Any]] = []
+        ready = True
+        for trace_id in trace_ids:
+            result_id = launched_id_by_trace.get(trace_id)
+            result = (
+                by_id.get(result_id)
+                if result_id is not None
+                else _latest_agent_result(listed, agent_id=agent_id, trace_id=trace_id)
             )
-            if result.get("qa_agent_id") == agent_id
-        ]
-        if len(results) == len(trace_ids) and all(
-            result["status"] in _TERMINAL_STATUSES for result in results
-        ):
-            return results
+            if result is None or result["status"] not in _TERMINAL_STATUSES:
+                ready = False
+                break
+            selected.append(result)
+        if ready:
+            return selected
         if time.monotonic() >= deadline:
             raise HudTimeoutError(f"Timed out after {timeout:g}s waiting for QA runs.")
         time.sleep(_POLL_INTERVAL_SECONDS)
@@ -308,7 +334,13 @@ def run_agent(
         _print_results(runs, json_output=json_output)
         return
 
-    results = _wait_for_results(platform, timeout, trace_ids=trace_ids, agent_id=agent_id)
+    results = _wait_for_results(
+        platform,
+        timeout,
+        trace_ids=trace_ids,
+        agent_id=agent_id,
+        launched=runs,
+    )
     _print_results(results, json_output=json_output)
     if any(
         result["status"] == "error"

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -1,38 +1,54 @@
-"""Discover, run, and inspect resource-scoped platform QA agents."""
+"""Author, run, and inspect trace-level platform QA agents."""
 
 from __future__ import annotations
 
 import json
 import time
-from enum import StrEnum
 from typing import Any, cast
 
 import typer
 
+from hud.cli.models import _resolve_model_id
 from hud.cli.utils.api import require_api_key
 from hud.utils.exceptions import HudTimeoutError
 from hud.utils.platform import PlatformClient
 
 _POLL_INTERVAL_SECONDS = 2.0
 _TERMINAL_STATUSES = {"completed", "error"}
-
-
-class ResourceSubjectType(StrEnum):
-    environment = "environment"
-    taskset = "taskset"
-    task = "task"
-
+_TRACE_SUBJECT = "trace"
 
 qa_app = typer.Typer(
     name="qa",
-    help="Discover, run, and inspect platform QA agents.",
+    help="Author, run, and inspect trace-level platform QA agents.",
     add_completion=False,
     rich_markup_mode="rich",
     no_args_is_help=True,
 )
 
 
-def _render_results(results: list[dict[str, Any]]) -> None:
+def _platform() -> PlatformClient:
+    require_api_key("use platform QA agents")
+    return PlatformClient.from_settings()
+
+
+def _print_json(payload: Any) -> None:
+    typer.echo(json.dumps(payload, indent=2, sort_keys=True, default=str))
+
+
+def _print_agent(agent: dict[str, Any], *, json_output: bool = False) -> None:
+    if json_output:
+        _print_json(agent)
+        return
+    typer.echo(
+        f"{agent.get('id', '-')}\t{agent.get('name', '-')}\t"
+        f"{agent.get('subject_type', '-')}\t{agent.get('model_name') or '-'}"
+    )
+
+
+def _print_results(results: list[dict[str, Any]], *, json_output: bool) -> None:
+    if json_output:
+        _print_json(results)
+        return
     if not results:
         typer.echo("No QA results found.")
         return
@@ -40,28 +56,55 @@ def _render_results(results: list[dict[str, Any]]) -> None:
         output = result.get("canonical_result") or result.get("result") or {}
         verdict = output.get("verdict") or result.get("status", "unknown")
         summary = output.get("summary") or result.get("error")
-        subject_id = result.get("subject_id", "-")
+        subject_id = result.get("subject_trace_id") or "-"
         agent = result.get("agent_name") or result.get("qa_agent_id") or "-"
         stale = " stale" if result.get("stale") is True else ""
         line = f"{subject_id}\t{agent}\t{verdict}{stale}"
         typer.echo(f"{line}\t{summary}" if summary else line)
 
 
+def _parse_args(raw: str | None) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        parsed = None
+    if not isinstance(parsed, dict):
+        typer.echo("--args must be a JSON object.", err=True)
+        raise typer.Exit(1)
+    return parsed
+
+
+def _require_trace_agent(platform: PlatformClient, agent_id: str) -> None:
+    agent = cast("dict[str, Any]", platform.get(f"/qa-agents/{agent_id}"))
+    if agent.get("subject_type") != _TRACE_SUBJECT:
+        typer.echo(
+            f"Agent {agent_id} is a {agent.get('subject_type')} QA agent. "
+            "The CLI currently supports trace agents only.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
 def _wait_for_results(
     platform: PlatformClient,
-    result_ids: list[str],
     timeout: float,
+    *,
+    trace_ids: list[str],
+    agent_id: str,
 ) -> list[dict[str, Any]]:
     deadline = time.monotonic() + timeout
     while True:
-        results = cast(
-            "list[dict[str, Any]]",
-            platform.get(
-                "/qa-agents/results/resources",
-                params={"result_ids": result_ids},
-            ),
-        )
-        if len(results) == len(result_ids) and all(
+        results = [
+            result
+            for result in cast(
+                "list[dict[str, Any]]",
+                platform.get("/qa-agents/results", params={"subject_trace_ids": trace_ids}),
+            )
+            if result.get("qa_agent_id") == agent_id
+        ]
+        if len(results) == len(trace_ids) and all(
             result["status"] in _TERMINAL_STATUSES for result in results
         ):
             return results
@@ -70,50 +113,168 @@ def _wait_for_results(
         time.sleep(_POLL_INTERVAL_SECONDS)
 
 
+@qa_app.command("scenarios")
+def list_scenarios(
+    json_output: bool = typer.Option(False, "--json", help="Output the machine-readable response."),
+    limit: int = typer.Option(500, "--limit", min=1, max=1000, help="Maximum scenarios to return."),
+) -> None:
+    """List scenarios that can be used to author a trace QA agent."""
+    scenarios = cast(
+        "list[dict[str, Any]]",
+        _platform().get(
+            "/qa-agents/scenarios",
+            params={"subject_type": _TRACE_SUBJECT, "limit": limit},
+        ),
+    )
+    if json_output:
+        _print_json(scenarios)
+        return
+    if not scenarios:
+        typer.echo("No trace QA scenarios found.")
+        return
+    for scenario in scenarios:
+        typer.echo(
+            f"{scenario.get('id', '-')}\t{scenario.get('name', '-')}\t"
+            f"{scenario.get('registry_display_name') or '-'}"
+        )
+
+
 @qa_app.command("agents")
 def list_agents(
-    subject_type: ResourceSubjectType = typer.Option(  # noqa: B008
-        ResourceSubjectType.environment,
-        "--subject-type",
-        help="Resource scope: environment, taskset, or task.",
-    ),
     json_output: bool = typer.Option(False, "--json", help="Output the machine-readable response."),
     limit: int = typer.Option(50, "--limit", min=1, max=500, help="Maximum agents to return."),
     offset: int = typer.Option(0, "--offset", min=0, help="Number of agents to skip."),
 ) -> None:
-    """List QA agents available for a resource type."""
-    require_api_key("use platform QA agents")
+    """List trace QA agents available to this team."""
     response = cast(
         "dict[str, Any]",
-        PlatformClient.from_settings().get(
+        _platform().get(
             "/qa-agents",
-            params={
-                "subject_type": subject_type.value,
-                "limit": limit,
-                "offset": offset,
-            },
+            params={"subject_type": _TRACE_SUBJECT, "limit": limit, "offset": offset},
         ),
     )
     if json_output:
-        typer.echo(json.dumps(response, indent=2, sort_keys=True, default=str))
+        _print_json(response)
         return
     agents = response["items"]
     if not agents:
-        typer.echo(f"No {subject_type.value} QA agents found.")
+        typer.echo("No trace QA agents found.")
         return
     for agent in agents:
-        typer.echo(
-            f"{agent.get('id', '-')}\t{agent.get('name', '-')}\t"
-            f"{agent.get('subject_type', '-')}\t{agent.get('model_name') or '-'}"
-        )
+        _print_agent(agent)
+
+
+@qa_app.command("create")
+def create_agent(
+    name: str = typer.Option(..., "--name", help="Display name for the agent."),
+    scenario: str = typer.Option(
+        ...,
+        "--scenario",
+        help="Scenario UUID from `hud qa scenarios`.",
+    ),
+    model: str = typer.Option(
+        ...,
+        "--model",
+        help="Model UUID or slug from `hud models list`.",
+    ),
+    description: str | None = typer.Option(
+        None,
+        "--description",
+        help="Optional agent description.",
+    ),
+    max_steps: int | None = typer.Option(
+        None,
+        "--max-steps",
+        min=1,
+        help="Maximum analysis steps.",
+    ),
+    args: str | None = typer.Option(None, "--args", help="JSON object of scenario partial args."),
+    public: bool = typer.Option(False, "--public", help="Make the agent visible to other teams."),
+    json_output: bool = typer.Option(False, "--json", help="Output the created agent as JSON."),
+) -> None:
+    """Create a trace QA agent."""
+    body: dict[str, Any] = {
+        "name": name,
+        "scenario_id": scenario,
+        "model_id": _resolve_model_id(model),
+        "subject_type": _TRACE_SUBJECT,
+    }
+    if description is not None:
+        body["description"] = description
+    if max_steps is not None:
+        body["max_steps"] = max_steps
+    if args is not None:
+        body["partial_args"] = _parse_args(args)
+    if public:
+        body["public"] = True
+    _print_agent(
+        cast("dict[str, Any]", _platform().post("/qa-agents", json=body)),
+        json_output=json_output,
+    )
+
+
+@qa_app.command("update")
+def update_agent(
+    agent_id: str = typer.Argument(..., help="QA agent UUID."),
+    name: str | None = typer.Option(None, "--name", help="New display name."),
+    model: str | None = typer.Option(None, "--model", help="Model UUID or slug."),
+    description: str | None = typer.Option(None, "--description", help="New description."),
+    max_steps: int | None = typer.Option(
+        None,
+        "--max-steps",
+        min=1,
+        help="Maximum analysis steps.",
+    ),
+    args: str | None = typer.Option(None, "--args", help="JSON object of scenario partial args."),
+    public: bool | None = typer.Option(
+        None,
+        "--public/--private",
+        help="Whether this agent is visible to other teams.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output the updated agent as JSON."),
+) -> None:
+    """Update a trace QA agent's configuration."""
+    platform = _platform()
+    _require_trace_agent(platform, agent_id)
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = name
+    if model is not None:
+        body["model_id"] = _resolve_model_id(model)
+    if description is not None:
+        body["description"] = description
+    if max_steps is not None:
+        body["max_steps"] = max_steps
+    if args is not None:
+        body["partial_args"] = _parse_args(args)
+    if public is not None:
+        body["public"] = public
+    if not body:
+        typer.echo("Pass at least one field to update.", err=True)
+        raise typer.Exit(1)
+    _print_agent(
+        cast("dict[str, Any]", platform.patch(f"/qa-agents/{agent_id}", json=body)),
+        json_output=json_output,
+    )
+
+
+@qa_app.command("delete")
+def delete_agent(
+    agent_id: str = typer.Argument(..., help="QA agent UUID."),
+) -> None:
+    """Delete a trace QA agent."""
+    platform = _platform()
+    _require_trace_agent(platform, agent_id)
+    platform.delete(f"/qa-agents/{agent_id}")
+    typer.echo(f"Deleted {agent_id}.")
 
 
 @qa_app.command("run")
 def run_agent(
     agent_id: str = typer.Argument(..., help="QA agent UUID."),
-    subject_ids: list[str] = typer.Argument(  # noqa: B008
+    trace_ids: list[str] = typer.Argument(  # noqa: B008
         ...,
-        help="One or more Environment, Taskset, or Task UUIDs.",
+        help="One or more trace UUIDs.",
     ),
     overwrite: bool = typer.Option(
         False,
@@ -133,28 +294,22 @@ def run_agent(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output machine-readable results."),
 ) -> None:
-    """Run one QA agent against resource subjects."""
-    require_api_key("use platform QA agents")
-    platform = PlatformClient.from_settings()
+    """Run one trace QA agent against the given traces."""
+    platform = _platform()
+    _require_trace_agent(platform, agent_id)
     runs = cast(
         "list[dict[str, Any]]",
         platform.post(
-            f"/qa-agents/{agent_id}/run-resources",
-            json={"subject_ids": subject_ids, "overwrite": overwrite},
+            f"/qa-agents/{agent_id}/run",
+            json={"trace_ids": trace_ids, "overwrite": overwrite},
         ),
     )
     if not wait:
-        if json_output:
-            typer.echo(json.dumps(runs, indent=2, sort_keys=True, default=str))
-        else:
-            _render_results(runs)
+        _print_results(runs, json_output=json_output)
         return
 
-    results = _wait_for_results(platform, [str(run["id"]) for run in runs], timeout)
-    if json_output:
-        typer.echo(json.dumps(results, indent=2, sort_keys=True, default=str))
-    else:
-        _render_results(results)
+    results = _wait_for_results(platform, timeout, trace_ids=trace_ids, agent_id=agent_id)
+    _print_results(results, json_output=json_output)
     if any(
         result["status"] == "error"
         or (result.get("canonical_result") or {}).get("verdict") != "passed"
@@ -165,29 +320,15 @@ def run_agent(
 
 @qa_app.command("results")
 def list_results(
-    subject_type: ResourceSubjectType = typer.Argument(  # noqa: B008
+    trace_ids: list[str] = typer.Argument(  # noqa: B008
         ...,
-        help="Resource scope: environment, taskset, or task.",
-    ),
-    subject_ids: list[str] = typer.Argument(  # noqa: B008
-        ...,
-        help="One or more Environment, Taskset, or Task UUIDs.",
+        help="One or more trace UUIDs.",
     ),
     json_output: bool = typer.Option(False, "--json", help="Output machine-readable results."),
 ) -> None:
-    """Inspect QA results attached to resource subjects."""
-    require_api_key("use platform QA agents")
+    """Inspect QA results attached to the given traces."""
     results = cast(
         "list[dict[str, Any]]",
-        PlatformClient.from_settings().get(
-            "/qa-agents/results/resources",
-            params={
-                "subject_type": subject_type.value,
-                "subject_ids": subject_ids,
-            },
-        ),
+        _platform().get("/qa-agents/results", params={"subject_trace_ids": trace_ids}),
     )
-    if json_output:
-        typer.echo(json.dumps(results, indent=2, sort_keys=True, default=str))
-    else:
-        _render_results(results)
+    _print_results(results, json_output=json_output)

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -139,13 +139,13 @@ def _wait_for_results(
         time.sleep(_POLL_INTERVAL_SECONDS)
 
 
-@qa_app.command("scenarios")
-def list_scenarios(
+@qa_app.command("templates")
+def list_templates(
     json_output: bool = typer.Option(False, "--json", help="Output the machine-readable response."),
-    limit: int = typer.Option(500, "--limit", min=1, max=1000, help="Maximum scenarios to return."),
+    limit: int = typer.Option(500, "--limit", min=1, max=1000, help="Maximum templates to return."),
 ) -> None:
-    """List scenarios that can be used to author a trace QA agent."""
-    scenarios = cast(
+    """List templates that can be used to author a trace QA agent."""
+    templates = cast(
         "list[dict[str, Any]]",
         _platform().get(
             "/qa-agents/scenarios",
@@ -153,15 +153,15 @@ def list_scenarios(
         ),
     )
     if json_output:
-        _print_json(scenarios)
+        _print_json(templates)
         return
-    if not scenarios:
-        typer.echo("No trace QA scenarios found.")
+    if not templates:
+        typer.echo("No trace QA templates found.")
         return
-    for scenario in scenarios:
+    for template in templates:
         typer.echo(
-            f"{scenario.get('id', '-')}\t{scenario.get('name', '-')}\t"
-            f"{scenario.get('registry_display_name') or '-'}"
+            f"{template.get('id', '-')}\t{template.get('name', '-')}\t"
+            f"{template.get('registry_display_name') or '-'}"
         )
 
 
@@ -193,10 +193,10 @@ def list_agents(
 @qa_app.command("create")
 def create_agent(
     name: str = typer.Option(..., "--name", help="Display name for the agent."),
-    scenario: str = typer.Option(
+    template: str = typer.Option(
         ...,
-        "--scenario",
-        help="Scenario UUID from `hud qa scenarios`.",
+        "--template",
+        help="Template UUID from `hud qa templates`.",
     ),
     model: str = typer.Option(
         ...,
@@ -214,14 +214,14 @@ def create_agent(
         min=1,
         help="Maximum analysis steps.",
     ),
-    args: str | None = typer.Option(None, "--args", help="JSON object of scenario partial args."),
+    args: str | None = typer.Option(None, "--args", help="JSON object of template partial args."),
     public: bool = typer.Option(False, "--public", help="Make the agent visible to other teams."),
     json_output: bool = typer.Option(False, "--json", help="Output the created agent as JSON."),
 ) -> None:
     """Create a trace QA agent."""
     body: dict[str, Any] = {
         "name": name,
-        "scenario_id": scenario,
+        "scenario_id": template,
         "model_id": _resolve_model_id(model),
         "subject_type": _TRACE_SUBJECT,
     }
@@ -251,7 +251,7 @@ def update_agent(
         min=1,
         help="Maximum analysis steps.",
     ),
-    args: str | None = typer.Option(None, "--args", help="JSON object of scenario partial args."),
+    args: str | None = typer.Option(None, "--args", help="JSON object of template partial args."),
     public: bool | None = typer.Option(
         None,
         "--public/--private",

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -16,8 +16,6 @@ _AGENT_ID = "00000000-0000-4000-a000-000000000001"
 _TRACE_ID = "00000000-0000-4000-a000-000000000002"
 _RESULT_ID = "00000000-0000-4000-a000-000000000003"
 _OTHER_AGENT_ID = "00000000-0000-4000-a000-000000000004"
-_TEMPLATE_ID = "00000000-0000-4000-a000-000000000005"
-_MODEL_ID = "00000000-0000-4000-a000-000000000006"
 
 
 def _agent(*, subject_type: str = "trace") -> dict[str, object]:
@@ -64,7 +62,7 @@ def _invoke(platform: MagicMock, args: list[str]):
         return runner.invoke(app, args)
 
 
-def test_qa_agents_lists_trace_scope() -> None:
+def test_qa_lists_agent_name_and_uuid() -> None:
     platform = MagicMock()
     platform.get.return_value = {
         "items": [_agent()],
@@ -73,135 +71,25 @@ def test_qa_agents_lists_trace_scope() -> None:
         "offset": 0,
     }
 
-    result = _invoke(platform, ["qa", "agents"])
+    result = _invoke(platform, ["qa"])
 
     assert result.exit_code == 0
-    assert _AGENT_ID in result.output
+    assert result.output.strip() == f"Failure Analysis\t{_AGENT_ID}"
     platform.get.assert_called_once_with(
         "/qa-agents",
         params={"subject_type": "trace", "limit": 50, "offset": 0},
     )
 
 
-def test_qa_templates_lists_trace_candidates() -> None:
-    platform = MagicMock()
-    platform.get.return_value = [
-        {"id": _TEMPLATE_ID, "name": "qa:failure-analysis", "registry_display_name": "Trace QA"},
-    ]
-
-    result = _invoke(platform, ["qa", "templates"])
-
-    assert result.exit_code == 0
-    assert _TEMPLATE_ID in result.output
-    platform.get.assert_called_once_with(
-        "/qa-agents/scenarios",
-        params={"subject_type": "trace", "limit": 500},
-    )
-
-
-def test_qa_create_posts_a_trace_agent() -> None:
-    platform = MagicMock()
-    platform.post.return_value = _agent()
-
-    result = _invoke(
-        platform,
-        [
-            "qa",
-            "create",
-            "--name",
-            "Failure Analysis",
-            "--template",
-            _TEMPLATE_ID,
-            "--model",
-            _MODEL_ID,
-            "--args",
-            '{"threshold": 0.5}',
-            "--json",
-        ],
-    )
-
-    assert result.exit_code == 0
-    assert json.loads(result.output)["id"] == _AGENT_ID
-    platform.post.assert_called_once_with(
-        "/qa-agents",
-        json={
-            "name": "Failure Analysis",
-            "scenario_id": _TEMPLATE_ID,
-            "model_id": _MODEL_ID,
-            "subject_type": "trace",
-            "partial_args": {"threshold": 0.5},
-        },
-    )
-
-
-def test_qa_create_rejects_invalid_args() -> None:
-    platform = MagicMock()
-
-    result = _invoke(
-        platform,
-        [
-            "qa",
-            "create",
-            "--name",
-            "Failure Analysis",
-            "--template",
-            _TEMPLATE_ID,
-            "--model",
-            _MODEL_ID,
-            "--args",
-            "not-json",
-        ],
-    )
-
-    assert result.exit_code == 1
-    assert "--args must be a JSON object" in result.output
-    platform.post.assert_not_called()
-
-
-def test_qa_update_patches_trace_agent() -> None:
-    platform = MagicMock()
-    platform.get.return_value = _agent()
-    platform.patch.return_value = {**_agent(), "name": "Renamed"}
-
-    result = _invoke(platform, ["qa", "update", _AGENT_ID, "--name", "Renamed", "--private"])
-
-    assert result.exit_code == 0
-    assert "Renamed" in result.output
-    platform.patch.assert_called_once_with(
-        f"/qa-agents/{_AGENT_ID}",
-        json={"name": "Renamed", "public": False},
-    )
-
-
-@pytest.mark.parametrize(
-    ("args", "method"),
-    [
-        (["qa", "update", _AGENT_ID, "--name", "Nope"], "patch"),
-        (["qa", "delete", _AGENT_ID], "delete"),
-        (["qa", "run", _AGENT_ID, _TRACE_ID, "--no-wait"], "post"),
-    ],
-)
-def test_qa_commands_reject_resource_agents(args: list[str], method: str) -> None:
+def test_qa_run_rejects_resource_agents() -> None:
     platform = MagicMock()
     platform.get.return_value = _agent(subject_type="environment")
 
-    result = _invoke(platform, args)
+    result = _invoke(platform, ["qa", "run", _AGENT_ID, _TRACE_ID, "--no-wait"])
 
     assert result.exit_code == 1
     assert "trace agents only" in result.output
-    getattr(platform, method).assert_not_called()
-
-
-def test_qa_delete_removes_trace_agent() -> None:
-    platform = MagicMock()
-    platform.get.return_value = _agent()
-    platform.delete.return_value = {}
-
-    result = _invoke(platform, ["qa", "delete", _AGENT_ID])
-
-    assert result.exit_code == 0
-    assert f"Deleted {_AGENT_ID}" in result.output
-    platform.delete.assert_called_once_with(f"/qa-agents/{_AGENT_ID}")
+    platform.post.assert_not_called()
 
 
 def test_qa_run_no_wait_uses_trace_endpoint() -> None:

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -1,10 +1,11 @@
-"""CLI behavior for resource-scoped platform QA agents."""
+"""CLI behavior for trace-level platform QA agents."""
 
 from __future__ import annotations
 
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from hud.cli import app
@@ -12,16 +13,29 @@ from hud.cli import app
 runner = CliRunner()
 
 _AGENT_ID = "00000000-0000-4000-a000-000000000001"
-_SUBJECT_ID = "00000000-0000-4000-a000-000000000002"
+_TRACE_ID = "00000000-0000-4000-a000-000000000002"
 _RESULT_ID = "00000000-0000-4000-a000-000000000003"
+_OTHER_AGENT_ID = "00000000-0000-4000-a000-000000000004"
+_SCENARIO_ID = "00000000-0000-4000-a000-000000000005"
+_MODEL_ID = "00000000-0000-4000-a000-000000000006"
+
+
+def _agent(*, subject_type: str = "trace") -> dict[str, object]:
+    return {
+        "id": _AGENT_ID,
+        "name": "Failure Analysis",
+        "subject_type": subject_type,
+        "model_name": "claude-sonnet",
+    }
 
 
 def _run(status: str = "queued") -> dict[str, object]:
     return {
         "id": _RESULT_ID,
         "qa_agent_id": _AGENT_ID,
-        "subject_type": "task",
-        "subject_id": _SUBJECT_ID,
+        "subject_type": "trace",
+        "subject_id": _TRACE_ID,
+        "subject_trace_id": _TRACE_ID,
         "status": status,
     }
 
@@ -29,7 +43,7 @@ def _run(status: str = "queued") -> dict[str, object]:
 def _result(verdict: str = "passed") -> dict[str, object]:
     return {
         **_run(status="completed"),
-        "agent_name": "Task Contract Auditor",
+        "agent_name": "Failure Analysis",
         "canonical_result": {
             "schema_version": "qa_agent_result.v1",
             "verdict": verdict,
@@ -42,48 +56,157 @@ def _result(verdict: str = "passed") -> dict[str, object]:
     }
 
 
-def test_qa_agents_lists_requested_resource_scope() -> None:
+def _invoke(platform: MagicMock, args: list[str]):
+    with (
+        patch("hud.cli.qa.require_api_key", return_value="api-key"),
+        patch("hud.cli.qa.PlatformClient.from_settings", return_value=platform),
+    ):
+        return runner.invoke(app, args)
+
+
+def test_qa_agents_lists_trace_scope() -> None:
     platform = MagicMock()
     platform.get.return_value = {
-        "items": [
-            {
-                "id": _AGENT_ID,
-                "name": "Task Contract Auditor",
-                "subject_type": "task",
-                "model_name": "claude-sonnet",
-            },
-        ],
+        "items": [_agent()],
         "total": 1,
         "limit": 50,
         "offset": 0,
     }
 
-    with (
-        patch("hud.cli.qa.require_api_key", return_value="api-key"),
-        patch("hud.cli.qa.PlatformClient.from_settings", return_value=platform),
-    ):
-        result = runner.invoke(app, ["qa", "agents", "--subject-type", "task"])
+    result = _invoke(platform, ["qa", "agents"])
 
     assert result.exit_code == 0
     assert _AGENT_ID in result.output
-    assert "Task Contract Auditor" in result.output
     platform.get.assert_called_once_with(
         "/qa-agents",
-        params={"subject_type": "task", "limit": 50, "offset": 0},
+        params={"subject_type": "trace", "limit": 50, "offset": 0},
     )
 
 
-def test_qa_subject_type_uses_typer_validation() -> None:
-    with patch("hud.cli.qa.require_api_key") as require_api_key:
-        result = runner.invoke(app, ["qa", "agents", "--subject-type", "trace"])
-
-    assert result.exit_code == 2
-    assert "Invalid value" in result.output
-    require_api_key.assert_not_called()
-
-
-def test_qa_run_no_wait_returns_the_launch_response_without_scoring_it() -> None:
+def test_qa_scenarios_lists_trace_candidates() -> None:
     platform = MagicMock()
+    platform.get.return_value = [
+        {"id": _SCENARIO_ID, "name": "qa:failure-analysis", "registry_display_name": "Trace QA"},
+    ]
+
+    result = _invoke(platform, ["qa", "scenarios"])
+
+    assert result.exit_code == 0
+    assert _SCENARIO_ID in result.output
+    platform.get.assert_called_once_with(
+        "/qa-agents/scenarios",
+        params={"subject_type": "trace", "limit": 500},
+    )
+
+
+def test_qa_create_posts_a_trace_agent() -> None:
+    platform = MagicMock()
+    platform.post.return_value = _agent()
+
+    result = _invoke(
+        platform,
+        [
+            "qa",
+            "create",
+            "--name",
+            "Failure Analysis",
+            "--scenario",
+            _SCENARIO_ID,
+            "--model",
+            _MODEL_ID,
+            "--args",
+            '{"threshold": 0.5}',
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["id"] == _AGENT_ID
+    platform.post.assert_called_once_with(
+        "/qa-agents",
+        json={
+            "name": "Failure Analysis",
+            "scenario_id": _SCENARIO_ID,
+            "model_id": _MODEL_ID,
+            "subject_type": "trace",
+            "partial_args": {"threshold": 0.5},
+        },
+    )
+
+
+def test_qa_create_rejects_invalid_args() -> None:
+    platform = MagicMock()
+
+    result = _invoke(
+        platform,
+        [
+            "qa",
+            "create",
+            "--name",
+            "Failure Analysis",
+            "--scenario",
+            _SCENARIO_ID,
+            "--model",
+            _MODEL_ID,
+            "--args",
+            "not-json",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--args must be a JSON object" in result.output
+    platform.post.assert_not_called()
+
+
+def test_qa_update_patches_trace_agent() -> None:
+    platform = MagicMock()
+    platform.get.return_value = _agent()
+    platform.patch.return_value = {**_agent(), "name": "Renamed"}
+
+    result = _invoke(platform, ["qa", "update", _AGENT_ID, "--name", "Renamed", "--private"])
+
+    assert result.exit_code == 0
+    assert "Renamed" in result.output
+    platform.patch.assert_called_once_with(
+        f"/qa-agents/{_AGENT_ID}",
+        json={"name": "Renamed", "public": False},
+    )
+
+
+@pytest.mark.parametrize(
+    ("args", "method"),
+    [
+        (["qa", "update", _AGENT_ID, "--name", "Nope"], "patch"),
+        (["qa", "delete", _AGENT_ID], "delete"),
+        (["qa", "run", _AGENT_ID, _TRACE_ID, "--no-wait"], "post"),
+    ],
+)
+def test_qa_commands_reject_resource_agents(args: list[str], method: str) -> None:
+    platform = MagicMock()
+    platform.get.return_value = _agent(subject_type="environment")
+
+    result = _invoke(platform, args)
+
+    assert result.exit_code == 1
+    assert "trace agents only" in result.output
+    getattr(platform, method).assert_not_called()
+
+
+def test_qa_delete_removes_trace_agent() -> None:
+    platform = MagicMock()
+    platform.get.return_value = _agent()
+    platform.delete.return_value = {}
+
+    result = _invoke(platform, ["qa", "delete", _AGENT_ID])
+
+    assert result.exit_code == 0
+    assert f"Deleted {_AGENT_ID}" in result.output
+    platform.delete.assert_called_once_with(f"/qa-agents/{_AGENT_ID}")
+
+
+def test_qa_run_no_wait_uses_trace_endpoint() -> None:
+    platform = MagicMock()
+    platform.get.return_value = _agent()
     platform.post.return_value = [
         {
             **_run(status="completed"),
@@ -95,77 +218,56 @@ def test_qa_run_no_wait_returns_the_launch_response_without_scoring_it() -> None
         },
     ]
 
-    with (
-        patch("hud.cli.qa.require_api_key", return_value="api-key"),
-        patch("hud.cli.qa.PlatformClient.from_settings", return_value=platform),
-    ):
-        result = runner.invoke(
-            app,
-            ["qa", "run", _AGENT_ID, _SUBJECT_ID, "--no-wait", "--json"],
-        )
+    result = _invoke(platform, ["qa", "run", _AGENT_ID, _TRACE_ID, "--no-wait", "--json"])
 
     assert result.exit_code == 0
     assert json.loads(result.output)[0]["result"]["verdict"] == "failed"
     platform.post.assert_called_once_with(
-        f"/qa-agents/{_AGENT_ID}/run-resources",
-        json={"subject_ids": [_SUBJECT_ID], "overwrite": False},
+        f"/qa-agents/{_AGENT_ID}/run",
+        json={"trace_ids": [_TRACE_ID], "overwrite": False},
     )
-    platform.get.assert_not_called()
 
 
-def test_qa_run_waits_for_exact_result_ids_and_returns_quality_exit() -> None:
+@pytest.mark.parametrize(("verdict", "exit_code"), [("failed", 1), ("passed", 0)])
+def test_qa_run_waits_and_scores(verdict: str, exit_code: int) -> None:
     platform = MagicMock()
     platform.post.return_value = [_run()]
-    platform.get.side_effect = [[], [_result("failed")]]
+    platform.get.side_effect = [_agent(), [], [_result(verdict)]]
 
-    with (
-        patch("hud.cli.qa.require_api_key", return_value="api-key"),
-        patch("hud.cli.qa.PlatformClient.from_settings", return_value=platform),
-        patch("hud.cli.qa.time.sleep"),
-    ):
-        result = runner.invoke(app, ["qa", "run", _AGENT_ID, _SUBJECT_ID])
+    with patch("hud.cli.qa.time.sleep"):
+        result = _invoke(platform, ["qa", "run", _AGENT_ID, _TRACE_ID])
 
-    assert result.exit_code == 1
-    assert "failed" in result.output
-    assert "A gap was found." in result.output
-    assert platform.get.call_count == 2
+    assert result.exit_code == exit_code
+    assert verdict in result.output
     platform.get.assert_called_with(
-        "/qa-agents/results/resources",
-        params={"result_ids": [_RESULT_ID]},
+        "/qa-agents/results",
+        params={"subject_trace_ids": [_TRACE_ID]},
     )
 
 
-def test_qa_run_returns_zero_for_passed_results() -> None:
+def test_qa_run_waits_for_trace_results_and_ignores_other_agents() -> None:
     platform = MagicMock()
-    platform.post.return_value = [_run()]
-    platform.get.return_value = [_result()]
+    platform.post.return_value = []
+    platform.get.side_effect = [
+        _agent(),
+        [{**_result("failed"), "qa_agent_id": _OTHER_AGENT_ID}, _result("passed")],
+    ]
 
-    with (
-        patch("hud.cli.qa.require_api_key", return_value="api-key"),
-        patch("hud.cli.qa.PlatformClient.from_settings", return_value=platform),
-    ):
-        result = runner.invoke(app, ["qa", "run", _AGENT_ID, _SUBJECT_ID])
+    result = _invoke(platform, ["qa", "run", _AGENT_ID, _TRACE_ID])
 
     assert result.exit_code == 0
     assert "passed" in result.output
 
 
-def test_qa_results_queries_resource_subjects() -> None:
+def test_qa_results_queries_traces() -> None:
     platform = MagicMock()
     platform.get.return_value = [_result()]
 
-    with (
-        patch("hud.cli.qa.require_api_key", return_value="api-key"),
-        patch("hud.cli.qa.PlatformClient.from_settings", return_value=platform),
-    ):
-        result = runner.invoke(
-            app,
-            ["qa", "results", "task", _SUBJECT_ID, "--json"],
-        )
+    result = _invoke(platform, ["qa", "results", _TRACE_ID, "--json"])
 
     assert result.exit_code == 0
     assert json.loads(result.output)[0]["canonical_result"]["verdict"] == "passed"
     platform.get.assert_called_once_with(
-        "/qa-agents/results/resources",
-        params={"subject_type": "task", "subject_ids": [_SUBJECT_ID]},
+        "/qa-agents/results",
+        params={"subject_trace_ids": [_TRACE_ID]},
     )

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -16,7 +16,7 @@ _AGENT_ID = "00000000-0000-4000-a000-000000000001"
 _TRACE_ID = "00000000-0000-4000-a000-000000000002"
 _RESULT_ID = "00000000-0000-4000-a000-000000000003"
 _OTHER_AGENT_ID = "00000000-0000-4000-a000-000000000004"
-_SCENARIO_ID = "00000000-0000-4000-a000-000000000005"
+_TEMPLATE_ID = "00000000-0000-4000-a000-000000000005"
 _MODEL_ID = "00000000-0000-4000-a000-000000000006"
 
 
@@ -83,16 +83,16 @@ def test_qa_agents_lists_trace_scope() -> None:
     )
 
 
-def test_qa_scenarios_lists_trace_candidates() -> None:
+def test_qa_templates_lists_trace_candidates() -> None:
     platform = MagicMock()
     platform.get.return_value = [
-        {"id": _SCENARIO_ID, "name": "qa:failure-analysis", "registry_display_name": "Trace QA"},
+        {"id": _TEMPLATE_ID, "name": "qa:failure-analysis", "registry_display_name": "Trace QA"},
     ]
 
-    result = _invoke(platform, ["qa", "scenarios"])
+    result = _invoke(platform, ["qa", "templates"])
 
     assert result.exit_code == 0
-    assert _SCENARIO_ID in result.output
+    assert _TEMPLATE_ID in result.output
     platform.get.assert_called_once_with(
         "/qa-agents/scenarios",
         params={"subject_type": "trace", "limit": 500},
@@ -110,8 +110,8 @@ def test_qa_create_posts_a_trace_agent() -> None:
             "create",
             "--name",
             "Failure Analysis",
-            "--scenario",
-            _SCENARIO_ID,
+            "--template",
+            _TEMPLATE_ID,
             "--model",
             _MODEL_ID,
             "--args",
@@ -126,7 +126,7 @@ def test_qa_create_posts_a_trace_agent() -> None:
         "/qa-agents",
         json={
             "name": "Failure Analysis",
-            "scenario_id": _SCENARIO_ID,
+            "scenario_id": _TEMPLATE_ID,
             "model_id": _MODEL_ID,
             "subject_type": "trace",
             "partial_args": {"threshold": 0.5},
@@ -144,8 +144,8 @@ def test_qa_create_rejects_invalid_args() -> None:
             "create",
             "--name",
             "Failure Analysis",
-            "--scenario",
-            _SCENARIO_ID,
+            "--template",
+            _TEMPLATE_ID,
             "--model",
             _MODEL_ID,
             "--args",

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -245,6 +245,35 @@ def test_qa_run_waits_and_scores(verdict: str, exit_code: int) -> None:
     )
 
 
+def test_qa_run_wait_scores_launched_ids_not_older_rows() -> None:
+    older = {**_result("failed"), "id": "00000000-0000-4000-a000-000000000099"}
+    launched = _run()
+    completed = _result("passed")
+    platform = MagicMock()
+    platform.post.return_value = [launched]
+    platform.get.side_effect = [_agent(), [older], [older, completed]]
+
+    with patch("hud.cli.qa.time.sleep"):
+        result = _invoke(platform, ["qa", "run", _AGENT_ID, _TRACE_ID])
+
+    assert result.exit_code == 0
+    assert "passed" in result.output
+    assert "failed" not in result.output
+
+
+def test_qa_run_wait_reuses_latest_when_launch_returns_empty() -> None:
+    older = {**_result("failed"), "id": "00000000-0000-4000-a000-000000000099"}
+    newer = _result("passed")
+    platform = MagicMock()
+    platform.post.return_value = []
+    platform.get.side_effect = [_agent(), [older, newer]]
+
+    result = _invoke(platform, ["qa", "run", _AGENT_ID, _TRACE_ID])
+
+    assert result.exit_code == 0
+    assert "passed" in result.output
+
+
 def test_qa_run_waits_for_trace_results_and_ignores_other_agents() -> None:
     platform = MagicMock()
     platform.post.return_value = []

--- a/hud/utils/platform.py
+++ b/hud/utils/platform.py
@@ -55,6 +55,12 @@ class PlatformClient:
     def post(self, path: str, *, json: Any | None = None) -> Any:
         return make_request_sync("POST", self.url(path), json=json, api_key=self.api_key)
 
+    def patch(self, path: str, *, json: Any | None = None) -> Any:
+        return make_request_sync("PATCH", self.url(path), json=json, api_key=self.api_key)
+
+    def delete(self, path: str) -> Any:
+        return make_request_sync("DELETE", self.url(path), api_key=self.api_key)
+
     async def aget(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
         return await make_request("GET", self.url(path, params), api_key=self.api_key)
 

--- a/hud/utils/requests.py
+++ b/hud/utils/requests.py
@@ -70,6 +70,13 @@ def _create_default_sync_client() -> httpx.Client:
     )
 
 
+def _response_payload(response: httpx.Response) -> Any:
+    """Decode JSON, treating 204 / empty bodies as an empty object."""
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
 async def make_request(
     method: str,
     url: str,
@@ -135,7 +142,7 @@ async def make_request(
                     continue
 
                 response.raise_for_status()
-                result = response.json()
+                result = _response_payload(response)
                 return result
             except httpx.TimeoutException as e:
                 raise HudTimeoutError(f"Request timed out: {e!s}") from None
@@ -236,7 +243,7 @@ def make_request_sync(
                     continue
 
                 response.raise_for_status()
-                result = response.json()
+                result = _response_payload(response)
                 return result
             except httpx.TimeoutException as e:
                 raise HudTimeoutError(f"Request timed out: {e!s}") from None

--- a/hud/utils/tests/test_platform.py
+++ b/hud/utils/tests/test_platform.py
@@ -35,7 +35,7 @@ def test_url_encodes_repeated_query_parameters() -> None:
     )
 
 
-def test_get_and_post_route_through_shared_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_http_methods_route_through_shared_requests(monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[dict[str, object]] = []
 
     def fake_request(
@@ -49,9 +49,13 @@ def test_get_and_post_route_through_shared_requests(monkeypatch: pytest.MonkeyPa
 
     assert platform.get("/x", params={"a": 1}) == {"ok": True}
     assert platform.post("/y", json={"b": 2}) == {"ok": True}
+    assert platform.patch("/z", json={"c": 3}) == {"ok": True}
+    assert platform.delete("/z") == {"ok": True}
     assert calls == [
         {"method": "GET", "url": "https://api.example/v2/x?a=1", "json": None, "api_key": "key"},
         {"method": "POST", "url": "https://api.example/v2/y", "json": {"b": 2}, "api_key": "key"},
+        {"method": "PATCH", "url": "https://api.example/v2/z", "json": {"c": 3}, "api_key": "key"},
+        {"method": "DELETE", "url": "https://api.example/v2/z", "json": None, "api_key": "key"},
     ]
 
 

--- a/hud/utils/tests/test_requests.py
+++ b/hud/utils/tests/test_requests.py
@@ -273,3 +273,19 @@ def test_make_request_sync_auto_client_creation():
 
         assert result == {"result": "success"}
         mock_client.close.assert_called_once()
+
+
+def test_make_request_sync_empty_204() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(204, request=request)
+
+    sync_client = httpx.Client(transport=httpx.MockTransport(handler))
+    assert (
+        make_request_sync(
+            "DELETE",
+            "https://api.test.com/data",
+            api_key="test-key",
+            client=sync_client,
+        )
+        == {}
+    )


### PR DESCRIPTION
## What changed

`hud qa` lists and runs trace QA agents. Create, update, and delete are not in the CLI.

- `hud qa` lists agents as `name<TAB>uuid`, including public agents
- `hud qa run <agent-id> <trace-id>`
- `hud qa results <trace-id>`

Resource CLI subjects are removed. Resource agents are rejected on run. `PlatformClient` still has `patch` and `delete`. Empty 204 responses decode as `{}`.

Frontend is unchanged.

## Why

Trace QA was UI-only. The CLI needs to run existing (including public) agents on a team's traces. Agent authoring stays on the platform. Resource QA on the public CLI is out of scope while that product is HUD-gated.

## Impact

`hud qa` is the SDK entry point for running trace QA. Callers of `hud qa agents --subject-type environment` or `hud qa results environment` need the new trace commands. Needs the platform API-key change deployed for run and results.

## Validation

Fail-to-pass: `pytest hud/cli/tests/test_qa.py`

Pass-to-pass: `pytest hud/utils/tests/test_platform.py hud/utils/tests/test_requests.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking CLI and API surface for QA (resource subjects removed); wait logic changes how pass/fail is determined when multiple result rows exist per trace.
> 
> **Overview**
> **`hud qa` is now trace-only** and drops environment/taskset/task resource QA from the public CLI. Listing agents is the default `hud qa` (no `agents` subcommand); output is **name + UUID** for trace agents. **`hud qa run`** takes trace UUIDs, calls `POST /qa-agents/{id}/run` with `trace_ids`, and **rejects non-trace agents** after a GET on the agent. **`hud qa results`** takes trace UUIDs and queries `GET /qa-agents/results` with `subject_trace_ids`. Display uses `subject_trace_id` instead of generic `subject_id`.
> 
> **Wait/poll behavior** no longer keys off launched result IDs alone: it polls by trace, prefers the launched result row when present, and otherwise picks the latest result for that agent + trace (so reused evidence and stale rows from other agents don’t skew exit codes).
> 
> **Platform HTTP helpers:** `PlatformClient` adds **`patch`** and **`delete`**; shared request decoding treats **204 / empty bodies as `{}`** (sync and async). Docs under **Platform QA** match the new command shapes.
> 
> **Breaking:** callers of `hud qa agents --subject-type …`, `hud qa results <type> <id>`, and resource run endpoints need the trace-based commands and matching platform API deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293b97530557dbcb49b774bf39a2a207161528dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->