### PR TITLE
feat(cli): print QA analysis summaries and optional rollouts

### DIFF
--- a/docs/v6/reference/cli.mdx
+++ b/docs/v6/reference/cli.mdx
@@ -150,7 +150,10 @@ for every requested trace. Pass `--overwrite` to create a fresh attempt,
 Exit code `1` means a completed QA result failed or the SDK could not
 complete the command.
 
-`hud qa results` prints the analysis summary and findings. Pass `--rollout`
+`hud qa results` prints the analysis verdict (`passed` or `failed`), not the
+job status. Failure Analysis shows a cause and numbered findings when present.
+Boolean agents (false negative, false positive, reward hacking, prompt
+alignment) show yes/no and a summary, without a findings list. Pass `--rollout`
 for the sanitized analysis trajectory. `--json` still prints the raw result
 list and does not fetch the trajectory.
 

--- a/docs/v6/reference/cli.mdx
+++ b/docs/v6/reference/cli.mdx
@@ -140,6 +140,7 @@ experimental [Harbor integration](/v6/experimental/harbor).
 hud qa
 hud qa run <agent-id> <trace-id>
 hud qa results <trace-id>
+hud qa results <trace-id> --rollout
 ```
 
 `hud qa` lists **trace** agents (name and UUID), including public ones.
@@ -148,6 +149,10 @@ for every requested trace. Pass `--overwrite` to create a fresh attempt,
 `--no-wait` to return after launch, or `--json` for machine-readable output.
 Exit code `1` means a completed QA result failed or the SDK could not
 complete the command.
+
+`hud qa results` prints the analysis summary and findings. Pass `--rollout`
+for the sanitized analysis trajectory. `--json` still prints the raw result
+list and does not fetch the trajectory.
 
 ## Inspect
 

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -86,22 +86,17 @@ def _fetch_rollout(platform: PlatformClient, result_id: str) -> list[dict[str, A
         since_seq = next_seq
 
 
-def _fmt_args(args: Any) -> str:
-    if isinstance(args, dict):
-        return ", ".join(f"{k}={v!r}" for k, v in args.items())
-    return str(args)
-
-
 def _tool_command(event: dict[str, Any]) -> str:
     args = event.get("arguments") or {}
-    if isinstance(args, dict):
-        commands = args.get("commands")
-        if isinstance(commands, list):
-            return "\n".join(str(item) for item in commands)
-        claims = args.get("claims")
-        if claims:
-            return str(claims)
-    return _fmt_args(args)
+    if not isinstance(args, dict):
+        return str(args)
+    commands = args.get("commands")
+    if isinstance(commands, list):
+        return "\n".join(str(item) for item in commands)
+    claims = args.get("claims")
+    if claims:
+        return str(claims)
+    return ", ".join(f"{k}={v!r}" for k, v in args.items())
 
 
 def _capped_text(value: str, *, max_lines: int) -> Text:
@@ -171,7 +166,7 @@ def _render_qa_rollout(events: list[dict[str, Any]]) -> None:
             args = event.get("arguments") or {}
             _console.print(
                 Panel(
-                    Text(_fmt_args(args) if args else name, style=DIM),
+                    Text(_tool_command(event) if args else name, style=DIM),
                     title=_bold_title(name),
                     border_style=GOLD,
                     padding=(0, 1),

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -180,6 +180,10 @@ def _capped_text(value: str, *, max_lines: int) -> Text:
     return text
 
 
+def _bold_title(label: str) -> Text:
+    return Text(label, style="bold")
+
+
 def _render_qa_rollout(events: list[dict[str, Any]]) -> None:
     turn = 0
     for event in events:
@@ -202,7 +206,7 @@ def _render_qa_rollout(events: list[dict[str, Any]]) -> None:
             _console.print(
                 Panel(
                     body,
-                    title=f"[bold]Turn {turn} · agent[/bold]",
+                    title=_bold_title(f"Turn {turn} · agent"),
                     border_style=SECONDARY,
                     padding=(0, 1),
                 )
@@ -223,7 +227,7 @@ def _render_qa_rollout(events: list[dict[str, Any]]) -> None:
             _console.print(
                 Panel(
                     body,
-                    title=f"[bold]{name}[/bold]",
+                    title=_bold_title(name),
                     border_style=border,
                     padding=(0, 1),
                 )
@@ -234,7 +238,7 @@ def _render_qa_rollout(events: list[dict[str, Any]]) -> None:
             _console.print(
                 Panel(
                     Text(_fmt_args(args) if args else name, style=DIM),
-                    title=f"[bold]{name}[/bold]",
+                    title=_bold_title(name),
                     border_style=GOLD,
                     padding=(0, 1),
                 )
@@ -270,7 +274,7 @@ def _print_result_tui(
         _console.print(
             Panel(
                 Text(str(summary)),
-                title="[bold]Summary[/bold]",
+                title=_bold_title("Summary"),
                 border_style=GOLD,
                 padding=(0, 1),
             )
@@ -288,7 +292,7 @@ def _print_result_tui(
         _console.print(
             Panel(
                 body,
-                title=f"[bold]{index}. {title}[/bold]",
+                title=_bold_title(f"{index}. {title}"),
                 border_style=GOLD,
                 padding=(0, 1),
             )

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -7,14 +7,23 @@ import time
 from typing import Any, cast
 
 import typer
+from rich.console import Console
+from rich.panel import Panel
+from rich.text import Text
 
 from hud.cli.utils.api import require_api_key
+from hud.settings import settings
 from hud.utils.exceptions import HudTimeoutError
+from hud.utils.hud_console import DIM, GOLD, GREEN, RED, SECONDARY, HUDConsole
 from hud.utils.platform import PlatformClient
+
+hud_console = HUDConsole()
+_console = Console()
 
 _POLL_INTERVAL_SECONDS = 2.0
 _TERMINAL_STATUSES = {"completed", "error"}
 _TRACE_SUBJECT = "trace"
+_RESULT_LINE_CAP = 12
 
 qa_app = typer.Typer(
     name="qa",
@@ -54,6 +63,243 @@ def _print_results(results: list[dict[str, Any]], *, json_output: bool) -> None:
         stale = " stale" if result.get("stale") is True else ""
         line = f"{subject_id}\t{agent}\t{verdict}{stale}"
         typer.echo(f"{line}\t{summary}" if summary else line)
+
+
+def _as_problems(payload: dict[str, Any]) -> list[Any]:
+    problems = payload.get("problems")
+    if isinstance(problems, list):
+        return problems
+    findings = payload.get("findings")
+    return findings if isinstance(findings, list) else []
+
+
+def _parse_analysis_blob(
+    payload: dict[str, Any],
+    *,
+    fallback_verdict: str,
+) -> dict[str, Any] | None:
+    if (
+        payload.get("verdict")
+        or payload.get("summary")
+        or payload.get("problems")
+        or payload.get("findings")
+    ):
+        return {
+            "verdict": str(payload.get("verdict") or fallback_verdict),
+            "summary": payload.get("summary"),
+            "problems": _as_problems(payload),
+            "confidence": payload.get("confidence"),
+        }
+    content = payload.get("content")
+    if not isinstance(content, str):
+        return None
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return {
+        "verdict": str(parsed.get("verdict") or fallback_verdict),
+        "summary": parsed.get("summary"),
+        "problems": _as_problems(parsed),
+        "confidence": parsed.get("confidence"),
+    }
+
+
+def _analysis_view(result: dict[str, Any]) -> dict[str, Any]:
+    """Verdict, summary, and findings from a canonical row or a JSON content blob."""
+    fallback = str(result.get("status") or "unknown")
+    for payload in (result.get("canonical_result"), result.get("result")):
+        if isinstance(payload, dict):
+            parsed = _parse_analysis_blob(payload, fallback_verdict=fallback)
+            if parsed is not None:
+                return parsed
+    error = result.get("error")
+    return {
+        "verdict": fallback,
+        "summary": str(error) if error else None,
+        "problems": [],
+        "confidence": None,
+    }
+
+
+def _fetch_rollout(platform: PlatformClient, result_id: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    since_seq = -1
+    while True:
+        page = cast(
+            "dict[str, Any]",
+            platform.get(
+                f"/qa-agents/results/{result_id}/rollout",
+                params={"since_seq": since_seq, "limit": 100},
+            ),
+        )
+        events.extend(cast("list[dict[str, Any]]", page.get("events") or []))
+        if not page.get("has_more"):
+            return events
+        next_seq = int(page["next_seq"])
+        if next_seq == since_seq:
+            return events
+        since_seq = next_seq
+
+
+def _fmt_args(args: Any) -> str:
+    if isinstance(args, dict):
+        return ", ".join(f"{k}={v!r}" for k, v in args.items())
+    return str(args)
+
+
+def _is_analysis_json(text: str) -> bool:
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(parsed, dict) and "summary" in parsed
+
+
+def _tool_command(event: dict[str, Any]) -> str:
+    args = event.get("arguments") or {}
+    if isinstance(args, dict):
+        commands = args.get("commands")
+        if isinstance(commands, list):
+            return "\n".join(str(item) for item in commands)
+        claims = args.get("claims")
+        if claims:
+            return str(claims)
+    return _fmt_args(args)
+
+
+def _capped_text(value: str, *, max_lines: int) -> Text:
+    lines = value.splitlines() or [value]
+    shown = lines[:max_lines]
+    text = Text("\n".join(shown))
+    extra = len(lines) - len(shown)
+    if extra > 0:
+        text.append(f"\n… {extra} more lines", style=DIM)
+    return text
+
+
+def _render_qa_rollout(events: list[dict[str, Any]]) -> None:
+    turn = 0
+    for event in events:
+        kind = event.get("kind")
+        if kind == "agent_message":
+            text = event.get("text")
+            reasoning = event.get("reasoning")
+            if isinstance(text, str) and _is_analysis_json(text):
+                continue
+            if not text and not reasoning:
+                continue
+            turn += 1
+            body = Text()
+            if reasoning:
+                body.append(str(reasoning), style=f"italic {DIM}")
+                if text:
+                    body.append("\n")
+            if text:
+                body.append(str(text))
+            _console.print(
+                Panel(
+                    body,
+                    title=f"[bold]Turn {turn} · agent[/bold]",
+                    border_style=SECONDARY,
+                    padding=(0, 1),
+                )
+            )
+        elif kind in ("tool_call", "tool_result"):
+            name = str(event.get("tool_name") or event.get("name") or "tool")
+            error = event.get("error")
+            result = event.get("result_text") or event.get("result") or ""
+            body = Text(_tool_command(event))
+            if error:
+                body.append(f"\n\nerror: {error}", style=RED)
+                border = RED
+            else:
+                if result:
+                    body.append("\n\n")
+                    body.append_text(_capped_text(str(result), max_lines=_RESULT_LINE_CAP))
+                border = GREEN
+            _console.print(
+                Panel(
+                    body,
+                    title=f"[bold]{name}[/bold]",
+                    border_style=border,
+                    padding=(0, 1),
+                )
+            )
+        elif kind == "subagent":
+            name = str(event.get("agent_name") or "subagent")
+            args = event.get("arguments") or {}
+            _console.print(
+                Panel(
+                    Text(_fmt_args(args) if args else name, style=DIM),
+                    title=f"[bold]{name}[/bold]",
+                    border_style=GOLD,
+                    padding=(0, 1),
+                )
+            )
+
+
+def _print_result_tui(
+    result: dict[str, Any],
+    events: list[dict[str, Any]] | None,
+) -> None:
+    agent = str(result.get("agent_name") or result.get("qa_agent_id") or "QA")
+    subject_id = str(result.get("subject_trace_id") or "-")
+    analysis = _analysis_view(result)
+    verdict = str(analysis["verdict"])
+    if verdict == "passed":
+        status = "success"
+    elif verdict in {"failed", "error"}:
+        status = "error"
+    else:
+        status = "info"
+    hud_console.header(agent, icon="", stderr=False)
+    hud_console.status_item("verdict", verdict, status=status, stderr=False)
+    hud_console.dim_info("trace", subject_id, stderr=False)
+    if analysis.get("confidence"):
+        hud_console.dim_info("confidence", str(analysis["confidence"]), stderr=False)
+    if result.get("stale") is True:
+        hud_console.warning(
+            "This result is stale relative to the current agent config.",
+            stderr=False,
+        )
+    summary = analysis.get("summary")
+    if summary:
+        _console.print(
+            Panel(
+                Text(str(summary)),
+                title="[bold]Summary[/bold]",
+                border_style=GOLD,
+                padding=(0, 1),
+            )
+        )
+    problems = analysis.get("problems") or []
+    for index, problem in enumerate(problems, start=1):
+        if not isinstance(problem, dict):
+            continue
+        title = str(problem.get("problem") or problem.get("title") or f"Finding {index}")
+        description = str(problem.get("description") or "")
+        fault = problem.get("fault")
+        body = Text(description)
+        if fault:
+            body.append(f"\n\nfault: {fault}", style=DIM)
+        _console.print(
+            Panel(
+                body,
+                title=f"[bold]{index}. {title}[/bold]",
+                border_style=GOLD,
+                padding=(0, 1),
+            )
+        )
+    if events is None:
+        hud_console.dim_info("trajectory", "hidden; pass --rollout to show", stderr=False)
+    elif events:
+        hud_console.section_title("Rollout", stderr=False)
+        _render_qa_rollout(events)
+    web = settings.hud_web_url.rstrip("/")
+    hud_console.link(f"{web}/trace/{subject_id}", stderr=False)
 
 
 def _require_trace_agent(platform: PlatformClient, agent_id: str) -> None:
@@ -208,11 +454,28 @@ def list_results(
         ...,
         help="One or more trace UUIDs.",
     ),
-    json_output: bool = typer.Option(False, "--json", help="Output machine-readable results."),
+    json_output: bool = typer.Option(False, "--json", help="Output the machine-readable response."),
+    rollout: bool = typer.Option(
+        False,
+        "--rollout",
+        help="Show the sanitized analysis trajectory (agent turns and tool calls).",
+    ),
 ) -> None:
-    """Inspect QA results attached to the given traces."""
+    """Inspect QA results for the given traces. Pass --rollout for the trajectory."""
+    platform = _platform()
     results = cast(
         "list[dict[str, Any]]",
-        _platform().get("/qa-agents/results", params={"subject_trace_ids": trace_ids}),
+        platform.get("/qa-agents/results", params={"subject_trace_ids": trace_ids}),
     )
-    _print_results(results, json_output=json_output)
+    if json_output:
+        _print_results(results, json_output=True)
+        return
+    if not results:
+        typer.echo("No QA results found.")
+        return
+    for result in results:
+        events: list[dict[str, Any]] | None = None
+        result_id = result.get("id")
+        if rollout and result_id:
+            events = _fetch_rollout(platform, str(result_id))
+        _print_result_tui(result, events)

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
+from hud.cli.qa_analysis import is_standard_result_blob, presentation_for_result
 from hud.cli.utils.api import require_api_key
 from hud.settings import settings
 from hud.utils.exceptions import HudTimeoutError
@@ -55,73 +56,14 @@ def _print_results(results: list[dict[str, Any]], *, json_output: bool) -> None:
         typer.echo("No QA results found.")
         return
     for result in results:
-        output = result.get("canonical_result") or result.get("result") or {}
-        verdict = output.get("verdict") or result.get("status", "unknown")
-        summary = output.get("summary") or result.get("error")
+        view = presentation_for_result(result)
+        verdict = result.get("status", "unknown") if view.kind == "pending" else view.tag
+        summary = view.summary or result.get("error")
         subject_id = result.get("subject_trace_id") or "-"
         agent = result.get("agent_name") or result.get("qa_agent_id") or "-"
         stale = " stale" if result.get("stale") is True else ""
         line = f"{subject_id}\t{agent}\t{verdict}{stale}"
         typer.echo(f"{line}\t{summary}" if summary else line)
-
-
-def _as_problems(payload: dict[str, Any]) -> list[Any]:
-    problems = payload.get("problems")
-    if isinstance(problems, list):
-        return problems
-    findings = payload.get("findings")
-    return findings if isinstance(findings, list) else []
-
-
-def _parse_analysis_blob(
-    payload: dict[str, Any],
-    *,
-    fallback_verdict: str,
-) -> dict[str, Any] | None:
-    if (
-        payload.get("verdict")
-        or payload.get("summary")
-        or payload.get("problems")
-        or payload.get("findings")
-    ):
-        return {
-            "verdict": str(payload.get("verdict") or fallback_verdict),
-            "summary": payload.get("summary"),
-            "problems": _as_problems(payload),
-            "confidence": payload.get("confidence"),
-        }
-    content = payload.get("content")
-    if not isinstance(content, str):
-        return None
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    return {
-        "verdict": str(parsed.get("verdict") or fallback_verdict),
-        "summary": parsed.get("summary"),
-        "problems": _as_problems(parsed),
-        "confidence": parsed.get("confidence"),
-    }
-
-
-def _analysis_view(result: dict[str, Any]) -> dict[str, Any]:
-    """Verdict, summary, and findings from a canonical row or a JSON content blob."""
-    fallback = str(result.get("status") or "unknown")
-    for payload in (result.get("canonical_result"), result.get("result")):
-        if isinstance(payload, dict):
-            parsed = _parse_analysis_blob(payload, fallback_verdict=fallback)
-            if parsed is not None:
-                return parsed
-    error = result.get("error")
-    return {
-        "verdict": fallback,
-        "summary": str(error) if error else None,
-        "problems": [],
-        "confidence": None,
-    }
 
 
 def _fetch_rollout(platform: PlatformClient, result_id: str) -> list[dict[str, Any]]:
@@ -148,14 +90,6 @@ def _fmt_args(args: Any) -> str:
     if isinstance(args, dict):
         return ", ".join(f"{k}={v!r}" for k, v in args.items())
     return str(args)
-
-
-def _is_analysis_json(text: str) -> bool:
-    try:
-        parsed = json.loads(text)
-    except json.JSONDecodeError:
-        return False
-    return isinstance(parsed, dict) and "summary" in parsed
 
 
 def _tool_command(event: dict[str, Any]) -> str:
@@ -191,7 +125,7 @@ def _render_qa_rollout(events: list[dict[str, Any]]) -> None:
         if kind == "agent_message":
             text = event.get("text")
             reasoning = event.get("reasoning")
-            if isinstance(text, str) and _is_analysis_json(text):
+            if isinstance(text, str) and is_standard_result_blob(text):
                 continue
             if not text and not reasoning:
                 continue
@@ -251,48 +185,54 @@ def _print_result_tui(
 ) -> None:
     agent = str(result.get("agent_name") or result.get("qa_agent_id") or "QA")
     subject_id = str(result.get("subject_trace_id") or "-")
-    analysis = _analysis_view(result)
-    verdict = str(analysis["verdict"])
-    if verdict == "passed":
-        status = "success"
-    elif verdict in {"failed", "error"}:
-        status = "error"
-    else:
-        status = "info"
+    view = presentation_for_result(result)
     hud_console.header(agent, icon="", stderr=False)
-    hud_console.status_item("verdict", verdict, status=status, stderr=False)
+    if view.kind == "pending":
+        hud_console.status_item(
+            "status",
+            str(result.get("status") or "unknown"),
+            status="info",
+            stderr=False,
+        )
+    else:
+        if view.tag == "passed":
+            status = "success"
+        elif view.tag == "failed":
+            status = "error"
+        else:
+            status = "info"
+        hud_console.status_item("verdict", view.tag, status=status, stderr=False)
+        if view.kind == "boolean" and view.answer:
+            hud_console.dim_info(view.label.lower(), view.answer, stderr=False)
+        elif view.answer:
+            hud_console.dim_info("cause", view.answer, stderr=False)
     hud_console.dim_info("trace", subject_id, stderr=False)
-    if analysis.get("confidence"):
-        hud_console.dim_info("confidence", str(analysis["confidence"]), stderr=False)
+    if view.confidence:
+        hud_console.dim_info("confidence", view.confidence, stderr=False)
     if result.get("stale") is True:
         hud_console.warning(
             "This result is stale relative to the current agent config.",
             stderr=False,
         )
-    summary = analysis.get("summary")
-    if summary:
+    if view.summary:
         _console.print(
             Panel(
-                Text(str(summary)),
+                Text(view.summary),
                 title=_bold_title("Summary"),
                 border_style=GOLD,
                 padding=(0, 1),
             )
         )
-    problems = analysis.get("problems") or []
-    for index, problem in enumerate(problems, start=1):
-        if not isinstance(problem, dict):
-            continue
-        title = str(problem.get("problem") or problem.get("title") or f"Finding {index}")
-        description = str(problem.get("description") or "")
-        fault = problem.get("fault")
-        body = Text(description)
-        if fault:
-            body.append(f"\n\nfault: {fault}", style=DIM)
+    for index, finding in enumerate(view.findings, start=1):
+        body = Text(finding.description)
+        if finding.fault:
+            if finding.description:
+                body.append("\n\n")
+            body.append(f"fault: {finding.fault}", style=DIM)
         _console.print(
             Panel(
                 body,
-                title=_bold_title(f"{index}. {title}"),
+                title=_bold_title(f"{index}. {finding.title}"),
                 border_style=GOLD,
                 padding=(0, 1),
             )
@@ -445,8 +385,7 @@ def run_agent(
     )
     _print_results(results, json_output=json_output)
     if any(
-        result["status"] == "error"
-        or (result.get("canonical_result") or {}).get("verdict") != "passed"
+        result["status"] == "error" or presentation_for_result(result).tag != "passed"
         for result in results
     ):
         raise typer.Exit(1)

--- a/hud/cli/qa_analysis.py
+++ b/hud/cli/qa_analysis.py
@@ -1,0 +1,494 @@
+"""Interpret QA-agent result blobs the same way the platform review UI does."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+_QA_V1_VERDICTS = frozenset({"passed", "failed", "unknown"})
+_BOOLEAN_KEYS = (
+    ("is_false_negative", "False Negative"),
+    ("is_false_positive", "False Positive"),
+    ("is_reward_hacking", "Reward Hacking"),
+    ("is_prompt_misaligned", "Prompt Misaligned"),
+)
+_REWARD_HACKING_STRATEGIES = frozenset(
+    {
+        "none",
+        "test_manipulation",
+        "output_hardcoding",
+        "check_disabling",
+        "environment_exploitation",
+        "grader_exploitation",
+        "method_substitution",
+        "shortcut",
+        "other",
+    }
+)
+_SKIP_EXTRA_KEYS = frozenset(
+    {
+        "confidence",
+        "reasoning",
+        "summary",
+        "output",
+        "problems",
+        "root_cause",
+        "content",
+        "reward",
+        "score",
+        "schema_version",
+        "verdict",
+        "findings",
+        "issues",
+        "gaps",
+        "metadata",
+    }
+)
+
+
+@dataclass(frozen=True)
+class QaFinding:
+    title: str
+    description: str
+    fault: str | None = None
+
+
+@dataclass(frozen=True)
+class QaPresentation:
+    kind: str
+    tag: str
+    label: str
+    answer: str | None
+    summary: str | None
+    confidence: str | None
+    findings: tuple[QaFinding, ...]
+
+
+def is_standard_result_blob(text: str) -> bool:
+    """True when text is a structured QA result, not agent prose."""
+    loaded = _loads_object(text)
+    if loaded is None:
+        return False
+    return str(_parse_object(loaded).get("kind") or "unknown") != "unknown"
+
+
+def presentation_for_result(row: dict[str, Any]) -> QaPresentation:
+    """Review chrome for one QA result row: pass/fail tag plus agent-shaped body."""
+    status = str(row.get("status") or "")
+    error = row.get("error")
+    if status == "error":
+        return QaPresentation(
+            kind="unknown",
+            tag="failed",
+            label="QA Result",
+            answer=None,
+            summary=str(error) if error else "QA run failed.",
+            confidence=None,
+            findings=(),
+        )
+    if status and status != "completed":
+        return QaPresentation(
+            kind="pending",
+            tag="unknown",
+            label=status,
+            answer=None,
+            summary=str(error) if error else None,
+            confidence=None,
+            findings=(),
+        )
+    payload = row.get("canonical_result")
+    if not isinstance(payload, dict):
+        payload = row.get("result")
+    if not isinstance(payload, dict):
+        return _unknown(str(error) if error else None)
+    return _present(_parse(payload))
+
+
+def _parse(payload: dict[str, Any] | str) -> dict[str, Any]:
+    parsed = _coerce_object(payload)
+    if parsed is None:
+        if isinstance(payload, str) and payload.strip():
+            return {
+                "kind": "unknown",
+                "label": "QA Result",
+                "value": "unknown",
+                "summary": payload.strip(),
+            }
+        return {"kind": "unknown", "label": "QA Result", "value": "unknown"}
+    return _parse_object(parsed)
+
+
+def _coerce_object(payload: dict[str, Any] | str) -> dict[str, Any] | None:
+    parsed: dict[str, Any] | None
+    if isinstance(payload, str):
+        parsed = _loads_object(payload)
+    elif isinstance(payload, dict):
+        parsed = payload
+    else:
+        return None
+    if parsed is None:
+        return None
+    output = parsed.get("output")
+    if isinstance(output, str):
+        inner = _loads_object(output)
+        if inner is not None:
+            parsed = inner
+    content = parsed.get("content")
+    if isinstance(content, str):
+        inner = _loads_object(content)
+        if inner is not None:
+            parsed = inner
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _loads_object(raw: str) -> dict[str, Any] | None:
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def _parse_object(parsed: dict[str, Any]) -> dict[str, Any]:
+    confidence = _confidence_text(parsed.get("confidence"))
+    reasoning = parsed.get("reasoning") if isinstance(parsed.get("reasoning"), str) else None
+    summary = parsed.get("summary") if isinstance(parsed.get("summary"), str) else None
+    if summary is None and isinstance(parsed.get("root_cause"), str):
+        summary = parsed["root_cause"]
+
+    qa_findings = _first_finding_list(parsed)
+    verdict = parsed.get("verdict")
+    if (
+        isinstance(verdict, str)
+        and verdict in _QA_V1_VERDICTS
+        and (parsed.get("schema_version") == "qa_agent_result.v1" or qa_findings is not None)
+    ):
+        return {
+            "kind": "qa_result",
+            "label": "QA Result",
+            "value": verdict,
+            "summary": summary,
+            "reasoning": reasoning,
+            "confidence": confidence,
+            "findings": tuple(
+                finding
+                for finding in (_normalize_qa_finding(item) for item in (qa_findings or []))
+                if finding.title
+            ),
+        }
+
+    for key, label in _BOOLEAN_KEYS:
+        if key in parsed:
+            return _boolean_verdict(parsed, key, label, summary, reasoning, confidence)
+
+    if _is_prompt_alignment(parsed):
+        return _boolean_verdict(
+            parsed,
+            "is_prompt_misaligned",
+            "Prompt Misaligned",
+            summary,
+            reasoning,
+            confidence,
+            inferred=_inferred_prompt_alignment(parsed),
+        )
+    if _is_reward_hacking(parsed):
+        return _boolean_verdict(
+            parsed,
+            "is_reward_hacking",
+            "Reward Hacking",
+            summary,
+            reasoning,
+            confidence,
+            inferred=_inferred_reward_hacking(parsed),
+        )
+
+    if isinstance(parsed.get("problems"), list):
+        findings = tuple(
+            finding
+            for finding in (_normalize_problem(item) for item in parsed["problems"])
+            if finding is not None
+        )
+        return {
+            "kind": "problems",
+            "label": "Failure Analysis",
+            "value": _failure_analysis_label(findings),
+            "summary": summary,
+            "reasoning": reasoning,
+            "confidence": confidence,
+            "findings": findings,
+        }
+
+    category = parsed.get("failure_category", parsed.get("failure_mode"))
+    if "failure_category" in parsed or "failure_mode" in parsed:
+        if (
+            not isinstance(category, str)
+            or not category.strip()
+            or category.strip().lower() in {"unknown", "unavailable", "null"}
+        ):
+            return {
+                "kind": "unknown",
+                "label": "Failure Analysis",
+                "value": "unknown",
+                "summary": summary,
+                "reasoning": reasoning,
+                "confidence": confidence,
+            }
+        return {
+            "kind": "category",
+            "label": "Failure Analysis",
+            "value": category.strip(),
+            "summary": summary,
+            "reasoning": reasoning,
+            "confidence": confidence,
+            "findings": (QaFinding(title=category.strip().replace("_", " "), description=""),),
+        }
+
+    return {
+        "kind": "unknown",
+        "label": "QA Result",
+        "value": "unknown",
+        "summary": summary or reasoning,
+        "reasoning": reasoning,
+        "confidence": confidence,
+    }
+
+
+def _boolean_verdict(
+    parsed: dict[str, Any],
+    key: str,
+    label: str,
+    summary: str | None,
+    reasoning: str | None,
+    confidence: str | None,
+    *,
+    inferred: bool | None = None,
+) -> dict[str, Any]:
+    raw = parsed.get(key)
+    value: bool | None
+    if key in parsed and not isinstance(raw, bool):
+        value = None
+    elif isinstance(raw, bool):
+        value = raw
+    else:
+        value = inferred
+    extras = _string_extras(parsed, extra_exclude={key})
+    if value is None:
+        return {
+            "kind": "unknown",
+            "label": label,
+            "value": "unknown",
+            "summary": summary,
+            "reasoning": reasoning,
+            "confidence": confidence,
+            "extras": extras,
+        }
+    return {
+        "kind": "boolean",
+        "label": label,
+        "value": value,
+        "summary": summary,
+        "reasoning": reasoning,
+        "confidence": confidence,
+        "extras": extras,
+    }
+
+
+def _as_findings(parsed: dict[str, Any], *, require_title: bool = False) -> tuple[QaFinding, ...]:
+    items = parsed.get("findings") or ()
+    findings: list[QaFinding] = []
+    for item in items:
+        if not isinstance(item, QaFinding):
+            continue
+        if require_title and not item.title:
+            continue
+        findings.append(item)
+    return tuple(findings)
+
+
+def _present(parsed: dict[str, Any]) -> QaPresentation:
+    kind = str(parsed.get("kind") or "unknown")
+    label = str(parsed.get("label") or "QA Result")
+    summary = _narrative(parsed)
+    confidence = parsed.get("confidence") if isinstance(parsed.get("confidence"), str) else None
+    if kind == "qa_result":
+        tag = str(parsed.get("value") or "unknown")
+        if tag not in _QA_V1_VERDICTS:
+            tag = "unknown"
+        findings = _as_findings(parsed, require_title=True)
+        return QaPresentation(kind, tag, label, None, summary, confidence, findings)
+    if kind == "boolean":
+        value = parsed.get("value")
+        if value is True:
+            tag = "failed"
+            answer = "yes"
+        elif value is False:
+            tag = "passed"
+            answer = "no"
+        else:
+            tag = "unknown"
+            answer = "unknown"
+        return QaPresentation(kind, tag, label, answer, summary, confidence, ())
+    if kind == "problems":
+        findings = _as_findings(parsed)
+        tag = "failed" if findings else "passed"
+        answer = str(parsed.get("value") or ("Agent failure" if findings else "No failure"))
+        return QaPresentation(kind, tag, label, answer, summary, confidence, findings)
+    if kind == "category":
+        answer = str(parsed.get("value") or "unknown").replace("_", " ")
+        findings = _as_findings(parsed)
+        return QaPresentation(kind, "failed", label, answer, summary, confidence, findings)
+    return QaPresentation(
+        "unknown",
+        "unknown",
+        label,
+        None,
+        summary,
+        confidence,
+        (),
+    )
+
+
+def _narrative(parsed: dict[str, Any]) -> str | None:
+    parts: list[str] = []
+    summary = parsed.get("summary")
+    reasoning = parsed.get("reasoning")
+    if isinstance(summary, str) and summary.strip():
+        parts.append(summary.strip())
+    if isinstance(reasoning, str) and reasoning.strip() and reasoning.strip() not in parts:
+        parts.append(reasoning.strip())
+    extras = parsed.get("extras")
+    if isinstance(extras, dict):
+        for key, value in extras.items():
+            parts.append(f"{key.replace('_', ' ')}: {value}")
+    return "\n\n".join(parts) if parts else None
+
+
+def _unknown(summary: str | None) -> QaPresentation:
+    return QaPresentation("unknown", "unknown", "QA Result", None, summary, None, ())
+
+
+def _confidence_text(raw: Any) -> str | None:
+    if isinstance(raw, str) and raw.strip():
+        lower = raw.strip().lower()
+        if lower in {"high", "medium", "low", "very high", "very low"}:
+            return lower
+        try:
+            number = float(lower)
+        except ValueError:
+            return raw.strip()
+        raw = number
+    if isinstance(raw, int | float):
+        value = raw / 100 if raw > 1 else raw
+        return f"{round(value * 100)}%"
+    return None
+
+
+def _first_finding_list(parsed: dict[str, Any]) -> list[Any] | None:
+    for key in ("findings", "issues", "gaps"):
+        value = parsed.get(key)
+        if isinstance(value, list):
+            return value
+    return None
+
+
+def _normalize_problem(raw: Any) -> QaFinding | None:
+    if not isinstance(raw, dict):
+        return None
+    title = (
+        raw.get("problem") or raw.get("title") or raw.get("name") or raw.get("failure_mode") or ""
+    )
+    if not isinstance(title, str) or not title.strip():
+        return None
+    description = _problem_description(raw)
+    fault = raw.get("fault") if isinstance(raw.get("fault"), str) else None
+    return QaFinding(title=title.strip(), description=description, fault=fault)
+
+
+def _normalize_qa_finding(raw: Any) -> QaFinding:
+    if not isinstance(raw, dict):
+        return QaFinding(title="", description="")
+    title = raw.get("summary") if isinstance(raw.get("summary"), str) else ""
+    description = _problem_description(raw)
+    return QaFinding(title=title.strip(), description=description)
+
+
+def _problem_description(raw: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for key in ("description", "root_cause", "impact"):
+        value = raw.get(key)
+        if isinstance(value, str) and value.strip():
+            parts.append(value.strip())
+    remedy = raw.get("what_should_have_happened") or raw.get("recommended_action")
+    if isinstance(remedy, str) and remedy.strip():
+        parts.append(remedy.strip())
+    return "\n\n".join(parts)
+
+
+def _normalize_owner(raw: str | None) -> str:
+    if raw is None:
+        return "unclear"
+    owner = raw.strip().lower()
+    if owner in {"agent", "agent_failure"}:
+        return "agent"
+    if owner in {"eval", "evaluation", "eval_failure", "evaluation_failure"}:
+        return "eval"
+    if owner in {"platform", "platform_failure"}:
+        return "platform"
+    return "unclear"
+
+
+def _failure_analysis_label(findings: tuple[QaFinding, ...]) -> str:
+    if not findings:
+        return "No failure"
+    owners = {_normalize_owner(item.fault) for item in findings}
+    if len(owners) != 1:
+        return "Mixed failure"
+    owner = next(iter(owners))
+    return {
+        "agent": "Agent failure",
+        "eval": "Evaluation failure",
+        "platform": "Platform failure",
+        "unclear": "Unclear",
+    }[owner]
+
+
+def _is_prompt_alignment(parsed: dict[str, Any]) -> bool:
+    return (
+        "is_prompt_misaligned" in parsed
+        or isinstance(parsed.get("grader_check"), str)
+        or isinstance(parsed.get("prompt_quote"), str)
+        or isinstance(parsed.get("misalignment_proof"), str)
+    )
+
+
+def _is_reward_hacking(parsed: dict[str, Any]) -> bool:
+    strategy = parsed.get("hacking_strategy")
+    return "is_reward_hacking" in parsed or (
+        isinstance(strategy, str) and strategy in _REWARD_HACKING_STRATEGIES
+    )
+
+
+def _inferred_prompt_alignment(parsed: dict[str, Any]) -> bool | None:
+    proof = parsed.get("misalignment_proof")
+    if isinstance(proof, str):
+        return bool(proof.strip())
+    return None
+
+
+def _inferred_reward_hacking(parsed: dict[str, Any]) -> bool | None:
+    strategy = parsed.get("hacking_strategy")
+    if not isinstance(strategy, str) or strategy not in _REWARD_HACKING_STRATEGIES:
+        return None
+    return strategy != "none"
+
+
+def _string_extras(parsed: dict[str, Any], *, extra_exclude: set[str]) -> dict[str, str]:
+    extras: dict[str, str] = {}
+    skip = _SKIP_EXTRA_KEYS | extra_exclude | {key for key, _ in _BOOLEAN_KEYS}
+    for key, value in parsed.items():
+        if key in skip or value is None:
+            continue
+        if isinstance(value, str | int | float | bool):
+            extras[key] = str(value)
+    return extras

--- a/hud/cli/qa_analysis.py
+++ b/hud/cli/qa_analysis.py
@@ -1,4 +1,4 @@
-"""Interpret QA-agent result blobs the same way the platform review UI does."""
+"""Turn a QA result row into pass/fail review chrome for the CLI TUI."""
 
 from __future__ import annotations
 
@@ -6,45 +6,18 @@ import json
 from dataclasses import dataclass
 from typing import Any
 
-_QA_V1_VERDICTS = frozenset({"passed", "failed", "unknown"})
+_QA_V1 = frozenset({"passed", "failed", "unknown"})
 _BOOLEAN_KEYS = (
     ("is_false_negative", "False Negative"),
     ("is_false_positive", "False Positive"),
     ("is_reward_hacking", "Reward Hacking"),
     ("is_prompt_misaligned", "Prompt Misaligned"),
 )
-_REWARD_HACKING_STRATEGIES = frozenset(
-    {
-        "none",
-        "test_manipulation",
-        "output_hardcoding",
-        "check_disabling",
-        "environment_exploitation",
-        "grader_exploitation",
-        "method_substitution",
-        "shortcut",
-        "other",
-    }
-)
-_SKIP_EXTRA_KEYS = frozenset(
-    {
-        "confidence",
-        "reasoning",
-        "summary",
-        "output",
-        "problems",
-        "root_cause",
-        "content",
-        "reward",
-        "score",
-        "schema_version",
-        "verdict",
-        "findings",
-        "issues",
-        "gaps",
-        "metadata",
-    }
-)
+_CAUSE = {
+    "agent": "Agent failure",
+    "eval": "Evaluation failure",
+    "platform": "Platform failure",
+}
 
 
 @dataclass(frozen=True)
@@ -66,83 +39,112 @@ class QaPresentation:
 
 
 def is_standard_result_blob(text: str) -> bool:
-    """True when text is a structured QA result, not agent prose."""
-    loaded = _loads_object(text)
-    if loaded is None:
-        return False
-    return str(_parse_object(loaded).get("kind") or "unknown") != "unknown"
+    parsed = _loads(text)
+    return parsed is not None and _from_blob(parsed).kind != "unknown"
 
 
 def presentation_for_result(row: dict[str, Any]) -> QaPresentation:
-    """Review chrome for one QA result row: pass/fail tag plus agent-shaped body."""
     status = str(row.get("status") or "")
     error = row.get("error")
     if status == "error":
-        return QaPresentation(
-            kind="unknown",
-            tag="failed",
-            label="QA Result",
-            answer=None,
-            summary=str(error) if error else "QA run failed.",
-            confidence=None,
-            findings=(),
-        )
+        return _view("unknown", "failed", summary=str(error) if error else "QA run failed.")
     if status and status != "completed":
-        return QaPresentation(
-            kind="pending",
-            tag="unknown",
-            label=status,
-            answer=None,
-            summary=str(error) if error else None,
-            confidence=None,
-            findings=(),
-        )
+        return _view("pending", "unknown", label=status, summary=str(error) if error else None)
     payload = row.get("canonical_result")
     if not isinstance(payload, dict):
         payload = row.get("result")
-    if not isinstance(payload, dict):
-        return _unknown(str(error) if error else None)
-    return _present(_parse(payload))
+    blob = _unwrap(payload) if isinstance(payload, dict | str) else None
+    if blob is None:
+        return _view("unknown", "unknown", summary=str(error) if error else None)
+    return _from_blob(blob)
 
 
-def _parse(payload: dict[str, Any] | str) -> dict[str, Any]:
-    parsed = _coerce_object(payload)
+def _from_blob(parsed: dict[str, Any]) -> QaPresentation:
+    summary = _text(parsed.get("summary"), parsed.get("reasoning"))
+    confidence = _confidence(parsed.get("confidence"))
+
+    verdict = parsed.get("verdict")
+    findings_raw = parsed.get("findings")
+    if (
+        isinstance(verdict, str)
+        and verdict in _QA_V1
+        and (parsed.get("schema_version") == "qa_agent_result.v1" or isinstance(findings_raw, list))
+    ):
+        findings = _findings(findings_raw if isinstance(findings_raw, list) else [], "summary")
+        return _view(
+            "qa_result",
+            verdict,
+            summary=summary,
+            confidence=confidence,
+            findings=findings,
+        )
+
+    for key, label in _BOOLEAN_KEYS:
+        if key not in parsed:
+            continue
+        value = parsed[key]
+        if not isinstance(value, bool):
+            return _view("unknown", "unknown", label=label, summary=summary, confidence=confidence)
+        return _view(
+            "boolean",
+            "failed" if value else "passed",
+            label=label,
+            answer="yes" if value else "no",
+            summary=summary,
+            confidence=confidence,
+        )
+
+    if isinstance(parsed.get("problems"), list):
+        findings = _findings(parsed["problems"], "problem", "title")
+        owners = {_finding_owner(item.fault) for item in findings}
+        if not findings:
+            cause, tag = "No failure", "passed"
+        elif len(owners) != 1:
+            cause, tag = "Mixed failure", "failed"
+        elif "unclear" in owners:
+            cause, tag = "Unclear", "failed"
+        else:
+            cause, tag = _CAUSE[next(iter(owners))], "failed"
+        return _view(
+            "problems",
+            tag,
+            label="Failure Analysis",
+            answer=cause,
+            summary=summary,
+            confidence=confidence,
+            findings=findings,
+        )
+
+    return _view("unknown", "unknown", summary=summary, confidence=confidence)
+
+
+def _view(
+    kind: str,
+    tag: str,
+    *,
+    label: str = "QA Result",
+    answer: str | None = None,
+    summary: str | None = None,
+    confidence: str | None = None,
+    findings: tuple[QaFinding, ...] = (),
+) -> QaPresentation:
+    return QaPresentation(kind, tag, label, answer, summary, confidence, findings)
+
+
+def _unwrap(payload: dict[str, Any] | str) -> dict[str, Any] | None:
+    parsed: dict[str, Any] | None = _loads(payload) if isinstance(payload, str) else payload
     if parsed is None:
-        if isinstance(payload, str) and payload.strip():
-            return {
-                "kind": "unknown",
-                "label": "QA Result",
-                "value": "unknown",
-                "summary": payload.strip(),
-            }
-        return {"kind": "unknown", "label": "QA Result", "value": "unknown"}
-    return _parse_object(parsed)
-
-
-def _coerce_object(payload: dict[str, Any] | str) -> dict[str, Any] | None:
-    parsed: dict[str, Any] | None
-    if isinstance(payload, str):
-        parsed = _loads_object(payload)
-    elif isinstance(payload, dict):
-        parsed = payload
-    else:
         return None
-    if parsed is None:
-        return None
-    output = parsed.get("output")
-    if isinstance(output, str):
-        inner = _loads_object(output)
-        if inner is not None:
-            parsed = inner
-    content = parsed.get("content")
-    if isinstance(content, str):
-        inner = _loads_object(content)
-        if inner is not None:
-            parsed = inner
+    for key in ("output", "content"):
+        raw = parsed.get(key)
+        if isinstance(raw, str):
+            inner = _loads(raw)
+            if inner is not None:
+                parsed = inner
     return parsed if isinstance(parsed, dict) else None
 
 
-def _loads_object(raw: str) -> dict[str, Any] | None:
+def _loads(raw: str) -> dict[str, Any] | None:
     try:
         loaded = json.loads(raw)
     except json.JSONDecodeError:
@@ -150,345 +152,56 @@ def _loads_object(raw: str) -> dict[str, Any] | None:
     return loaded if isinstance(loaded, dict) else None
 
 
-def _parse_object(parsed: dict[str, Any]) -> dict[str, Any]:
-    confidence = _confidence_text(parsed.get("confidence"))
-    reasoning = parsed.get("reasoning") if isinstance(parsed.get("reasoning"), str) else None
-    summary = parsed.get("summary") if isinstance(parsed.get("summary"), str) else None
-    if summary is None and isinstance(parsed.get("root_cause"), str):
-        summary = parsed["root_cause"]
-
-    qa_findings = _first_finding_list(parsed)
-    verdict = parsed.get("verdict")
-    if (
-        isinstance(verdict, str)
-        and verdict in _QA_V1_VERDICTS
-        and (parsed.get("schema_version") == "qa_agent_result.v1" or qa_findings is not None)
-    ):
-        return {
-            "kind": "qa_result",
-            "label": "QA Result",
-            "value": verdict,
-            "summary": summary,
-            "reasoning": reasoning,
-            "confidence": confidence,
-            "findings": tuple(
-                finding
-                for finding in (_normalize_qa_finding(item) for item in (qa_findings or []))
-                if finding.title
-            ),
-        }
-
-    for key, label in _BOOLEAN_KEYS:
-        if key in parsed:
-            return _boolean_verdict(parsed, key, label, summary, reasoning, confidence)
-
-    if _is_prompt_alignment(parsed):
-        return _boolean_verdict(
-            parsed,
-            "is_prompt_misaligned",
-            "Prompt Misaligned",
-            summary,
-            reasoning,
-            confidence,
-            inferred=_inferred_prompt_alignment(parsed),
-        )
-    if _is_reward_hacking(parsed):
-        return _boolean_verdict(
-            parsed,
-            "is_reward_hacking",
-            "Reward Hacking",
-            summary,
-            reasoning,
-            confidence,
-            inferred=_inferred_reward_hacking(parsed),
-        )
-
-    if isinstance(parsed.get("problems"), list):
-        findings = tuple(
-            finding
-            for finding in (_normalize_problem(item) for item in parsed["problems"])
-            if finding is not None
-        )
-        return {
-            "kind": "problems",
-            "label": "Failure Analysis",
-            "value": _failure_analysis_label(findings),
-            "summary": summary,
-            "reasoning": reasoning,
-            "confidence": confidence,
-            "findings": findings,
-        }
-
-    category = parsed.get("failure_category", parsed.get("failure_mode"))
-    if "failure_category" in parsed or "failure_mode" in parsed:
-        if (
-            not isinstance(category, str)
-            or not category.strip()
-            or category.strip().lower() in {"unknown", "unavailable", "null"}
-        ):
-            return {
-                "kind": "unknown",
-                "label": "Failure Analysis",
-                "value": "unknown",
-                "summary": summary,
-                "reasoning": reasoning,
-                "confidence": confidence,
-            }
-        return {
-            "kind": "category",
-            "label": "Failure Analysis",
-            "value": category.strip(),
-            "summary": summary,
-            "reasoning": reasoning,
-            "confidence": confidence,
-            "findings": (QaFinding(title=category.strip().replace("_", " "), description=""),),
-        }
-
-    return {
-        "kind": "unknown",
-        "label": "QA Result",
-        "value": "unknown",
-        "summary": summary or reasoning,
-        "reasoning": reasoning,
-        "confidence": confidence,
-    }
-
-
-def _boolean_verdict(
-    parsed: dict[str, Any],
-    key: str,
-    label: str,
-    summary: str | None,
-    reasoning: str | None,
-    confidence: str | None,
-    *,
-    inferred: bool | None = None,
-) -> dict[str, Any]:
-    raw = parsed.get(key)
-    value: bool | None
-    if key in parsed and not isinstance(raw, bool):
-        value = None
-    elif isinstance(raw, bool):
-        value = raw
-    else:
-        value = inferred
-    extras = _string_extras(parsed, extra_exclude={key})
-    if value is None:
-        return {
-            "kind": "unknown",
-            "label": label,
-            "value": "unknown",
-            "summary": summary,
-            "reasoning": reasoning,
-            "confidence": confidence,
-            "extras": extras,
-        }
-    return {
-        "kind": "boolean",
-        "label": label,
-        "value": value,
-        "summary": summary,
-        "reasoning": reasoning,
-        "confidence": confidence,
-        "extras": extras,
-    }
-
-
-def _as_findings(parsed: dict[str, Any], *, require_title: bool = False) -> tuple[QaFinding, ...]:
-    items = parsed.get("findings") or ()
-    findings: list[QaFinding] = []
-    for item in items:
-        if not isinstance(item, QaFinding):
-            continue
-        if require_title and not item.title:
-            continue
-        findings.append(item)
-    return tuple(findings)
-
-
-def _present(parsed: dict[str, Any]) -> QaPresentation:
-    kind = str(parsed.get("kind") or "unknown")
-    label = str(parsed.get("label") or "QA Result")
-    summary = _narrative(parsed)
-    confidence = parsed.get("confidence") if isinstance(parsed.get("confidence"), str) else None
-    if kind == "qa_result":
-        tag = str(parsed.get("value") or "unknown")
-        if tag not in _QA_V1_VERDICTS:
-            tag = "unknown"
-        findings = _as_findings(parsed, require_title=True)
-        return QaPresentation(kind, tag, label, None, summary, confidence, findings)
-    if kind == "boolean":
-        value = parsed.get("value")
-        if value is True:
-            tag = "failed"
-            answer = "yes"
-        elif value is False:
-            tag = "passed"
-            answer = "no"
-        else:
-            tag = "unknown"
-            answer = "unknown"
-        return QaPresentation(kind, tag, label, answer, summary, confidence, ())
-    if kind == "problems":
-        findings = _as_findings(parsed)
-        tag = "failed" if findings else "passed"
-        answer = str(parsed.get("value") or ("Agent failure" if findings else "No failure"))
-        return QaPresentation(kind, tag, label, answer, summary, confidence, findings)
-    if kind == "category":
-        answer = str(parsed.get("value") or "unknown").replace("_", " ")
-        findings = _as_findings(parsed)
-        return QaPresentation(kind, "failed", label, answer, summary, confidence, findings)
-    return QaPresentation(
-        "unknown",
-        "unknown",
-        label,
-        None,
-        summary,
-        confidence,
-        (),
-    )
-
-
-def _narrative(parsed: dict[str, Any]) -> str | None:
+def _text(*values: Any) -> str | None:
     parts: list[str] = []
-    summary = parsed.get("summary")
-    reasoning = parsed.get("reasoning")
-    if isinstance(summary, str) and summary.strip():
-        parts.append(summary.strip())
-    if isinstance(reasoning, str) and reasoning.strip() and reasoning.strip() not in parts:
-        parts.append(reasoning.strip())
-    extras = parsed.get("extras")
-    if isinstance(extras, dict):
-        for key, value in extras.items():
-            parts.append(f"{key.replace('_', ' ')}: {value}")
+    for value in values:
+        if isinstance(value, str) and value.strip() and value.strip() not in parts:
+            parts.append(value.strip())
     return "\n\n".join(parts) if parts else None
 
 
-def _unknown(summary: str | None) -> QaPresentation:
-    return QaPresentation("unknown", "unknown", "QA Result", None, summary, None, ())
-
-
-def _confidence_text(raw: Any) -> str | None:
+def _confidence(raw: Any) -> str | None:
     if isinstance(raw, str) and raw.strip():
         lower = raw.strip().lower()
-        if lower in {"high", "medium", "low", "very high", "very low"}:
-            return lower
-        try:
-            number = float(lower)
-        except ValueError:
-            return raw.strip()
-        raw = number
+        labels = {"high", "medium", "low", "very high", "very low"}
+        return lower if lower in labels else raw.strip()
     if isinstance(raw, int | float):
         value = raw / 100 if raw > 1 else raw
         return f"{round(value * 100)}%"
     return None
 
 
-def _first_finding_list(parsed: dict[str, Any]) -> list[Any] | None:
-    for key in ("findings", "issues", "gaps"):
-        value = parsed.get(key)
-        if isinstance(value, list):
-            return value
-    return None
-
-
-def _normalize_problem(raw: Any) -> QaFinding | None:
-    if not isinstance(raw, dict):
-        return None
-    title = (
-        raw.get("problem") or raw.get("title") or raw.get("name") or raw.get("failure_mode") or ""
-    )
-    if not isinstance(title, str) or not title.strip():
-        return None
-    description = _problem_description(raw)
-    fault = raw.get("fault") if isinstance(raw.get("fault"), str) else None
-    return QaFinding(title=title.strip(), description=description, fault=fault)
-
-
-def _normalize_qa_finding(raw: Any) -> QaFinding:
-    if not isinstance(raw, dict):
-        return QaFinding(title="", description="")
-    title = raw.get("summary") if isinstance(raw.get("summary"), str) else ""
-    description = _problem_description(raw)
-    return QaFinding(title=title.strip(), description=description)
-
-
-def _problem_description(raw: dict[str, Any]) -> str:
-    parts: list[str] = []
-    for key in ("description", "root_cause", "impact"):
-        value = raw.get(key)
-        if isinstance(value, str) and value.strip():
-            parts.append(value.strip())
-    remedy = raw.get("what_should_have_happened") or raw.get("recommended_action")
-    if isinstance(remedy, str) and remedy.strip():
-        parts.append(remedy.strip())
-    return "\n\n".join(parts)
-
-
-def _normalize_owner(raw: str | None) -> str:
-    if raw is None:
-        return "unclear"
-    owner = raw.strip().lower()
-    if owner in {"agent", "agent_failure"}:
-        return "agent"
-    if owner in {"eval", "evaluation", "eval_failure", "evaluation_failure"}:
-        return "eval"
-    if owner in {"platform", "platform_failure"}:
-        return "platform"
-    return "unclear"
-
-
-def _failure_analysis_label(findings: tuple[QaFinding, ...]) -> str:
-    if not findings:
-        return "No failure"
-    owners = {_normalize_owner(item.fault) for item in findings}
-    if len(owners) != 1:
-        return "Mixed failure"
-    owner = next(iter(owners))
-    return {
-        "agent": "Agent failure",
-        "eval": "Evaluation failure",
-        "platform": "Platform failure",
-        "unclear": "Unclear",
-    }[owner]
-
-
-def _is_prompt_alignment(parsed: dict[str, Any]) -> bool:
-    return (
-        "is_prompt_misaligned" in parsed
-        or isinstance(parsed.get("grader_check"), str)
-        or isinstance(parsed.get("prompt_quote"), str)
-        or isinstance(parsed.get("misalignment_proof"), str)
-    )
-
-
-def _is_reward_hacking(parsed: dict[str, Any]) -> bool:
-    strategy = parsed.get("hacking_strategy")
-    return "is_reward_hacking" in parsed or (
-        isinstance(strategy, str) and strategy in _REWARD_HACKING_STRATEGIES
-    )
-
-
-def _inferred_prompt_alignment(parsed: dict[str, Any]) -> bool | None:
-    proof = parsed.get("misalignment_proof")
-    if isinstance(proof, str):
-        return bool(proof.strip())
-    return None
-
-
-def _inferred_reward_hacking(parsed: dict[str, Any]) -> bool | None:
-    strategy = parsed.get("hacking_strategy")
-    if not isinstance(strategy, str) or strategy not in _REWARD_HACKING_STRATEGIES:
-        return None
-    return strategy != "none"
-
-
-def _string_extras(parsed: dict[str, Any], *, extra_exclude: set[str]) -> dict[str, str]:
-    extras: dict[str, str] = {}
-    skip = _SKIP_EXTRA_KEYS | extra_exclude | {key for key, _ in _BOOLEAN_KEYS}
-    for key, value in parsed.items():
-        if key in skip or value is None:
+def _findings(items: list[Any], *title_keys: str) -> tuple[QaFinding, ...]:
+    findings: list[QaFinding] = []
+    for item in items:
+        if not isinstance(item, dict):
             continue
-        if isinstance(value, str | int | float | bool):
-            extras[key] = str(value)
-    return extras
+        title = next(
+            (
+                item[key].strip()
+                for key in title_keys
+                if isinstance(item.get(key), str) and item[key].strip()
+            ),
+            "",
+        )
+        if not title:
+            continue
+        description = item.get("description")
+        fault = item.get("fault") if isinstance(item.get("fault"), str) else None
+        findings.append(
+            QaFinding(
+                title=title,
+                description=description.strip() if isinstance(description, str) else "",
+                fault=fault,
+            )
+        )
+    return tuple(findings)
+
+
+def _finding_owner(fault: str | None) -> str:
+    if fault is None:
+        return "unclear"
+    owner = fault.strip().lower()
+    if owner in _CAUSE:
+        return owner
+    return "unclear"

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -231,6 +231,56 @@ def test_qa_results_default_tui_hides_trajectory() -> None:
     )
 
 
+def test_qa_results_tui_preserves_bracketed_titles() -> None:
+    platform = MagicMock()
+    platform.get.side_effect = [
+        [
+            {
+                **_run(status="completed"),
+                "agent_name": "Failure Analysis",
+                "result": {
+                    "content": json.dumps(
+                        {
+                            "summary": "The agent never wrote /app/regex.txt.",
+                            "problems": [
+                                {
+                                    "problem": "Required [/output] file was never created",
+                                    "description": "Save the regex at /app/[regex].txt.",
+                                }
+                            ],
+                        }
+                    ),
+                },
+            }
+        ],
+        {
+            "events": [
+                {
+                    "kind": "tool_call",
+                    "tool_name": "shell[cmd]",
+                    "arguments": {"commands": ["ls /workspace"]},
+                },
+                {
+                    "kind": "subagent",
+                    "agent_name": "checker[v1]",
+                    "arguments": {},
+                },
+            ],
+            "has_more": False,
+            "next_seq": 2,
+            "status": "completed",
+        },
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID, "--rollout"])
+
+    assert result.exit_code == 0
+    assert "Required [/output] file was never created" in result.output
+    assert "Save the regex at /app/[regex].txt." in result.output
+    assert "shell[cmd]" in result.output
+    assert "checker[v1]" in result.output
+
+
 def test_qa_results_renders_sanitized_rollout() -> None:
     platform = MagicMock()
     platform.get.side_effect = [

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -188,3 +188,123 @@ def test_qa_results_queries_traces() -> None:
         "/qa-agents/results",
         params={"subject_trace_ids": [_TRACE_ID]},
     )
+
+
+def test_qa_results_default_tui_hides_trajectory() -> None:
+    platform = MagicMock()
+    platform.get.return_value = [
+        {
+            **_run(status="completed"),
+            "agent_name": "Failure Analysis",
+            "result": {
+                "content": json.dumps(
+                    {
+                        "summary": "The agent never wrote /app/regex.txt.",
+                        "confidence": "high",
+                        "problems": [
+                            {
+                                "problem": "Required output file was never created",
+                                "description": "The agent did not save any regex.",
+                                "fault": "agent",
+                            }
+                        ],
+                    }
+                ),
+                "reward": 0.0,
+            },
+        }
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID])
+
+    assert result.exit_code == 0
+    assert "The agent never wrote /app/regex.txt." in result.output
+    assert "Required output file was never created" in result.output
+    assert "The agent did not save any regex." in result.output
+    assert "pass --rollout to show" in result.output
+    assert "shell" not in result.output
+    assert "ls /workspace" not in result.output
+    assert f"https://hud.ai/trace/{_TRACE_ID}" in result.output
+    platform.get.assert_called_once_with(
+        "/qa-agents/results",
+        params={"subject_trace_ids": [_TRACE_ID]},
+    )
+
+
+def test_qa_results_renders_sanitized_rollout() -> None:
+    platform = MagicMock()
+    platform.get.side_effect = [
+        [_result()],
+        {
+            "events": [
+                {"kind": "agent_message", "text": "Checking the workspace."},
+                {"kind": "agent_message", "text": ""},
+                {
+                    "kind": "agent_message",
+                    "text": json.dumps({"summary": "Looks good.", "problems": []}),
+                },
+                {
+                    "kind": "tool_call",
+                    "tool_name": "shell",
+                    "arguments": {"commands": ["ls /workspace"]},
+                    "result_text": "task.py",
+                },
+            ],
+            "has_more": False,
+            "next_seq": 2,
+            "latest_seq": 1,
+            "status": "completed",
+        },
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID, "--rollout"])
+
+    assert result.exit_code == 0
+    assert "Failure Analysis" in result.output
+    assert "Looks good." in result.output
+    assert "Checking the workspace." in result.output
+    assert "shell" in result.output
+    assert "ls /workspace" in result.output
+    assert "task.py" in result.output
+    assert result.output.count("Turn 1") == 1
+    assert "pass --rollout to show" not in result.output
+    assert f"https://hud.ai/trace/{_TRACE_ID}" in result.output
+    assert platform.get.call_args_list[0].args[0] == "/qa-agents/results"
+    assert platform.get.call_args_list[1].args == (f"/qa-agents/results/{_RESULT_ID}/rollout",)
+    assert platform.get.call_args_list[1].kwargs["params"] == {
+        "since_seq": -1,
+        "limit": 100,
+    }
+
+
+def test_qa_results_pages_sanitized_rollout() -> None:
+    platform = MagicMock()
+    platform.get.side_effect = [
+        [_result()],
+        {
+            "events": [{"kind": "tool_call", "tool_name": "shell", "arguments": {}}],
+            "has_more": True,
+            "next_seq": 10,
+            "status": "completed",
+        },
+        {
+            "events": [
+                {
+                    "kind": "tool_call",
+                    "tool_name": "verify_failure_claims",
+                    "arguments": {"claims": "The file was missing."},
+                }
+            ],
+            "has_more": False,
+            "next_seq": 11,
+            "status": "completed",
+        },
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID, "--rollout"])
+
+    assert result.exit_code == 0
+    assert "shell" in result.output
+    assert "verify_failure_claims" in result.output
+    assert "The file was missing." in result.output
+    assert platform.get.call_count == 3

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -218,6 +218,9 @@ def test_qa_results_default_tui_hides_trajectory() -> None:
     result = _invoke(platform, ["qa", "results", _TRACE_ID])
 
     assert result.exit_code == 0
+    assert "verdict: failed" in result.output
+    assert "verdict: completed" not in result.output
+    assert "Agent failure" in result.output
     assert "The agent never wrote /app/regex.txt." in result.output
     assert "Required output file was never created" in result.output
     assert "The agent did not save any regex." in result.output
@@ -358,3 +361,114 @@ def test_qa_results_pages_sanitized_rollout() -> None:
     assert "verify_failure_claims" in result.output
     assert "The file was missing." in result.output
     assert platform.get.call_count == 3
+
+
+def test_qa_results_empty_problems_is_passed() -> None:
+    platform = MagicMock()
+    platform.get.return_value = [
+        {
+            **_run(status="completed"),
+            "agent_name": "Failure Analysis",
+            "result": {
+                "content": json.dumps(
+                    {
+                        "summary": "The agent completed the task.",
+                        "problems": [],
+                        "confidence": "high",
+                    }
+                ),
+            },
+        }
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID])
+
+    assert result.exit_code == 0
+    assert "verdict: passed" in result.output
+    assert "No failure" in result.output
+    assert "1. " not in result.output
+
+
+def test_qa_results_boolean_agent_omits_findings() -> None:
+    platform = MagicMock()
+    platform.get.return_value = [
+        {
+            **_run(status="completed"),
+            "agent_name": "False Negative Analysis",
+            "result": {
+                "content": json.dumps(
+                    {
+                        "is_false_negative": False,
+                        "reasoning": "The zero reward matches the missing file.",
+                        "confidence": "high",
+                    }
+                ),
+                "reward": 1.0,
+            },
+        }
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID])
+
+    assert result.exit_code == 0
+    assert "False Negative Analysis" in result.output
+    assert "verdict: passed" in result.output
+    assert "false negative no" in result.output.lower()
+    assert "verdict: completed" not in result.output
+    assert "1. " not in result.output
+    assert "fault:" not in result.output
+    assert "The zero reward matches the missing file." in result.output
+
+
+def test_qa_results_false_negative_yes_is_failed() -> None:
+    platform = MagicMock()
+    platform.get.return_value = [
+        {
+            **_run(status="completed"),
+            "agent_name": "False Negative Analysis",
+            "result": {
+                "is_false_negative": True,
+                "reasoning": "The grader rejected a valid answer.",
+            },
+        }
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID])
+
+    assert result.exit_code == 0
+    assert "verdict: failed" in result.output
+    assert "false negative yes" in result.output.lower()
+    assert "1. " not in result.output
+    assert "The grader rejected a valid answer." in result.output
+
+
+def test_qa_results_rollout_skips_boolean_result_json() -> None:
+    blob = json.dumps(
+        {"is_false_negative": False, "reasoning": "The zero reward matches the missing file."}
+    )
+    platform = MagicMock()
+    platform.get.side_effect = [
+        [
+            {
+                **_run(status="completed"),
+                "agent_name": "False Negative Analysis",
+                "result": {"content": blob},
+            }
+        ],
+        {
+            "events": [
+                {"kind": "agent_message", "text": "Checking the grader."},
+                {"kind": "agent_message", "text": blob},
+            ],
+            "has_more": False,
+            "next_seq": 2,
+            "status": "completed",
+        },
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID, "--rollout"])
+
+    assert result.exit_code == 0
+    assert "Checking the grader." in result.output
+    assert result.output.count("Turn 1") == 1
+    assert '"is_false_negative"' not in result.output

--- a/hud/cli/tests/test_qa_analysis.py
+++ b/hud/cli/tests/test_qa_analysis.py
@@ -1,0 +1,87 @@
+"""Parse standard QA-agent result blobs into review chrome."""
+
+from __future__ import annotations
+
+from hud.cli.qa_analysis import is_standard_result_blob, presentation_for_result
+
+
+def test_failure_analysis_problems_are_a_failed_agent_finding() -> None:
+    view = presentation_for_result(
+        {
+            "status": "completed",
+            "result": {
+                "content": (
+                    '{"summary": "Missing file.", "problems": ['
+                    '{"problem": "No regex", "fault": "agent", "description": "Never wrote it."}'
+                    '], "confidence": "high"}'
+                )
+            },
+        }
+    )
+
+    assert view.kind == "problems"
+    assert view.tag == "failed"
+    assert view.answer == "Agent failure"
+    assert view.findings[0].title == "No regex"
+    assert view.findings[0].fault == "agent"
+
+
+def test_failure_analysis_empty_problems_is_passed() -> None:
+    view = presentation_for_result(
+        {
+            "status": "completed",
+            "result": {"summary": "Clean.", "problems": [], "confidence": "high"},
+        }
+    )
+
+    assert view.tag == "passed"
+    assert view.answer == "No failure"
+    assert view.findings == ()
+
+
+def test_mixed_faults_are_labeled_mixed_failure() -> None:
+    view = presentation_for_result(
+        {
+            "status": "completed",
+            "result": {
+                "problems": [
+                    {"problem": "Bad regex", "fault": "agent"},
+                    {"problem": "Cut off", "fault": "unclear"},
+                ]
+            },
+        }
+    )
+
+    assert view.tag == "failed"
+    assert view.answer == "Mixed failure"
+
+
+def test_false_negative_yes_is_failed_without_findings() -> None:
+    view = presentation_for_result(
+        {
+            "status": "completed",
+            "result": {"content": '{"is_false_negative": true, "reasoning": "Grader missed it."}'},
+        }
+    )
+
+    assert view.kind == "boolean"
+    assert view.tag == "failed"
+    assert view.label == "False Negative"
+    assert view.answer == "yes"
+    assert view.findings == ()
+    assert view.summary == "Grader missed it."
+
+
+def test_queued_runs_are_pending_not_passed() -> None:
+    view = presentation_for_result({"status": "queued", "canonical_result": None})
+
+    assert view.kind == "pending"
+    assert view.tag == "unknown"
+    assert view.label == "queued"
+
+
+def test_standard_result_blob_detects_boolean_and_problems() -> None:
+    assert is_standard_result_blob('{"is_false_negative": false}')
+    assert is_standard_result_blob('{"summary": "x", "problems": []}')
+    assert not is_standard_result_blob("Checking the workspace.")
+    assert not is_standard_result_blob('{"notes": "still working"}')


### PR DESCRIPTION
## What changed

`hud qa results <trace-id>` prints a summary TUI by default: analysis verdict, boxed summary, and a link to the subject trace. It does not fetch or print the analysis trajectory.

The verdict is `passed` or `failed` from the analysis blob, not the job status `completed`. Failure Analysis shows a cause (Agent failure, Evaluation failure, Mixed failure, and similar) and numbered findings only when there are problems. Boolean agents (false negative, false positive, reward hacking, prompt alignment) show yes/no and a summary, with no findings list.

Pass `--rollout` to fetch the sanitized QA rollout and print it as separate colored boxes for agent turns, tool calls, and subagents. Empty agent turns and the final structured analysis JSON are skipped, including boolean-agent blobs. Shell commands print as lines instead of a single `commands=[...]` argument. Panel titles use Rich Text so brackets in names are not parsed as markup.

`--json` is unchanged: the result list only, no rollout fetch.

`hud qa run --wait` uses the same derived pass/fail for its text verdict and exit code.

CLI docs describe the default TUI, pass/fail, agent-shaped layouts, and `--rollout`.

Platform, frontend, and Data Vendor are unchanged.

## Why

Default results output dumped the full analysis trajectory as one-line tool calls, empty agent turns, and a duplicate JSON blob. The useful artifact is the analysis conclusion.

The TUI then showed job status as the verdict (`completed`) and rendered every agent as numbered findings. Failure Analysis does not emit `passed`/`failed`, and boolean agents do not return a problems list.

## Impact

Operators can inspect QA conclusions from the CLI without scrolling through the analysis trajectory. The trajectory remains available behind `--rollout`. The CLI verdict matches the platform review tag. Existing `--json` scripts are unaffected.

## Validation

Fail-to-pass: `test_qa_results_default_tui_hides_trajectory` asserts summary, findings, `verdict: failed` rather than `completed`, the `--rollout` hint, and a single GET to `/qa-agents/results`. `test_qa_results_boolean_agent_omits_findings` and `test_qa_results_false_negative_yes_is_failed` assert yes/no layouts with no numbered findings. `test_qa_results_tui_preserves_bracketed_titles` keeps brackets in panel titles.

Pass-to-pass: `hud/cli/tests/test_qa.py`, `hud/cli/tests/test_qa_analysis.py`, and `hud/cli/tests/test_trace.py` (24 passed). `--json` still one GET. `--rollout` still pages `/qa-agents/results/{id}/rollout`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only presentation and parsing changes; `--json` behavior is preserved and coverage is added via unit tests.
> 
> **Overview**
> **`hud qa results`** now defaults to a Rich summary view instead of dumping the full analysis trajectory. The CLI shows an analysis **verdict** (`passed` / `failed`) derived from the result blob—not job status like `completed`—plus summary panels, numbered findings for Failure Analysis (with cause labels such as Agent failure), and yes/no lines for boolean QA agents without a findings list. A link to the subject trace is included; the trajectory is omitted unless you pass **`--rollout`**.
> 
> **`--rollout`** pages `/qa-agents/results/{id}/rollout` and renders sanitized agent turns, tool calls, and subagents in colored panels, skipping empty turns and structured result JSON (including boolean blobs). Tabular output from **`hud qa run`** / multi-result listing uses the same presentation logic for verdict text; **`hud qa run --wait`** exit code now keys off that derived pass/fail. **`--json`** is unchanged (results list only, no rollout fetch).
> 
> New **`hud/cli/qa_analysis.py`** centralizes parsing of canonical/embedded JSON (v1 verdicts, `problems`, boolean flags). CLI docs describe the default TUI and **`--rollout`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 175cd38d67909c982758df6526e1f439ef805167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->