### PR TITLE
feat(runtime): pass registry_secret to Modal image pulls

### DIFF
--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -157,7 +157,7 @@ security override are documented in
 ### `ModalRuntime`
 
 ```python
-ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=None, workdir=None, port=8765, runtime_config=None, env_vars=None, secrets=None)
+ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=None, workdir=None, port=8765, runtime_config=None, env_vars=None, secrets=None, registry_secret=None)
 ```
 
 - **`image_name`** - published Modal image name (the preferred durable handle), e.g. `ModalRuntime("hud-libero-env")`.
@@ -168,6 +168,23 @@ ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=No
 - **`app_name`** - a Modal app to look up. Defaults to `hud-envs` when `app` is not supplied; `app` and `app_name` are mutually exclusive.
 - **`port`** / **`env_vars`** - in-sandbox serving port and extra environment variables.
 - **`secrets`** - Modal `Secret` objects to attach to the sandbox. Resolve named secrets with `modal.Secret.from_name(...)`; their values never pass through the local process. Secrets require an image runtime and are rejected for Docker-in-Docker Compose because attaching them to the outer sandbox would not expose them to `main`.
+- **`registry_secret`** - optional Modal `Secret` for pulling a private registry image (`REGISTRY_USERNAME` / `REGISTRY_PASSWORD`). Unused for `modal://` images and Compose.
+
+<Accordion title="Running a private Docker image">
+
+```python
+import modal
+from hud.eval import ModalRuntime
+from hud.eval.runtime import RuntimeConfig
+
+ModalRuntime(
+    runtime_config=RuntimeConfig(image="ghcr.io/org/private:tag"),
+    registry_secret=modal.Secret.from_name("registry-creds"),
+    secrets=[modal.Secret.from_name("hf-token")],
+)
+```
+
+</Accordion>
 
 For Compose input, `ModalRuntime` runs the project in a Docker-in-Docker
 sandbox in your Modal account and merges `env_vars` into `main` at acquisition

--- a/hud/eval/runtime/modal.py
+++ b/hud/eval/runtime/modal.py
@@ -139,6 +139,7 @@ class ModalRuntime:
         runtime_config: RuntimeConfig | dict[str, Any] | None = None,
         env_vars: Mapping[str, str] | None = None,
         secrets: Sequence[modal.Secret] | None = None,
+        registry_secret: modal.Secret | None = None,
     ) -> None:
         if app is not None and app_name is not None:
             raise ValueError("ModalRuntime accepts either app or app_name, not both")
@@ -146,6 +147,7 @@ class ModalRuntime:
         self.port = port
         self.env_vars = dict(env_vars or {})
         self.secrets = tuple(secrets or ())
+        self.registry_secret = registry_secret
         self.workdir = workdir
         # Default CMD mirrors the scaffolded Dockerfile.hud entrypoint. Leave
         # workdir unset by default so Modal preserves the image WORKDIR.
@@ -208,7 +210,7 @@ class ModalRuntime:
             image = (
                 modal.Image.from_id(config.image.removeprefix("modal://"))
                 if config.image.startswith("modal://")
-                else modal.Image.from_registry(config.image)
+                else modal.Image.from_registry(config.image, secret=self.registry_secret)  # pull auth
             )
         elif self.image_name is not None:
             image = modal.Image.from_name(self.image_name)

--- a/hud/eval/runtime/modal.py
+++ b/hud/eval/runtime/modal.py
@@ -210,7 +210,9 @@ class ModalRuntime:
             image = (
                 modal.Image.from_id(config.image.removeprefix("modal://"))
                 if config.image.startswith("modal://")
-                else modal.Image.from_registry(config.image, secret=self.registry_secret)  # pull auth
+                else modal.Image.from_registry(
+                    config.image, secret=self.registry_secret
+                )  # pull auth
             )
         elif self.image_name is not None:
             image = modal.Image.from_name(self.image_name)

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -266,8 +266,9 @@ def _install_fake_modal(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
             return _ModalImageRef("name", name)
 
         @staticmethod
-        def from_registry(name: str) -> _ModalImageRef:
+        def from_registry(name: str, secret: object = None) -> _ModalImageRef:
             calls["registry_image"] = name
+            calls["registry_secret"] = secret
             return _ModalImageRef("registry", name)
 
         @staticmethod
@@ -1370,6 +1371,24 @@ async def test_modal_runtime_attaches_secrets_to_sandbox(
     sandbox_kwargs = calls["sandbox_kwargs"]
     assert isinstance(sandbox_kwargs, dict)
     assert sandbox_kwargs["secrets"] == (secret,)
+    assert calls["registry_secret"] is None
+
+
+async def test_modal_runtime_passes_registry_secret_to_from_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = _install_fake_modal(monkeypatch)
+    registry_secret = _ModalSecretRef("registry-creds")
+    provider = ModalRuntime(
+        runtime_config=RuntimeConfig(image="ghcr.io/org/private:tag"),
+        registry_secret=cast("Any", registry_secret),
+    )
+
+    async with provider(_row()):
+        pass
+
+    assert calls["registry_image"] == "ghcr.io/org/private:tag"
+    assert calls["registry_secret"] is registry_secret
 
 
 async def test_modal_runtime_rejects_secrets_for_compose(


### PR DESCRIPTION
## Issue

`ModalRuntime` can boot a public registry image, or a `modal://` image that was already built. It could not pull a **private** GHCR, ECR, or Docker Hub image.

Modal's API for that is `Image.from_registry(ref, secret=...)`. The secret must contain `REGISTRY_USERNAME` and `REGISTRY_PASSWORD`. We already had `secrets=` on `ModalRuntime`, but those attach to the **sandbox** after the image is pulled. They cannot authenticate the pull. Using `secrets[0]` as pull auth would also be wrong as soon as someone passes an HF token and a registry secret together.

This does **not** change hosted HUD. Platform Settings secrets and environment variables are injected after the instance starts. Hosted rollouts still pull public images only.

## Solution

Add an explicit `registry_secret=` argument and pass it through to `Image.from_registry`. Sandbox `secrets=` are unchanged.

```python
import modal
from hud.eval import ModalRuntime
from hud.eval.runtime import RuntimeConfig

ModalRuntime(
    runtime_config=RuntimeConfig(image="ghcr.io/org/private:tag"),
    registry_secret=modal.Secret.from_name("registry-creds"),
    secrets=[modal.Secret.from_name("hf-token")],
)
```

Create the pull secret in the caller's Modal account:

```bash
modal secret create registry-creds REGISTRY_USERNAME=... REGISTRY_PASSWORD=...
```

`registry_secret` is unused for `modal://` images and Compose (those paths do not call `from_registry` on the user's image). Pass the same `Secret` object to both kwargs if the running box also needs the registry creds.

## Outcome / Verification

- Private registry refs can be pulled when `registry_secret` is set.
- Sandbox `secrets=` still attach only to the running sandbox; they are not forwarded to `from_registry`.
- Docs: `registry_secret` is listed on `ModalRuntime`, with an accordion example ("Running a private Docker image").
- Tests: `test_modal_runtime_passes_registry_secret_to_from_registry` checks the pull path; `test_modal_runtime_attaches_secrets_to_sandbox` asserts sandbox secrets do not become pull auth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Modal registry image resolution; sandbox secret behavior is unchanged and hosted HUD is unaffected.
> 
> **Overview**
> **`ModalRuntime` can now authenticate pulls from private container registries** (GHCR, ECR, Docker Hub, etc.) via a new optional `registry_secret=` argument, separate from sandbox `secrets=`.
> 
> When `runtime_config.image` is a plain registry ref (not `modal://`), the runtime passes that secret to `modal.Image.from_registry(..., secret=...)`. Sandbox `secrets=` still attach only to the running sandbox and are **not** reused for pull auth, so you can pass both registry creds and an HF token without conflating them. `registry_secret` is ignored for `modal://` images, Compose/DinD, and `image_name` lookups.
> 
> Docs add a `registry_secret` parameter description and an accordion example for private images. Tests assert the secret is forwarded on the registry pull path and stays `None` when only sandbox secrets are set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 257c1d7179d3d3340755e8e93c0421fb671d6510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->