### PR TITLE
refactor(runtime): clarify Modal sandbox secrets

### DIFF
--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -157,7 +157,7 @@ security override are documented in
 ### `ModalRuntime`
 
 ```python
-ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=None, workdir=None, port=8765, runtime_config=None, env_vars=None, secrets=None, registry_secret=None)
+ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=None, workdir=None, port=8765, runtime_config=None, env_vars=None, sandbox_secrets=None, registry_secret=None)
 ```
 
 - **`image_name`** - published Modal image name (the preferred durable handle), e.g. `ModalRuntime("hud-libero-env")`.
@@ -167,7 +167,7 @@ ModalRuntime(image_name=None, *, image=None, command=None, app=None, app_name=No
 - **`app`** - an already-running, caller-owned Modal app. `ModalRuntime` does not manage its lifecycle.
 - **`app_name`** - a Modal app to look up. Defaults to `hud-envs` when `app` is not supplied; `app` and `app_name` are mutually exclusive.
 - **`port`** / **`env_vars`** - in-sandbox serving port and extra environment variables.
-- **`secrets`** - Modal `Secret` objects to attach to the sandbox. Resolve named secrets with `modal.Secret.from_name(...)`; their values never pass through the local process. Secrets require an image runtime and are rejected for Docker-in-Docker Compose because attaching them to the outer sandbox would not expose them to `main`.
+- **`sandbox_secrets`** - Modal `Secret` objects to attach to the sandbox. Resolve named secrets with `modal.Secret.from_name(...)`; their values never pass through the local process. Sandbox secrets require an image runtime and are rejected for Docker-in-Docker Compose because attaching them to the outer sandbox would not expose them to `main`.
 - **`registry_secret`** - optional Modal `Secret` for pulling a private registry image (`REGISTRY_USERNAME` / `REGISTRY_PASSWORD`). Unused for `modal://` images and Compose.
 
 <Accordion title="Running a private Docker image">
@@ -180,7 +180,7 @@ from hud.eval.runtime import RuntimeConfig
 ModalRuntime(
     runtime_config=RuntimeConfig(image="ghcr.io/org/private:tag"),
     registry_secret=modal.Secret.from_name("registry-creds"),
-    secrets=[modal.Secret.from_name("hf-token")],
+    sandbox_secrets=[modal.Secret.from_name("hf-token")],
 )
 ```
 

--- a/hud/eval/runtime/modal.py
+++ b/hud/eval/runtime/modal.py
@@ -138,7 +138,7 @@ class ModalRuntime:
         port: int = 8765,
         runtime_config: RuntimeConfig | dict[str, Any] | None = None,
         env_vars: Mapping[str, str] | None = None,
-        secrets: Sequence[modal.Secret] | None = None,
+        sandbox_secrets: Sequence[modal.Secret] | None = None,
         registry_secret: modal.Secret | None = None,
     ) -> None:
         if app is not None and app_name is not None:
@@ -146,7 +146,7 @@ class ModalRuntime:
         self.image_name = image_name
         self.port = port
         self.env_vars = dict(env_vars or {})
-        self.secrets = tuple(secrets or ())
+        self.sandbox_secrets = tuple(sandbox_secrets or ())
         self.registry_secret = registry_secret
         self.workdir = workdir
         # Default CMD mirrors the scaffolded Dockerfile.hud entrypoint. Leave
@@ -198,9 +198,9 @@ class ModalRuntime:
                 "ModalRuntime cannot attach GPUs to services inside Docker-in-Docker; "
                 "use a materialized image or omit runtime_config.compose"
             )
-        if compose is not None and self.secrets:
+        if compose is not None and self.sandbox_secrets:
             raise ValueError(
-                "ModalRuntime secrets require an image runtime; attaching them to "
+                "ModalRuntime sandbox secrets require an image runtime; attaching them to "
                 "the outer Docker-in-Docker sandbox would not expose them to main"
             )
         port_service = ComposeConfig.from_file(compose).network_owner("main") if compose else "main"
@@ -257,8 +257,8 @@ class ModalRuntime:
                 sandbox_kwargs["memory"] = resources.memory_mb
             if self.env_vars:
                 sandbox_kwargs["env"] = self.env_vars
-            if self.secrets:
-                sandbox_kwargs["secrets"] = self.secrets
+            if self.sandbox_secrets:
+                sandbox_kwargs["secrets"] = self.sandbox_secrets
         if resources is not None and resources.gpu is not None:
             gpu_types = resources.gpu.acceptable_types
             gpu_type = gpu_types[0] if gpu_types else "any"

--- a/hud/eval/tests/test_docker_provider.py
+++ b/hud/eval/tests/test_docker_provider.py
@@ -1355,14 +1355,14 @@ async def test_modal_runtime_bounds_output_teardown(
     assert calls["terminated"] is True
 
 
-async def test_modal_runtime_attaches_secrets_to_sandbox(
+async def test_modal_runtime_attaches_sandbox_secrets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls = _install_fake_modal(monkeypatch)
     secret = _ModalSecretRef("datacuration-cpu50-grader-auth")
     provider = ModalRuntime(
         runtime_config=RuntimeConfig(image="img:tag"),
-        secrets=[cast("Any", secret)],
+        sandbox_secrets=[cast("Any", secret)],
     )
 
     async with provider(_row()):
@@ -1391,17 +1391,17 @@ async def test_modal_runtime_passes_registry_secret_to_from_registry(
     assert calls["registry_secret"] is registry_secret
 
 
-async def test_modal_runtime_rejects_secrets_for_compose(
+async def test_modal_runtime_rejects_sandbox_secrets_for_compose(
     tmp_path: Path,
 ) -> None:
     compose = tmp_path / "compose.yaml"
     compose.write_text("services:\n  main:\n    image: hud-env:one\n", encoding="utf-8")
     provider = ModalRuntime(
         runtime_config=RuntimeConfig(compose=ComposeProject(document=compose)),
-        secrets=[cast("Any", _ModalSecretRef("grader-auth"))],
+        sandbox_secrets=[cast("Any", _ModalSecretRef("grader-auth"))],
     )
 
-    with pytest.raises(ValueError, match="secrets require an image runtime"):
+    with pytest.raises(ValueError, match="sandbox secrets require an image runtime"):
         async with provider(_row()):
             pass
 


### PR DESCRIPTION
## Summary

- rename the unreleased `ModalRuntime(secrets=...)` argument to `sandbox_secrets=`
- keep sandbox injection distinct from `registry_secret`, which authenticates private image pulls
- update the runtime reference and focused tests without adding a compatibility alias

## Testing

- `uv run --all-extras pytest hud/eval/tests/test_docker_provider.py -q` (72 passed)
- `uv run --with=".[dev]" ruff format . --check`
- `uv run --with=".[dev]" ruff check .`
- `uv run --extra dev --extra train --extra modal --extra daytona ty check --error-on-warning`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only API change with no runtime logic changes; callers using the old unreleased `secrets=` kwarg will break until updated.
> 
> **Overview**
> Renames the unreleased **`ModalRuntime`** constructor argument from **`secrets=`** to **`sandbox_secrets=`** so sandbox-injected Modal secrets are clearly separate from **`registry_secret`** (private image pull auth).
> 
> Runtime behavior is unchanged: values still flow to Modal **`Sandbox.create`** as **`secrets`**, Compose + sandbox secrets still raise the same validation error (message now says “sandbox secrets”), and docs/examples/tests follow the new name. **No compatibility alias** for **`secrets=`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6635cf59fd04613e913e98281d7365c2bfcc195d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->