### PR TITLE
fix(claude): fall back to generic input_schema tools for non-Anthropic models

### DIFF
--- a/hud/agents/claude/tools/base.py
+++ b/hud/agents/claude/tools/base.py
@@ -14,4 +14,13 @@ class ClaudeToolSpec(AgentToolSpec):
     beta: str | None = None
 
 
-__all__ = ["ClaudeToolSpec"]
+def is_anthropic_model(model: str | None) -> bool:
+    """Whether the model accepts Anthropic server-tool shorthands (``bash_20250124`` etc.).
+
+    Non-Anthropic models served over Anthropic-compatible endpoints (e.g. OpenRouter)
+    reject those shorthands, so tools fall back to plain ``input_schema`` definitions.
+    """
+    return bool(model) and "claude" in model.lower()
+
+
+__all__ = ["ClaudeToolSpec", "is_anthropic_model"]

--- a/hud/agents/claude/tools/coding.py
+++ b/hud/agents/claude/tools/coding.py
@@ -10,12 +10,13 @@ from hud.agents.tools import SSHTool
 from hud.agents.tools.base import result_text, tool_err
 from hud.types import MCPToolResult
 
-from .base import ClaudeToolSpec
+from .base import ClaudeToolSpec, is_anthropic_model
 
 if TYPE_CHECKING:
     from anthropic.types.beta import (
         BetaToolBash20250124Param,
         BetaToolTextEditor20250728Param,
+        BetaToolUnionParam,
     )
 
 
@@ -24,10 +25,63 @@ CLAUDE_BASH_SPEC = ClaudeToolSpec(
     api_name="bash",
 )
 
+GENERIC_BASH_SPEC = ClaudeToolSpec(
+    api_type="function",
+    api_name="bash",
+)
+
 CLAUDE_TEXT_EDITOR_SPEC = ClaudeToolSpec(
     api_type="text_editor_20250728",
     api_name="str_replace_based_edit_tool",
 )
+
+GENERIC_TEXT_EDITOR_SPEC = ClaudeToolSpec(
+    api_type="function",
+    api_name="str_replace_based_edit_tool",
+)
+
+_BASH_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "description": "The bash command to run.",
+        },
+    },
+    "required": ["command"],
+}
+
+_TEXT_EDITOR_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "enum": ["view", "create", "str_replace", "insert"],
+            "description": "The editor operation to run.",
+        },
+        "path": {
+            "type": "string",
+            "description": "Absolute path to the file.",
+        },
+        "file_text": {
+            "type": "string",
+            "description": "Full file contents for `create`.",
+        },
+        "old_str": {
+            "type": "string",
+            "description": "Exact existing text to replace for `str_replace`; must be unique.",
+        },
+        "new_str": {
+            "type": "string",
+            "description": "Replacement text for `str_replace`, or text to insert for `insert`.",
+        },
+        "insert_line": {
+            "type": "integer",
+            "description": "Line number after which to insert for `insert` (0 = top of file).",
+        },
+    },
+    "required": ["command", "path"],
+}
 
 
 class ClaudeBashTool(SSHTool):
@@ -37,10 +91,18 @@ class ClaudeBashTool(SSHTool):
 
     @classmethod
     def default_spec(cls, model: str) -> ClaudeToolSpec:
-        del model
-        return CLAUDE_BASH_SPEC
+        return CLAUDE_BASH_SPEC if is_anthropic_model(model) else GENERIC_BASH_SPEC
 
-    def to_params(self) -> BetaToolBash20250124Param:
+    def to_params(self) -> BetaToolUnionParam:
+        if self.spec.api_type == "function":
+            return cast(
+                "BetaToolUnionParam",
+                {
+                    "name": self.name,
+                    "description": "Run a command in a bash shell on the remote machine.",
+                    "input_schema": _BASH_INPUT_SCHEMA,
+                },
+            )
         return cast(
             "BetaToolBash20250124Param",
             {"type": self.spec.api_type, "name": self.name},
@@ -77,14 +139,25 @@ class ClaudeTextEditorTool(SSHTool):
 
     @classmethod
     def default_spec(cls, model: str) -> ClaudeToolSpec:
-        del model
-        return CLAUDE_TEXT_EDITOR_SPEC
+        return CLAUDE_TEXT_EDITOR_SPEC if is_anthropic_model(model) else GENERIC_TEXT_EDITOR_SPEC
 
     @property
     def provider_name(self) -> str:
         return self.spec.api_name
 
-    def to_params(self) -> BetaToolTextEditor20250728Param:
+    def to_params(self) -> BetaToolUnionParam:
+        if self.spec.api_type == "function":
+            return cast(
+                "BetaToolUnionParam",
+                {
+                    "name": self.provider_name,
+                    "description": (
+                        "View, create, and edit files on the remote machine "
+                        "(view/create/str_replace/insert)."
+                    ),
+                    "input_schema": _TEXT_EDITOR_INPUT_SCHEMA,
+                },
+            )
         return cast(
             "BetaToolTextEditor20250728Param",
             {"type": self.spec.api_type, "name": self.provider_name},
@@ -142,4 +215,11 @@ class ClaudeTextEditorTool(SSHTool):
         return await self.file_write(path, "".join(lines))
 
 
-__all__ = ["CLAUDE_BASH_SPEC", "CLAUDE_TEXT_EDITOR_SPEC", "ClaudeBashTool", "ClaudeTextEditorTool"]
+__all__ = [
+    "CLAUDE_BASH_SPEC",
+    "CLAUDE_TEXT_EDITOR_SPEC",
+    "GENERIC_BASH_SPEC",
+    "GENERIC_TEXT_EDITOR_SPEC",
+    "ClaudeBashTool",
+    "ClaudeTextEditorTool",
+]

--- a/hud/agents/claude/tools/computer.py
+++ b/hud/agents/claude/tools/computer.py
@@ -19,12 +19,13 @@ from hud.agents.tools.base import tool_err, tool_ok
 from hud.capabilities.rfb import ScreenshotEncoding, WebPScreenshotEncoding
 from hud.types import MCPToolResult
 
-from .base import ClaudeToolSpec
+from .base import ClaudeToolSpec, is_anthropic_model
 
 if TYPE_CHECKING:
     from anthropic.types.beta import (
         BetaToolComputerUse20250124Param,
         BetaToolComputerUse20251124Param,
+        BetaToolUnionParam,
     )
 
     from hud.agents.tools.rfb import Button
@@ -110,8 +111,88 @@ CLAUDE_COMPUTER_SPECS: tuple[ClaudeToolSpec, ...] = (
     ),
 )
 
-# Fallback for unknown models — use the latest version.
+# Fallback for unknown Claude models — use the latest version.
 _DEFAULT_COMPUTER_SPEC = CLAUDE_COMPUTER_SPECS[0]
+
+GENERIC_COMPUTER_SPEC = ClaudeToolSpec(
+    api_type="function",
+    api_name="computer",
+)
+
+_COMPUTER_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": [
+                "screenshot",
+                "zoom",
+                "left_click",
+                "right_click",
+                "middle_click",
+                "double_click",
+                "triple_click",
+                "mouse_move",
+                "left_mouse_down",
+                "left_mouse_up",
+                "type",
+                "key",
+                "hold_key",
+                "scroll",
+                "left_click_drag",
+                "wait",
+                "cursor_position",
+            ],
+            "description": "The action to perform on the screen.",
+        },
+        "coordinate": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "minItems": 2,
+            "maxItems": 2,
+            "description": "[x, y] pixel coordinate for click/move/scroll, or drag end point.",
+        },
+        "start_coordinate": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "minItems": 2,
+            "maxItems": 2,
+            "description": "[x, y] drag start point for `left_click_drag`.",
+        },
+        "text": {
+            "type": "string",
+            "description": (
+                "Text to type for `type`; key chord (xdotool syntax, e.g. `ctrl+s`) for "
+                "`key`/`hold_key`; optional modifier keys held during clicks and scrolls."
+            ),
+        },
+        "duration": {
+            "type": "number",
+            "description": "Seconds to hold for `hold_key` or pause for `wait`.",
+        },
+        "scroll_direction": {
+            "type": "string",
+            "enum": ["up", "down", "left", "right"],
+            "description": "Direction for `scroll`.",
+        },
+        "scroll_amount": {
+            "type": "integer",
+            "description": "Number of scroll clicks for `scroll`.",
+        },
+        "repeat": {
+            "type": "integer",
+            "description": "Times to repeat the key chord for `key`.",
+        },
+        "region": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "minItems": 4,
+            "maxItems": 4,
+            "description": "[x0, y0, x1, y1] region to magnify for `zoom`.",
+        },
+    },
+    "required": ["action"],
+}
 
 
 class ClaudeComputerTool(RFBTool):
@@ -121,12 +202,29 @@ class ClaudeComputerTool(RFBTool):
 
     @classmethod
     def default_spec(cls, model: str) -> ClaudeToolSpec | None:
+        if not is_anthropic_model(model):
+            return GENERIC_COMPUTER_SPEC
         for candidate in CLAUDE_COMPUTER_SPECS:
             if candidate.supports_model(model):
                 return candidate
         return _DEFAULT_COMPUTER_SPEC
 
-    def to_params(self) -> BetaToolComputerUse20250124Param | BetaToolComputerUse20251124Param:
+    def to_params(
+        self,
+    ) -> BetaToolComputerUse20250124Param | BetaToolComputerUse20251124Param | BetaToolUnionParam:
+        if self.spec.api_type == "function":
+            return cast(
+                "BetaToolUnionParam",
+                {
+                    "name": self.name,
+                    "description": (
+                        "Control the remote computer's screen, mouse, and keyboard. "
+                        f"The display is {self.display_width}x{self.display_height} pixels. "
+                        "Most actions return a screenshot of the result."
+                    ),
+                    "input_schema": _COMPUTER_INPUT_SCHEMA,
+                },
+            )
         if self.spec.api_type == "computer_20251124":
             return cast(
                 "BetaToolComputerUse20251124Param",
@@ -375,4 +473,4 @@ def _crop_png(
     return buf.getvalue(), encoding.mime_type
 
 
-__all__ = ["CLAUDE_COMPUTER_SPECS", "ClaudeComputerTool"]
+__all__ = ["CLAUDE_COMPUTER_SPECS", "GENERIC_COMPUTER_SPEC", "ClaudeComputerTool"]

--- a/hud/agents/claude/tools/tests/test_computer.py
+++ b/hud/agents/claude/tools/tests/test_computer.py
@@ -14,6 +14,7 @@ from PIL import Image
 
 from hud.agents.claude.tools.computer import (
     CLAUDE_COMPUTER_SPECS,
+    GENERIC_COMPUTER_SPEC,
     ClaudeComputerTool,
     _crop_png,
     _hold_keys,
@@ -120,18 +121,31 @@ def test_default_spec_per_model() -> None:
     spec_45 = ClaudeComputerTool.default_spec("claude-sonnet-4-5-20250101")
     assert spec_45 is not None
     assert spec_45.api_type == "computer_20250124"
-    # Unknown model falls back to the latest spec.
-    spec_unknown = ClaudeComputerTool.default_spec("totally-unknown")
+    # Unknown Claude model falls back to the latest spec.
+    spec_unknown = ClaudeComputerTool.default_spec("claude-totally-unknown")
     assert spec_unknown is not None
     assert spec_unknown.api_type == "computer_20251124"
+    # Non-Anthropic models get the generic input_schema spec.
+    assert ClaudeComputerTool.default_spec("qwen/qwen3.8-max") is GENERIC_COMPUTER_SPEC
 
 
 def test_to_params_reflects_spec_version() -> None:
     tool = RecordingComputer()
     tool.spec = CLAUDE_COMPUTER_SPECS[0]
-    assert tool.to_params()["type"] == "computer_20251124"
+    assert tool.to_params().get("type") == "computer_20251124"
     tool.spec = CLAUDE_COMPUTER_SPECS[1]
-    assert tool.to_params()["type"] == "computer_20250124"
+    assert tool.to_params().get("type") == "computer_20250124"
+
+
+def test_to_params_generic_spec_uses_input_schema() -> None:
+    tool = RecordingComputer()
+    tool.spec = GENERIC_COMPUTER_SPEC
+    params: Any = tool.to_params()
+    assert "type" not in params
+    assert params["name"] == "computer"
+    assert "200x100" in params["description"]
+    assert params["input_schema"]["required"] == ["action"]
+    assert "left_click" in params["input_schema"]["properties"]["action"]["enum"]
 
 
 # ─── action dispatch ──────────────────────────────────────────────────

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -562,6 +562,25 @@ def test_claude_bash_to_params_carries_native_schema() -> None:
     assert params == {"type": "bash_20250124", "name": "bash"}
 
 
+def test_claude_bash_generic_spec_for_non_anthropic_model() -> None:
+    tool = ClaudeBashTool(spec=ClaudeBashTool.default_spec("qwen/qwen3.8-max"), client=_ssh())
+    params: Any = tool.to_params()
+    assert "type" not in params
+    assert params["name"] == "bash"
+    assert params["input_schema"]["required"] == ["command"]
+
+
+def test_claude_editor_generic_spec_for_non_anthropic_model() -> None:
+    tool = ClaudeTextEditorTool(
+        spec=ClaudeTextEditorTool.default_spec("qwen/qwen3.8-max"),
+        client=_ssh(),
+    )
+    params: Any = tool.to_params()
+    assert "type" not in params
+    assert params["name"] == "str_replace_based_edit_tool"
+    assert params["input_schema"]["required"] == ["command", "path"]
+
+
 # ─── editor tools over SSH exec ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Anthropic-compatible endpoints serving non-Claude models (e.g. OpenRouter) reject server-tool shorthands like `bash_20250124` / `text_editor_20250728` / `computer_2025*`, failing runs at step 0 with `Unknown server-tool shorthand` (prod trace `d582a92d-be1d-4ba0-91ec-bf1ed23c9bce`, `agent_config.type = "claude"` with `model = "qwen/qwen3.8-max"`).
- The bash, text editor, and computer tools now emit plain `name`/`description`/`input_schema` definitions when the model is not a Claude model (`is_anthropic_model()` in `claude/tools/base.py`). Claude models keep the native shorthands and version-gated computer specs unchanged. Generic specs carry no beta flag, so no computer-use beta headers are sent for non-Anthropic models.
- Execution paths are unchanged; the generic schemas mirror exactly what each tool's `execute()` already handles.

## Test plan

- [x] Unit tests for the generic spec selection and params (`test_computer.py`, `test_provider_native_tools.py`); full tool suites pass (84 tests).
- [x] Live A/B against the prod inference gateway with `qwen/qwen3.8-max`: old shorthand params reproduce the 400 (`tools[1].type — Unknown server-tool shorthand`); the generic params succeed with `stop_reason=tool_use` and a proper `bash` tool call.
- [x] ruff clean; pyright reports no new errors vs `main`.

Made with [Cursor](https://cursor.com)