### PR TITLE
fix: canonicalize HUD record links

### DIFF
--- a/hud/cli/eval.py
+++ b/hud/cli/eval.py
@@ -28,6 +28,7 @@ from hud.cli.utils.config import parse_key_value
 from hud.settings import settings
 from hud.types import AgentType
 from hud.utils.hud_console import HUDConsole
+from hud.utils.platform import canonical_record_id
 
 _BEDROCK_ARN_PATTERN = re.compile(r"^arn:aws:bedrock:[a-z0-9-]+:\d+:inference-profile/.+$")
 
@@ -851,7 +852,7 @@ async def _run_evaluation(cfg: EvalConfig) -> Any:
         max_concurrent=cfg.max_concurrent,
     )
     if job.runs and settings.telemetry_enabled and settings.api_key:
-        hud_console.info(f"{settings.hud_web_url}/jobs/{job.id}")
+        hud_console.info(f"{settings.hud_web_url}/jobs/{canonical_record_id(job.id)}")
 
     return job
 

--- a/hud/cli/jobs.py
+++ b/hud/cli/jobs.py
@@ -99,10 +99,11 @@ def _list_jobs(*, json_output: bool, limit: int) -> None:
 
 def _show_job_traces(job_id: str, *, json_output: bool, limit: int) -> None:
     from hud.settings import settings
-    from hud.utils.platform import PlatformClient
+    from hud.utils.platform import PlatformClient, canonical_record_id
 
     client = PlatformClient.from_settings()
     try:
+        job_id = canonical_record_id(job_id)
         data = client.get(f"/jobs/{job_id}/traces", params={"limit": limit})
     except Exception as e:
         console.print(f"[red]Failed to fetch traces: {e}[/red]")

--- a/hud/cli/tests/test_jobs.py
+++ b/hud/cli/tests/test_jobs.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from typer.testing import CliRunner
+
+from hud.cli import jobs
+from hud.settings import settings
+from hud.utils.platform import PlatformClient
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any] | None]] = []
+
+    def get(self, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append((path, params))
+        return {"items": []}
+
+
+def test_job_detail_accepts_compact_id_and_prints_canonical_link(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    compact_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
+    canonical_id = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
+    client = _Client()
+    monkeypatch.setattr(settings, "api_key", "test-key")
+    monkeypatch.setattr(settings, "hud_web_url", "https://hud.test")
+    monkeypatch.setattr(PlatformClient, "from_settings", classmethod(lambda cls: client))
+
+    result = CliRunner().invoke(jobs.jobs_app, [compact_id])
+
+    assert result.exit_code == 0
+    assert client.calls == [(f"/jobs/{canonical_id}/traces", {"limit": 20})]
+    assert f"https://hud.test/jobs/{canonical_id}" in result.stdout

--- a/hud/cli/trace.py
+++ b/hud/cli/trace.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import contextlib
 import json
-import uuid
 from typing import Any
 
 import typer
@@ -44,6 +43,7 @@ def trace_command(
     from hud.cli.utils.api import require_api_key
     from hud.settings import settings
     from hud.telemetry.span import normalize_trace_id
+    from hud.utils.platform import canonical_record_id
 
     dir_to_use = local_dir or settings.telemetry_local_dir
     otel_id = normalize_trace_id(trace_id)
@@ -78,7 +78,7 @@ def trace_command(
     _render_events(events)
 
     web = settings.hud_web_url.rstrip("/")
-    console.print(f"\n[dim]View: {web}/trace/{uuid.UUID(otel_id)}[/dim]")
+    console.print(f"\n[dim]View: {web}/trace/{canonical_record_id(otel_id)}[/dim]")
 
 
 # ── local JSONL ────────────────────────────────────────────────────────────────

--- a/hud/environment/robot/gym.py
+++ b/hud/environment/robot/gym.py
@@ -486,7 +486,7 @@ class TracedEnv:
     trace per episode per slot (``done[i]`` closes slot ``i``'s trace and opens the next).
 
     - ``job`` - job name on the platform (default: the env's spec id / class name).
-    - ``job_id`` - share one job across several wrapped envs (multi-task suites).
+    - ``job_id`` - existing HUD Job UUID shared across wrapped envs; omitted to mint one.
     - ``task`` - optional instruction/label shown on each trace's timeline.
     - ``fps`` - control rate override (default: detected from the env).
     - ``contract`` - path for the derived contract round-trip; ``None`` disables it.

--- a/hud/environment/tests/test_robot_regressions.py
+++ b/hud/environment/tests/test_robot_regressions.py
@@ -197,17 +197,29 @@ def test_job_recorder_canonicalizes_shared_job_id(monkeypatch: pytest.MonkeyPatc
     assert recorder.job_url == f"https://hud.test/jobs/{canonical_id}"
 
 
-def test_seeded_trace_id_uses_stable_compact_job_namespace() -> None:
+def test_seeded_recording_reports_stable_trace_id(monkeypatch: pytest.MonkeyPatch) -> None:
     compact_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
     canonical_id = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
     expected_id = uuid.uuid5(
         uuid.NAMESPACE_URL,
         f"hud.vec:{compact_id}:0:0:7",
     ).hex
+    reports: list[tuple[str, dict[str, Any]]] = []
+
+    def capture_report(path: str, payload: dict[str, Any]) -> None:
+        reports.append((path, payload))
+
+    monkeypatch.setattr("hud.telemetry.robot.recorder._report_sync", capture_report)
 
     for job_id in (compact_id, canonical_id):
+        reports.clear()
         recorder = JobRecorder("test", 1, record_indices=[0], seed=7, job_id=job_id)
-        assert recorder._open(0).trace_id == expected_id
+        recorder.record(done=np.array([True]))
+
+        assert (
+            f"/trace/{expected_id}/enter",
+            {"job_id": canonical_id, "group_id": None, "model": None},
+        ) in reports
 
 
 def test_job_recorder_rejects_non_uuid_job_id() -> None:

--- a/hud/environment/tests/test_robot_regressions.py
+++ b/hud/environment/tests/test_robot_regressions.py
@@ -188,12 +188,18 @@ def test_job_recorder_canonicalizes_shared_job_id(monkeypatch: pytest.MonkeyPatc
 
     compact_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
     canonical_id = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
+    reports: list[tuple[str, dict[str, Any]]] = []
     monkeypatch.setattr(settings, "hud_web_url", "https://hud.test")
+    monkeypatch.setattr(
+        "hud.telemetry.robot.recorder._report_sync",
+        lambda path, payload: reports.append((path, payload)),
+    )
 
     recorder = JobRecorder("test", 1, record_indices=[], job_id=compact_id)
 
     assert recorder.job_id == canonical_id
     assert recorder.job_url == f"https://hud.test/jobs/{canonical_id}"
+    assert reports == [(f"/trace/job/{canonical_id}/enter", {"name": "test", "group": 1})]
 
 
 def test_seeded_recording_preserves_trace_id_for_each_job_id_spelling(

--- a/hud/environment/tests/test_robot_regressions.py
+++ b/hud/environment/tests/test_robot_regressions.py
@@ -15,6 +15,7 @@ from hud.environment.env import current_session_id
 from hud.environment.robot.bridge import _HUD_STATE, RobotBridge, _apply_declaration_state
 from hud.environment.robot.endpoint import RobotEndpoint, _bridge_init_kwargs
 from hud.environment.robot.gym import GymBridge, action_dim_of
+from hud.telemetry.robot.recorder import JobRecorder
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -180,6 +181,24 @@ def test_plain_env_observation_always_gets_batch_axis() -> None:
     assert data["reward"].shape == (1,)
     assert data["reward"][0] == pytest.approx(0.5)
     assert terminated.shape == (1,)
+
+
+def test_job_recorder_canonicalizes_shared_job_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    from hud.settings import settings
+
+    compact_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
+    canonical_id = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
+    monkeypatch.setattr(settings, "hud_web_url", "https://hud.test")
+
+    recorder = JobRecorder("test", 1, record_indices=[], job_id=compact_id)
+
+    assert recorder.job_id == canonical_id
+    assert recorder.job_url == f"https://hud.test/jobs/{canonical_id}"
+
+
+def test_job_recorder_rejects_non_uuid_job_id() -> None:
+    with pytest.raises(ValueError, match="job_id must be a UUID"):
+        JobRecorder("test", 1, record_indices=[], job_id="shared-suite")
 
 
 # --- endpoint session claims -----------------------------------------------------------

--- a/hud/environment/tests/test_robot_regressions.py
+++ b/hud/environment/tests/test_robot_regressions.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import uuid
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock
@@ -194,6 +195,19 @@ def test_job_recorder_canonicalizes_shared_job_id(monkeypatch: pytest.MonkeyPatc
 
     assert recorder.job_id == canonical_id
     assert recorder.job_url == f"https://hud.test/jobs/{canonical_id}"
+
+
+def test_seeded_trace_id_uses_stable_compact_job_namespace() -> None:
+    compact_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
+    canonical_id = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
+    expected_id = uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        f"hud.vec:{compact_id}:0:0:7",
+    ).hex
+
+    for job_id in (compact_id, canonical_id):
+        recorder = JobRecorder("test", 1, record_indices=[0], seed=7, job_id=job_id)
+        assert recorder._open(0).trace_id == expected_id
 
 
 def test_job_recorder_rejects_non_uuid_job_id() -> None:

--- a/hud/environment/tests/test_robot_regressions.py
+++ b/hud/environment/tests/test_robot_regressions.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import uuid
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock
@@ -197,13 +196,15 @@ def test_job_recorder_canonicalizes_shared_job_id(monkeypatch: pytest.MonkeyPatc
     assert recorder.job_url == f"https://hud.test/jobs/{canonical_id}"
 
 
-def test_seeded_recording_reports_stable_trace_id(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_seeded_recording_preserves_trace_id_for_each_job_id_spelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     compact_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
     canonical_id = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
-    expected_id = uuid.uuid5(
-        uuid.NAMESPACE_URL,
-        f"hud.vec:{compact_id}:0:0:7",
-    ).hex
+    legacy_trace_ids = {
+        compact_id: "e9266339c6fa58b08102ce7f41c4f372",
+        canonical_id: "7b3269f689b65c5887542a9bc1ffb5c8",
+    }
     reports: list[tuple[str, dict[str, Any]]] = []
 
     def capture_report(path: str, payload: dict[str, Any]) -> None:
@@ -211,7 +212,7 @@ def test_seeded_recording_reports_stable_trace_id(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr("hud.telemetry.robot.recorder._report_sync", capture_report)
 
-    for job_id in (compact_id, canonical_id):
+    for job_id, expected_id in legacy_trace_ids.items():
         reports.clear()
         recorder = JobRecorder("test", 1, record_indices=[0], seed=7, job_id=job_id)
         recorder.record(done=np.array([True]))

--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -22,7 +22,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from hud.utils.platform import PlatformClient
+from hud.utils.platform import PlatformClient, canonical_record_id
 
 if TYPE_CHECKING:
     from .run import Run
@@ -120,7 +120,7 @@ async def job_enter(job_id: str, *, name: str, group: int, taskset_id: str | Non
     )
     from hud.settings import settings
 
-    logger.info("job: %s/jobs/%s", settings.hud_web_url, job_id)
+    logger.info("job: %s/jobs/%s", settings.hud_web_url, canonical_record_id(job_id))
 
 
 async def trace_enter(

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -5,6 +5,7 @@ No network: the platform client is replaced with a recorder.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -66,6 +67,24 @@ async def test_trace_enter_reports_task_and_group_identity(recorder: _Recorder) 
             },
         )
     ]
+
+
+async def test_job_enter_logs_canonical_web_uuid(
+    recorder: _Recorder,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from hud.settings import settings
+
+    compact_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
+    canonical_id = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
+    monkeypatch.setattr(settings, "hud_web_url", "https://hud.test")
+    caplog.set_level(logging.INFO, logger="hud.eval.job")
+
+    await job_mod.job_enter(compact_id, name="test", group=1)
+
+    assert recorder.calls[0][0] == f"/trace/job/{compact_id}/enter"
+    assert f"job: https://hud.test/jobs/{canonical_id}" in caplog.text
 
 
 async def test_trace_exit_propagates_stop_reason(recorder: _Recorder) -> None:

--- a/hud/telemetry/robot/recorder.py
+++ b/hud/telemetry/robot/recorder.py
@@ -165,6 +165,8 @@ class JobRecorder:
     slots (``record_indices``) gets rich traces; each ``done[i]`` closes that
     slot's trace (reporting reward — env-reported ``success`` outranks
     accumulated shaped reward) and opens a fresh one, all under one Job.
+
+    ``job_id`` is an existing HUD Job UUID to share; omit it to mint one.
     """
 
     def __init__(
@@ -188,7 +190,10 @@ class JobRecorder:
         self.seed = seed
         self.group_id = group_id
         self.model = model
-        self.job_id = job_id or uuid.uuid4().hex
+        try:
+            self.job_id = canonical_record_id(job_id or uuid.uuid4().hex)
+        except ValueError as exc:
+            raise ValueError("job_id must be a UUID") from exc
         self._prompt = prompt
         self._action_names = action_names
         self._state_names = state_names
@@ -209,7 +214,7 @@ class JobRecorder:
     def job_url(self) -> str:
         from hud.settings import settings
 
-        return f"{settings.hud_web_url}/jobs/{canonical_record_id(self.job_id)}"
+        return f"{settings.hud_web_url}/jobs/{self.job_id}"
 
     def _open(self, i: int) -> TraceRecorder:
         # Deterministic trace ids (reproducible, idempotent re-uploads) when seeded.

--- a/hud/telemetry/robot/recorder.py
+++ b/hud/telemetry/robot/recorder.py
@@ -190,12 +190,13 @@ class JobRecorder:
         self.seed = seed
         self.group_id = group_id
         self.model = model
+        seed_job_id = job_id or uuid.uuid4().hex
         try:
-            self.job_id = canonical_record_id(job_id or uuid.uuid4().hex)
+            self.job_id = canonical_record_id(seed_job_id)
         except ValueError as exc:
             raise ValueError("job_id must be a UUID") from exc
-        # Seeded trace IDs use the compact UUID namespace so accepted spellings stay idempotent.
-        self._trace_namespace = uuid.UUID(self.job_id).hex
+        # The input spelling is part of the shipped deterministic trace-ID contract.
+        self._seed_job_id = seed_job_id
         self._prompt = prompt
         self._action_names = action_names
         self._state_names = state_names
@@ -221,7 +222,7 @@ class JobRecorder:
     def _open(self, i: int) -> TraceRecorder:
         # Deterministic trace ids (reproducible, idempotent re-uploads) when seeded.
         if self.seed is not None:
-            key = f"hud.vec:{self._trace_namespace}:{i}:{self._episode[i]}:{self.seed}"
+            key = f"hud.vec:{self._seed_job_id}:{i}:{self._episode[i]}:{self.seed}"
             trace_id = uuid.uuid5(uuid.NAMESPACE_URL, key).hex
         else:
             trace_id = uuid.uuid4().hex

--- a/hud/telemetry/robot/recorder.py
+++ b/hud/telemetry/robot/recorder.py
@@ -24,7 +24,7 @@ import numpy as np
 from hud.agents.types import InferenceStep, ObservationStep, StateFeature
 from hud.telemetry.context import get_current_trace_id
 from hud.types import Step
-from hud.utils.platform import PlatformClient
+from hud.utils.platform import PlatformClient, canonical_record_id
 
 from .video import VideoStreamer
 
@@ -209,7 +209,7 @@ class JobRecorder:
     def job_url(self) -> str:
         from hud.settings import settings
 
-        return f"{settings.hud_web_url}/jobs/{self.job_id}"
+        return f"{settings.hud_web_url}/jobs/{canonical_record_id(self.job_id)}"
 
     def _open(self, i: int) -> TraceRecorder:
         # Deterministic trace ids (reproducible, idempotent re-uploads) when seeded.

--- a/hud/telemetry/robot/recorder.py
+++ b/hud/telemetry/robot/recorder.py
@@ -194,6 +194,8 @@ class JobRecorder:
             self.job_id = canonical_record_id(job_id or uuid.uuid4().hex)
         except ValueError as exc:
             raise ValueError("job_id must be a UUID") from exc
+        # Seeded trace IDs use the compact UUID namespace so accepted spellings stay idempotent.
+        self._trace_namespace = uuid.UUID(self.job_id).hex
         self._prompt = prompt
         self._action_names = action_names
         self._state_names = state_names
@@ -219,7 +221,7 @@ class JobRecorder:
     def _open(self, i: int) -> TraceRecorder:
         # Deterministic trace ids (reproducible, idempotent re-uploads) when seeded.
         if self.seed is not None:
-            key = f"hud.vec:{self.job_id}:{i}:{self._episode[i]}:{self.seed}"
+            key = f"hud.vec:{self._trace_namespace}:{i}:{self._episode[i]}:{self.seed}"
             trace_id = uuid.uuid5(uuid.NAMESPACE_URL, key).hex
         else:
             trace_id = uuid.uuid4().hex

--- a/hud/utils/platform.py
+++ b/hud/utils/platform.py
@@ -10,8 +10,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlencode
+from uuid import UUID
 
 from hud.utils.requests import make_request, make_request_sync
+
+
+def canonical_record_id(record_id: str) -> str:
+    """Return the canonical UUID representation of a HUD record id."""
+    return str(UUID(record_id))
 
 
 @dataclass(frozen=True)

--- a/hud/utils/tests/test_platform.py
+++ b/hud/utils/tests/test_platform.py
@@ -7,7 +7,19 @@ from typing import Any
 import pytest
 
 from hud.utils.exceptions import HudAuthenticationError
-from hud.utils.platform import PlatformClient
+from hud.utils.platform import PlatformClient, canonical_record_id
+
+
+def test_canonical_record_id_accepts_uuid_and_compact_hex() -> None:
+    canonical = "03dd2a73-d3df-4d10-a54a-e3d87c2d530d"
+
+    assert canonical_record_id(canonical) == canonical
+    assert canonical_record_id(canonical.replace("-", "")) == canonical
+
+
+def test_canonical_record_id_rejects_non_uuid() -> None:
+    with pytest.raises(ValueError):
+        canonical_record_id("not-a-uuid")
 
 
 def test_url_prefixes_version_segment_and_joins_params() -> None:


### PR DESCRIPTION
## Summary

- add one canonical HUD record-ID formatter at the platform boundary
- use canonical lowercase UUIDs for every SDK-produced HUD job and trace web link
- canonicalize compact job IDs accepted by hud jobs before its API request and output
- preserve compact 32-character IDs for OpenTelemetry and internal reporting

## Why

HUD jobs and traces are UUID-backed records, but the SDK commonly mints their internal identities with uuid4().hex. Several CLI, evaluation, and robot-recorder paths interpolated that compact representation directly into web URLs. The trace command had its own conversion, while the other paths remained inconsistent.

## Verification

- uv run pytest hud/utils/tests/test_platform.py hud/cli/tests/test_trace.py hud/cli/tests/test_jobs.py hud/eval/tests/test_job.py -q (15 passed)
- uv run ruff format --check and uv run ruff check on all touched files
- uv run ty check on all touched implementation modules

The repository-wide ty check still encounters the existing hud/environment/robot/bridge.py:299 Iterable[socket] indexing diagnostic; no touched module reports a diagnostic.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting and ID normalization for URLs and one jobs API call; seeded trace IDs are explicitly preserved for backward compatibility.
> 
> **Overview**
> Introduces **`canonical_record_id`** in `hud.utils.platform` so compact 32-char hex and standard UUID strings normalize to hyphenated lowercase UUIDs.
> 
> **Web links** from the SDK now use that form everywhere: `hud eval` job URLs, `hud trace` “View” links (replacing ad-hoc `uuid.UUID`), and eval **`job_enter`** log lines. **`hud jobs <id>`** accepts compact IDs, canonicalizes before **`GET /jobs/{id}/traces`**, and prints canonical job links.
> 
> **Robot `JobRecorder`**: shared **`job_id`** is validated and stored canonically for **`job_url`** and platform **`/trace/job/...`** paths; non-UUID strings raise **`ValueError`**. Seeded deterministic trace IDs still key off the **original spelling** via **`_seed_job_id`**, so compact vs canonical job IDs keep their legacy trace-id behavior. API trace paths in reporting otherwise stay on existing compact hex where unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6d2e54e411cb073d0855462fcc4cc5c8371a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->