### PR TITLE
fix(agents): retry transient Claude stream failures

### DIFF
--- a/hud/agents/claude/agent.py
+++ b/hud/agents/claude/agent.py
@@ -59,6 +59,7 @@ _RETRYABLE_STREAM_ERROR_TYPES = frozenset(
         "gateway_timeout",
         "overloaded_error",
         "rate_limit_error",
+        "timeout_error",
         "upstream_error",
     }
 )

--- a/hud/agents/claude/agent.py
+++ b/hud/agents/claude/agent.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import json
 import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 import mcp.types as mcp_types
-from anthropic import AsyncAnthropic, AsyncAnthropicBedrock, Omit
+from anthropic import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AsyncAnthropic,
+    AsyncAnthropicBedrock,
+    Omit,
+)
 from anthropic.types import CacheControlEphemeralParam
 from anthropic.types.beta import (
     BetaBase64ImageSourceParam,
@@ -41,6 +49,18 @@ logger = logging.getLogger(__name__)
 
 ClaudeImageMediaType = Literal["image/jpeg", "image/png", "image/gif", "image/webp"]
 ClaudeToolResultContent = BetaTextBlockParam | BetaImageBlockParam | BetaRequestDocumentBlockParam
+
+_RETRYABLE_STREAM_ERROR_TYPES = frozenset(
+    {
+        "api_error",
+        "gateway_error",
+        "gateway_timeout",
+        "overloaded_error",
+        "rate_limit_error",
+        "upstream_error",
+    }
+)
+_STREAM_RETRY_DELAY_SECONDS = 1.0
 
 
 class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
@@ -168,6 +188,51 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
 
     # ─── Anthropic call ───────────────────────────────────────────────
 
+    async def _stream_response(
+        self,
+        client: AsyncAnthropic,
+        *,
+        messages: list[BetaMessageParam],
+        system: str | Omit,
+        tools: list[BetaToolUnionParam],
+        tool_choice: BetaToolChoiceAutoParam,
+        betas: list[str] | Omit,
+    ) -> BetaMessage:
+        retries = 0
+        while True:
+            stream_opened = False
+            try:
+                async with client.beta.messages.stream(
+                    model=self.config.model,
+                    system=system,
+                    max_tokens=self.config.max_tokens,
+                    messages=messages,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    betas=betas,
+                ) as stream:
+                    stream_opened = True
+                    async for _ in stream:
+                        pass
+                    return await stream.get_final_message()
+            except (APIConnectionError, APIStatusError, APITimeoutError) as exc:
+                inline_error = (
+                    isinstance(exc, APIStatusError)
+                    and exc.status_code == 200
+                    and exc.type in _RETRYABLE_STREAM_ERROR_TYPES
+                )
+                interrupted_stream = stream_opened and isinstance(
+                    exc,
+                    APIConnectionError | APITimeoutError,
+                )
+                if retries or not (inline_error or interrupted_stream):
+                    raise
+
+                retries += 1
+                error_type = exc.type if isinstance(exc, APIStatusError) else type(exc).__name__
+                logger.warning("Claude stream failed with %s; retrying once", error_type)
+                await asyncio.sleep(_STREAM_RETRY_DELAY_SECONDS)
+
     async def get_response(
         self,
         state: RunState[BetaMessageParam],
@@ -202,18 +267,14 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
                     )
                 else:
                     client = cast("AsyncAnthropic", self.anthropic_client)
-                    async with client.beta.messages.stream(
-                        model=self.config.model,
-                        system=system,
-                        max_tokens=self.config.max_tokens,
+                    response = await self._stream_response(
+                        client,
                         messages=messages_cached,
+                        system=system,
                         tools=tools,
                         tool_choice=tool_choice,
                         betas=betas,
-                    ) as stream:
-                        async for _ in stream:
-                            pass
-                        response = await stream.get_final_message()
+                    )
 
                 state.messages.append(
                     BetaMessageParam(role="assistant", content=response.content),

--- a/hud/agents/claude/agent.py
+++ b/hud/agents/claude/agent.py
@@ -9,6 +9,7 @@ import logging
 from typing import TYPE_CHECKING, Literal, cast
 
 import httpx
+import httpx2
 import mcp.types as mcp_types
 from anthropic import (
     APIConnectionError,
@@ -221,6 +222,7 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
                 APIStatusError,
                 APITimeoutError,
                 httpx.TransportError,
+                httpx2.TransportError,
             ) as exc:
                 inline_error = (
                     isinstance(exc, APIStatusError)
@@ -229,7 +231,10 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
                 )
                 interrupted_stream = stream_opened and isinstance(
                     exc,
-                    APIConnectionError | APITimeoutError | httpx.TransportError,
+                    APIConnectionError
+                    | APITimeoutError
+                    | httpx.TransportError
+                    | httpx2.TransportError,
                 )
                 if retries or not (inline_error or interrupted_stream):
                     raise

--- a/hud/agents/claude/agent.py
+++ b/hud/agents/claude/agent.py
@@ -8,6 +8,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Literal, cast
 
+import httpx
 import mcp.types as mcp_types
 from anthropic import (
     APIConnectionError,
@@ -215,7 +216,12 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
                     async for _ in stream:
                         pass
                     return await stream.get_final_message()
-            except (APIConnectionError, APIStatusError, APITimeoutError) as exc:
+            except (
+                APIConnectionError,
+                APIStatusError,
+                APITimeoutError,
+                httpx.TransportError,
+            ) as exc:
                 inline_error = (
                     isinstance(exc, APIStatusError)
                     and exc.status_code == 200
@@ -223,7 +229,7 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
                 )
                 interrupted_stream = stream_opened and isinstance(
                     exc,
-                    APIConnectionError | APITimeoutError,
+                    APIConnectionError | APITimeoutError | httpx.TransportError,
                 )
                 if retries or not (inline_error or interrupted_stream):
                     raise

--- a/hud/agents/tests/test_claude_agent.py
+++ b/hud/agents/tests/test_claude_agent.py
@@ -140,14 +140,16 @@ async def test_get_response_collects_thinking() -> None:
     assert result.reasoning == "pondering"
 
 
+@pytest.mark.parametrize("error_type", ["upstream_error", "timeout_error"])
 async def test_get_response_retries_transient_inline_stream_error(
     monkeypatch: pytest.MonkeyPatch,
+    error_type: str,
 ) -> None:
     final = _final(
         SimpleNamespace(type="text", text="recovered", citations=None),
         stop_reason="end_turn",
     )
-    agent = _agent(_inline_error("upstream_error"), final)
+    agent = _agent(_inline_error(error_type), final)
     state = _state(agent)
     sleep = AsyncMock()
     monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", sleep)

--- a/hud/agents/tests/test_claude_agent.py
+++ b/hud/agents/tests/test_claude_agent.py
@@ -9,6 +9,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import httpx
+import httpx2
 import pytest
 from anthropic import APIStatusError
 
@@ -175,17 +176,37 @@ async def test_get_response_raises_after_transient_stream_retry_is_exhausted(
     assert len(state.messages) == 1
 
 
-@pytest.mark.parametrize("error_type", [httpx.ReadError, httpx.ReadTimeout])
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.ReadError(
+            "stream interrupted",
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+        ),
+        httpx.ReadTimeout(
+            "stream interrupted",
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+        ),
+        httpx2.ReadError(
+            "stream interrupted",
+            request=httpx2.Request("POST", "https://api.anthropic.com/v1/messages"),
+        ),
+        httpx2.ReadTimeout(
+            "stream interrupted",
+            request=httpx2.Request("POST", "https://api.anthropic.com/v1/messages"),
+        ),
+    ],
+    ids=["httpx-read-error", "httpx-read-timeout", "httpx2-read-error", "httpx2-read-timeout"],
+)
 async def test_get_response_retries_interrupted_stream(
     monkeypatch: pytest.MonkeyPatch,
-    error_type: type[httpx.TransportError],
+    error: httpx.TransportError | httpx2.TransportError,
 ) -> None:
-    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
     final = _final(
         SimpleNamespace(type="text", text="recovered", citations=None),
         stop_reason="end_turn",
     )
-    agent = _agent(error_type("stream interrupted", request=request), final)
+    agent = _agent(error, final)
     state = _state(agent)
     monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", AsyncMock())
 

--- a/hud/agents/tests/test_claude_agent.py
+++ b/hud/agents/tests/test_claude_agent.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock
 
 import httpx
 import pytest
-from anthropic import APIConnectionError, APIStatusError
+from anthropic import APIStatusError
 
 from hud.agents.claude.agent import ClaudeAgent
 
@@ -175,13 +175,17 @@ async def test_get_response_raises_after_transient_stream_retry_is_exhausted(
     assert len(state.messages) == 1
 
 
-async def test_get_response_retries_interrupted_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("error_type", [httpx.ReadError, httpx.ReadTimeout])
+async def test_get_response_retries_interrupted_stream(
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[httpx.TransportError],
+) -> None:
     request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
     final = _final(
         SimpleNamespace(type="text", text="recovered", citations=None),
         stop_reason="end_turn",
     )
-    agent = _agent(APIConnectionError(request=request), final)
+    agent = _agent(error_type("stream interrupted", request=request), final)
     state = _state(agent)
     monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", AsyncMock())
 

--- a/hud/agents/tests/test_claude_agent.py
+++ b/hud/agents/tests/test_claude_agent.py
@@ -6,13 +6,18 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from anthropic import APIConnectionError, APIStatusError
 
 from hud.agents.claude.agent import ClaudeAgent
 
 
 class FakeStream:
-    def __init__(self, final: Any) -> None:
-        self._final = final
+    def __init__(self, outcome: Any) -> None:
+        self._outcome = outcome
 
     async def __aenter__(self) -> FakeStream:
         return self
@@ -24,23 +29,28 @@ class FakeStream:
         return self
 
     async def __anext__(self) -> Any:
+        if isinstance(self._outcome, BaseException):
+            raise self._outcome
         raise StopAsyncIteration
 
     async def get_final_message(self) -> Any:
-        return self._final
+        return self._outcome
 
 
 class FakeMessages:
-    def __init__(self, final: Any) -> None:
-        self._final = final
+    def __init__(self, *outcomes: Any) -> None:
+        self._outcomes = list(outcomes)
+        self.calls = 0
 
     def stream(self, **_kwargs: Any) -> FakeStream:
-        return FakeStream(self._final)
+        outcome = self._outcomes[self.calls]
+        self.calls += 1
+        return FakeStream(outcome)
 
 
 class FakeAnthropic:
-    def __init__(self, final: Any) -> None:
-        self.beta = SimpleNamespace(messages=FakeMessages(final))
+    def __init__(self, *outcomes: Any) -> None:
+        self.beta = SimpleNamespace(messages=FakeMessages(*outcomes))
 
 
 def _final(*content: Any, stop_reason: str) -> Any:
@@ -53,11 +63,11 @@ def _final(*content: Any, stop_reason: str) -> Any:
     )
 
 
-def _agent(final: Any) -> ClaudeAgent:
+def _agent(*outcomes: Any) -> ClaudeAgent:
     from hud.agents.types import ClaudeConfig
 
     return ClaudeAgent(
-        ClaudeConfig(model="claude-test", max_tokens=1024, model_client=FakeAnthropic(final))
+        ClaudeConfig(model="claude-test", max_tokens=1024, model_client=FakeAnthropic(*outcomes))
     )
 
 
@@ -65,6 +75,15 @@ def _state(agent: ClaudeAgent) -> Any:
     from hud.agents.tool_agent import RunState
 
     return RunState(messages=[agent._format_message("user", "go")])
+
+
+def _inline_error(type_: str) -> APIStatusError:
+    body = {"type": "error", "error": {"type": type_, "message": "stream failed"}}
+    response = httpx.Response(
+        200,
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+    )
+    return APIStatusError(str(body), response=response, body=body)
 
 
 def test_format_message_shape() -> None:
@@ -118,6 +137,77 @@ async def test_get_response_collects_thinking() -> None:
     agent = _agent(final)
     result = await agent.get_response(_state(agent))
     assert result.reasoning == "pondering"
+
+
+async def test_get_response_retries_transient_inline_stream_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    final = _final(
+        SimpleNamespace(type="text", text="recovered", citations=None),
+        stop_reason="end_turn",
+    )
+    agent = _agent(_inline_error("upstream_error"), final)
+    state = _state(agent)
+    sleep = AsyncMock()
+    monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", sleep)
+
+    result = await agent.get_response(state)
+
+    messages = cast("FakeMessages", cast("Any", agent.anthropic_client).beta.messages)
+    assert messages.calls == 2
+    assert result.content == "recovered"
+    assert len(state.messages) == 2
+    sleep.assert_awaited_once_with(1.0)
+
+
+async def test_get_response_raises_after_transient_stream_retry_is_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _agent(_inline_error("gateway_timeout"), _inline_error("gateway_timeout"))
+    state = _state(agent)
+    monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", AsyncMock())
+
+    with pytest.raises(APIStatusError, match="gateway_timeout"):
+        await agent.get_response(state)
+
+    messages = cast("FakeMessages", cast("Any", agent.anthropic_client).beta.messages)
+    assert messages.calls == 2
+    assert len(state.messages) == 1
+
+
+async def test_get_response_retries_interrupted_stream(monkeypatch: pytest.MonkeyPatch) -> None:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    final = _final(
+        SimpleNamespace(type="text", text="recovered", citations=None),
+        stop_reason="end_turn",
+    )
+    agent = _agent(APIConnectionError(request=request), final)
+    state = _state(agent)
+    monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", AsyncMock())
+
+    result = await agent.get_response(state)
+
+    messages = cast("FakeMessages", cast("Any", agent.anthropic_client).beta.messages)
+    assert messages.calls == 2
+    assert result.content == "recovered"
+    assert len(state.messages) == 2
+
+
+async def test_get_response_does_not_retry_non_transient_inline_stream_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent = _agent(_inline_error("invalid_request_error"))
+    state = _state(agent)
+    sleep = AsyncMock()
+    monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", sleep)
+
+    with pytest.raises(APIStatusError, match="invalid_request_error"):
+        await agent.get_response(state)
+
+    messages = cast("FakeMessages", cast("Any", agent.anthropic_client).beta.messages)
+    assert messages.calls == 1
+    assert len(state.messages) == 1
+    sleep.assert_not_awaited()
 
 
 def test_citation_char_location() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ license = { file = "LICENSE" }
 dependencies = [
     # Core dependencies - minimal for MCP servers and CLI
     "httpx>=0.23.0,<1",
+    "httpx2>=2.0.0,<3",
     "packaging>=21.0",
     "pydantic>=2.10,<3",
     "pydantic-settings>=2.2,<3",


### PR DESCRIPTION
## Summary

- replay an unchanged Claude model turn once when an established Anthropic stream reports a transient inline error or transport interruption
- keep malformed tool JSON recovery separate from stream transport retry policy
- propagate non-transient and repeated failures without appending partial assistant state

## Tests

- agent suite: 157 passed
- full default suite: 1124 passed; the 3 tests requiring the optional Modal dependency also pass with the modal extra installed
- ruff format --check
- ruff check
- repository-wide ty check with dev, train, modal, and daytona extras

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live on the critical agent inference path and alter failure/retry behavior, but scope is limited to one automatic retry with unchanged message state on failure.
> 
> **Overview**
> **Claude streaming** now goes through `_stream_response`, which **replays the same model turn once** after a 1s pause when the stream fails in a recoverable way.
> 
> Retries apply to Anthropic **inline stream errors** (HTTP 200 with types like `rate_limit_error`, `gateway_timeout`, `upstream_error`) and to **mid-stream transport failures** after the stream has opened (`APIConnectionError`, timeouts, and `httpx` / `httpx2` transport errors). Non-retryable inline errors, failures before the stream opens, and a second failure still propagate without appending a partial assistant message. Existing **invalid tool JSON** retry behavior in `get_response` is unchanged.
> 
> Tests use multi-outcome fakes to cover success-after-retry, exhausted retry, transport interruption, and no-retry on `invalid_request_error`. **`httpx2`** is added as a core dependency so transport errors from either HTTP stack are handled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a66878cedbab7610762f854874a74fcc185db38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->