### PR TITLE
release: 0.6.16.dev3

### DIFF
--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.16.dev2"
+__version__ = "0.6.16.dev3"


### PR DESCRIPTION
## Summary

Bump the HUD SDK package version from `0.6.16.dev2` to `0.6.16.dev3` for a prerelease containing the merged Claude stream-retry fix.

## Verification

- `UV_CACHE_DIR=/private/tmp/hud-python-release-dev3-cache uv build --wheel --out-dir /private/tmp/hud-python-release-dev3-dist`
- built `hud-0.6.16.dev3-py3-none-any.whl`
- wheel metadata reports `Version: 0.6.16.dev3`

After merge, publish GitHub prerelease `v0.6.16.dev3`; the release workflow will build and publish the `hud` package to PyPI. Prerelease publication does not move the stable `docs` branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant change with no runtime or security impact.
> 
> **Overview**
> Bumps the package version in `hud/version.py` from **`0.6.16.dev2`** to **`0.6.16.dev3`** for the next dev prerelease (including the merged Claude stream-retry fix).
> 
> After merge, the intended follow-up is publishing GitHub prerelease **`v0.6.16.dev3`** so the release workflow can build and ship the **`hud`** wheel to PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a44eff01da2e649066f59ff03c3475f858a786a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->