### PR TITLE
Propagate nested rollout trace lineage

### DIFF
--- a/hud/agents/claude/sdk/agent.py
+++ b/hud/agents/claude/sdk/agent.py
@@ -10,6 +10,7 @@ Inspired by harbor-framework/harbor's ClaudeCode agent.
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import shlex
@@ -20,6 +21,7 @@ from typing import TYPE_CHECKING, Any, cast
 from hud.agents.base import Agent
 from hud.agents.types import AgentStep, ClaudeSDKConfig, Usage
 from hud.settings import settings
+from hud.telemetry.context import get_current_trace_id, get_trace_headers
 from hud.types import Step
 
 if TYPE_CHECKING:
@@ -83,6 +85,7 @@ class ClaudeSDKAgent(Agent):
 
     async def __call__(self, run: Run) -> None:
         mcp_servers: dict[str, dict[str, Any]] = {}
+        trace_id = get_current_trace_id()
         manifest = run.client.manifest
         bindings = manifest.bindings if manifest is not None else []
         families = {c.protocol.split("/", 1)[0] for c in bindings}
@@ -100,8 +103,11 @@ class ClaudeSDKAgent(Agent):
                     token = cap.params.get("auth_token")
                     transport = "http" if cap.params["transport"] == "streamable-http" else "sse"
                     server_config: dict[str, Any] = {"type": transport, "url": cap.url}
+                    headers = {"Trace-Id": trace_id} if trace_id is not None else {}
                     if token:
-                        server_config["headers"] = {"Authorization": f"Bearer {token}"}
+                        headers["Authorization"] = f"Bearer {token}"
+                    if headers:
+                        server_config["headers"] = headers
                     if cap.name in mcp_servers:
                         raise RuntimeError(f"duplicate MCP server name {cap.name!r}")
                     mcp_servers[cap.name] = server_config
@@ -188,6 +194,11 @@ class ClaudeSDKAgent(Agent):
         if settings.api_key:
             env["ANTHROPIC_BASE_URL"] = settings.hud_gateway_url
             env["ANTHROPIC_API_KEY"] = settings.api_key
+            trace_headers = get_trace_headers()
+            if trace_headers:
+                env["ANTHROPIC_CUSTOM_HEADERS"] = "\n".join(
+                    f"{name}: {value}" for name, value in trace_headers.items()
+                )
         elif settings.anthropic_api_key:
             env["ANTHROPIC_API_KEY"] = settings.anthropic_api_key
 
@@ -259,16 +270,18 @@ class ClaudeSDKAgent(Agent):
             # Solution: use `cmd /c claude [args]` (no inline prompt) and feed the
             # prompt via stdin from .hud_prompt.txt. claude --print reads stdin as
             # the initial message when no -- argument is provided.
-            set_parts = [f"set {k}={v}" for k, v in env_vars.items()]
             cmd_args = ["cmd", "/c", "claude"] + base_args[1:]  # noqa: RUF005
             py_args_repr = "[" + ",".join(f"'{a}'" for a in cmd_args) + "]"
+            encoded_env = base64.b64encode(json.dumps(env_vars).encode()).decode()
             python_launcher = (
                 'python -c "'
-                "import subprocess,sys;"
-                f"r=subprocess.run({py_args_repr},stdin=open('.hud_prompt.txt','rb'));"
+                "import base64,json,os,subprocess,sys;"
+                "env=os.environ.copy();"
+                f"env.update(json.loads(base64.b64decode('{encoded_env}')));"
+                f"r=subprocess.run({py_args_repr},stdin=open('.hud_prompt.txt','rb'),env=env);"
                 'sys.exit(r.returncode)"'
             )
-            return " && ".join([*set_parts, python_launcher])
+            return python_launcher
 
         # POSIX path: shell-quote everything and embed prompt inline.
         cli_parts = [shlex.quote(a) for a in base_args]

--- a/hud/agents/tests/test_claude_sdk_agent.py
+++ b/hud/agents/tests/test_claude_sdk_agent.py
@@ -26,6 +26,8 @@ from hud.agents.claude.sdk.agent import ClaudeSDKAgent, build_remote_invocation
 from hud.agents.types import ClaudeSDKConfig
 from hud.capabilities import Capability, SSHClient
 from hud.capabilities.rfb import WebPScreenshotEncoding
+from hud.settings import settings
+from hud.telemetry.context import set_trace_context
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -50,6 +52,20 @@ def test_posix_shell_runs_inline_with_install_check() -> None:
     assert inv.script_body is None
     assert "install.sh" in inv.command  # one-shot bootstrap prefix
     assert inv.command.endswith(" && claude --print -- hi")
+
+
+def test_gateway_trace_headers_are_forwarded_to_claude_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "api_key", "test-key")
+    agent = ClaudeSDKAgent()
+
+    with set_trace_context("child-trace", parent_trace_id="parent-trace"):
+        env = agent._build_env_vars()
+
+    assert env["ANTHROPIC_CUSTOM_HEADERS"] == (
+        "Trace-Id: child-trace\nX-HUD-Parent-Trace-Id: parent-trace"
+    )
 
 
 # ─── _exec end-to-end over a fake SSH workspace ────────────────────────
@@ -246,17 +262,22 @@ async def test_manifest_mcp_capability_is_written_for_remote_claude(
     execute = AsyncMock()
     monkeypatch.setattr(agent, "_exec", execute)
 
-    await agent(
-        cast(
-            "Any",
-            SimpleNamespace(client=Client(), prompt_text="call the tool"),
+    with set_trace_context("child-trace"):
+        await agent(
+            cast(
+                "Any",
+                SimpleNamespace(client=Client(), prompt_text="call the tool"),
+            )
         )
-    )
 
     await_args = execute.await_args
     assert await_args is not None
     assert await_args.kwargs["mcp_servers"] == {
-        "database": {"type": claude_type, "url": "http://database:8000/mcp"}
+        "database": {
+            "type": claude_type,
+            "url": "http://database:8000/mcp",
+            "headers": {"Trace-Id": "child-trace"},
+        }
     }
     execute.assert_awaited_once()
 

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -7,6 +7,7 @@ scripted ``get_response`` so the loop, dispatch, and message formatting run offl
 from __future__ import annotations
 
 import asyncio
+from contextlib import AsyncExitStack
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Literal, cast
 from unittest.mock import AsyncMock, Mock
@@ -25,9 +26,17 @@ from hud.agents.tools.base import AgentToolSpec, result_text
 from hud.agents.tools.rfb import RFBTool
 from hud.agents.tools.ssh import SSHInfrastructureErrorResult
 from hud.agents.types import AgentConfig, AgentStep, ClaudeConfig, ClaudeSDKConfig, ToolStep
-from hud.capabilities import Capability, CapabilityClient, MCPClient, RFBClient, SSHClient
+from hud.capabilities import (
+    Capability,
+    CapabilityClient,
+    MCPClient,
+    RFBClient,
+    SSHClient,
+)
+from hud.capabilities.mcp import get_mcp_trace_id
 from hud.capabilities.rfb import PngScreenshotEncoding, WebPScreenshotEncoding
 from hud.capabilities.ssh import SSHConnectionError
+from hud.telemetry.context import set_trace_context
 from hud.types import MCPToolCall, MCPToolResult, Step, Trace
 
 if TYPE_CHECKING:
@@ -251,6 +260,57 @@ async def test_mcp_client_uses_the_declared_http_transport(
     await client.close()
 
     assert isinstance(transports[0], expected_type)
+
+
+async def test_mcp_client_propagates_active_trace_context() -> None:
+    calls: list[dict[str, Any]] = []
+
+    class Client:
+        async def call_tool_mcp(self, **kwargs: Any) -> mcp_types.CallToolResult:
+            calls.append(kwargs)
+            return mcp_types.CallToolResult(content=[])
+
+    capability = Capability.mcp(url="https://tools.example/mcp")
+    client = MCPClient(capability, cast("Any", Client()), AsyncExitStack())
+
+    with set_trace_context("child-trace"):
+        await client.call_tool("verify", {})
+
+    assert calls == [
+        {
+            "name": "verify",
+            "arguments": {},
+            "meta": {"hud/trace-id": "child-trace"},
+        }
+    ]
+
+
+def test_mcp_server_reads_propagated_trace_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    request_context = SimpleNamespace(
+        meta=SimpleNamespace(model_extra={"hud/trace-id": "child-trace"})
+    )
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_context",
+        lambda: SimpleNamespace(request_context=request_context),
+    )
+
+    assert get_mcp_trace_id() == "child-trace"
+
+
+def test_mcp_server_reads_propagated_trace_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    request_context = SimpleNamespace(meta=SimpleNamespace(model_extra={}))
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_context",
+        lambda: SimpleNamespace(request_context=request_context),
+    )
+    monkeypatch.setattr(
+        "fastmcp.server.dependencies.get_http_headers",
+        lambda: {
+            "trace-id": "child-trace",
+        },
+    )
+
+    assert get_mcp_trace_id() == "child-trace"
 
 
 async def test_multiple_mcp_capabilities_qualify_tool_names() -> None:

--- a/hud/capabilities/mcp.py
+++ b/hud/capabilities/mcp.py
@@ -14,12 +14,35 @@ import fastmcp
 from fastmcp.client.auth import BearerAuth
 from fastmcp.client.transports import SSETransport, StreamableHttpTransport
 
+from hud.telemetry.context import get_current_trace_id
+
 from .base import Capability, CapabilityClient
 
 if TYPE_CHECKING:
     import mcp.types as mcp_types
 
     from hud.types import MCPToolResult
+
+_TRACE_ID_META_KEY = "hud/trace-id"
+
+
+def get_mcp_trace_id() -> str | None:
+    """Get the trace ID propagated with the active inbound MCP request."""
+    from fastmcp.server.dependencies import get_context, get_http_headers
+
+    try:
+        context = get_context()
+    except RuntimeError:
+        return None
+    request_context = context.request_context
+    meta = request_context.meta if request_context else None
+    extra = (meta.model_extra or {}) if meta else {}
+    trace_id = extra.get(_TRACE_ID_META_KEY)
+    if trace_id is None:
+        trace_id = get_http_headers().get("trace-id")
+    if trace_id is not None and not isinstance(trace_id, str):
+        raise TypeError(f"{_TRACE_ID_META_KEY} must be a string")
+    return trace_id
 
 
 class MCPClient(CapabilityClient):
@@ -65,7 +88,9 @@ class MCPClient(CapabilityClient):
         """
         from hud.types import MCPToolResult as _Result
 
-        raw = await self._client.call_tool_mcp(name=name, arguments=arguments)
+        trace_id = get_current_trace_id()
+        meta = {_TRACE_ID_META_KEY: trace_id} if trace_id is not None else None
+        raw = await self._client.call_tool_mcp(name=name, arguments=arguments, meta=meta)
         data = raw.model_dump()
         if "isError" not in data and "is_error" in data:
             data["isError"] = data.pop("is_error")
@@ -78,4 +103,4 @@ class MCPClient(CapabilityClient):
         await self._exit_stack.aclose()
 
 
-__all__ = ["MCPClient"]
+__all__ = ["MCPClient", "get_mcp_trace_id"]

--- a/hud/eval/job.py
+++ b/hud/eval/job.py
@@ -130,6 +130,7 @@ async def trace_enter(
     group_id: str | None,
     task_slug: str,
     model: str | None = None,
+    parent_trace_id: str | None = None,
 ) -> None:
     """Report that one rollout started.
 
@@ -147,6 +148,7 @@ async def trace_enter(
             "group_id": group_id,
             "task_slug": task_slug,
             "model": model,
+            "parent_trace_id": parent_trace_id,
         },
     )
 

--- a/hud/eval/run.py
+++ b/hud/eval/run.py
@@ -30,9 +30,11 @@ from typing import TYPE_CHECKING, Any, Literal, Self, cast
 
 import mcp.types as mcp_types
 
+from hud.capabilities.mcp import get_mcp_trace_id
 from hud.clients import HudProtocolError, connect
 from hud.graders.results import SubScore
-from hud.telemetry.context import set_trace_context
+from hud.telemetry.context import get_current_trace_id, set_trace_context
+from hud.telemetry.span import normalize_trace_id
 from hud.types import Step, TaskCall, Trace
 from hud.utils.time import now_iso
 
@@ -488,6 +490,11 @@ async def rollout(
         job_id = uuid.uuid4().hex
         await job_enter(job_id, name=task.id, group=1)
     trace_id = trace_id or uuid.uuid4().hex
+    parent_trace_id = get_current_trace_id() or get_mcp_trace_id()
+    if parent_trace_id is not None and normalize_trace_id(parent_trace_id) == normalize_trace_id(
+        trace_id
+    ):
+        parent_trace_id = None
     # Report the model the agent will sample so the platform attributes the
     # trace to it on enter. Only LLM tool agents carry an inference-model slug
     # (``config.model``); robot/other agents have none. Local import avoids an
@@ -495,13 +502,14 @@ async def rollout(
     from hud.agents.tool_agent import ToolAgent
 
     agent_model = agent.config.model if isinstance(agent, ToolAgent) else None
-    with set_trace_context(trace_id):
+    with set_trace_context(trace_id, parent_trace_id=parent_trace_id):
         await trace_enter(
             trace_id,
             job_id=job_id,
             group_id=group_id,
             task_slug=task.slug,
             model=agent_model,
+            parent_trace_id=parent_trace_id,
         )
         run: Run | None = None
         _phase = "provisioning"

--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -8,9 +8,12 @@ import uuid
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from hud.capabilities.mcp import get_mcp_trace_id
 from hud.eval.run import Grade, Run, validate_rollout_timeouts
+from hud.telemetry.context import get_current_trace_id
+from hud.telemetry.span import normalize_trace_id
 from hud.types import Step
-from hud.utils.platform import PlatformClient
+from hud.utils.platform import PlatformClient, canonical_record_id
 
 if TYPE_CHECKING:
     from hud.agents.base import Agent
@@ -70,6 +73,16 @@ class HostedRuntime:
         local cancel propagate after requesting remote cancellation.
         """
         trace_id = trace_id or uuid.uuid4().hex
+        parent_trace_id = get_current_trace_id() or get_mcp_trace_id()
+        if parent_trace_id is not None and normalize_trace_id(
+            parent_trace_id
+        ) == normalize_trace_id(trace_id):
+            parent_trace_id = None
+        if parent_trace_id is not None:
+            try:
+                parent_trace_id = canonical_record_id(parent_trace_id)
+            except ValueError:
+                parent_trace_id = None
         timeout = self.run_timeout if rollout_timeout is None else rollout_timeout
         validate_rollout_timeouts(
             task,
@@ -83,12 +96,22 @@ class HostedRuntime:
         try:
             if timeout is None:
                 state = await self._submit_and_await(
-                    task, agent, job_id=job_id, group_id=group_id, trace_id=trace_id
+                    task,
+                    agent,
+                    job_id=job_id,
+                    group_id=group_id,
+                    trace_id=trace_id,
+                    parent_trace_id=parent_trace_id,
                 )
             else:
                 async with asyncio.timeout(timeout):
                     state = await self._submit_and_await(
-                        task, agent, job_id=job_id, group_id=group_id, trace_id=trace_id
+                        task,
+                        agent,
+                        job_id=job_id,
+                        group_id=group_id,
+                        trace_id=trace_id,
+                        parent_trace_id=parent_trace_id,
                     )
         except asyncio.CancelledError:
             self._cancel_later(trace_id)
@@ -118,6 +141,7 @@ class HostedRuntime:
         job_id: str,
         group_id: str | None,
         trace_id: str,
+        parent_trace_id: str | None,
     ) -> dict[str, Any]:
         from hud.agents.tool_agent import ToolAgent
 
@@ -147,6 +171,8 @@ class HostedRuntime:
         }
         if group_id is not None:
             payload["group_id"] = group_id
+        if parent_trace_id is not None:
+            payload["parent_trace_id"] = parent_trace_id
         if task.runtime_config is not None:
             runtime_config = task.runtime_config.model_dump(mode="json", exclude_unset=True)
             if runtime_config:

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -199,6 +199,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     hosted = HostedRuntime(poll_interval=0.0)
     trace_id = uuid.uuid4().hex
     job_id = uuid.uuid4().hex
+    parent_trace_id = uuid.uuid4().hex
     task = Task(
         env="sums",
         id="add",
@@ -218,7 +219,8 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
         ),
     )
 
-    run = await hosted.run(task, _agent(), job_id=job_id, group_id="g1", trace_id=trace_id)
+    with set_trace_context(parent_trace_id):
+        run = await hosted.run(task, _agent(), job_id=job_id, group_id="g1", trace_id=trace_id)
 
     assert run.reward == 0.5
     assert run.trace.status == "completed"
@@ -231,6 +233,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     # Hex ids travel as canonical UUID strings.
     assert payload["trace_id"] == str(uuid.UUID(trace_id))
     assert payload["job_id"] == str(uuid.UUID(job_id))
+    assert payload["parent_trace_id"] == str(uuid.UUID(parent_trace_id))
     assert payload["env"] == "sums"
     assert payload["task"] == "add"
     assert payload["slug"] == "sums-add"
@@ -270,6 +273,47 @@ async def test_run_preserves_runtime_config_null_override(
     )
 
     assert platform.posts[0][1]["runtime_config"] == {"resources": None}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("parent_trace_id", "trace_id"),
+    [
+        ("external-run-id", "00000000000000000000000000000001"),
+        (
+            "00000000-0000-0000-0000-000000000001",
+            "00000000000000000000000000000001",
+        ),
+        (
+            "{00000000-0000-0000-0000-000000000001}",
+            "00000000000000000000000000000001",
+        ),
+        (
+            "urn:uuid:00000000-0000-0000-0000-000000000001",
+            "00000000000000000000000000000001",
+        ),
+    ],
+)
+async def test_run_omits_unusable_parent_trace_id(
+    monkeypatch: pytest.MonkeyPatch,
+    parent_trace_id: str,
+    trace_id: str,
+) -> None:
+    platform = _FakePlatform([{"status": "completed", "reward": 0.5}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+
+    with set_trace_context(parent_trace_id):
+        run = await HostedRuntime(poll_interval=0.0).run(
+            Task(env="sums", id="add"),
+            _agent(),
+            job_id=uuid.uuid4().hex,
+            trace_id=trace_id,
+        )
+
+    assert run.trace.status == "completed"
+    assert "parent_trace_id" not in platform.posts[0][1]
 
 
 @pytest.mark.asyncio

--- a/hud/eval/tests/test_job.py
+++ b/hud/eval/tests/test_job.py
@@ -54,6 +54,7 @@ async def test_trace_enter_reports_task_and_group_identity(recorder: _Recorder) 
         group_id="group-1",
         task_slug="fix-bug-3",
         model="test-model",
+        parent_trace_id="parent-1",
     )
 
     assert recorder.calls == [
@@ -64,6 +65,7 @@ async def test_trace_enter_reports_task_and_group_identity(recorder: _Recorder) 
                 "group_id": "group-1",
                 "task_slug": "fix-bug-3",
                 "model": "test-model",
+                "parent_trace_id": "parent-1",
             },
         )
     ]

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -28,12 +28,14 @@ import mcp.types as mcp_types
 import pytest
 from pydantic import BaseModel
 
+import hud.eval.run as run_module
 from hud.agents.base import Agent
 from hud.agents.openai_compatible import OpenAIChatAgent
 from hud.agents.types import OpenAIChatConfig
 from hud.environment import Answer, Environment
 from hud.eval import Job, LocalRuntime, Runtime, SubprocessRuntime, Task, Taskset
 from hud.eval.run import Run, rollout
+from hud.telemetry.context import get_current_trace_id, get_trace_headers, set_trace_context
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -1277,6 +1279,62 @@ async def test_rollout_threads_job_and_group_ids(env_file: Path) -> None:
     assert run.reward == 1.0
     assert run.job_id == "j1"
     assert run.group_id == "g1"
+
+
+@pytest.mark.parametrize(
+    ("ambient_trace_id", "trace_id", "expected_parent_trace_id"),
+    [
+        ("parent-trace", "child-trace", "parent-trace"),
+        (
+            "00000000-0000-0000-0000-000000000001",
+            "00000000000000000000000000000001",
+            None,
+        ),
+    ],
+)
+async def test_nested_rollout_binds_child_and_parent_trace_context(
+    monkeypatch: pytest.MonkeyPatch,
+    ambient_trace_id: str,
+    trace_id: str,
+    expected_parent_trace_id: str | None,
+) -> None:
+    entered: dict[str, Any] = {}
+    active: dict[str, str | None] = {}
+    env = Environment("nested")
+
+    @env.template(id="add")
+    async def add(a: int, b: int):
+        answer = yield f"add:{a}:{b}"
+        yield 1.0 if answer == str(a + b) else 0.0
+
+    async def capture_enter(trace_id: str, **kwargs: Any) -> None:
+        entered["trace_id"] = trace_id
+        entered.update(kwargs)
+
+    class ContextAgent(Agent):
+        async def __call__(self, run: Run) -> None:
+            active["trace_id"] = get_current_trace_id()
+            active["parent_trace_id"] = get_trace_headers().get("X-HUD-Parent-Trace-Id")
+            run.trace.content = "2"
+
+    monkeypatch.setattr(run_module, "trace_enter", capture_enter)
+
+    with set_trace_context(ambient_trace_id):
+        run = await rollout(
+            Task(env="nested", id="add", args={"a": 1, "b": 1}),
+            ContextAgent(),
+            runtime=LocalRuntime(env),
+            job_id="job-1",
+            trace_id=trace_id,
+        )
+
+    assert run.trace_id == trace_id
+    assert active == {
+        "trace_id": trace_id,
+        "parent_trace_id": expected_parent_trace_id,
+    }
+    assert entered["trace_id"] == trace_id
+    assert entered["parent_trace_id"] == expected_parent_trace_id
 
 
 # ─── Run prompt views (what agents consume) ───────────────────────────

--- a/hud/telemetry/context.py
+++ b/hud/telemetry/context.py
@@ -14,27 +14,37 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-# Current trace headers (for span attribution via @instrument).
 _current_trace_headers: contextvars.ContextVar[dict[str, str] | None] = contextvars.ContextVar(
     "current_trace_headers", default=None
 )
 
 
 def get_current_trace_id() -> str | None:
-    """Get the current trace ID (task_run_id) from context, or None.
-
-    Used by ``@instrument`` to know where to send telemetry.
-    """
+    """Get the current trace ID (task_run_id) from context, or None."""
     headers = _current_trace_headers.get()
-    if headers:
-        return headers.get("Trace-Id")
-    return None
+    return headers.get("Trace-Id") if headers else None
+
+
+def get_trace_headers() -> dict[str, str]:
+    """Get the active trace headers."""
+    headers = _current_trace_headers.get()
+    if headers is not None:
+        return dict(headers)
+    trace_id = get_current_trace_id()
+    return {"Trace-Id": trace_id} if trace_id is not None else {}
 
 
 @contextmanager
-def set_trace_context(trace_id: str) -> Generator[None, None, None]:
-    """Temporarily bind ``trace_id`` as the active trace (for span attribution)."""
-    token = _current_trace_headers.set({"Trace-Id": trace_id})
+def set_trace_context(
+    trace_id: str,
+    *,
+    parent_trace_id: str | None = None,
+) -> Generator[None, None, None]:
+    """Temporarily bind an active trace and its immediate parent."""
+    headers = {"Trace-Id": trace_id}
+    if parent_trace_id is not None:
+        headers["X-HUD-Parent-Trace-Id"] = parent_trace_id
+    token = _current_trace_headers.set(headers)
     try:
         yield
     finally:
@@ -43,5 +53,6 @@ def set_trace_context(trace_id: str) -> Generator[None, None, None]:
 
 __all__ = [
     "get_current_trace_id",
+    "get_trace_headers",
     "set_trace_context",
 ]

--- a/hud/telemetry/span.py
+++ b/hud/telemetry/span.py
@@ -69,15 +69,10 @@ def new_span_id() -> str:
 
 def normalize_trace_id(trace_id: str) -> str:
     """Map an arbitrary run identifier onto a 32-hex OTel trace id."""
-    clean = trace_id.replace("-", "")
-    if len(clean) == 32:
-        try:
-            int(clean, 16)
-        except ValueError:
-            pass
-        else:
-            return clean.lower()
-    return uuid.uuid5(uuid.NAMESPACE_URL, f"hud.task_run:{trace_id}").hex
+    try:
+        return uuid.UUID(trace_id).hex
+    except ValueError:
+        return uuid.uuid5(uuid.NAMESPACE_URL, f"hud.task_run:{trace_id}").hex
 
 
 __all__ = [

--- a/hud/utils/gateway.py
+++ b/hud/utils/gateway.py
@@ -15,7 +15,7 @@ from openai import AsyncOpenAI, DefaultAsyncHttpxClient
 from pydantic import BaseModel, Field
 
 from hud.settings import settings
-from hud.telemetry.context import get_current_trace_id
+from hud.telemetry.context import get_trace_headers
 from hud.utils.exceptions import HudAuthenticationError
 from hud.utils.platform import PlatformClient
 
@@ -61,9 +61,7 @@ _MODEL_ALIASES: dict[str, str] = {
 
 
 def _inject_trace_id(request: httpx.Request) -> None:
-    trace_id = get_current_trace_id()
-    if trace_id is not None:
-        request.headers["Trace-Id"] = trace_id
+    request.headers.update(get_trace_headers())
 
 
 async def _inject_trace_id_async(request: httpx.Request) -> None:

--- a/hud/utils/tests/test_gateway.py
+++ b/hud/utils/tests/test_gateway.py
@@ -97,6 +97,38 @@ async def test_openai_client_trace_context_overrides_empty_header(
 
 
 @pytest.mark.asyncio
+async def test_openai_client_sends_child_and_parent_trace_ids(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen_headers: dict[str, str] = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers["Trace-Id"] = request.headers["Trace-Id"]
+        seen_headers["X-HUD-Parent-Trace-Id"] = request.headers["X-HUD-Parent-Trace-Id"]
+        return httpx.Response(200, json={"object": "list", "data": []})
+
+    transport = httpx.MockTransport(handler)
+    real_client_factory = gateway.DefaultAsyncHttpxClient
+    monkeypatch.setattr(
+        gateway,
+        "DefaultAsyncHttpxClient",
+        partial(real_client_factory, transport=transport),
+    )
+    client = cast("AsyncOpenAI", gateway.build_gateway_client("openai"))
+
+    try:
+        with set_trace_context("child", parent_trace_id="parent"):
+            await client.get("/models/nested", cast_to=object)
+    finally:
+        await client.close()
+
+    assert seen_headers == {
+        "Trace-Id": "child",
+        "X-HUD-Parent-Trace-Id": "parent",
+    }
+
+
+@pytest.mark.asyncio
 async def test_anthropic_client_receives_trace_aware_http_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- keep telemetry context as simple trace-header storage
- propagate the active trace across MCP and decode inbound MCP trace metadata at the MCP boundary
- derive local and hosted rollout parentage when a rollout starts, keeping nested rollouts on distinct child traces
- send child and parent headers through SDK gateway clients and Claude Code gateway requests, prevent equivalent-ID self-parenting across standard UUID forms, and omit invalid hosted parent IDs

## Verification
- UV_CACHE_DIR=/private/tmp/hud-python-uv-cache uv run --extra dev pytest -q hud/agents/tests/test_tool_agent.py hud/agents/tests/test_claude_sdk_agent.py hud/utils/tests/test_gateway.py hud/eval/tests/test_job.py hud/eval/tests/test_rollout.py hud/eval/tests/test_hosted.py hud/telemetry/tests/test_instrument.py hud/tests/test_trace.py hud/agents/tests/test_trace.py hud/eval/tests/test_file_tracking_observer.py (202 passed)
- UV_CACHE_DIR=/private/tmp/hud-python-uv-cache uv run --extra dev --extra train ty check on changed source files
- UV_CACHE_DIR=/private/tmp/hud-python-uv-cache uv run ruff format and ruff check on all changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches trace context, platform reporting, and gateway/MCP headers across eval and agents; behavior changes are mostly additive but affect how nested and hosted rollouts are attributed.
> 
> **Overview**
> Adds **parent–child trace lineage** so nested rollouts and downstream calls stay linked in HUD telemetry and on the platform.
> 
> **Context and propagation:** `set_trace_context` now accepts an optional `parent_trace_id` and exposes **`Trace-Id`** plus **`X-HUD-Parent-Trace-Id`** via `get_trace_headers()`. The inference gateway and Claude SDK agent (gateway MCP headers, `ANTHROPIC_CUSTOM_HEADERS`, Windows remote env via base64 JSON) forward those headers. Outbound **MCP tool calls** attach `hud/trace-id` in request meta; **`get_mcp_trace_id()`** reads it (or `trace-id` HTTP header) on the server side.
> 
> **Rollouts:** Local `rollout` and **hosted** submit derive the parent from the ambient trace or inbound MCP context, bind the child trace with that parent, and report **`parent_trace_id`** on trace enter / rollout submit. **Self-parenting is dropped** when parent and child normalize to the same id; hosted submit also omits parents that fail canonical UUID formatting.
> 
> **Other:** `normalize_trace_id` prefers `uuid.UUID` parsing before the namespaced fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5e1592cf5b3d87d126e9884b761097628ff377a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->