### PR TITLE
fix(agents): strengthen Claude stream retries

### DIFF
--- a/hud/agents/claude/agent.py
+++ b/hud/agents/claude/agent.py
@@ -6,6 +6,8 @@ import asyncio
 import copy
 import json
 import logging
+import math
+from random import SystemRandom
 from typing import TYPE_CHECKING, Literal, cast
 
 import httpx
@@ -63,7 +65,30 @@ _RETRYABLE_STREAM_ERROR_TYPES = frozenset(
         "upstream_error",
     }
 )
-_STREAM_RETRY_DELAY_SECONDS = 1.0
+_STREAM_MAX_ATTEMPTS = 3
+_STREAM_RETRY_BASE_DELAY_SECONDS = 1.0
+_STREAM_RETRY_MAX_DELAY_SECONDS = 5.0
+_STREAM_JITTER = SystemRandom()
+
+
+def _stream_retry_delay(attempt: int, error: Exception) -> float:
+    if isinstance(error, APIStatusError):
+        for header, divisor in (("retry-after-ms", 1000.0), ("retry-after", 1.0)):
+            value = error.response.headers.get(header)
+            if value is None:
+                continue
+            try:
+                retry_after = float(value) / divisor
+            except ValueError:
+                continue
+            if math.isfinite(retry_after):
+                return min(max(retry_after, 0.0), _STREAM_RETRY_MAX_DELAY_SECONDS)
+
+    backoff_limit = min(
+        _STREAM_RETRY_BASE_DELAY_SECONDS * (2 ** (attempt - 1)),
+        _STREAM_RETRY_MAX_DELAY_SECONDS,
+    )
+    return _STREAM_JITTER.uniform(0.0, backoff_limit)
 
 
 class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
@@ -201,7 +226,7 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
         tool_choice: BetaToolChoiceAutoParam,
         betas: list[str] | Omit,
     ) -> BetaMessage:
-        retries = 0
+        attempt = 1
         while True:
             stream_opened = False
             try:
@@ -237,13 +262,20 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
                     | httpx.TransportError
                     | httpx2.TransportError,
                 )
-                if retries or not (inline_error or interrupted_stream):
+                if attempt >= _STREAM_MAX_ATTEMPTS or not (inline_error or interrupted_stream):
                     raise
 
-                retries += 1
+                retry_delay = _stream_retry_delay(attempt, exc)
                 error_type = exc.type if isinstance(exc, APIStatusError) else type(exc).__name__
-                logger.warning("Claude stream failed with %s; retrying once", error_type)
-                await asyncio.sleep(_STREAM_RETRY_DELAY_SECONDS)
+                logger.warning(
+                    "Claude stream failed with %s; retrying in %.2fs (attempt %d/%d)",
+                    error_type,
+                    retry_delay,
+                    attempt + 1,
+                    _STREAM_MAX_ATTEMPTS,
+                )
+                attempt += 1
+                await asyncio.sleep(retry_delay)
 
     async def get_response(
         self,

--- a/hud/agents/tests/test_claude_agent.py
+++ b/hud/agents/tests/test_claude_agent.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock, call
 
 import httpx
 import httpx2
@@ -78,10 +78,11 @@ def _state(agent: ClaudeAgent) -> Any:
     return RunState(messages=[agent._format_message("user", "go")])
 
 
-def _inline_error(type_: str) -> APIStatusError:
+def _inline_error(type_: str, *, headers: dict[str, str] | None = None) -> APIStatusError:
     body = {"type": "error", "error": {"type": type_, "message": "stream failed"}}
     response = httpx.Response(
         200,
+        headers=headers,
         request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
     )
     return APIStatusError(str(body), response=response, body=body)
@@ -149,33 +150,74 @@ async def test_get_response_retries_transient_inline_stream_error(
         SimpleNamespace(type="text", text="recovered", citations=None),
         stop_reason="end_turn",
     )
-    agent = _agent(_inline_error(error_type), final)
+    agent = _agent(_inline_error(error_type), _inline_error(error_type), final)
     state = _state(agent)
     sleep = AsyncMock()
+    jitter = Mock(side_effect=[0.25, 1.5])
     monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", sleep)
+    monkeypatch.setattr("hud.agents.claude.agent._STREAM_JITTER.uniform", jitter)
 
     result = await agent.get_response(state)
 
     messages = cast("FakeMessages", cast("Any", agent.anthropic_client).beta.messages)
-    assert messages.calls == 2
+    assert messages.calls == 3
     assert result.content == "recovered"
     assert len(state.messages) == 2
-    sleep.assert_awaited_once_with(1.0)
+    assert sleep.await_args_list == [call(0.25), call(1.5)]
+    assert jitter.call_args_list == [call(0.0, 1.0), call(0.0, 2.0)]
 
 
 async def test_get_response_raises_after_transient_stream_retry_is_exhausted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    agent = _agent(_inline_error("gateway_timeout"), _inline_error("gateway_timeout"))
+    agent = _agent(
+        _inline_error("gateway_timeout"),
+        _inline_error("gateway_timeout"),
+        _inline_error("gateway_timeout"),
+    )
     state = _state(agent)
-    monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", AsyncMock())
+    sleep = AsyncMock()
+    monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", sleep)
+    monkeypatch.setattr("hud.agents.claude.agent._STREAM_JITTER.uniform", Mock(return_value=0.0))
 
     with pytest.raises(APIStatusError, match="gateway_timeout"):
         await agent.get_response(state)
 
     messages = cast("FakeMessages", cast("Any", agent.anthropic_client).beta.messages)
-    assert messages.calls == 2
+    assert messages.calls == 3
     assert len(state.messages) == 1
+    assert sleep.await_count == 2
+
+
+@pytest.mark.parametrize(
+    ("headers", "expected_delay"),
+    [
+        ({"retry-after": "1.75"}, 1.75),
+        ({"retry-after-ms": "1750"}, 1.75),
+        ({"retry-after": "60"}, 5.0),
+    ],
+    ids=["seconds", "milliseconds", "capped"],
+)
+async def test_get_response_honors_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+    headers: dict[str, str],
+    expected_delay: float,
+) -> None:
+    final = _final(
+        SimpleNamespace(type="text", text="recovered", citations=None),
+        stop_reason="end_turn",
+    )
+    agent = _agent(_inline_error("overloaded_error", headers=headers), final)
+    sleep = AsyncMock()
+    jitter = Mock()
+    monkeypatch.setattr("hud.agents.claude.agent.asyncio.sleep", sleep)
+    monkeypatch.setattr("hud.agents.claude.agent._STREAM_JITTER.uniform", jitter)
+
+    result = await agent.get_response(_state(agent))
+
+    assert result.content == "recovered"
+    sleep.assert_awaited_once_with(expected_delay)
+    jitter.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- allow three total attempts for transient Claude stream failures
- use bounded full-jitter exponential backoff and honor numeric retry delay headers
- preserve the existing post-stream and transient-error retry boundary

## Validation

- uv run --all-extras pytest -q: 1141 passed, 17 deselected
- uv run --all-extras pytest -q hud/agents/tests/test_claude_agent.py: 17 passed
- uv run --all-extras ruff format . --check
- uv run --all-extras ruff check .
- uv run --all-extras ty check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized resilience change in Claude streaming retries with bounded delays; no auth or data-handling changes.
> 
> **Overview**
> **Claude message streaming** now retries transient failures up to **three attempts** (was effectively two with a single retry), using smarter delays instead of a fixed 1s sleep.
> 
> `_stream_response` adds `_stream_retry_delay`: for inline `APIStatusError` responses it prefers **`Retry-After` / `Retry-After-Ms`** (clamped to 0–5s); otherwise it uses **full-jitter exponential backoff** (1s base, 5s cap). Retry logging reports delay and attempt `n/3`. Which errors qualify for retry is unchanged.
> 
> Tests were updated for two backoff sleeps before success, exhaustion after three failures, and header-based delay behavior (including capping long `retry-after` values).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca11eb0680b8c54d8485f7d95e8ea16dbd5a7f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->