### PR TITLE
Normalize QA results onto qa_agent_result.v1

### DIFF
--- a/docs/v6/reference/cli.mdx
+++ b/docs/v6/reference/cli.mdx
@@ -154,8 +154,11 @@ complete the command.
 job status. Failure Analysis shows a cause and numbered findings when present.
 Boolean agents (false negative, false positive, reward hacking, prompt
 alignment) show yes/no and a summary, without a findings list. Pass `--rollout`
-for the sanitized analysis trajectory. `--json` still prints the raw result
-list and does not fetch the trajectory.
+for the sanitized analysis trajectory. `--json` prints the result list and
+fills `canonical_result` with the unified `qa_agent_result.v1` object
+(`verdict`, `summary`, `findings`, `metadata`) derived from every completed
+blob — v1, boolean judges, and Failure Analysis `problems`. It does not fetch
+the trajectory.
 
 ## Inspect
 

--- a/hud/cli/qa.py
+++ b/hud/cli/qa.py
@@ -11,7 +11,11 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
 
-from hud.cli.qa_analysis import is_standard_result_blob, presentation_for_result
+from hud.cli.qa_analysis import (
+    is_standard_result_blob,
+    presentation_for_result,
+    to_qa_agent_result_v1,
+)
 from hud.cli.utils.api import require_api_key
 from hud.settings import settings
 from hud.utils.exceptions import HudTimeoutError
@@ -48,9 +52,16 @@ def _print_agent(agent: dict[str, Any]) -> None:
     typer.echo(f"{agent.get('name', '-')}\t{agent.get('id', '-')}")
 
 
+def _with_canonical_v1(result: dict[str, Any]) -> dict[str, Any]:
+    canonical = to_qa_agent_result_v1(result)
+    if canonical is None:
+        return result
+    return {**result, "canonical_result": canonical}
+
+
 def _print_results(results: list[dict[str, Any]], *, json_output: bool) -> None:
     if json_output:
-        _print_json(results)
+        _print_json([_with_canonical_v1(result) for result in results])
         return
     if not results:
         typer.echo("No QA results found.")

--- a/hud/cli/qa_analysis.py
+++ b/hud/cli/qa_analysis.py
@@ -1,10 +1,13 @@
-"""Turn a QA result row into pass/fail review chrome for the CLI TUI."""
+"""Normalize QA-agent blobs to ``qa_agent_result.v1`` and render review chrome."""
 
 from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal, cast
+
+QA_AGENT_RESULT_V1 = "qa_agent_result.v1"
+QaVerdict = Literal["passed", "failed", "unknown"]
 
 _QA_V1 = frozenset({"passed", "failed", "unknown"})
 _BOOLEAN_KEYS = (
@@ -13,6 +16,10 @@ _BOOLEAN_KEYS = (
     ("is_reward_hacking", "Reward Hacking"),
     ("is_prompt_misaligned", "Prompt Misaligned"),
 )
+_BOOLEAN_EXTRAS = {
+    "is_reward_hacking": ("hacking_strategy",),
+    "is_prompt_misaligned": ("grader_check", "prompt_quote", "misalignment_proof"),
+}
 _CAUSE = {
     "agent": "Agent failure",
     "eval": "Evaluation failure",
@@ -40,26 +47,80 @@ class QaPresentation:
 
 def is_standard_result_blob(text: str) -> bool:
     parsed = _loads(text)
-    return parsed is not None and _from_blob(parsed).kind != "unknown"
+    if parsed is None:
+        return False
+    return str(_blob_to_v1(parsed)["metadata"].get("kind") or "unknown") != "unknown"
 
 
-def presentation_for_result(row: dict[str, Any]) -> QaPresentation:
+def to_qa_agent_result_v1(row: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a ``qa_agent_result.v1`` object for a platform QA result row.
+
+    Pending rows (queued, running, …) return ``None``. Completed analysis blobs
+    — v1, boolean judges, and Failure Analysis ``problems`` — are rewritten to
+    the same schema. Error rows become ``verdict=failed``. Unrecognized
+    completed payloads become ``verdict=unknown``.
+    """
     status = str(row.get("status") or "")
     error = row.get("error")
     if status == "error":
-        return _view("unknown", "failed", summary=str(error) if error else "QA run failed.")
+        return _v1(
+            "failed",
+            summary=str(error) if error else "QA run failed.",
+            metadata={"kind": "unknown"},
+        )
     if status and status != "completed":
-        return _view("pending", "unknown", label=status, summary=str(error) if error else None)
+        return None
     payload = row.get("canonical_result")
     if not isinstance(payload, dict):
         payload = row.get("result")
     blob = _unwrap(payload) if isinstance(payload, dict | str) else None
     if blob is None:
+        return _v1("unknown", summary=str(error) if error else None)
+    return _blob_to_v1(blob)
+
+
+def presentation_for_result(row: dict[str, Any]) -> QaPresentation:
+    status = str(row.get("status") or "")
+    error = row.get("error")
+    if status and status not in {"completed", "error"}:
+        return _view("pending", "unknown", label=status, summary=str(error) if error else None)
+    canonical = to_qa_agent_result_v1(row)
+    if canonical is None:
         return _view("unknown", "unknown", summary=str(error) if error else None)
-    return _from_blob(blob)
+    return _present_v1(canonical)
 
 
-def _from_blob(parsed: dict[str, Any]) -> QaPresentation:
+def _present_v1(parsed: dict[str, Any]) -> QaPresentation:
+    metadata = parsed.get("metadata")
+    extra = metadata if isinstance(metadata, dict) else {}
+    kind = extra.get("kind") if isinstance(extra.get("kind"), str) else "qa_result"
+    label = extra.get("label") if isinstance(extra.get("label"), str) else "QA Result"
+    answer = extra.get("answer") if isinstance(extra.get("answer"), str) else None
+    confidence = extra.get("confidence") if isinstance(extra.get("confidence"), str) else None
+    verdict = parsed.get("verdict")
+    tag = verdict if isinstance(verdict, str) and verdict in _QA_V1 else "unknown"
+    findings = tuple(
+        QaFinding(
+            title=str(item["summary"]),
+            description=str(item.get("description") or ""),
+            fault=item.get("fault") if isinstance(item.get("fault"), str) else None,
+        )
+        for item in parsed.get("findings") or []
+        if isinstance(item, dict) and isinstance(item.get("summary"), str) and item["summary"]
+    )
+    summary = parsed.get("summary")
+    return _view(
+        kind,
+        tag,
+        label=label,
+        answer=answer,
+        summary=summary if isinstance(summary, str) else None,
+        confidence=confidence,
+        findings=findings,
+    )
+
+
+def _blob_to_v1(parsed: dict[str, Any]) -> dict[str, Any]:
     summary = _text(parsed.get("summary"), parsed.get("reasoning"))
     confidence = _confidence(parsed.get("confidence"))
 
@@ -68,35 +129,39 @@ def _from_blob(parsed: dict[str, Any]) -> QaPresentation:
     if (
         isinstance(verdict, str)
         and verdict in _QA_V1
-        and (parsed.get("schema_version") == "qa_agent_result.v1" or isinstance(findings_raw, list))
+        and (parsed.get("schema_version") == QA_AGENT_RESULT_V1 or isinstance(findings_raw, list))
     ):
-        findings = _findings(findings_raw if isinstance(findings_raw, list) else [], "summary")
-        return _view(
-            "qa_result",
-            verdict,
+        metadata = dict(parsed["metadata"]) if isinstance(parsed.get("metadata"), dict) else {}
+        metadata.setdefault("kind", "qa_result")
+        if confidence and "confidence" not in metadata:
+            metadata["confidence"] = confidence
+        raw_findings = findings_raw if isinstance(findings_raw, list) else []
+        return _v1(
+            cast("QaVerdict", verdict),
             summary=summary,
-            confidence=confidence,
-            findings=findings,
+            findings=_finding_dicts(raw_findings, "summary"),
+            metadata=metadata,
         )
 
     for key, label in _BOOLEAN_KEYS:
         if key not in parsed:
             continue
         value = parsed[key]
+        metadata: dict[str, Any] = {"kind": "boolean", "label": label, key: value}
+        if confidence:
+            metadata["confidence"] = confidence
+        for extra in _BOOLEAN_EXTRAS.get(key, ()):
+            extra_value = parsed.get(extra)
+            if isinstance(extra_value, str) and extra_value.strip():
+                metadata[extra] = extra_value.strip()
         if not isinstance(value, bool):
-            return _view("unknown", "unknown", label=label, summary=summary, confidence=confidence)
-        return _view(
-            "boolean",
-            "failed" if value else "passed",
-            label=label,
-            answer="yes" if value else "no",
-            summary=summary,
-            confidence=confidence,
-        )
+            return _v1("unknown", summary=summary, metadata=metadata)
+        metadata["answer"] = "yes" if value else "no"
+        return _v1("failed" if value else "passed", summary=summary, metadata=metadata)
 
     if isinstance(parsed.get("problems"), list):
-        findings = _findings(parsed["problems"], "problem", "title")
-        owners = {_finding_owner(item.fault) for item in findings}
+        findings = _finding_dicts(parsed["problems"], "problem", "title")
+        owners = {_finding_owner(item.get("fault")) for item in findings}
         if not findings:
             cause, tag = "No failure", "passed"
         elif len(owners) != 1:
@@ -105,17 +170,31 @@ def _from_blob(parsed: dict[str, Any]) -> QaPresentation:
             cause, tag = "Unclear", "failed"
         else:
             cause, tag = _CAUSE[next(iter(owners))], "failed"
-        return _view(
-            "problems",
-            tag,
-            label="Failure Analysis",
-            answer=cause,
-            summary=summary,
-            confidence=confidence,
-            findings=findings,
-        )
+        metadata = {"kind": "problems", "label": "Failure Analysis", "answer": cause}
+        if confidence:
+            metadata["confidence"] = confidence
+        return _v1(cast("QaVerdict", tag), summary=summary, findings=findings, metadata=metadata)
 
-    return _view("unknown", "unknown", summary=summary, confidence=confidence)
+    metadata = {"kind": "unknown"}
+    if confidence:
+        metadata["confidence"] = confidence
+    return _v1("unknown", summary=summary, metadata=metadata)
+
+
+def _v1(
+    verdict: QaVerdict,
+    *,
+    summary: str | None = None,
+    findings: list[dict[str, Any]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": QA_AGENT_RESULT_V1,
+        "verdict": verdict,
+        "summary": summary,
+        "findings": findings or [],
+        "metadata": metadata or {},
+    }
 
 
 def _view(
@@ -171,8 +250,8 @@ def _confidence(raw: Any) -> str | None:
     return None
 
 
-def _findings(items: list[Any], *title_keys: str) -> tuple[QaFinding, ...]:
-    findings: list[QaFinding] = []
+def _finding_dicts(items: list[Any], *title_keys: str) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -186,20 +265,19 @@ def _findings(items: list[Any], *title_keys: str) -> tuple[QaFinding, ...]:
         )
         if not title:
             continue
+        finding: dict[str, Any] = {"summary": title}
         description = item.get("description")
+        if isinstance(description, str) and description.strip():
+            finding["description"] = description.strip()
         fault = item.get("fault") if isinstance(item.get("fault"), str) else None
-        findings.append(
-            QaFinding(
-                title=title,
-                description=description.strip() if isinstance(description, str) else "",
-                fault=fault,
-            )
-        )
-    return tuple(findings)
+        if fault:
+            finding["fault"] = fault
+        findings.append(finding)
+    return findings
 
 
-def _finding_owner(fault: str | None) -> str:
-    if fault is None:
+def _finding_owner(fault: Any) -> str:
+    if not isinstance(fault, str):
         return "unclear"
     owner = fault.strip().lower()
     if owner in _CAUSE:

--- a/hud/cli/qa_analysis.py
+++ b/hud/cli/qa_analysis.py
@@ -93,8 +93,10 @@ def presentation_for_result(row: dict[str, Any]) -> QaPresentation:
 def _present_v1(parsed: dict[str, Any]) -> QaPresentation:
     metadata = parsed.get("metadata")
     extra = metadata if isinstance(metadata, dict) else {}
-    kind = extra.get("kind") if isinstance(extra.get("kind"), str) else "qa_result"
-    label = extra.get("label") if isinstance(extra.get("label"), str) else "QA Result"
+    raw_kind = extra.get("kind")
+    raw_label = extra.get("label")
+    kind = raw_kind if isinstance(raw_kind, str) else "qa_result"
+    label = raw_label if isinstance(raw_label, str) else "QA Result"
     answer = extra.get("answer") if isinstance(extra.get("answer"), str) else None
     confidence = extra.get("confidence") if isinstance(extra.get("confidence"), str) else None
     verdict = parsed.get("verdict")

--- a/hud/cli/tests/test_qa.py
+++ b/hud/cli/tests/test_qa.py
@@ -420,6 +420,38 @@ def test_qa_results_boolean_agent_omits_findings() -> None:
     assert "The zero reward matches the missing file." in result.output
 
 
+def test_qa_results_json_normalizes_boolean_blob_to_v1() -> None:
+    platform = MagicMock()
+    platform.get.return_value = [
+        {
+            **_run(status="completed"),
+            "agent_name": "False Negative Analysis",
+            "result": {
+                "is_false_negative": True,
+                "reasoning": "The grader rejected a valid answer.",
+            },
+        }
+    ]
+
+    result = _invoke(platform, ["qa", "results", _TRACE_ID, "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)[0]
+    assert payload["result"]["is_false_negative"] is True
+    assert payload["canonical_result"] == {
+        "schema_version": "qa_agent_result.v1",
+        "verdict": "failed",
+        "summary": "The grader rejected a valid answer.",
+        "findings": [],
+        "metadata": {
+            "kind": "boolean",
+            "label": "False Negative",
+            "is_false_negative": True,
+            "answer": "yes",
+        },
+    }
+
+
 def test_qa_results_false_negative_yes_is_failed() -> None:
     platform = MagicMock()
     platform.get.return_value = [

--- a/hud/cli/tests/test_qa_analysis.py
+++ b/hud/cli/tests/test_qa_analysis.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from hud.cli.qa_analysis import is_standard_result_blob, presentation_for_result
+from hud.cli.qa_analysis import (
+    QA_AGENT_RESULT_V1,
+    is_standard_result_blob,
+    presentation_for_result,
+    to_qa_agent_result_v1,
+)
 
 
 def test_failure_analysis_problems_are_a_failed_agent_finding() -> None:
@@ -85,3 +90,113 @@ def test_standard_result_blob_detects_boolean_and_problems() -> None:
     assert is_standard_result_blob('{"summary": "x", "problems": []}')
     assert not is_standard_result_blob("Checking the workspace.")
     assert not is_standard_result_blob('{"notes": "still working"}')
+
+
+def test_queued_rows_have_no_canonical_v1() -> None:
+    assert to_qa_agent_result_v1({"status": "queued", "canonical_result": None}) is None
+
+
+def test_boolean_blob_normalizes_to_v1() -> None:
+    result = to_qa_agent_result_v1(
+        {
+            "status": "completed",
+            "result": {
+                "is_false_negative": True,
+                "reasoning": "The grader rejected a valid answer.",
+                "confidence": "high",
+            },
+        }
+    )
+
+    assert result == {
+        "schema_version": QA_AGENT_RESULT_V1,
+        "verdict": "failed",
+        "summary": "The grader rejected a valid answer.",
+        "findings": [],
+        "metadata": {
+            "kind": "boolean",
+            "label": "False Negative",
+            "is_false_negative": True,
+            "confidence": "high",
+            "answer": "yes",
+        },
+    }
+
+
+def test_reward_hacking_blob_keeps_strategy_in_v1_metadata() -> None:
+    result = to_qa_agent_result_v1(
+        {
+            "status": "completed",
+            "result": {
+                "is_reward_hacking": True,
+                "hacking_strategy": "test_manipulation",
+                "reasoning": "The agent rewrote the hidden tests.",
+            },
+        }
+    )
+
+    assert result is not None
+    assert result["verdict"] == "failed"
+    assert result["metadata"]["is_reward_hacking"] is True
+    assert result["metadata"]["hacking_strategy"] == "test_manipulation"
+
+
+def test_failure_analysis_problems_normalize_to_v1_findings() -> None:
+    result = to_qa_agent_result_v1(
+        {
+            "status": "completed",
+            "result": {
+                "summary": "Missing file.",
+                "problems": [
+                    {
+                        "problem": "No regex",
+                        "fault": "agent",
+                        "description": "Never wrote it.",
+                    }
+                ],
+                "confidence": "high",
+            },
+        }
+    )
+
+    assert result == {
+        "schema_version": QA_AGENT_RESULT_V1,
+        "verdict": "failed",
+        "summary": "Missing file.",
+        "findings": [
+            {
+                "summary": "No regex",
+                "description": "Never wrote it.",
+                "fault": "agent",
+            }
+        ],
+        "metadata": {
+            "kind": "problems",
+            "label": "Failure Analysis",
+            "answer": "Agent failure",
+            "confidence": "high",
+        },
+    }
+
+
+def test_existing_v1_blob_is_returned_as_v1() -> None:
+    result = to_qa_agent_result_v1(
+        {
+            "status": "completed",
+            "canonical_result": {
+                "schema_version": QA_AGENT_RESULT_V1,
+                "verdict": "passed",
+                "summary": "Looks good.",
+                "findings": [],
+                "metadata": {},
+            },
+        }
+    )
+
+    assert result == {
+        "schema_version": QA_AGENT_RESULT_V1,
+        "verdict": "passed",
+        "summary": "Looks good.",
+        "findings": [],
+        "metadata": {"kind": "qa_result"},
+    }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`qa_agent_result.v1` was the shared review contract (verdict, summary, findings, metadata). Resource QA already emits it. The five trace-viewer agents still write judge-specific blobs:

- Failure Analysis → `problems[]` + `fault`
- False negative / false positive / reward hacking / prompt alignment → a boolean flag

The CLI then kept a second parser for those shapes instead of using v1 as the return schema.

## What changed

`to_qa_agent_result_v1()` rewrites every completed analysis onto `qa_agent_result.v1`:

```json
{
  "schema_version": "qa_agent_result.v1",
  "verdict": "passed | failed | unknown",
  "summary": "...",
  "findings": [{"summary": "...", "description": "...", "fault": "agent"}],
  "metadata": {"kind": "boolean|problems|qa_result", "label": "...", "answer": "..."}
}
```

- Boolean yes/no and Failure Analysis cause stay in `metadata` so the TUI chrome is unchanged.
- `hud qa --json` keeps the raw `result` blob and fills `canonical_result` with the unified object.
- Presentation now reads only the v1 object.

Pending rows still have no canonical result. Error rows become `verdict=failed`.

## Validation

- Converter tests for boolean, reward-hacking extras, Failure Analysis findings, and passthrough v1.
- CLI `--json` test asserts a false-negative blob is rewritten to v1 while the raw `result` is preserved.
- `uv run pytest -q hud/cli/tests/test_qa.py hud/cli/tests/test_qa_analysis.py` — 29 passed.
- `ruff check` and `ty check` on the changed CLI modules passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a24b32c5-4f69-42cf-8868-971303cfc758?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a24b32c5-4f69-42cf-8868-971303cfc758&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

