### PR TITLE
fix(agents): bound provider-visible SSH tool output

### DIFF
--- a/hud/agents/claude/tools/coding.py
+++ b/hud/agents/claude/tools/coding.py
@@ -191,7 +191,7 @@ class ClaudeTextEditorTool(SSHTool):
                 return tool_err(f"unknown editor command: {command!r}")
 
     async def _str_replace(self, path: str, old: str, new: str) -> MCPToolResult:
-        existing = await self.file_read(path)
+        existing = await self.raw_file_read(path)
         if existing.isError:
             return existing
         text = result_text(existing)
@@ -203,7 +203,7 @@ class ClaudeTextEditorTool(SSHTool):
         return await self.file_write(path, text.replace(old, new, 1))
 
     async def _insert(self, path: str, line: int, text: str) -> MCPToolResult:
-        existing = await self.file_read(path)
+        existing = await self.raw_file_read(path)
         if existing.isError:
             return existing
         lines = result_text(existing).splitlines(keepends=True)

--- a/hud/agents/gemini/tools/coding.py
+++ b/hud/agents/gemini/tools/coding.py
@@ -97,7 +97,7 @@ class GeminiEditTool(SSHTool):
         new_string = arguments.get("new_string", "")
         if old_string == "":
             return await self.file_write(file_path, str(new_string))
-        existing = await self.file_read(file_path)
+        existing = await self.raw_file_read(file_path)
         if existing.isError:
             return existing
         text = result_text(existing)

--- a/hud/agents/gemini/tools/filesystem.py
+++ b/hud/agents/gemini/tools/filesystem.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from hud.agents.tools import SSHTool
-from hud.types import MCPToolResult
+from hud.agents.tools.base import result_text, tool_ok
 
 from .base import GeminiToolSpec
 from .coding import required_str, tool_decl
 
 if TYPE_CHECKING:
     from google.genai import types as genai_types
+
+    from hud.types import MCPToolResult
 
 GEMINI_READ_SPEC = GeminiToolSpec(api_type="read_file", api_name="read_file")
 GEMINI_SEARCH_SPEC = GeminiToolSpec(api_type="grep_search", api_name="grep_search")
@@ -42,24 +44,18 @@ class GeminiReadTool(SSHTool):
 
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         path = required_str(arguments, "file_path")
-        result = await self.file_read(path)
+        result = await self.raw_file_read(path)
         if result.isError:
             return result
+        text = result_text(result)
         start = arguments.get("start_line")
         end = arguments.get("end_line")
         if isinstance(start, int) and start > 0:
-            import mcp.types as mcp_types
-
-            from hud.agents.tools.base import result_text
-
-            lines = result_text(result).splitlines(keepends=True)
+            lines = text.splitlines(keepends=True)
             offset = start - 1
             limit = (end - start + 1) if isinstance(end, int) and end >= start else len(lines)
-            sliced = lines[offset : offset + limit]
-            return MCPToolResult(
-                content=[mcp_types.TextContent(type="text", text="".join(sliced))],
-            )
-        return result
+            text = "".join(lines[offset : offset + limit])
+        return tool_ok(await self.bound_text(text))
 
 
 class GeminiSearchTool(SSHTool):

--- a/hud/agents/openai/tools/coding.py
+++ b/hud/agents/openai/tools/coding.py
@@ -8,7 +8,6 @@ from typing import Any, cast
 import mcp.types as mcp_types
 
 from hud.agents.tools import SSHTool
-from hud.agents.tools.ssh import MAX_SHELL_OUTPUT_LENGTH, bound_shell_output
 from hud.types import MCPToolResult
 
 from .base import OpenAIToolSpec
@@ -35,7 +34,7 @@ class OpenAIShellTool(SSHTool):
     async def execute(self, arguments: dict[str, Any]) -> MCPToolResult:
         requested_limit = arguments.get("max_output_length")
         if requested_limit is None:
-            max_output_length = MAX_SHELL_OUTPUT_LENGTH
+            max_output_length = self.output_limit()
         elif (
             isinstance(requested_limit, bool)
             or not isinstance(requested_limit, int)
@@ -48,7 +47,7 @@ class OpenAIShellTool(SSHTool):
                 structured={"output": [shell_output("", text, 1)]},
             )
         else:
-            max_output_length = min(requested_limit, MAX_SHELL_OUTPUT_LENGTH)
+            max_output_length = min(requested_limit, self.output_limit())
 
         def invalid_commands_result() -> MCPToolResult:
             text = "commands must be a list of strings"
@@ -90,7 +89,11 @@ class OpenAIShellTool(SSHTool):
             stderr = completed.stderr if isinstance(completed.stderr, str) else ""
             exit_code = completed.returncode
             assert exit_code is not None
-            stdout, stderr = bound_shell_output(stdout, stderr, max_output_length)
+            stdout, stderr = await self.bound_output(
+                stdout,
+                stderr,
+                limit=max_output_length,
+            )
             outputs.append(shell_output(stdout, stderr, exit_code))
             display_outputs.append(stdout + stderr)
             is_error = is_error or bool(exit_code)

--- a/hud/agents/openai_compatible/tools/filesystem.py
+++ b/hud/agents/openai_compatible/tools/filesystem.py
@@ -40,7 +40,9 @@ class _FilesystemTool(SSHTool):
         completed = await self.client.run(f"mkdir -p {shlex.quote(parent)}", check=False)
         if completed.returncode == 0:
             return MCPToolResult(content=[])
-        message = completed.stderr or completed.stdout or f"could not create {parent}"
+        stderr = completed.stderr if isinstance(completed.stderr, str) else ""
+        stdout = completed.stdout if isinstance(completed.stdout, str) else ""
+        message = stderr or stdout or f"could not create {parent}"
         return tool_err(await self.bound_text(message))
 
 

--- a/hud/agents/openai_compatible/tools/filesystem.py
+++ b/hud/agents/openai_compatible/tools/filesystem.py
@@ -7,10 +7,8 @@ import posixpath
 import shlex
 from typing import Any, ClassVar
 
-import mcp.types as mcp_types
-
 from hud.agents.tools import SSHTool
-from hud.agents.tools.base import AgentToolSpec, result_text, tool_err
+from hud.agents.tools.base import AgentToolSpec, result_text, tool_err, tool_ok
 from hud.types import MCPToolResult
 
 DEFAULT_READ_LIMIT = 2000
@@ -68,9 +66,10 @@ class ReadTool(_FilesystemTool):
             raise ValueError("filePath is required")
         offset = _read_offset(arguments.get("offset"))
         limit = _positive_int(arguments.get("limit"), default=DEFAULT_READ_LIMIT, name="limit")
-        if not (await self.bash(f"test -d {shlex.quote(path)}")).isError:
+        is_directory = await self.client.run(f"test -d {shlex.quote(path)}", check=False)
+        if is_directory.returncode == 0:
             return await self._read_directory(path, offset=offset, limit=limit)
-        result = await self.file_read(path)
+        result = await self.raw_file_read(path)
         if result.isError:
             return result
         text = result_text(result)
@@ -95,10 +94,10 @@ class ReadTool(_FilesystemTool):
         else:
             body.append(f"\n(End of file - total {len(lines)} lines)")
         body.append("</content>")
-        return MCPToolResult(content=[mcp_types.TextContent(type="text", text="\n".join(body))])
+        return tool_ok(await self.bound_text("\n".join(body)))
 
     async def _read_directory(self, path: str, *, offset: int, limit: int) -> MCPToolResult:
-        result = await self.file_list(path)
+        result = await self.raw_file_list(path)
         if result.isError:
             return result
         entries = result_text(result).splitlines()
@@ -121,7 +120,7 @@ class ReadTool(_FilesystemTool):
         else:
             body.append(f"\n({len(entries)} entries)")
         body.append("</entries>")
-        return MCPToolResult(content=[mcp_types.TextContent(type="text", text="\n".join(body))])
+        return tool_ok(await self.bound_text("\n".join(body)))
 
 
 class BashTool(_FilesystemTool):
@@ -213,7 +212,7 @@ class EditTool(_FilesystemTool):
                 return mkdir
             return await self.file_write(path, new)
 
-        existing = await self.file_read(path)
+        existing = await self.raw_file_read(path)
         if existing.isError:
             return existing
         text = result_text(existing)

--- a/hud/agents/openai_compatible/tools/filesystem.py
+++ b/hud/agents/openai_compatible/tools/filesystem.py
@@ -33,6 +33,16 @@ class _FilesystemTool(SSHTool):
             },
         }
 
+    async def _ensure_parent(self, path: str) -> MCPToolResult:
+        parent = posixpath.dirname(path)
+        if not parent or parent in {".", "/"}:
+            return MCPToolResult(content=[])
+        completed = await self.client.run(f"mkdir -p {shlex.quote(parent)}", check=False)
+        if completed.returncode == 0:
+            return MCPToolResult(content=[])
+        message = completed.stderr or completed.stdout or f"could not create {parent}"
+        return tool_err(await self.bound_text(message))
+
 
 class ReadTool(_FilesystemTool):
     name = "read"
@@ -201,8 +211,8 @@ class EditTool(_FilesystemTool):
         if old == new:
             return tool_err("No changes to apply: oldString and newString are identical.")
         if old == "":
-            exists = not (await self.bash(f"test -e {shlex.quote(path)}")).isError
-            if exists:
+            probe = await self.client.run(f"test -e {shlex.quote(path)}", check=False)
+            if probe.returncode == 0:
                 return tool_err(
                     "oldString cannot be empty when editing an existing file. "
                     "Provide exact text to replace, or use write for full-file replacement."
@@ -224,12 +234,6 @@ class EditTool(_FilesystemTool):
             return tool_err(f"oldString matches {count} times in {path}; set replaceAll to true")
         next_text = text.replace(old, new) if replace_all else text.replace(old, new, 1)
         return await self.file_write(path, next_text)
-
-    async def _ensure_parent(self, path: str) -> MCPToolResult:
-        parent = posixpath.dirname(path)
-        if not parent or parent in {".", "/"}:
-            return MCPToolResult(content=[])
-        return await self.bash(f"mkdir -p {shlex.quote(parent)}")
 
 
 class WriteTool(_FilesystemTool):
@@ -258,12 +262,6 @@ class WriteTool(_FilesystemTool):
         if mkdir.isError:
             return mkdir
         return await self.file_write(path, content)
-
-    async def _ensure_parent(self, path: str) -> MCPToolResult:
-        parent = posixpath.dirname(path)
-        if not parent or parent in {".", "/"}:
-            return MCPToolResult(content=[])
-        return await self.bash(f"mkdir -p {shlex.quote(parent)}")
 
 
 class GrepTool(_FilesystemTool):

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -23,7 +23,7 @@ from hud.agents.openai_compatible.agent import OpenAIChatAgent
 from hud.agents.openai_compatible.tools import BashTool, EditTool, ReadTool, WriteTool
 from hud.agents.tool_agent import RunState
 from hud.agents.tools.base import result_text
-from hud.agents.tools.ssh import bound_shell_output
+from hud.agents.tools.ssh import OUTPUT_BUDGET_EXHAUSTED, bound_shell_output
 from hud.agents.types import OpenAIChatConfig
 from hud.capabilities import Capability, SSHClient
 from hud.capabilities.ssh import (
@@ -551,6 +551,38 @@ async def test_openai_compatible_write_stores_file_via_ssh_exec() -> None:
 
     assert result.isError is False
     assert ssh.files["/REPORT.md"] == b"done"
+
+
+@pytest.mark.parametrize(
+    ("tool_type", "arguments"),
+    [
+        (WriteTool, {"filePath": "/nested/report.md", "content": "done"}),
+        (
+            EditTool,
+            {
+                "filePath": "/nested/report.md",
+                "oldString": "",
+                "newString": "done",
+            },
+        ),
+    ],
+)
+async def test_internal_file_probes_do_not_consume_provider_output_budget(
+    tool_type: type[EditTool] | type[WriteTool],
+    arguments: dict[str, Any],
+) -> None:
+    expected = "wrote 4 bytes to /nested/report.md"
+    ssh = _FakeSSH(
+        max_output_chars=256,
+        max_total_output_chars=len(expected) + len(OUTPUT_BUDGET_EXHAUSTED) + 2,
+    )
+    tool = tool_type(spec=tool_type.default_spec("qwen"), client=cast("SSHClient", ssh))
+
+    result = await tool.execute(arguments)
+
+    assert result.isError is False
+    assert result_text(result) == expected
+    assert ssh.files["/nested/report.md"] == b"done"
 
 
 async def test_paths_reach_the_session_verbatim() -> None:

--- a/hud/agents/tests/test_provider_native_tools.py
+++ b/hud/agents/tests/test_provider_native_tools.py
@@ -17,6 +17,7 @@ import pytest
 
 from hud.agents.claude.tools.coding import ClaudeBashTool, ClaudeTextEditorTool
 from hud.agents.gemini.tools.coding import GeminiEditTool, GeminiShellTool
+from hud.agents.gemini.tools.filesystem import GeminiReadTool
 from hud.agents.openai.tools.coding import OpenAIShellTool
 from hud.agents.openai_compatible.agent import OpenAIChatAgent
 from hud.agents.openai_compatible.tools import BashTool, EditTool, ReadTool, WriteTool
@@ -25,6 +26,11 @@ from hud.agents.tools.base import result_text
 from hud.agents.tools.ssh import bound_shell_output
 from hud.agents.types import OpenAIChatConfig
 from hud.capabilities import Capability, SSHClient
+from hud.capabilities.ssh import (
+    TOOL_MAX_OUTPUT_CHARS_PARAM,
+    TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM,
+    TOOL_OUTPUT_BUDGET_MARKER_PARAM,
+)
 from hud.types import MCPToolCall
 
 
@@ -144,9 +150,18 @@ class _FakeSSH(SSHClient):
         exit_status: int = 0,
         files: dict[str, bytes] | None = None,
         cwd: str | None = None,
+        max_output_chars: int | None = None,
+        max_total_output_chars: int | None = None,
+        output_budget_exhausted_path: str | None = None,
     ) -> None:
         self.files: dict[str, bytes] = files or {}
         params = {"cwd": cwd} if cwd else {}
+        if max_output_chars is not None:
+            params[TOOL_MAX_OUTPUT_CHARS_PARAM] = max_output_chars
+        if max_total_output_chars is not None:
+            params[TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM] = max_total_output_chars
+        if output_budget_exhausted_path is not None:
+            params[TOOL_OUTPUT_BUDGET_MARKER_PARAM] = output_budget_exhausted_path
         super().__init__(
             Capability(name="shell", protocol="ssh/2", url="ssh://localhost:22", params=params),
             cast(
@@ -300,6 +315,49 @@ async def test_openai_shell_uses_safe_effective_limit(max_output_length: int | N
     assert result.structuredContent["max_output_length"] == 10 * 1024 * 1024
 
 
+async def test_openai_shell_honors_capability_output_limit() -> None:
+    tool = OpenAIShellTool(
+        spec=OpenAIShellTool.default_spec("gpt-5.5"),
+        client=_ssh(stdout="x" * 200, max_output_chars=64),
+    )
+
+    result = await tool.execute({"commands": ["noisy"], "max_output_length": 20 * 1024 * 1024})
+
+    assert result.structuredContent is not None
+    assert result.structuredContent["max_output_length"] == 64
+    [output] = result.structuredContent["output"]
+    assert len(output["stdout"]) + len(output["stderr"]) == 64
+    assert "[truncated]" in output["stdout"]
+
+
+async def test_openai_shell_marks_run_wide_output_budget_exhaustion() -> None:
+    marker_path = "/workspace/.qa-output-budget-exhausted"
+    fake_client = _FakeSSH(
+        stdout="x" * 80,
+        max_output_chars=80,
+        max_total_output_chars=200,
+        output_budget_exhausted_path=marker_path,
+    )
+    client = cast("SSHClient", fake_client)
+    tool = OpenAIShellTool(
+        spec=OpenAIShellTool.default_spec("gpt-5.5"),
+        client=client,
+    )
+
+    result = await tool.execute({"commands": ["first", "second"]})
+
+    assert result.structuredContent is not None
+    first, second = result.structuredContent["output"]
+    assert len(first["stdout"]) + len(first["stderr"]) == 80
+    assert "[tool output budget exhausted" in second["stderr"]
+    assert len(second["stdout"]) + len(second["stderr"]) <= 80
+    assert marker_path in fake_client.files
+
+    del fake_client.files[marker_path]
+    await tool.execute({"commands": ["third"]})
+    assert marker_path in fake_client.files
+
+
 async def test_openai_shell_rejects_non_list_commands_without_running() -> None:
     tool = OpenAIShellTool(spec=OpenAIShellTool.default_spec("gpt-5.5"), client=_ssh())
 
@@ -401,12 +459,88 @@ async def test_shared_ssh_tool_bounds_combined_output(
     result = await tool.execute({"command": "noisy"})
 
     text = result_text(result)
-    output = text.split("\n", 1)[1].rsplit("\n(exit 0)", 1)[0]
-    stdout, stderr = output.split("\nstderr:\n", 1)
-    assert len(stdout) + len(stderr) == 80
-    assert stdout.startswith("stdout-start-")
-    assert stderr.endswith("-stderr-end")
-    assert "[truncated]" in output
+    assert len(text) == 80
+    assert text.startswith("$ noisy\nstdout-start-")
+    assert text.endswith("-stderr-end\n(exit 0)")
+    assert "[truncated]" in text
+
+
+async def test_shared_file_read_honors_capability_output_limit() -> None:
+    tool = ReadTool(
+        spec=ReadTool.default_spec("qwen"),
+        client=_ssh(
+            files={"/workspace/large.txt": b"x" * 200},
+            max_output_chars=64,
+        ),
+    )
+
+    result = await tool.execute({"filePath": "/workspace/large.txt"})
+
+    text = result_text(result)
+    assert "[truncated]" in text
+    assert "x" * 65 not in text
+
+
+async def test_paginated_reads_slice_before_bounding_output() -> None:
+    content = "".join(f"line-{line:03d}\n" for line in range(1, 101)).encode()
+    openai = ReadTool(
+        spec=ReadTool.default_spec("qwen"),
+        client=_ssh(files={"/workspace/large.txt": content}, max_output_chars=256),
+    )
+    gemini = GeminiReadTool(
+        spec=GeminiReadTool.default_spec("gemini"),
+        client=_ssh(files={"/workspace/large.txt": content}, max_output_chars=256),
+    )
+
+    openai_result = await openai.execute(
+        {"filePath": "/workspace/large.txt", "offset": 80, "limit": 1}
+    )
+    gemini_result = await gemini.execute(
+        {"file_path": "/workspace/large.txt", "start_line": 80, "end_line": 80}
+    )
+
+    assert "line-080" in result_text(openai_result)
+    assert result_text(gemini_result) == "line-080\n"
+
+
+async def test_editors_do_not_write_truncated_source() -> None:
+    original = ("x" * 100 + "TARGET" + "y" * 100).encode()
+    cases = [
+        (
+            EditTool,
+            "qwen",
+            {"filePath": "/workspace/large.txt", "oldString": "TARGET", "newString": "DONE"},
+        ),
+        (
+            GeminiEditTool,
+            "gemini",
+            {"file_path": "/workspace/large.txt", "old_string": "TARGET", "new_string": "DONE"},
+        ),
+        (
+            ClaudeTextEditorTool,
+            "claude",
+            {
+                "command": "str_replace",
+                "path": "/workspace/large.txt",
+                "old_str": "TARGET",
+                "new_str": "DONE",
+            },
+        ),
+    ]
+
+    for tool_type, model, arguments in cases:
+        client = _FakeSSH(
+            files={"/workspace/large.txt": original},
+            max_output_chars=64,
+        )
+        spec = tool_type.default_spec(model)
+        assert spec is not None
+        tool = tool_type(spec=spec, client=cast("SSHClient", client))
+
+        result = await tool.execute(arguments)
+
+        assert result.isError is False
+        assert client.files["/workspace/large.txt"] == original.replace(b"TARGET", b"DONE")
 
 
 async def test_openai_compatible_write_stores_file_via_ssh_exec() -> None:

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -546,9 +546,7 @@ async def test_composite_editor_uses_one_tool_deadline(
             url="ssh://workspace",
             host_pubkey="ssh-ed25519 key",
         ),
-        claim_output_chars=AsyncMock(
-            side_effect=lambda desired, **_: (desired, False, False)
-        ),
+        claim_output_chars=AsyncMock(side_effect=lambda desired, **_: (desired, False, False)),
         read_text=AsyncMock(return_value="old"),
         write_text=AsyncMock(),
     )

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -542,6 +542,13 @@ async def test_composite_editor_uses_one_tool_deadline(
     deadline = Mock(wraps=asyncio.timeout)
     monkeypatch.setattr(asyncio, "timeout", deadline)
     ssh = SimpleNamespace(
+        capability=Capability.ssh(
+            url="ssh://workspace",
+            host_pubkey="ssh-ed25519 key",
+        ),
+        claim_output_chars=AsyncMock(
+            side_effect=lambda desired, **_: (desired, False, False)
+        ),
         read_text=AsyncMock(return_value="old"),
         write_text=AsyncMock(),
     )

--- a/hud/agents/tools/ssh.py
+++ b/hud/agents/tools/ssh.py
@@ -10,12 +10,18 @@ from __future__ import annotations
 import asyncssh
 import mcp.types as mcp_types
 
-from hud.agents.tools.base import AgentTool, tool_err, tool_ok
+from hud.agents.tools.base import AgentTool, result_text, tool_err, tool_ok
 from hud.capabilities import SSHClient
+from hud.capabilities.ssh import (
+    TOOL_MAX_OUTPUT_CHARS_PARAM,
+    TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM,
+    TOOL_OUTPUT_BUDGET_MARKER_PARAM,
+)
 from hud.types import MCPToolResult
 
 MAX_SHELL_OUTPUT_LENGTH = 10 * 1024 * 1024
 TRUNCATION_MARKER = "[truncated]"
+OUTPUT_BUDGET_EXHAUSTED = "[tool output budget exhausted; return an unknown result]"
 
 
 class SSHInfrastructureErrorResult(MCPToolResult):
@@ -37,27 +43,86 @@ class SSHTool(AgentTool[SSHClient]):
 
     # ─── action helpers ───────────────────────────────────────────────
 
+    def output_limit(self) -> int:
+        value = self.client.capability.params.get(TOOL_MAX_OUTPUT_CHARS_PARAM)
+        if value is None:
+            return MAX_SHELL_OUTPUT_LENGTH
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"{TOOL_MAX_OUTPUT_CHARS_PARAM} must be a positive integer")
+        return min(value, MAX_SHELL_OUTPUT_LENGTH)
+
+    async def bound_output(
+        self,
+        stdout: str,
+        stderr: str,
+        *,
+        limit: int | None = None,
+    ) -> tuple[str, str]:
+        configured_limit = self.output_limit()
+        if limit is None:
+            per_result_limit = configured_limit
+        else:
+            if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+                raise ValueError("output limit must be a positive integer")
+            per_result_limit = min(limit, configured_limit)
+        desired = min(len(stdout) + len(stderr), per_result_limit)
+        notice_chars = len(OUTPUT_BUDGET_EXHAUSTED) + 1
+        if (
+            self.client.capability.params.get(TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM)
+            is not None
+            and per_result_limit < notice_chars
+        ):
+            raise ValueError(
+                f"{TOOL_MAX_OUTPUT_CHARS_PARAM} must fit the output budget notice"
+            )
+        allowed, exhausted, notify = await self.client.claim_output_chars(
+            desired,
+            exhaustion_notice_chars=notice_chars,
+        )
+        if notify:
+            allowed = min(allowed, per_result_limit - notice_chars)
+        stdout, stderr = bound_shell_output(stdout, stderr, allowed)
+        if exhausted:
+            marker_path = self.client.capability.params.get(TOOL_OUTPUT_BUDGET_MARKER_PARAM)
+            if isinstance(marker_path, str) and marker_path:
+                await self.client.write_text(marker_path, OUTPUT_BUDGET_EXHAUSTED)
+            if notify:
+                stderr = f"{stderr}\n{OUTPUT_BUDGET_EXHAUSTED}".lstrip()
+        return stdout, stderr
+
+    async def bound_text(self, text: str, *, limit: int | None = None) -> str:
+        text, warning = await self.bound_output(text, "", limit=limit)
+        return text + (f"\n{warning}" if warning else "")
+
     async def bash(self, command: str) -> MCPToolResult:
         """Run a shell command. Returns combined stdout/stderr + exit code."""
         completed = await self.client.run(command, check=False)
         stdout = completed.stdout if isinstance(completed.stdout, str) else ""
         stderr = completed.stderr if isinstance(completed.stderr, str) else ""
-        stdout, stderr = bound_shell_output(stdout, stderr, MAX_SHELL_OUTPUT_LENGTH)
         body = f"$ {command}\n{stdout}"
         if stderr:
             body += f"\nstderr:\n{stderr}"
         body += f"\n(exit {completed.returncode})"
+        body = await self.bound_text(body)
         return MCPToolResult(
             content=[mcp_types.TextContent(type="text", text=body)],
             isError=completed.returncode != 0,
         )
 
-    async def file_read(self, path: str) -> MCPToolResult:
-        """Read a text file through SSH exec."""
+    async def raw_file_read(self, path: str) -> MCPToolResult:
+        """Read a text file without changing content used by mutation helpers."""
         try:
-            return tool_ok(await self.client.read_text(path))
+            text = await self.client.read_text(path)
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
+        return tool_ok(text)
+
+    async def file_read(self, path: str) -> MCPToolResult:
+        """Read a text file and bound the provider-visible result."""
+        result = await self.raw_file_read(path)
+        if result.isError:
+            return result
+        return tool_ok(await self.bound_text(result_text(result)))
 
     async def file_write(self, path: str, content: str) -> MCPToolResult:
         """Write a text file through SSH exec."""
@@ -65,15 +130,22 @@ class SSHTool(AgentTool[SSHClient]):
             await self.client.write_text(path, content)
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
-        return tool_ok(f"wrote {len(content)} bytes to {path}")
+        return tool_ok(await self.bound_text(f"wrote {len(content)} bytes to {path}"))
 
-    async def file_list(self, path: str = "/") -> MCPToolResult:
-        """List directory entries through SSH exec."""
+    async def raw_file_list(self, path: str = "/") -> MCPToolResult:
+        """List directory entries before provider-facing pagination."""
         try:
             names = await self.client.listdir(path)
         except asyncssh.ProcessError as e:
             return tool_err(_remote_error(e))
         return tool_ok("\n".join(names) if names else "(empty)")
+
+    async def file_list(self, path: str = "/") -> MCPToolResult:
+        """List directory entries and bound the provider-visible result."""
+        result = await self.raw_file_list(path)
+        if result.isError:
+            return result
+        return tool_ok(await self.bound_text(result_text(result)))
 
 
 def bound_shell_output(stdout: str, stderr: str, limit: int) -> tuple[str, str]:

--- a/hud/agents/tools/ssh.py
+++ b/hud/agents/tools/ssh.py
@@ -68,13 +68,10 @@ class SSHTool(AgentTool[SSHClient]):
         desired = min(len(stdout) + len(stderr), per_result_limit)
         notice_chars = len(OUTPUT_BUDGET_EXHAUSTED) + 1
         if (
-            self.client.capability.params.get(TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM)
-            is not None
+            self.client.capability.params.get(TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM) is not None
             and per_result_limit < notice_chars
         ):
-            raise ValueError(
-                f"{TOOL_MAX_OUTPUT_CHARS_PARAM} must fit the output budget notice"
-            )
+            raise ValueError(f"{TOOL_MAX_OUTPUT_CHARS_PARAM} must fit the output budget notice")
         allowed, exhausted, notify = await self.client.claim_output_chars(
             desired,
             exhaustion_notice_chars=notice_chars,

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -102,9 +102,7 @@ class SSHClient(CapabilityClient):
         if isinstance(total, bool) or not isinstance(total, int) or total <= 0:
             raise ValueError(f"{TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM} must be a positive integer")
         if total < exhaustion_notice_chars:
-            raise ValueError(
-                f"{TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM} must fit the exhaustion notice"
-            )
+            raise ValueError(f"{TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM} must fit the exhaustion notice")
         async with self._output_budget_lock:
             if self._output_budget_exhausted:
                 return 0, True, False

--- a/hud/capabilities/ssh.py
+++ b/hud/capabilities/ssh.py
@@ -16,6 +16,9 @@ from .base import Capability, CapabilityClient
 SSH_RECONNECT_ATTEMPTS = 3
 SSH_RECONNECT_BASE_DELAY_S = 0.25
 SSH_SESSION_CLOSE_TIMEOUT_S = 5.0
+TOOL_MAX_OUTPUT_CHARS_PARAM = "tool_max_output_chars"
+TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM = "tool_max_total_output_chars"
+TOOL_OUTPUT_BUDGET_MARKER_PARAM = "tool_output_budget_marker_path"
 
 
 class SSHConnectionError(ConnectionError):
@@ -37,6 +40,9 @@ class SSHClient(CapabilityClient):
         self.capability = capability
         self._conn = conn
         self._reconnect_lock = asyncio.Lock()
+        self._output_budget_lock = asyncio.Lock()
+        self._output_chars_claimed = 0
+        self._output_budget_exhausted = False
         self._closing = False
 
     @classmethod
@@ -74,6 +80,43 @@ class SSHClient(CapabilityClient):
     def conn(self) -> asyncssh.SSHClientConnection:
         """Raw asyncssh connection for commands and port forwarding."""
         return self._conn
+
+    async def claim_output_chars(
+        self,
+        desired: int,
+        *,
+        exhaustion_notice_chars: int = 0,
+    ) -> tuple[int, bool, bool]:
+        """Reserve provider-visible evidence against the optional tool budget."""
+        if isinstance(desired, bool) or not isinstance(desired, int) or desired < 0:
+            raise ValueError("desired output chars must be a non-negative integer")
+        if (
+            isinstance(exhaustion_notice_chars, bool)
+            or not isinstance(exhaustion_notice_chars, int)
+            or exhaustion_notice_chars < 0
+        ):
+            raise ValueError("exhaustion notice chars must be a non-negative integer")
+        total = self.capability.params.get(TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM)
+        if total is None:
+            return desired, False, False
+        if isinstance(total, bool) or not isinstance(total, int) or total <= 0:
+            raise ValueError(f"{TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM} must be a positive integer")
+        if total < exhaustion_notice_chars:
+            raise ValueError(
+                f"{TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM} must fit the exhaustion notice"
+            )
+        async with self._output_budget_lock:
+            if self._output_budget_exhausted:
+                return 0, True, False
+            remaining = total - self._output_chars_claimed
+            if desired < max(0, remaining - exhaustion_notice_chars):
+                self._output_chars_claimed += desired
+                return desired, False, False
+
+            allowed = max(0, remaining - exhaustion_notice_chars)
+            self._output_chars_claimed = total
+            self._output_budget_exhausted = True
+            return allowed, True, True
 
     async def create_process(self, command: str) -> asyncssh.SSHClientProcess[bytes]:
         """Open a binary exec channel after restoring a dropped SSH transport."""

--- a/hud/capabilities/tests/test_ssh.py
+++ b/hud/capabilities/tests/test_ssh.py
@@ -8,7 +8,11 @@ import asyncssh
 import pytest
 
 from hud.capabilities.base import Capability
-from hud.capabilities.ssh import SSHClient, SSHConnectionError
+from hud.capabilities.ssh import (
+    TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM,
+    SSHClient,
+    SSHConnectionError,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -125,6 +129,35 @@ def _capability() -> Capability:
 
 def _client(connection: object) -> SSHClient:
     return SSHClient(_capability(), cast("asyncssh.SSHClientConnection", connection))
+
+
+async def test_output_budget_claims_are_atomic() -> None:
+    capability = _capability()
+    capability.params[TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM] = 10
+    client = SSHClient(capability, cast("asyncssh.SSHClientConnection", object()))
+
+    claims = await asyncio.gather(
+        client.claim_output_chars(8),
+        client.claim_output_chars(8),
+    )
+
+    assert sum(allowed for allowed, _, _ in claims) == 10
+    assert sum(exhausted for _, exhausted, _ in claims) == 1
+
+
+async def test_output_budget_exhaustion_is_sticky() -> None:
+    capability = _capability()
+    capability.params[TOOL_MAX_TOTAL_OUTPUT_CHARS_PARAM] = 10
+    client = SSHClient(capability, cast("asyncssh.SSHClientConnection", object()))
+
+    assert await client.claim_output_chars(10) == (10, True, True)
+    assert await client.claim_output_chars(0) == (0, True, False)
+
+
+@pytest.mark.parametrize("desired", [-1, True])
+async def test_output_budget_rejects_invalid_claim(desired: int) -> None:
+    with pytest.raises(ValueError, match="non-negative integer"):
+        await _client(object()).claim_output_chars(desired)
 
 
 async def test_connect_keeps_tunneled_connection_active(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What changed
- Add per-result and run-wide output budgets for SSH-backed agent tools.
- Apply limits to shell, file read, directory listing, and write confirmations across provider-native tools.
- Keep raw file reads internal to edit operations so bounded output cannot truncate source before mutation.
- Make total-budget exhaustion atomic and sticky, and emit a marker for the QA environment.

## Why
Large tool responses could consume the model context and prevent QA runs from returning a usable result. Applying truncation at the wrong boundary could also feed incomplete file contents into editor tools.

## Impact
QA environments can cap provider-visible tool evidence deterministically while preserving safe, lossless file edits. Exhausted runs can be classified explicitly instead of failing from context overflow.

## Validation
- `uv run pytest hud/agents/tests/test_provider_native_tools.py hud/agents/tests/test_tool_agent.py hud/capabilities/tests/test_ssh.py`
- `uv run ruff check hud/agents hud/capabilities`
- Covered concurrent claims, sticky exhaustion, pagination-before-bounding, and mutation safety.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect all SSH tool paths and file-edit correctness boundaries; misconfiguration could truncate agent-visible output or affect QA classification, though mutation safety is explicitly tested.
> 
> **Overview**
> Adds **per-result and run-wide output budgets** for SSH-backed agent tools via capability params (`tool_max_output_chars`, `tool_max_total_output_chars`, optional marker path). `SSHClient.claim_output_chars` tracks the run budget atomically; when it is exhausted, later tool output is suppressed and QA can record a marker file.
> 
> **`SSHTool`** centralizes limiting through `output_limit()`, `bound_output()`, and `bound_text()`, applied to shell output, file reads/lists, and write confirmations. **Editors and internal mutations** use `raw_file_read` / direct `client.run` probes so truncation never corrupts files before replace/insert; paginated reads slice full content first, then bound what the model sees.
> 
> Provider-native tools (Claude, Gemini, OpenAI shell, OpenAI-compatible filesystem) are wired to these helpers; OpenAI shell caps respect both request `max_output_length` and the capability ceiling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cfda186a79d7406c54d713c9eed900c5b4b2a43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->