### PR TITLE
feat(openai): reuse prompt cache keys

### DIFF
--- a/docs/v6/reference/agents.mdx
+++ b/docs/v6/reference/agents.mdx
@@ -68,6 +68,9 @@ workspaces; computer use over an `rfb` capability currently requires a POSIX wor
 (`model`, `max_steps`, `timeout_seconds`, `tool_timeout_seconds`, `system_prompt`, `citations_enabled`, `stop_on`) lives on the
 config; `__call__(run)` takes only the run.
 
+`OpenAIConfig` generates a stable `prompt_cache_key` for the agent and sends it with every Responses
+request. Pass your own key when multiple agent instances should share the same cached prompt prefix.
+
 `timeout_seconds` bounds the complete agent phase. For provider tool agents, `tool_timeout_seconds` bounds each complete SSH-backed tool call, including multi-operation editor calls. It is unset by default except on `ClaudeConfig`, where it defaults to 120 seconds. A timeout is returned to the model as a tool error so the agent can continue. `ClaudeSDKAgent` does not apply this setting because its SSH process is the complete Claude Code agent, not one tool call.
 
 ```python

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -223,6 +223,7 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
             previous_response_id=(
                 oai_state.last_response_id if oai_state.last_response_id is not None else Omit()
             ),
+            prompt_cache_key=self.config.prompt_cache_key,
             truncation=self.truncation if self.truncation is not None else Omit(),
             include=include_param,
         )

--- a/hud/agents/tests/test_base.py
+++ b/hud/agents/tests/test_base.py
@@ -105,6 +105,7 @@ def test_create_agent_value_shortcut_leaves_client_out_of_config(
     assert isinstance(agent, OpenAIAgent)
     assert agent.config.model_client is None
     assert agent.openai_client is sentinel
+    assert agent.hosted_spec()["config"]["prompt_cache_key"] == agent.config.prompt_cache_key
 
 
 def test_create_agent_resolves_gateway_model_metadata(

--- a/hud/agents/tests/test_openai_agent.py
+++ b/hud/agents/tests/test_openai_agent.py
@@ -139,6 +139,19 @@ async def test_get_response_done_when_no_tool_calls() -> None:
     assert result.finish_reason is None
 
 
+async def test_get_response_reuses_prompt_cache_key() -> None:
+    agent = _agent(_api_response("resp_cache", []))
+    state = OpenAIRunState(messages=[agent._format_message("user", "first")])
+
+    await agent.get_response(state)
+    state.messages.append(agent._format_message("user", "second"))
+    await agent.get_response(state)
+
+    calls = cast("Any", agent.openai_client.responses).calls
+    assert calls[0]["prompt_cache_key"] == agent.config.prompt_cache_key
+    assert calls[1]["prompt_cache_key"] == agent.config.prompt_cache_key
+
+
 async def test_get_response_surfaces_token_cap_truncation() -> None:
     # Responses has no finish_reason; incomplete_details.reason carries the cap.
     response = _api_response(

--- a/hud/agents/types.py
+++ b/hud/agents/types.py
@@ -17,6 +17,7 @@ schema understands this family's payload.
 from __future__ import annotations
 
 from typing import Any, ClassVar, Literal, cast
+from uuid import uuid4
 
 from mcp.types import ContentBlock, ImageContent, TextContent
 from pydantic import (
@@ -121,6 +122,11 @@ class OpenAIConfig(AgentConfig):
     text: Any = None  # {"verbosity": "low"|"medium"|"high"}
     truncation: Literal["auto", "disabled"] | None = None
     parallel_tool_calls: bool | None = None
+    prompt_cache_key: str = Field(
+        default_factory=lambda: uuid4().hex,
+        min_length=1,
+        max_length=64,
+    )
 
 
 class OpenAIChatConfig(AgentConfig):


### PR DESCRIPTION
## Summary

- Generate a stable, overridable `prompt_cache_key` for each `OpenAIConfig`.
- Send that key with every `OpenAIAgent` Responses API request.
- Preserve the generated key through hosted-agent serialization and reconstruction.

## Issue

OpenAI prompt caching is enabled automatically, but `OpenAIAgent` did not provide a stable `prompt_cache_key`. At higher request volume, related turns could therefore be routed away from the machine holding their reusable cached prefix.

Hosted rollouts use the same SDK agent after reconstructing its serialized config, so the missing key affected both local SDK users and hosted execution.

## Solution

`OpenAIConfig` now creates a 32-character UUID-based cache key by default and allows callers to override it when multiple agent instances should share a cache group. `OpenAIAgent` forwards the same config key on every Responses request.

Because the key is regular agent configuration, the existing hosted-spec serialization carries it to the remote runner without adding hosted-only logic or changing inference.

OpenAI guidance: https://developers.openai.com/api/docs/guides/prompt-caching

## Impact

SDK users get stable prompt-cache routing without additional configuration. Hosted rollouts gain the same behavior after the monorepo updates its `hud-python` checkout and rebuilds the hosted AMI.

No inference-service change is required for cache-key propagation.

## Validation

- `uv run --extra dev --extra modal pytest -q` — 1167 passed, 17 deselected
- Focused OpenAI agent and hosted serialization tests — 30 passed
- Ruff lint and formatting checks passed
- Ty checks passed for the changed Python files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive config and API parameter with defaults; no auth or data-path changes, covered by unit tests for request forwarding and hosted serialization.
> 
> **Overview**
> **OpenAI Responses agents now send a stable `prompt_cache_key` on every request** so related turns can hit the same prompt-cache prefix instead of being scattered across machines at higher volume.
> 
> `OpenAIConfig` gains `prompt_cache_key` (default: 32-char UUID hex, overridable, max 64 chars). `OpenAIAgent` forwards that value on each `responses.create` call, including multi-turn runs that reuse `previous_response_id`. The key rides along in normal agent config, so **hosted rollouts** pick it up via existing `hosted_spec()` serialization without extra hosted-only plumbing.
> 
> Docs note the knob and when to share a key across multiple agent instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 388fdfd85276e0fb1683266f0e4688d23fb2a2fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->