### PR TITLE
fix(agents): discard OpenAI turns that emit a shell_call with no commands

### DIFF
--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -40,6 +40,22 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# The model can emit a shell_call whose ``commands`` array is empty. OpenAI
+# stores that turn but then returns 500 for every request continuing from it
+# via ``previous_response_id``, so accepting it would poison the rest of the
+# run. Resample instead: the prior response id stays continuable because the
+# degenerate turn is never referenced.
+_MAX_EMPTY_SHELL_CALL_RESAMPLES = 2
+
+
+def _empty_shell_call_ids(output: list[Any]) -> list[str]:
+    """Call ids of model-emitted shell calls with an empty ``commands`` array."""
+    return [
+        item.call_id
+        for item in output
+        if item.type == "shell_call" and item.action.to_dict().get("commands") == []
+    ]
+
 
 @dataclass
 class OpenAIRunState(RunState[ResponseInputItemParam]):
@@ -209,23 +225,40 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
                     ],
                 )
 
-        response = await self.openai_client.responses.create(
-            model=self._model,
-            input=new_items,
-            instructions=system_prompt,
-            max_output_tokens=self.max_output_tokens,
-            temperature=self.temperature,
-            text=self.text if self.text is not None else Omit(),
-            tool_choice=self.tool_choice if self.tool_choice is not None else Omit(),
-            parallel_tool_calls=self.parallel_tool_calls,
-            reasoning=self.reasoning if self.reasoning is not None else Omit(),
-            tools=effective_tools if effective_tools else Omit(),
-            previous_response_id=(
-                oai_state.last_response_id if oai_state.last_response_id is not None else Omit()
-            ),
-            truncation=self.truncation if self.truncation is not None else Omit(),
-            include=include_param,
-        )
+        for resample in range(_MAX_EMPTY_SHELL_CALL_RESAMPLES + 1):
+            response = await self.openai_client.responses.create(
+                model=self._model,
+                input=new_items,
+                instructions=system_prompt,
+                max_output_tokens=self.max_output_tokens,
+                temperature=self.temperature,
+                text=self.text if self.text is not None else Omit(),
+                tool_choice=self.tool_choice if self.tool_choice is not None else Omit(),
+                parallel_tool_calls=self.parallel_tool_calls,
+                reasoning=self.reasoning if self.reasoning is not None else Omit(),
+                tools=effective_tools if effective_tools else Omit(),
+                previous_response_id=(
+                    oai_state.last_response_id if oai_state.last_response_id is not None else Omit()
+                ),
+                truncation=self.truncation if self.truncation is not None else Omit(),
+                include=include_param,
+            )
+            degenerate = _empty_shell_call_ids(response.output)
+            if not degenerate:
+                break
+            logger.warning(
+                "Model emitted shell_call(s) with no commands (%s); resampling turn (%d/%d)",
+                ", ".join(degenerate),
+                resample + 1,
+                _MAX_EMPTY_SHELL_CALL_RESAMPLES,
+            )
+        else:
+            raise RuntimeError(
+                "Model emitted a shell_call with an empty commands array in "
+                f"{_MAX_EMPTY_SHELL_CALL_RESAMPLES + 1} consecutive samples. Continuing "
+                "from such a response poisons the previous_response_id chain (OpenAI "
+                "returns 500 for every follow-up request), so the run was aborted."
+            )
 
         oai_state.last_response_id = response.id
         oai_state.message_cursor = len(messages)

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -40,21 +40,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The model can emit a shell_call whose ``commands`` array is empty. OpenAI
-# stores that turn but then returns 500 for every request continuing from it
-# via ``previous_response_id``, so accepting it would poison the rest of the
-# run. Resample instead: the prior response id stays continuable because the
-# degenerate turn is never referenced.
-_MAX_EMPTY_SHELL_CALL_RESAMPLES = 2
 
+class EmptyShellCallError(RuntimeError):
+    """The model emitted a shell_call with an empty ``commands`` array.
 
-def _empty_shell_call_ids(output: list[Any]) -> list[str]:
-    """Call ids of model-emitted shell calls with an empty ``commands`` array."""
-    return [
-        item.call_id
-        for item in output
-        if item.type == "shell_call" and item.action.to_dict().get("commands") == []
-    ]
+    OpenAI stores such a turn but returns 500 for every request that continues
+    from it via ``previous_response_id``. The turn is rejected before its
+    response id is committed, so the run state still points at the last
+    healthy response and a caller-level retry samples a fresh turn.
+    """
 
 
 @dataclass
@@ -225,39 +219,34 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
                     ],
                 )
 
-        for resample in range(_MAX_EMPTY_SHELL_CALL_RESAMPLES + 1):
-            response = await self.openai_client.responses.create(
-                model=self._model,
-                input=new_items,
-                instructions=system_prompt,
-                max_output_tokens=self.max_output_tokens,
-                temperature=self.temperature,
-                text=self.text if self.text is not None else Omit(),
-                tool_choice=self.tool_choice if self.tool_choice is not None else Omit(),
-                parallel_tool_calls=self.parallel_tool_calls,
-                reasoning=self.reasoning if self.reasoning is not None else Omit(),
-                tools=effective_tools if effective_tools else Omit(),
-                previous_response_id=(
-                    oai_state.last_response_id if oai_state.last_response_id is not None else Omit()
-                ),
-                truncation=self.truncation if self.truncation is not None else Omit(),
-                include=include_param,
-            )
-            degenerate = _empty_shell_call_ids(response.output)
-            if not degenerate:
-                break
-            logger.warning(
-                "Model emitted shell_call(s) with no commands (%s); resampling turn (%d/%d)",
-                ", ".join(degenerate),
-                resample + 1,
-                _MAX_EMPTY_SHELL_CALL_RESAMPLES,
-            )
-        else:
-            raise RuntimeError(
-                "Model emitted a shell_call with an empty commands array in "
-                f"{_MAX_EMPTY_SHELL_CALL_RESAMPLES + 1} consecutive samples. Continuing "
-                "from such a response poisons the previous_response_id chain (OpenAI "
-                "returns 500 for every follow-up request), so the run was aborted."
+        response = await self.openai_client.responses.create(
+            model=self._model,
+            input=new_items,
+            instructions=system_prompt,
+            max_output_tokens=self.max_output_tokens,
+            temperature=self.temperature,
+            text=self.text if self.text is not None else Omit(),
+            tool_choice=self.tool_choice if self.tool_choice is not None else Omit(),
+            parallel_tool_calls=self.parallel_tool_calls,
+            reasoning=self.reasoning if self.reasoning is not None else Omit(),
+            tools=effective_tools if effective_tools else Omit(),
+            previous_response_id=(
+                oai_state.last_response_id if oai_state.last_response_id is not None else Omit()
+            ),
+            truncation=self.truncation if self.truncation is not None else Omit(),
+            include=include_param,
+        )
+
+        empty_shell_calls = [
+            item.call_id
+            for item in response.output
+            if item.type == "shell_call" and item.action.to_dict().get("commands") == []
+        ]
+        if empty_shell_calls:
+            raise EmptyShellCallError(
+                f"Model emitted shell_call(s) with an empty commands array "
+                f"({', '.join(empty_shell_calls)}); continuing from response {response.id} "
+                "would fail with OpenAI 500s, so it was not committed to the run state."
             )
 
         oai_state.last_response_id = response.id
@@ -368,4 +357,4 @@ class OpenAIAgent(ToolAgent[ResponseInputItemParam, OpenAIConfig]):
         )
 
 
-__all__ = ["OpenAIAgent"]
+__all__ = ["EmptyShellCallError", "OpenAIAgent"]

--- a/hud/agents/openai/agent.py
+++ b/hud/agents/openai/agent.py
@@ -24,7 +24,7 @@ from openai.types.responses.response_input_param import (
 )
 from openai.types.shared_params.reasoning import Reasoning  # noqa: TC002
 
-from hud.agents.tool_agent import RunState, ToolAgent
+from hud.agents.tool_agent import DegenerateTurnError, RunState, ToolAgent
 from hud.agents.types import AgentStep, Citation, OpenAIConfig, Usage
 from hud.settings import settings
 from hud.types import MCPToolCall, MCPToolResult
@@ -41,13 +41,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class EmptyShellCallError(RuntimeError):
+class EmptyShellCallError(DegenerateTurnError):
     """The model emitted a shell_call with an empty ``commands`` array.
 
     OpenAI stores such a turn but returns 500 for every request that continues
     from it via ``previous_response_id``. The turn is rejected before its
     response id is committed, so the run state still points at the last
-    healthy response and a caller-level retry samples a fresh turn.
+    healthy response and the next sample continues from there.
     """
 
 

--- a/hud/agents/tests/test_openai_agent.py
+++ b/hud/agents/tests/test_openai_agent.py
@@ -11,7 +11,7 @@ import mcp.types as mcp_types
 import pytest
 from openai.types.responses import ResponseOutputText
 
-from hud.agents.openai.agent import OpenAIAgent, OpenAIRunState
+from hud.agents.openai.agent import EmptyShellCallError, OpenAIAgent, OpenAIRunState
 from hud.agents.openai.tools.base import format_openai_result
 from hud.agents.openai.tools.computer import OPENAI_COMPUTER_SPEC, OpenAIComputerTool
 from hud.agents.types import OpenAIConfig
@@ -184,28 +184,12 @@ async def test_get_response_parses_shell_call() -> None:
     assert [tc.name for tc in result.tool_calls] == ["shell"]
 
 
-class FakeSequencedResponses:
-    """Fake ``responses`` endpoint returning queued payloads, repeating the last."""
-
-    def __init__(self, responses: list[Any]) -> None:
-        self._responses = list(responses)
-        self.calls: list[dict[str, Any]] = []
-
-    async def create(self, **kwargs: Any) -> Any:
-        self.calls.append(kwargs)
-        if len(self._responses) > 1:
-            return self._responses.pop(0)
-        return self._responses[0]
-
-
-def _sequenced_agent(responses: list[Any]) -> OpenAIAgent:
-    client = SimpleNamespace(responses=FakeSequencedResponses(responses))
-    return OpenAIAgent(OpenAIConfig(model="gpt-test", model_client=cast("Any", client)))
-
-
-def _empty_shell_call_response(id: str) -> Any:
-    return _api_response(
-        id,
+async def test_get_response_rejects_empty_shell_call() -> None:
+    # A shell_call with an empty commands array poisons the stored response
+    # chain (OpenAI 500s every continuation via previous_response_id), so the
+    # turn must fail fast and its response id must never be committed.
+    response = _api_response(
+        "resp_poisoned",
         [
             SimpleNamespace(
                 type="shell_call",
@@ -214,39 +198,10 @@ def _empty_shell_call_response(id: str) -> Any:
             ),
         ],
     )
-
-
-async def test_get_response_resamples_empty_shell_call() -> None:
-    # A shell_call with an empty commands array poisons the stored response
-    # chain (OpenAI 500s every continuation), so the turn must be resampled
-    # and the degenerate response id never committed.
-    healthy = _api_response(
-        "resp_good",
-        [
-            SimpleNamespace(
-                type="shell_call",
-                action=SimpleNamespace(to_dict=lambda: {"commands": ["pwd"]}),
-                call_id="call_ok",
-            ),
-        ],
-    )
-    agent = _sequenced_agent([_empty_shell_call_response("resp_poisoned"), healthy])
+    agent = _agent(response)
     state = OpenAIRunState(messages=[agent._format_message("user", "run")])
 
-    result = await agent.get_response(state)
-
-    assert len(cast("Any", agent.openai_client).responses.calls) == 2
-    assert state.last_response_id == "resp_good"
-    assert [tc.id for tc in result.tool_calls] == ["call_ok"]
-
-
-async def test_get_response_raises_after_repeated_empty_shell_calls() -> None:
-    agent = _sequenced_agent([_empty_shell_call_response("resp_poisoned")])
-    state = OpenAIRunState(messages=[agent._format_message("user", "run")])
-
-    with pytest.raises(RuntimeError, match="empty commands array"):
+    with pytest.raises(EmptyShellCallError, match="empty commands array"):
         await agent.get_response(state)
 
-    # 1 initial sample + 2 resamples, and the poisoned id was never committed.
-    assert len(cast("Any", agent.openai_client).responses.calls) == 3
     assert state.last_response_id is None

--- a/hud/agents/tests/test_openai_agent.py
+++ b/hud/agents/tests/test_openai_agent.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import mcp.types as mcp_types
+import pytest
 from openai.types.responses import ResponseOutputText
 
 from hud.agents.openai.agent import OpenAIAgent, OpenAIRunState
@@ -181,3 +182,71 @@ async def test_get_response_parses_shell_call() -> None:
 
     result = await agent.get_response(state)
     assert [tc.name for tc in result.tool_calls] == ["shell"]
+
+
+class FakeSequencedResponses:
+    """Fake ``responses`` endpoint returning queued payloads, repeating the last."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if len(self._responses) > 1:
+            return self._responses.pop(0)
+        return self._responses[0]
+
+
+def _sequenced_agent(responses: list[Any]) -> OpenAIAgent:
+    client = SimpleNamespace(responses=FakeSequencedResponses(responses))
+    return OpenAIAgent(OpenAIConfig(model="gpt-test", model_client=cast("Any", client)))
+
+
+def _empty_shell_call_response(id: str) -> Any:
+    return _api_response(
+        id,
+        [
+            SimpleNamespace(
+                type="shell_call",
+                action=SimpleNamespace(to_dict=lambda: {"commands": [], "timeout_ms": 10000}),
+                call_id="call_empty",
+            ),
+        ],
+    )
+
+
+async def test_get_response_resamples_empty_shell_call() -> None:
+    # A shell_call with an empty commands array poisons the stored response
+    # chain (OpenAI 500s every continuation), so the turn must be resampled
+    # and the degenerate response id never committed.
+    healthy = _api_response(
+        "resp_good",
+        [
+            SimpleNamespace(
+                type="shell_call",
+                action=SimpleNamespace(to_dict=lambda: {"commands": ["pwd"]}),
+                call_id="call_ok",
+            ),
+        ],
+    )
+    agent = _sequenced_agent([_empty_shell_call_response("resp_poisoned"), healthy])
+    state = OpenAIRunState(messages=[agent._format_message("user", "run")])
+
+    result = await agent.get_response(state)
+
+    assert len(cast("Any", agent.openai_client).responses.calls) == 2
+    assert state.last_response_id == "resp_good"
+    assert [tc.id for tc in result.tool_calls] == ["call_ok"]
+
+
+async def test_get_response_raises_after_repeated_empty_shell_calls() -> None:
+    agent = _sequenced_agent([_empty_shell_call_response("resp_poisoned")])
+    state = OpenAIRunState(messages=[agent._format_message("user", "run")])
+
+    with pytest.raises(RuntimeError, match="empty commands array"):
+        await agent.get_response(state)
+
+    # 1 initial sample + 2 resamples, and the poisoned id was never committed.
+    assert len(cast("Any", agent.openai_client).responses.calls) == 3
+    assert state.last_response_id is None

--- a/hud/agents/tests/test_tool_agent.py
+++ b/hud/agents/tests/test_tool_agent.py
@@ -21,7 +21,7 @@ from hud.agents.claude.agent import ClaudeAgent
 from hud.agents.claude.tools.coding import ClaudeBashTool, ClaudeTextEditorTool
 from hud.agents.openai.tools.coding import OpenAIShellTool
 from hud.agents.openai.tools.mcp_proxy import OpenAIMCPProxyTool
-from hud.agents.tool_agent import RunState, ToolAgent
+from hud.agents.tool_agent import DegenerateTurnError, RunState, ToolAgent
 from hud.agents.tools.base import AgentToolSpec, result_text
 from hud.agents.tools.rfb import RFBTool
 from hud.agents.tools.ssh import SSHInfrastructureErrorResult
@@ -590,6 +590,50 @@ async def test_loop_finishes_on_done_response() -> None:
     assert step.content == "final answer"
     assert step.model == "test-model"
     assert step.started_at is not None
+
+
+class _DegenerateDictAgent(DictAgent):
+    """DictAgent whose scripted turns may be ``DegenerateTurnError`` instances."""
+
+    def __init__(self, turns: list[AgentStep | DegenerateTurnError], **config: Any) -> None:
+        super().__init__(cast("list[AgentStep]", turns), **config)
+
+    async def get_response(
+        self, state: RunState[_Msg], *, system_prompt: Any = None, citations_enabled: bool = False
+    ) -> AgentStep:
+        turn = await super().get_response(
+            state, system_prompt=system_prompt, citations_enabled=citations_enabled
+        )
+        if isinstance(turn, DegenerateTurnError):
+            raise turn
+        return turn
+
+
+async def test_loop_discards_degenerate_turn_and_resamples() -> None:
+    agent = _DegenerateDictAgent(
+        [
+            DegenerateTurnError("empty shell_call"),
+            AgentStep(content="recovered", done=True),
+        ]
+    )
+    run = cast("Run", _FakeRun())
+
+    await agent._loop(run, RunState(), max_steps=3)
+
+    # The degenerate turn is discarded (consuming a step) and never recorded.
+    assert run.trace.status == "completed"
+    assert run.trace.content == "recovered"
+    assert [step.source for step in run.trace.steps] == ["agent"]
+
+
+async def test_loop_fails_when_degenerate_turn_exhausts_steps() -> None:
+    agent = _DegenerateDictAgent([DegenerateTurnError("empty shell_call")] * 2)
+    run = cast("Run", _FakeRun())
+
+    await agent._loop(run, RunState(), max_steps=2)
+
+    assert run.trace.status == "error"
+    assert run.trace.error == "empty shell_call"
 
 
 async def test_loop_dispatches_tool_calls_then_finishes() -> None:

--- a/hud/agents/tool_agent.py
+++ b/hud/agents/tool_agent.py
@@ -53,6 +53,16 @@ MessageT = TypeVar("MessageT")
 ConfigT = TypeVar("ConfigT", bound="AgentConfig")
 
 
+class DegenerateTurnError(Exception):
+    """A model sample was unusable and was not committed to the run state.
+
+    Raised by ``get_response`` implementations that reject a degenerate
+    response before recording it. The loop discards the turn and samples a
+    fresh one; each discarded turn still consumes a step from ``max_steps``,
+    and a degenerate final step fails the run.
+    """
+
+
 def _message_text(message: mcp_types.PromptMessage) -> str:
     """Best-effort plain text for a prompt message (text content only for now)."""
     content = message.content
@@ -229,11 +239,17 @@ class ToolAgent(Agent, Generic[MessageT, ConfigT]):
             for turn in range(1, max_steps + 1):
                 logger.info("step %d/%d", turn, max_steps)
                 started_at = now_iso()
-                step = await self.get_response(
-                    state,
-                    system_prompt=system_prompt,
-                    citations_enabled=citations_enabled,
-                )
+                try:
+                    step = await self.get_response(
+                        state,
+                        system_prompt=system_prompt,
+                        citations_enabled=citations_enabled,
+                    )
+                except DegenerateTurnError as exc:
+                    if turn == max_steps:
+                        raise
+                    logger.warning("Discarded degenerate turn: %s", exc)
+                    continue
                 step.started_at = step.started_at or started_at
                 step.model = step.model or self.config.model
                 run.record(step)


### PR DESCRIPTION
## Problem

Agent runs were dying with opaque OpenAI `500 server_error` responses. Investigation via gateway telemetry showed the trigger is upstream:

1. The model (observed with gpt-5.6-luna) occasionally emits a `shell_call` whose `action.commands` array is empty.
2. OpenAI stores that response, but every subsequent request that continues from it via `previous_response_id` deterministically fails with `500 server_error` — regardless of what `shell_call_output` we send back. Verified by live replay: the poisoned chain 500s across all shell-capable models, while forking from the previous healthy response id works fine.

Since `OpenAIAgent` chains every turn through `previous_response_id`, one degenerate sample kills the rest of the run, and the failure surfaces turns later as an unexplained 500.

## Fix

Two small pieces:

- `OpenAIAgent.get_response` detects the degenerate turn and raises a typed `EmptyShellCallError` before the response id is committed, so the run state still points at the last healthy response. Detection is exact (`commands == []`) to match the observed failure signature.
- `EmptyShellCallError` subclasses a new `DegenerateTurnError`; the `ToolAgent` loop discards such turns and samples a fresh one. No new retry machinery or budgets: each discarded turn consumes a step from the existing `max_steps` budget, and a degenerate final step fails the run with the typed error instead of a delayed 500.

Runs now survive one-off degenerate samples (the observed production pattern), and a persistently degenerate model ends the run with an explained error at the turn that caused it.

## Testing

- `uv run --extra dev pytest hud/agents/tests/test_openai_agent.py hud/agents/tests/test_tool_agent.py` — 41 passed, including new tests: the degenerate turn raises and its response id is never committed; the loop discards a degenerate turn and completes on the resample; a run whose final step is degenerate fails with the typed error.
- `ruff check`, `ruff format --check`, and `ty check` clean on the touched files.