### PR TITLE
fix(runtime): preserve structured grades for hosted rollouts

### DIFF
--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -131,6 +131,7 @@ class HostedRuntime:
         run.trace.trace_id = trace_id
         run.job_id = job_id
         run.group_id = group_id
+        run.slug = task.slug
         return run
 
     async def _submit_and_await(

--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -202,12 +202,16 @@ class HostedRuntime:
                 if run.trace.status == "cancelled"
                 else "rollout failed before grading"
             )
-        run.grade = Grade(
-            reward=float(reward) if reward is not None else 0.0,
-            is_error=ungraded_failure,
-            content=grade_error,
-            raw={"score": float(reward)} if reward is not None else {},
-        )
+        evaluation_result = state.get("evaluation_result")
+        if isinstance(evaluation_result, dict):
+            run.grade = Grade.from_dict(evaluation_result)
+        else:
+            run.grade = Grade(
+                reward=float(reward) if reward is not None else 0.0,
+                is_error=ungraded_failure,
+                content=grade_error,
+                raw={"score": float(reward)} if reward is not None else {},
+            )
         run._runtime = f"hud://trace/{trace_id}"
         return run
 
@@ -215,7 +219,8 @@ class HostedRuntime:
         while True:
             state: dict[str, Any] = await platform.aget(f"/trace/{trace_id}")
             if state.get("status") in _TERMINAL_TRACE_STATUSES:
-                return state
+                trace_info = await platform.aget(f"/trace/{trace_id}/info")
+                return {**state, "evaluation_result": trace_info.get("evaluation_result")}
             await asyncio.sleep(self.poll_interval)
 
     async def _cancel(self, platform: PlatformClient, trace_id: str) -> None:

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -51,8 +51,14 @@ class _FakePlatform:
 
     api_key = "test-key"
 
-    def __init__(self, states: list[dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        states: list[dict[str, Any]],
+        *,
+        trace_info: dict[str, Any] | None = None,
+    ) -> None:
         self.states = states
+        self.trace_info = trace_info
         self.posts: list[tuple[str, dict[str, Any]]] = []
         self.polled = 0
 
@@ -61,6 +67,8 @@ class _FakePlatform:
         return {"status": "queued"}
 
     async def aget(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
+        if path.endswith("/info"):
+            return self.trace_info if self.trace_info is not None else self.states[-1]
         state = self.states[min(self.polled, len(self.states) - 1)]
         self.polled += 1
         return state
@@ -190,7 +198,15 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
             {"status": "pending"},
             {"status": "running"},
             {"status": "completed", "reward": 0.5},
-        ]
+        ],
+        trace_info={
+            "status": "completed",
+            "reward": 0.5,
+            "evaluation_result": {
+                "score": 0.5,
+                "info": {"summary": {"passed": 3}},
+            },
+        },
     )
     monkeypatch.setattr(
         "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
@@ -227,6 +243,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert run.trace.trace_id == trace_id
     assert run.job_id == job_id
     assert run.group_id == "g1"
+    assert run.grade.info == {"summary": {"passed": 3}}
     assert platform.polled == 3
     (path, payload) = platform.posts[0]
     assert path == "/rollouts/submit"

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -244,6 +244,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert run.job_id == job_id
     assert run.group_id == "g1"
     assert run.grade.info == {"summary": {"passed": 3}}
+    assert Job(id="job", name="test", runs=[run]).results == {"sums-add": [run]}
     assert platform.polled == 3
     (path, payload) = platform.posts[0]
     assert path == "/rollouts/submit"


### PR DESCRIPTION
## Summary

Hosted rollouts currently reconstruct `Run.grade` from the terminal trace reward, which drops structured evaluation output such as `info`.

After a hosted trace reaches a terminal state, this change reads its detailed result and hydrates the local grade from `evaluation_result`.

The returned run also retains its task slug so callers can associate structured results through `Job.results`.

## API question

`HostedRuntime` currently polls `GET /v2/trace/{trace_id}`, whose terminal response contains status, reward, and error but not `evaluation_result`. The structured result is available from the broader `GET /v2/trace/{trace_id}/info` response, so this patch performs one additional detail request per terminal hosted rollout. If that request fails, the runtime surfaces the failure through its existing error handling.

Is `/info` the intended SDK path for retrieving the native evaluation result? If not, could the terminal trace response include `evaluation_result` once available, or could the API expose a result-only endpoint? Either option would let `HostedRuntime` preserve structured results without fetching the broader trace-info response.

## Testing

- `uv run pytest -q` (1,166 passed, 17 deselected)
- `uv run ruff format . --check`
- `uv run ruff check .`
- `uv run --extra dev --extra train ty check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how hosted runs are graded and adds a mandatory `/info` fetch at terminal state; failures or bad `evaluation_result` shapes can alter or break grade hydration compared to the old reward-only path.
> 
> **Overview**
> Hosted rollouts no longer build `Run.grade` only from the terminal trace’s scalar `reward`, which dropped structured fields like `grade.info`.
> 
> When a trace reaches a terminal state, **`HostedRuntime`** now calls **`GET /trace/{trace_id}/info`**, merges `evaluation_result` into the polled state, and in **`_fold`** uses **`Grade.from_dict`** when that payload is present (otherwise it keeps the previous reward-based fallback). Each completed hosted rollout therefore costs one extra platform request.
> 
> Returned runs also set **`run.slug`** from the task so **`Job.results`** can key runs by slug (e.g. `sums-add`).
> 
> Tests extend the fake platform client to serve `/info` and assert structured `grade.info` and slug-based job grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6e46762004f6397e74085138b377e4d43b7bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->