### PR TITLE
fix(cookbooks): migrate Fireworks RL to Qwen 3.8 27B and correct grading

### DIFF
--- a/cookbooks/fireworks-rl-training/README.md
+++ b/cookbooks/fireworks-rl-training/README.md
@@ -10,7 +10,7 @@ training service.
 |------|---------|
 | `env.py` | Local multiplication environment and grader |
 | `train.py` | Rollout, advantage, training, evaluation, and checkpoint loop |
-| `test_train.py` | Unit tests for URL handling, reward normalization, batch construction, and reward spread |
+| `test_train.py` | Unit tests for batching and the HUD rollout lifecycle; tokenizer compatibility check |
 
 ## Setup
 
@@ -25,12 +25,16 @@ key must have access to Fireworks Serverless Training.
 uv sync
 ```
 
-The default model is `accounts/fireworks/models/qwen3p5-9b`. A different
-model requires a matching `--base-model`, `--tokenizer-model`, and
+The default model is Qwen 3.8 27B (`accounts/fireworks/models/qwen3p8-27b`),
+with tokenizer `Qwen/Qwen3.8-27B`. Fireworks deprecated the Qwen 3.5 9B and
+Qwen 3.6 27B Serverless Training pools; see the
+[Fireworks changelog](https://docs.fireworks.ai/updates/changelog).
+A different model requires a matching `--base-model`, `--tokenizer-model`, and
 `--renderer`, since tokenization and prompt rendering happen on the client.
 
-The default renderer disables thinking mode. With thinking enabled and a
-small generation budget, the model may spend all available tokens on
+The default renderer is `qwen3_8_disable_thinking`, provided by
+`tinker-cookbook>=0.5.7`. With thinking enabled and a small generation
+budget, the model may spend all available tokens on
 reasoning without producing the final answer expected by the grader.
 
 ## Run
@@ -41,8 +45,8 @@ Calibrate the default task before taking an optimizer step:
 uv run train.py \
   --calibrate \
   --tasks-per-step 6 \
-  --group-size 6 \
-  --max-tokens 512 \
+  --group-size 4 \
+  --max-tokens 2048 \
   --debug-samples 4
 ```
 
@@ -53,7 +57,7 @@ uv run train.py \
   --steps 1 \
   --tasks-per-step 2 \
   --group-size 4 \
-  --max-tokens 512 \
+  --max-tokens 2048 \
   --eval-tasks 4 \
   --require-update
 ```
@@ -61,10 +65,12 @@ uv run train.py \
 `--require-update` fails if every group has identical rewards and the script
 cannot apply an optimizer update. A successful command verifies
 authentication, sampling, HUD grading, one update, checkpoint creation, and
-evaluation.
+evaluation. Calibration, training, and evaluation fail if any rollout has a
+sampling or grading error; failed attempts are not treated as zero-reward
+training examples.
 
 The default command requests 30 training steps with 8 task groups per step,
-8 rollouts per group, and up to 1,024 generated tokens per rollout. A step
+8 rollouts per group, and up to 2,048 generated tokens per rollout. A step
 with no reward variation skips its optimizer update. The run still collects
 1,920 paid training rollouts, followed by 16 evaluation rollouts. Fireworks
 meters prompt prefill, sampled output, and training tokens separately.
@@ -80,6 +86,15 @@ tests do not require an API key:
 ```bash
 uv run pytest
 ```
+
+To check the default renderer against Qwen's published chat template:
+
+```bash
+uv run pytest -m integration test_train.py -k default_renderer
+```
+
+This downloads the tokenizer from Hugging Face and requires network access,
+but does not call Fireworks or train a model.
 
 Serverless capacity is shared. `--max-concurrent` controls the number of
 simultaneous rollout requests; lower values reduce burst pressure when the
@@ -98,7 +113,7 @@ an optimizer update:
 uv run train.py \
   --calibrate \
   --tasks-per-step 6 \
-  --group-size 6 \
+  --group-size 4 \
   --debug-samples 4
 ```
 
@@ -109,7 +124,7 @@ The command reports:
 | `reward_mean` | Mean reward across completed rollouts |
 | `within_group_reward_std` | Mean reward standard deviation within rollout groups |
 
-`--debug-samples N` prints the reward, output-token count, and text for the
+`--debug-samples N` prints the reward, output-token count, and full response for the
 first N rollouts. During training, the within-group statistic is stored as
 `reward_std_within_group`. A positive value confirms reward variation in at
 least one group. Inspect the sample text to verify that the rewards track
@@ -118,8 +133,10 @@ answer quality.
 If groups are uniformly correct, increase the task difficulty with
 `--min-a`, `--max-a`, `--min-b`, and `--max-b`. If groups are uniformly
 incorrect, reduce the operand range or increase `--max-tokens`. The default
-three-digit multiplication range is intended to produce both correct and
-incorrect samples with the 9B model.
+four-digit multiplication range uses a 2,048-token budget. Three-digit tasks
+were nearly saturated on Qwen 3.8 27B, while smaller generation budgets cut
+off many answers. Inspect both correctness and output-token counts when
+calibrating; a clipped response does not establish arithmetic difficulty.
 
 ## Training flow
 
@@ -191,6 +208,10 @@ Resume a previous run with a fully qualified training checkpoint:
 ```bash
 uv run train.py --resume-from "<account>/<run-id>/state-0005"
 ```
+
+Resume restores the checkpoint's original base model; it does not migrate
+an older Qwen adapter to Qwen 3.8. Start a new run when changing base models.
+For a supported non-default checkpoint, pass its matching tokenizer and renderer.
 
 Resume creates a new Fireworks run, appends metrics to the existing
 `metrics.jsonl`, and restarts local step numbering at 1. Sampler checkpoints

--- a/cookbooks/fireworks-rl-training/env.py
+++ b/cookbooks/fireworks-rl-training/env.py
@@ -11,10 +11,9 @@ env = Environment(name="fireworks-arithmetic")
 
 
 def grade_final_integer(answer: object, expected: int) -> EvaluationResult:
-    """Compare the final numeric token as an integer, allowing thousands separators."""
-    text = answer if isinstance(answer, str) else str(answer)
-    numbers = re.findall(r"[+-]?(?:\d[\d,]*(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?", text)
-    final = numbers[-1] if numbers else ""
+    """Grade an integer on the last nonempty line, allowing thousands separators."""
+    text = (answer if isinstance(answer, str) else str(answer)).strip()
+    final = text.splitlines()[-1].strip() if text else ""
     got = (
         int(final.replace(",", ""))
         if re.fullmatch(r"[+-]?(?:\d+|\d{1,3}(?:,\d{3})+)", final)
@@ -22,7 +21,7 @@ def grade_final_integer(answer: object, expected: int) -> EvaluationResult:
     )
     return EvaluationResult(
         reward=1.0 if got == expected else 0.0,
-        content=text.strip(),
+        content=text,
         info={"expected": expected, "got": got},
     )
 

--- a/cookbooks/fireworks-rl-training/env.py
+++ b/cookbooks/fireworks-rl-training/env.py
@@ -11,10 +11,15 @@ env = Environment(name="fireworks-arithmetic")
 
 
 def grade_final_integer(answer: object, expected: int) -> EvaluationResult:
-    """Reward 1.0 when the last integer in the answer matches the expected value."""
+    """Compare the final numeric token as an integer, allowing thousands separators."""
     text = answer if isinstance(answer, str) else str(answer)
-    integers = re.findall(r"-?\d+", text)
-    got = int(integers[-1]) if integers else None
+    numbers = re.findall(r"[+-]?(?:\d[\d,]*(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?", text)
+    final = numbers[-1] if numbers else ""
+    got = (
+        int(final.replace(",", ""))
+        if re.fullmatch(r"[+-]?(?:\d+|\d{1,3}(?:,\d{3})+)", final)
+        else None
+    )
     return EvaluationResult(
         reward=1.0 if got == expected else 0.0,
         content=text.strip(),

--- a/cookbooks/fireworks-rl-training/pyproject.toml
+++ b/cookbooks/fireworks-rl-training/pyproject.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 description = "Train on HUD rewards with Fireworks Serverless RL"
 requires-python = ">=3.11,<3.13"
 dependencies = [
-    "fireworks-ai[training]",
+    "fireworks-ai[training]>=1.2.11",
     "hud",
     "python-dotenv",
     "tinker",
-    "tinker-cookbook",
+    "tinker-cookbook>=0.5.7",
 ]
 
 [tool.uv]
@@ -19,3 +19,10 @@ dev = ["pytest"]
 
 [tool.uv.sources]
 hud = { path = "../..", editable = true }
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+addopts = "-m 'not integration'"
+markers = [
+    "integration: requires network access to download the model tokenizer",
+]

--- a/cookbooks/fireworks-rl-training/test_train.py
+++ b/cookbooks/fireworks-rl-training/test_train.py
@@ -333,16 +333,26 @@ def test_default_renderer_matches_qwen38_chat_template() -> None:
     [
         (4861, 3217, "15637837", 1.0),
         (4861, 3217, "The final answer is:\n15,637,837", 1.0),
-        (4861, 3217, r"\boxed{15,637,837}", 1.0),
+        (4861, 3217, "The answer is 15637837, as calculated above.", 0.0),
+        (4861, 3217, "The answer is 15,637,837, as calculated above.", 0.0),
+        (2, 3, "6,", 0.0),
+        (4861, 3217, r"\boxed{15,637,837}", 0.0),
+        (4861, 3217, "Working...\n\n  15,637,837  \n \t\n", 1.0),
+        (4861, 3217, "+15,637,837", 1.0),
+        (4861, 3217, "15637837\n0", 0.0),
+        (4861, 3217, "15637837\nThat's my answer.", 0.0),
         (4861, -3217, "-15,637,837", 1.0),
         (3, 279, "15,637,837", 0.0),
         (4861, 3217, "0.15637837", 0.0),
         (4861, 3217, "1e15637837", 0.0),
         (4861, 3217, "15,63,7837", 0.0),
+        (4861, 3217, "15,63,7837,", 0.0),
+        (4861, 3217, "15,,637,837,", 0.0),
         (4861, 3217, "No answer", 0.0),
+        (4861, 3217, " \n\t\n", 0.0),
     ],
 )
-def test_grades_final_numeric_value(a, b, answer, reward, tokenizer, fireworks_service):
+def test_grades_integer_on_last_nonempty_line(a, b, answer, reward, tokenizer, fireworks_service):
     tokens = tokenizer.encode(f"{answer}<|im_end|>", add_special_tokens=False)
     sampler = fireworks_service.create_sampling_client.return_value
     sampler.sample.side_effect = None

--- a/cookbooks/fireworks-rl-training/test_train.py
+++ b/cookbooks/fireworks-rl-training/test_train.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+import asyncio
+import json
+import re
 from argparse import Namespace
+from concurrent.futures import Future
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from hud.agents.types import AgentStep, Sample
 from hud.eval import HUDRuntime, LocalRuntime, Taskset
 from hud.eval.run import Run
+from hud.settings import settings
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+from transformers import PreTrainedTokenizerFast
 
+import train as training
+from env import multiply
 from train import (
     group_relative_advantages,
     make_taskset,
@@ -16,6 +27,32 @@ from train import (
     split_taskset,
     within_group_reward_std,
 )
+
+
+@pytest.fixture(autouse=True)
+def isolate_hud(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "telemetry_enabled", False)
+    monkeypatch.setattr(settings, "api_key", None)
+    monkeypatch.setattr(settings, "telemetry_local_dir", None)
+
+
+@pytest.fixture
+def tokenizer() -> PreTrainedTokenizerFast:
+    vocabulary = {token: i for i, token in enumerate(sorted(pre_tokenizers.ByteLevel.alphabet()))}
+    backend = Tokenizer(models.BPE(vocab=vocabulary, merges=[]))
+    backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    backend.decoder = decoders.ByteLevel()
+    return PreTrainedTokenizerFast(
+        tokenizer_object=backend,
+        eos_token="<|im_end|>",
+        additional_special_tokens=["<|im_start|>", "<think>", "</think>"],
+    )
+
+
+def resolved(value: object) -> Future:
+    future = Future()
+    future.set_result(value)
+    return future
 
 
 def rollout(*, group: str, reward: float) -> Run:
@@ -137,3 +174,190 @@ def test_default_rollout_source_has_disjoint_evaluation_tasks() -> None:
 
     assert {task.slug for task in train}.isdisjoint(task.slug for task in evaluation)
     assert isinstance(runtime, LocalRuntime)
+
+
+@pytest.fixture
+def fireworks_service(tokenizer: PreTrainedTokenizerFast) -> MagicMock:
+    service = MagicMock()
+    client = service.create_lora_training_client.return_value
+    client.save_weights_for_sampler.side_effect = lambda name: resolved(
+        SimpleNamespace(path=f"test/run/{name}")
+    )
+    client.save_state.side_effect = lambda name: resolved(SimpleNamespace(path=f"test/run/{name}"))
+    client.forward_backward.return_value = resolved(
+        SimpleNamespace(metrics={"loss:sum": 1.0, "total_tokens:sum": 10})
+    )
+    client.optim_step.return_value = resolved(None)
+    attempts: dict[str, int] = {}
+
+    def sample(*, prompt, num_samples, sampling_params):
+        text = tokenizer.decode(prompt.to_ints())
+        operands = re.search(r"What is (\d+) \* (\d+)", text)
+        assert operands is not None
+        attempts[text] = attempts.get(text, 0) + 1
+        correct = int(operands[1]) * int(operands[2])
+        answer = correct if attempts[text] % 2 else correct + 1
+        tokens = tokenizer.encode(f"{answer}<|im_end|>", add_special_tokens=False)
+        return resolved(
+            SimpleNamespace(
+                sequences=[SimpleNamespace(tokens=tokens, logprobs=[-0.5] * len(tokens))]
+            )
+        )
+
+    service.create_sampling_client.return_value.sample.side_effect = sample
+    return service
+
+
+@pytest.mark.parametrize("calibrate", [False, True])
+def test_training_lifecycle_with_mocked_fireworks(
+    monkeypatch, tmp_path, tokenizer, fireworks_service, calibrate
+) -> None:
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(training, "get_tokenizer", lambda model: tokenizer)
+    factory = MagicMock(return_value=fireworks_service)
+    monkeypatch.setattr(training, "FiretitanServiceClient", factory)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "train.py",
+            "--steps",
+            "1",
+            "--tasks-per-step",
+            "1",
+            "--group-size",
+            "2",
+            "--eval-tasks",
+            "1",
+            "--max-concurrent",
+            "1",
+            "--require-update",
+            "--output-dir",
+            str(tmp_path),
+        ]
+        + (["--calibrate"] if calibrate else []),
+    )
+    args = training.parse_args()
+    assert args.base_model == "accounts/fireworks/models/qwen3p8-27b"
+    assert args.tokenizer_model == "Qwen/Qwen3.8-27B"
+    assert args.renderer == "qwen3_8_disable_thinking"
+
+    asyncio.run(training.train(args))
+
+    client = fireworks_service.create_lora_training_client.return_value
+    fireworks_service.create_lora_training_client.assert_called_once_with(
+        base_model=args.base_model, rank=8
+    )
+    if calibrate:
+        client.forward_backward.assert_not_called()
+        client.optim_step.assert_not_called()
+    else:
+        datums, loss_fn = client.forward_backward.call_args.args
+        assert loss_fn == "importance_sampling"
+        assert len(datums) == 2
+        assert any(value > 0 for value in datums[0].loss_fn_inputs["advantages"].data)
+        assert any(value < 0 for value in datums[1].loss_fn_inputs["advantages"].data)
+        client.optim_step.assert_called_once()
+        client.save_state.assert_called_once_with("final-state")
+        metric = json.loads((tmp_path / "metrics.jsonl").read_text())
+        assert metric["updated"] is True
+        assert metric["valid_rollouts"] == 2
+        assert metric["reward_std_within_group"] > 0
+    fireworks_service.close.assert_called_once()
+
+
+@pytest.mark.parametrize("failure", ["sampling", "grading"])
+def test_rollout_failure_fails_calibration(
+    monkeypatch, tmp_path, tokenizer, fireworks_service, failure
+):
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(training, "get_tokenizer", lambda model: tokenizer)
+    monkeypatch.setattr(training, "FiretitanServiceClient", lambda **kwargs: fireworks_service)
+    argv = [
+        "train.py",
+        "--calibrate",
+        "--tasks-per-step",
+        "1",
+        "--group-size",
+        "2",
+        "--output-dir",
+        str(tmp_path),
+    ]
+    sampler = fireworks_service.create_sampling_client.return_value
+    if failure == "sampling":
+        future = Future()
+        future.set_exception(RuntimeError("sampler unavailable"))
+        sampler.sample.side_effect = None
+        sampler.sample.return_value = future
+    else:
+        source = tmp_path / "broken.py"
+        source.write_text(
+            "from hud import Environment\n"
+            'env = Environment("broken-grader")\n'
+            "@env.template()\n"
+            "async def multiply():\n"
+            '    answer = yield "What is 123 * 456?"\n'
+            '    raise RuntimeError("grader unavailable")\n'
+            "tasks = [multiply()]\n"
+        )
+        argv.extend(["--tasks-file", str(source), "--env-path", str(source)])
+    monkeypatch.setattr("sys.argv", argv)
+
+    with pytest.raises(RuntimeError, match="2/2 rollouts failed"):
+        asyncio.run(training.train(training.parse_args()))
+
+    fireworks_service.create_lora_training_client.return_value.optim_step.assert_not_called()
+    sampler.close.assert_called_once()
+    fireworks_service.close.assert_called_once()
+
+
+@pytest.mark.integration
+def test_default_renderer_matches_qwen38_chat_template() -> None:
+    tokenizer = training.get_tokenizer(training.DEFAULT_TOKENIZER_MODEL)
+    renderer = training.get_renderer(training.DEFAULT_RENDERER, tokenizer)
+    messages = [{"role": "user", "content": "What is 123 * 456?"}]
+    expected = tokenizer.apply_chat_template(
+        messages,
+        tokenize=True,
+        return_dict=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    assert renderer.build_generation_prompt(messages).to_ints() == expected
+    tokens = tokenizer.encode("56088<|im_end|>", add_special_tokens=False)
+    message, _ = renderer.parse_response(tokens)
+    assert training.get_text_content(message) == "56088"
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "answer", "reward"),
+    [
+        (4861, 3217, "15637837", 1.0),
+        (4861, 3217, "The final answer is:\n15,637,837", 1.0),
+        (4861, 3217, r"\boxed{15,637,837}", 1.0),
+        (4861, -3217, "-15,637,837", 1.0),
+        (3, 279, "15,637,837", 0.0),
+        (4861, 3217, "0.15637837", 0.0),
+        (4861, 3217, "1e15637837", 0.0),
+        (4861, 3217, "15,63,7837", 0.0),
+        (4861, 3217, "No answer", 0.0),
+    ],
+)
+def test_grades_final_numeric_value(a, b, answer, reward, tokenizer, fireworks_service):
+    tokens = tokenizer.encode(f"{answer}<|im_end|>", add_special_tokens=False)
+    sampler = fireworks_service.create_sampling_client.return_value
+    sampler.sample.side_effect = None
+    sampler.sample.return_value = resolved(
+        SimpleNamespace(sequences=[SimpleNamespace(tokens=tokens, logprobs=[-0.5] * len(tokens))])
+    )
+    agent = training.FireworksAgent(
+        sampler=sampler,
+        renderer=training.get_renderer(training.DEFAULT_RENDERER, tokenizer),
+        model=training.DEFAULT_BASE_MODEL,
+        max_tokens=2048,
+        temperature=1.0,
+        timeout=10,
+        max_seq_len=8192,
+    )
+    job = asyncio.run(multiply(a=a, b=b).run(agent, runtime=LocalRuntime(training.HERE / "env.py")))
+    assert job.runs[0].trace.status == "completed"
+    assert job.runs[0].reward == reward

--- a/cookbooks/fireworks-rl-training/train.py
+++ b/cookbooks/fireworks-rl-training/train.py
@@ -26,11 +26,10 @@ from env import multiply
 
 HERE = Path(__file__).resolve().parent
 SERVERLESS_URL = "https://api.fireworks.ai/training/v1/serverless"
-DEFAULT_BASE_MODEL = "accounts/fireworks/models/qwen3p5-9b"
-DEFAULT_TOKENIZER_MODEL = "Qwen/Qwen3.5-9B"
-# Thinking mode spends the whole token budget on a <think> block and never
-# reaches the final answer line, so rewards collapse to zero on this task.
-DEFAULT_RENDERER = "qwen3_5_disable_thinking"
+DEFAULT_BASE_MODEL = "accounts/fireworks/models/qwen3p8-27b"
+DEFAULT_TOKENIZER_MODEL = "Qwen/Qwen3.8-27B"
+# Reserve the generation budget for the answer rather than hidden reasoning.
+DEFAULT_RENDERER = "qwen3_8_disable_thinking"
 
 
 def serverless_url(value: str) -> str:
@@ -89,8 +88,6 @@ def report_calibration(runs: list[Run], *, debug_samples: int) -> None:
         sample = _sample(run)
         assert sample is not None
         text = (run.trace.content or "").strip()
-        if len(text) > 400:
-            text = text[:400] + "..."
         print(
             f"--- reward={run.reward:.2f} output_tokens={len(sample.output_token_ids)}\n{text}",
             flush=True,
@@ -98,9 +95,6 @@ def report_calibration(runs: list[Run], *, debug_samples: int) -> None:
 
 
 def make_taskset(*, count: int, seed: int, a: tuple[int, int], b: tuple[int, int]) -> Taskset:
-    # The default 3-digit x 3-digit lands mid-difficulty for the 9B model:
-    # right often but not always, so groups keep the reward spread GRPO
-    # trains on. Tune the ranges with --min-a/--max-a/--min-b/--max-b.
     a_count = a[1] - a[0] + 1
     b_count = b[1] - b[0] + 1
     population = a_count * b_count
@@ -386,6 +380,17 @@ async def run_rollouts(
             group=group_size,
             max_concurrent=max_concurrent,
         )
+        failed = [
+            run
+            for run in job.runs
+            if run.trace.status != "completed" or run.grade.is_error or _sample(run) is None
+        ]
+        if failed:
+            first = failed[0]
+            detail = first.trace.error or first.grade.content or "missing completed sample"
+            raise RuntimeError(
+                f"{len(failed)}/{len(job.runs)} rollouts failed during {snapshot_name}: {detail}"
+            )
         return job.runs, snapshot.path
     finally:
         sampler.close()
@@ -651,7 +656,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--group-size", type=int, default=8, help="rollouts per task (the GRPO group)"
     )
-    parser.add_argument("--max-tokens", type=int, default=1024, help="generated tokens per rollout")
+    parser.add_argument("--max-tokens", type=int, default=2048, help="generated tokens per rollout")
     parser.add_argument("--max-concurrent", type=int, default=4, help="simultaneous rollouts")
     parser.add_argument(
         "--eval-tasks", type=int, default=16, help="held-out tasks for the final eval"
@@ -678,10 +683,10 @@ def parse_args() -> argparse.Namespace:
         default=0,
         help="with --calibrate, print the first N rollouts (reward, tokens, text)",
     )
-    parser.add_argument("--min-a", type=int, default=100, help="task difficulty: lower bound of a")
-    parser.add_argument("--max-a", type=int, default=999, help="task difficulty: upper bound of a")
-    parser.add_argument("--min-b", type=int, default=100, help="task difficulty: lower bound of b")
-    parser.add_argument("--max-b", type=int, default=999, help="task difficulty: upper bound of b")
+    parser.add_argument("--min-a", type=int, default=1000, help="task difficulty: lower bound of a")
+    parser.add_argument("--max-a", type=int, default=9999, help="task difficulty: upper bound of a")
+    parser.add_argument("--min-b", type=int, default=1000, help="task difficulty: lower bound of b")
+    parser.add_argument("--max-b", type=int, default=9999, help="task difficulty: upper bound of b")
     return parser.parse_args()
 
 

--- a/docs/v6/cookbooks/fireworks-rl-training.mdx
+++ b/docs/v6/cookbooks/fireworks-rl-training.mdx
@@ -93,8 +93,11 @@ Set a Fireworks API key with Serverless Training access:
 export FIREWORKS_API_KEY="fw_..."
 ```
 
-The default configuration uses `accounts/fireworks/models/qwen3p5-9b`. If you change the model,
-also provide the matching tokenizer and renderer:
+The default configuration uses Qwen 3.8 27B (`accounts/fireworks/models/qwen3p8-27b`)
+with tokenizer `Qwen/Qwen3.8-27B`. Fireworks deprecated the Qwen 3.5 9B and Qwen 3.6 27B
+Serverless Training pools; see the
+[Fireworks changelog](https://docs.fireworks.ai/updates/changelog).
+If you change the model, also provide the matching tokenizer and renderer:
 
 ```bash
 uv run train.py \
@@ -105,8 +108,9 @@ uv run train.py \
 ```
 
 Prompt rendering happens on the client, so the base model, tokenizer, and renderer must agree. The
-default renderer disables thinking mode. This leaves enough of the generation budget for the model
-to emit the final answer that the grader reads.
+default renderer, `qwen3_8_disable_thinking` from `tinker-cookbook>=0.5.7`, disables thinking mode.
+This leaves enough of the generation budget for the model to emit the final answer that the
+grader reads.
 
 ## Define the task and reward
 
@@ -123,8 +127,13 @@ env = Environment(name="fireworks-arithmetic")
 
 def grade_final_integer(answer: object, expected: int) -> EvaluationResult:
     text = answer if isinstance(answer, str) else str(answer)
-    integers = re.findall(r"-?\d+", text)
-    got = int(integers[-1]) if integers else None
+    numbers = re.findall(r"[+-]?(?:\d[\d,]*(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?", text)
+    final = numbers[-1] if numbers else ""
+    got = (
+        int(final.replace(",", ""))
+        if re.fullmatch(r"[+-]?(?:\d+|\d{1,3}(?:,\d{3})+)", final)
+        else None
+    )
     return EvaluationResult(
         reward=1.0 if got == expected else 0.0,
         content=text.strip(),
@@ -156,8 +165,8 @@ optimizer step:
 uv run train.py \
   --calibrate \
   --tasks-per-step 6 \
-  --group-size 6 \
-  --max-tokens 512 \
+  --group-size 4 \
+  --max-tokens 2048 \
   --debug-samples 4
 ```
 
@@ -172,6 +181,10 @@ counts; verify that better answers receive higher rewards. If all groups are cor
 operand range with `--min-a`, `--max-a`, `--min-b`, and `--max-b`. If all groups are incorrect,
 reduce the range or increase `--max-tokens`.
 
+The default uses four-digit operands and a 2,048-token budget. Three-digit tasks were nearly
+saturated on Qwen 3.8 27B, while smaller budgets cut off many answers. Inspect the full
+`--debug-samples` responses and token counts so truncation is not mistaken for arithmetic difficulty.
+
 ## Verify the complete path
 
 After calibration shows useful reward spread, run one bounded training step:
@@ -181,7 +194,7 @@ uv run train.py \
   --steps 1 \
   --tasks-per-step 2 \
   --group-size 4 \
-  --max-tokens 512 \
+  --max-tokens 2048 \
   --eval-tasks 4 \
   --require-update
 ```
@@ -189,6 +202,7 @@ uv run train.py \
 Groups with identical rewards cannot update the model. `--require-update` makes the command fail
 instead of silently skipping the optimizer. A successful run verifies authentication, sampling,
 HUD grading, one policy-gradient update, checkpoint creation, and held-out evaluation.
+Sampling or grading errors fail the command in every phase, including calibration and evaluation.
 
 ## Run the training loop
 
@@ -199,7 +213,7 @@ followed by 16 evaluation rollouts:
 uv run train.py
 ```
 
-Each rollout can generate up to 1,024 tokens and incurs Fireworks usage. Charges include prompt
+Each rollout can generate up to 2,048 tokens and incurs Fireworks usage. Charges include prompt
 prefill, sampled output, and training tokens at the selected model's
 [serverless rates](https://docs.fireworks.ai/fine-tuning/training-api/serverless#pricing).
 
@@ -259,6 +273,10 @@ Resume from a fully qualified training checkpoint:
 ```bash
 uv run train.py --resume-from "<account>/<run-id>/state-0005"
 ```
+
+Resume restores the checkpoint's original base model. Start a new run to migrate from an older
+Qwen model to Qwen 3.8; resuming does not convert the adapter. A supported non-default checkpoint
+requires its matching tokenizer and renderer.
 
 The resumed session creates a new Fireworks run and retains the optimizer state. The script prints
 the final `Sampler checkpoint` path. Sampler checkpoints are session-scoped, so use that path to

--- a/docs/v6/cookbooks/fireworks-rl-training.mdx
+++ b/docs/v6/cookbooks/fireworks-rl-training.mdx
@@ -126,9 +126,8 @@ from hud.graders import EvaluationResult
 env = Environment(name="fireworks-arithmetic")
 
 def grade_final_integer(answer: object, expected: int) -> EvaluationResult:
-    text = answer if isinstance(answer, str) else str(answer)
-    numbers = re.findall(r"[+-]?(?:\d[\d,]*(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?", text)
-    final = numbers[-1] if numbers else ""
+    text = (answer if isinstance(answer, str) else str(answer)).strip()
+    final = text.splitlines()[-1].strip() if text else ""
     got = (
         int(final.replace(",", ""))
         if re.fullmatch(r"[+-]?(?:\d+|\d{1,3}(?:,\d{3})+)", final)
@@ -136,7 +135,7 @@ def grade_final_integer(answer: object, expected: int) -> EvaluationResult:
     )
     return EvaluationResult(
         reward=1.0 if got == expected else 0.0,
-        content=text.strip(),
+        content=text,
         info={"expected": expected, "got": got},
     )
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default model, task difficulty, and grader semantics (stricter final-line parsing), which can shift rewards and break users still on old Qwen checkpoints without a new run.
> 
> **Overview**
> **Migrates the Fireworks RL cookbook** from deprecated Qwen 3.5 9B to **Qwen 3.8 27B** (`qwen3p8-27b`, `Qwen/Qwen3.8-27B`, renderer `qwen3_8_disable_thinking`), bumps **`fireworks-ai` and `tinker-cookbook`**, and retunes defaults: **2,048** `max-tokens`, **four-digit** multiplication operands, and updated calibration examples in README/docs.
> 
> **Grading** in `env.py` now scores only the **last nonempty line** as the final answer (comma-separated integers allowed), instead of the last integer anywhere in the response—aligned with the prompt asking for the answer on its own line.
> 
> **Training behavior:** calibration, training, and eval **abort** when any rollout fails sampling or grading (no silent zero-reward examples). Calibration debug output prints **full** responses.
> 
> **Tests:** mocked end-to-end Fireworks/HUD lifecycle, failure-path coverage, parametrized grader cases, optional **integration** check that the default renderer matches Qwen 3.8’s chat template (`pytest` excludes `integration` by default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed2e6fcc3f2c2e589efb8bf12497199621231e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->