### PR TITLE
fix(runtime): preserve structured hosted grades from trace polling

### DIFF
--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -228,10 +228,6 @@ The SDK leases your deployed env by name and tunnels to its control channel; the
 
 ### `HostedRuntime`
 
-Hosted runs preserve the structured evaluation result returned by the platform, including
-`run.grade.info`, subscores, and grading errors. Runs retain their task slug for
-`Job.results`. Traces without a structured result use the recorded reward.
-
 ```python
 HostedRuntime(*, poll_interval=5.0, run_timeout=None)
 ```

--- a/docs/v6/reference/runtime.mdx
+++ b/docs/v6/reference/runtime.mdx
@@ -228,6 +228,10 @@ The SDK leases your deployed env by name and tunnels to its control channel; the
 
 ### `HostedRuntime`
 
+Hosted runs preserve the structured evaluation result returned by the platform, including
+`run.grade.info`, subscores, and grading errors. Runs retain their task slug for
+`Job.results`. Traces without a structured result use the recorded reward.
+
 ```python
 HostedRuntime(*, poll_interval=5.0, run_timeout=None)
 ```

--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -113,6 +113,7 @@ class HostedRuntime:
                         trace_id=trace_id,
                         parent_trace_id=parent_trace_id,
                     )
+            run = self._fold(state, trace_id)
         except asyncio.CancelledError:
             self._cancel_later(trace_id)
             raise
@@ -124,13 +125,12 @@ class HostedRuntime:
             run = Run.failed(detail)
             run.trace.stop_reason = "timeout"
         except Exception as exc:
-            logger.warning("hosted rollout failed to launch: %s", exc)
+            logger.warning("hosted rollout failed: %s", exc)
             run = Run.failed(str(exc))
-        else:
-            run = self._fold(state, trace_id)
         run.trace.trace_id = trace_id
         run.job_id = job_id
         run.group_id = group_id
+        run.slug = task.slug
         return run
 
     async def _submit_and_await(
@@ -202,11 +202,16 @@ class HostedRuntime:
                 if run.trace.status == "cancelled"
                 else "rollout failed before grading"
             )
-        run.grade = Grade(
-            reward=float(reward) if reward is not None else 0.0,
-            is_error=ungraded_failure,
-            content=grade_error,
-            raw={"score": float(reward)} if reward is not None else {},
+        evaluation_result = state.get("evaluation_result")
+        run.grade = (
+            Grade.from_dict(evaluation_result)
+            if evaluation_result is not None
+            else Grade(
+                reward=float(reward) if reward is not None else 0.0,
+                is_error=ungraded_failure,
+                content=grade_error,
+                raw={"score": float(reward)} if reward is not None else {},
+            )
         )
         run._runtime = f"hud://trace/{trace_id}"
         return run

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -61,6 +61,7 @@ class _FakePlatform:
         return {"status": "queued"}
 
     async def aget(self, path: str, *, params: dict[str, Any] | None = None) -> Any:
+        assert path.startswith("/trace/") and path.count("/") == 2
         state = self.states[min(self.polled, len(self.states) - 1)]
         self.polled += 1
         return state
@@ -227,6 +228,8 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert run.trace.trace_id == trace_id
     assert run.job_id == job_id
     assert run.group_id == "g1"
+    assert run.slug == task.slug
+    assert Job(id="job", name="test", runs=[run]).results == {"sums-add": [run]}
     assert platform.polled == 3
     (path, payload) = platform.posts[0]
     assert path == "/rollouts/submit"
@@ -623,6 +626,54 @@ async def test_run_folds_completed_receipt(monkeypatch: pytest.MonkeyPatch) -> N
     # The platform owns the trace lifecycle: no local client ever existed.
     with pytest.raises(RuntimeError, match="no live client"):
         _ = run.client
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_error", [False, True])
+async def test_run_preserves_structured_grade(
+    monkeypatch: pytest.MonkeyPatch, is_error: bool
+) -> None:
+    result = {
+        "score": 0.5,
+        "info": {"passed": 3},
+        "content": "verifier failed" if is_error else "partial credit",
+        "isError": is_error,
+        "subscores": [{"name": "accuracy", "weight": 1.0, "value": 0.5}],
+    }
+    platform = _FakePlatform(
+        [
+            {
+                "status": "error" if is_error else "completed",
+                "reward": 0.5,
+                "evaluation_result": result,
+            }
+        ]
+    )
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+    run = await HostedRuntime(poll_interval=0.0).run(
+        Task(env="sums", id="add"), _agent(), job_id=uuid.uuid4().hex
+    )
+    assert run.reward == 0.5
+    assert run.grade.raw == result
+    assert run.grade.info == {"passed": 3}
+    assert run.grade.is_error is is_error
+    assert run.grade.content == result["content"]
+    assert platform.polled == 1
+
+
+@pytest.mark.asyncio
+async def test_run_reports_malformed_grade_as_a_failed_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    platform = _FakePlatform([{"status": "completed", "evaluation_result": {"score": "bad"}}])
+    monkeypatch.setattr(
+        "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
+    )
+    task = Task(env="sums", id="add")
+    run = await HostedRuntime(poll_interval=0.0).run(task, _agent(), job_id=uuid.uuid4().hex)
+    assert run.trace.is_error
+    assert "numeric 'score'" in (run.trace.error or "")
+    assert run.slug == task.slug
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hosted runs currently reconstruct grades from the scalar trace reward, dropping structured output. Parse `evaluation_result` from the existing trace polling response with `Grade.from_dict()` to retain info, subscores, and grading errors. Traces without a structured result keep the existing reward-only behavior.

Preserve the task slug for `Job.results`, and handle malformed result parsing within the existing per-run error handler. No additional `/info` request is needed after completion.

Validation: 39 hosted tests and 6 job tests passed; Ruff, formatting, and SDK type checks passed. Tests cover structured grades, grading errors, malformed results, task grouping, and polling without an additional detail request. No live hosted rollout was run.

Separate implementation following review of #647; that PR is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how hosted runs interpret grading payloads and job result grouping; behavior is covered by new tests but depends on platform returning `evaluation_result` on trace poll.
> 
> **Overview**
> Hosted rollouts now build **`Grade`** from the trace poll payload’s **`evaluation_result`** via **`Grade.from_dict()`**, keeping info, subscores, and grading-error flags instead of only the scalar **`reward`**. Traces without structured results still use the previous reward-only fallback.
> 
> Each returned **`Run`** sets **`run.slug`** from the task so **`Job.results`** can group by slug. **`_fold`** runs on the success path inside the main **`try`**, so malformed **`evaluation_result`** parsing surfaces as a failed run through the existing exception handler (no extra **`/info`** request).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b49d0d29c8289a3be2c054c490ec5b90074f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
