### PR TITLE
Exercise example task lifecycles after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: uv run --python ${{ matrix.python-version }} --all-extras pytest --cov --cov-report=''
 
   templates:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -70,52 +71,11 @@ jobs:
         working-directory: ${{ runner.temp }}/${{ matrix.template }}
         run: docker build --file Dockerfile.hud --tag "hud-example:${{ matrix.template }}" .
 
-      - name: Start example image
-        env:
-          TEMPLATE: ${{ matrix.template }}
-        run: |
-          docker_args=()
-          if [ "$TEMPLATE" = coding ]; then
-            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-            docker_args+=(
-              --security-opt "seccomp=$GITHUB_WORKSPACE/hud/eval/docker-seccomp.json"
-              --security-opt systempaths=unconfined
-              --security-opt apparmor=unconfined
-            )
-          fi
-          docker run --detach --name hud-example --publish 8765:8765 --shm-size 2g "${docker_args[@]}" \
-            "hud-example:${{ matrix.template }}"
-
-      - name: Inspect example image
+      - name: Run task lifecycle checks
         working-directory: ${{ runner.temp }}/${{ matrix.template }}
         run: |
-          for attempt in {1..60}; do
-            if (echo > /dev/tcp/127.0.0.1/8765) 2>/dev/null \
-              && uv run --no-sync hud client info --url tcp://127.0.0.1:8765; then
-              exit 0
-            fi
-            sleep 1
-          done
-          docker logs hud-example
-          exit 1
-
-      - name: Run blank task lifecycle
-        if: matrix.template == 'blank'
-        working-directory: ${{ runner.temp }}/${{ matrix.template }}
-        run: |
-          uv run --no-sync hud task start 0 --source tasks.py --url tcp://127.0.0.1:8765
-          test "$(uv run --no-sync hud task grade 0 --source tasks.py --url tcp://127.0.0.1:8765 --answer 4)" = "1.0"
-
-      - name: Run coding task lifecycle
-        if: matrix.template == 'coding'
-        working-directory: ${{ runner.temp }}/${{ matrix.template }}
-        run: |
-          uv run --no-sync hud task start flask-4992 --source tasks.py --url tcp://127.0.0.1:8765
-          test "$(uv run --no-sync hud task grade flask-4992 --source tasks.py --url tcp://127.0.0.1:8765 --answer done)" = "0.0"
-
-      - name: Stop example image
-        if: always()
-        run: docker rm --force hud-example || true
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" "${{ matrix.template }}"
 
   lint-ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
         working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
         env:
           HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
+          HUD_CI_DATA_FILE_ID: ${{ vars.HUD_CI_DATA_FILE_ID }}
           HUD_TELEMETRY_LOCAL_DIR: ${{ runner.temp }}/traces-${{ matrix.template }}
         run: |
           uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" prepare "${{ matrix.template }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "*" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,7 +31,7 @@ jobs:
         run: uv run --python ${{ matrix.python-version }} --all-extras pytest --cov --cov-report=''
 
   templates:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     environment: pre-release
     timeout-minutes: 45

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     environment: pre-release
     timeout-minutes: 45
     env:
-      EXAMPLE_DIR: ${{ runner.temp }}/ci-${{ matrix.template }}-${{ github.run_id }}-${{ github.run_attempt }}
+      EXAMPLE_NAME: ci-${{ matrix.template }}-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:
@@ -50,10 +50,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Create example environment
-        run: uv run hud init "$EXAMPLE_DIR" --template "${{ matrix.template }}"
+        run: uv run hud init "$RUNNER_TEMP/$EXAMPLE_NAME" --template "${{ matrix.template }}"
 
       - name: Install example with the SDK from this checkout
-        working-directory: ${{ env.EXAMPLE_DIR }}
+        working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
         run: |
           uv build --wheel --no-create-gitignore --out-dir .hud-sdk "$GITHUB_WORKSPACE"
           uv add --no-sync .hud-sdk/hud-*.whl
@@ -63,7 +63,7 @@ jobs:
           echo '!.hud-sdk/**' >> .dockerignore
 
       - name: Run example checks
-        working-directory: ${{ env.EXAMPLE_DIR }}
+        working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
         run: |
           uv run --no-sync hud task list --source .
           if [ -d tests ]; then
@@ -74,13 +74,13 @@ jobs:
 
       - name: Deploy example environment
         id: deploy
-        working-directory: ${{ env.EXAMPLE_DIR }}
+        working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
         env:
           HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
         run: uv run --no-sync hud deploy --no-env
 
       - name: Run hosted task lifecycle
-        working-directory: ${{ env.EXAMPLE_DIR }}
+        working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
         env:
           HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
           HUD_TELEMETRY_LOCAL_DIR: ${{ runner.temp }}/traces-${{ matrix.template }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Remove CI environment and attachment
         if: always() && steps.deploy.outcome != 'skipped'
-        working-directory: ${{ env.EXAMPLE_DIR }}
+        working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
         env:
           HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
         run: uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" cleanup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: pre-release
     timeout-minutes: 45
+    concurrency:
+      group: ci-example-${{ matrix.template }}
+      cancel-in-progress: false
     env:
-      EXAMPLE_NAME: ci-${{ matrix.template }}-${{ github.run_id }}-${{ github.run_attempt }}
+      EXAMPLE_NAME: ci-${{ matrix.template }}
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +76,6 @@ jobs:
           fi
 
       - name: Deploy example environment
-        id: deploy
         working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
         env:
           HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
@@ -89,13 +91,6 @@ jobs:
           timeout --signal=INT --kill-after=30s 15m uv run --no-sync hud eval .hud/ci-tasks.json claude \
             --model claude-sonnet-4-6 --gateway --runtime hud --max-steps 10 --config max_tokens=2048 -y
           uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" check
-
-      - name: Remove CI environment and attachment
-        if: always() && steps.deploy.outcome != 'skipped'
-        working-directory: ${{ runner.temp }}/${{ env.EXAMPLE_NAME }}
-        env:
-          HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
-        run: uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" cleanup
 
       - name: Save traces
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
   templates:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: pre-release
+    timeout-minutes: 45
+    env:
+      EXAMPLE_DIR: ${{ runner.temp }}/ci-${{ matrix.template }}-${{ github.run_id }}-${{ github.run_attempt }}
     strategy:
       fail-fast: false
       matrix:
@@ -45,10 +49,10 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Create example environment
-        run: uv run hud init "${{ runner.temp }}/${{ matrix.template }}" --template "${{ matrix.template }}"
+        run: uv run hud init "$EXAMPLE_DIR" --template "${{ matrix.template }}"
 
       - name: Install example with the SDK from this checkout
-        working-directory: ${{ runner.temp }}/${{ matrix.template }}
+        working-directory: ${{ env.EXAMPLE_DIR }}
         run: |
           uv build --wheel --no-create-gitignore --out-dir .hud-sdk "$GITHUB_WORKSPACE"
           uv add --no-sync .hud-sdk/hud-*.whl
@@ -58,7 +62,7 @@ jobs:
           echo '!.hud-sdk/**' >> .dockerignore
 
       - name: Run example checks
-        working-directory: ${{ runner.temp }}/${{ matrix.template }}
+        working-directory: ${{ env.EXAMPLE_DIR }}
         run: |
           uv run --no-sync hud task list --source .
           if [ -d tests ]; then
@@ -67,15 +71,38 @@ jobs:
             uv run --no-sync pytest -q
           fi
 
-      - name: Build example image
-        working-directory: ${{ runner.temp }}/${{ matrix.template }}
-        run: docker build --file Dockerfile.hud --tag "hud-example:${{ matrix.template }}" .
+      - name: Deploy example environment
+        id: deploy
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        env:
+          HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
+        run: uv run --no-sync hud deploy --no-env
 
-      - name: Run task lifecycle checks
-        working-directory: ${{ runner.temp }}/${{ matrix.template }}
+      - name: Run hosted task lifecycle
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        env:
+          HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
+          HUD_TELEMETRY_LOCAL_DIR: ${{ runner.temp }}/traces-${{ matrix.template }}
         run: |
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" "${{ matrix.template }}"
+          uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" prepare "${{ matrix.template }}"
+          timeout --signal=INT --kill-after=30s 15m uv run --no-sync hud eval .hud/ci-tasks.json claude \
+            --model claude-sonnet-4-6 --gateway --runtime hud --max-steps 10 --config max_tokens=2048 -y
+          uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" check
+
+      - name: Remove CI environment and attachment
+        if: always() && steps.deploy.outcome != 'skipped'
+        working-directory: ${{ env.EXAMPLE_DIR }}
+        env:
+          HUD_API_KEY: ${{ secrets.HUD_API_KEY }}
+        run: uv run --no-sync "$GITHUB_WORKSPACE/scripts/example_lifecycle.py" cleanup
+
+      - name: Save traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-traces-${{ matrix.template }}
+          path: ${{ runner.temp }}/traces-${{ matrix.template }}
+          retention-days: 7
 
   lint-ruff:
     runs-on: ubuntu-latest

--- a/environments/argument-hints/README.md
+++ b/environments/argument-hints/README.md
@@ -14,4 +14,6 @@ hud eval tasks.py claude --runtime local -y
 files into `/workspace/files`, hands the agent a shell and the prompt, and
 passes the criteria straight to `LLMJudgeGrader`. It also declares a
 `hud_api_key` argument (hidden in the console) — that declaration is what
-makes hosted rollouts inject the runner's key for staging and grading.
+makes hosted rollouts inject `HUD_API_KEY` into the container. Staging and
+grading use that runtime credential, not the argument's value. For local runs,
+configure `HUD_API_KEY` before starting the environment.

--- a/environments/argument-hints/env.py
+++ b/environments/argument-hints/env.py
@@ -98,12 +98,11 @@ def _destination(root: Path, relative: str) -> Path:
 async def _stage(
     refs: list[DataFileRef],
     root: Path,
-    hud_api_key: str | None = None,
 ) -> list[dict[str, str]]:
     """Pull each referenced file into ``root``; returns the start-frame declarations."""
     if not refs:
         return []
-    api_key = (hud_api_key or settings.api_key or "").strip()
+    api_key = (settings.api_key or "").strip()
     if not api_key:
         raise DataFileError("HUD_API_KEY is unset; the environment cannot read data files")
 
@@ -169,7 +168,10 @@ async def review_files(
     criteria: Criteria,
     hud_api_key: str | None = None,
 ):
-    """Answer a prompt about uploaded files, graded by weighted criteria."""
+    """Answer a prompt about uploaded files, graded by weighted criteria.
+
+    Declaring ``hud_api_key`` opts hosted rollouts into container-level HUD_API_KEY injection.
+    """
     refs = _ATTACHMENTS.validate_python(attachments)
     rows = _CRITERIA.validate_python(criteria)
 
@@ -177,7 +179,7 @@ async def review_files(
     # Clear prior tasks' leftovers so staging never writes through a stale symlink.
     shutil.rmtree(files_dir, ignore_errors=True)
     files_dir.mkdir(parents=True)
-    declared = await _stage(refs, files_dir, hud_api_key)
+    declared = await _stage(refs, files_dir)
 
     listing = "\n".join(f"- {entry['path']}" for entry in declared) or "- (none)"
     # A template that declares no `returns` is sent the agent's final text.
@@ -193,10 +195,4 @@ async def review_files(
         "data_files": declared,
     }
 
-    previous_key = settings.api_key
-    try:
-        settings.api_key = hud_api_key or previous_key
-        result = await _grade(str(answer or ""), prompt, rows)
-    finally:
-        settings.api_key = previous_key
-    yield result
+    yield await _grade(str(answer or ""), prompt, rows)

--- a/environments/argument-hints/env.py
+++ b/environments/argument-hints/env.py
@@ -193,4 +193,10 @@ async def review_files(
         "data_files": declared,
     }
 
-    yield await _grade(str(answer or ""), prompt, rows)
+    previous_key = settings.api_key
+    try:
+        settings.api_key = hud_api_key or previous_key
+        result = await _grade(str(answer or ""), prompt, rows)
+    finally:
+        settings.api_key = previous_key
+    yield result

--- a/environments/argument-hints/tests/test_env.py
+++ b/environments/argument-hints/tests/test_env.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import sys
+from functools import partial
 from pathlib import Path
 
+import httpx
 import pytest
+from hud import LocalRuntime, connect
+from hud.clients import HudProtocolError
 from hud.graders import SubScore
+from hud.utils import gateway
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -72,7 +79,7 @@ async def test_staging_directory_is_cleared_between_tasks(
     async def fake_compute_score(**kwargs: object):
         return SubScore(name="LLMJudgeGrader", value=1.0)
 
-    async def fake_stage(refs, root: Path, hud_api_key=None):
+    async def fake_stage(refs, root: Path):
         return []
 
     monkeypatch.setattr(env_module.LLMJudgeGrader, "compute_score", fake_compute_score)
@@ -106,7 +113,6 @@ async def test_arguments_arrive_as_plain_json(
     async def fake_stage(
         refs: list[env_module.DataFileRef],
         root: Path,
-        hud_api_key: str | None = None,
     ):
         staged.extend(refs)
         return [{"path": "files/resume.pdf", "file_id": refs[0].file_id}]
@@ -134,3 +140,114 @@ async def test_arguments_arrive_as_plain_json(
 
     assert seen["criteria"] == [("Recommends an interview.", 2.0)]
     assert result.reward == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("fail_second", [False, True])
+async def test_concurrent_sessions_use_the_runtime_credential(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, fail_second: bool
+):
+    monkeypatch.setattr(env_module, "WORKSPACE_ROOT", tmp_path)
+    monkeypatch.setattr(env_module.settings, "api_key", "process-key")
+    monkeypatch.setattr(env_module.settings, "hud_gateway_url", "https://gateway.test")
+    arrived = asyncio.Event()
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        prompt = json.loads(request.content)["messages"][-1]["content"]
+        answer = prompt.split("<response>\n", 1)[1].split("\n</response>", 1)[0]
+        seen[answer] = request.headers["Authorization"]
+        if len(seen) == 2:
+            arrived.set()
+        await asyncio.wait_for(arrived.wait(), timeout=5)
+        assert env_module.settings.api_key == "process-key"
+        if fail_second and answer == "second":
+            return httpx.Response(400, json={"error": {"message": "judge rejected request"}})
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {
+                            "content": '{"criterion_status":"MET","explanation":"fixture"}',
+                        }
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(
+        gateway,
+        "DefaultAsyncHttpxClient",
+        partial(
+            gateway.DefaultAsyncHttpxClient,
+            transport=httpx.MockTransport(handler),
+        ),
+    )
+    first_task = env_module.review_files(
+        prompt="Give an answer.",
+        attachments=[],
+        criteria=[{"requirement": "An answer is present.", "weight": 1}],
+        hud_api_key="first-key",
+    )
+    second_task = first_task.model_copy(update={"args": {**first_task.args, "hud_api_key": "second-key"}})
+    async with (
+        LocalRuntime(env_module.env)(first_task) as runtime,
+        connect(runtime) as first,
+        connect(runtime) as second,
+    ):
+        await first.start_task(first_task.id, first_task.args)
+        await second.start_task(second_task.id, second_task.args)
+        results = await asyncio.gather(
+            first.grade({"answer": "first"}),
+            second.grade({"answer": "second"}),
+            return_exceptions=True,
+        )
+
+    assert seen == {"first": "Bearer process-key", "second": "Bearer process-key"}
+    assert env_module.settings.api_key == "process-key"
+    for index, result in enumerate(results):
+        if fail_second and index == 1:
+            assert isinstance(result, HudProtocolError)
+            assert "judge rejected request" in str(result)
+            continue
+        assert isinstance(result, dict)
+        assert result["score"] == 1.0
+        assert "first-key" not in json.dumps(result)
+        assert "second-key" not in json.dumps(result)
+
+
+async def test_file_staging_uses_the_runtime_credential(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setattr(env_module, "WORKSPACE_ROOT", tmp_path)
+    monkeypatch.setattr(env_module.settings, "api_key", "runtime-key")
+    monkeypatch.setattr(env_module.settings, "hud_api_url", "https://api.test")
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "storage.test":
+            assert "Authorization" not in request.headers
+            return httpx.Response(200, content=b"notes")
+        assert request.headers["Authorization"] == "Bearer runtime-key"
+        if request.url.path.endswith("/download"):
+            return httpx.Response(200, json={"url": "https://storage.test/notes.txt"})
+        return httpx.Response(200, json={"filename": "notes.txt"})
+
+    monkeypatch.setattr(
+        env_module.httpx,
+        "AsyncClient",
+        partial(
+            httpx.AsyncClient,
+            transport=httpx.MockTransport(handler),
+        ),
+    )
+    task = env_module.review_files.func(
+        prompt="Read the file.",
+        attachments=[{"file_id": "notes"}],
+        criteria=[],
+        hud_api_key="task-key",
+    )
+    try:
+        frame = await anext(task)
+        assert frame["data_files"] == [{"path": "files/notes.txt", "file_id": "notes"}]
+        assert (tmp_path / "files/notes.txt").read_text() == "notes"
+        assert env_module.settings.api_key == "runtime-key"
+    finally:
+        await task.aclose()

--- a/environments/argument-hints/tests/test_env.py
+++ b/environments/argument-hints/tests/test_env.py
@@ -6,14 +6,15 @@ import asyncio
 import json
 import sys
 from functools import partial
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Barrier, Thread
 
 import httpx
 import pytest
 from hud import LocalRuntime, connect
 from hud.clients import HudProtocolError
 from hud.graders import SubScore
-from hud.utils import gateway
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -148,41 +149,37 @@ async def test_concurrent_sessions_use_the_runtime_credential(
 ):
     monkeypatch.setattr(env_module, "WORKSPACE_ROOT", tmp_path)
     monkeypatch.setattr(env_module.settings, "api_key", "process-key")
-    monkeypatch.setattr(env_module.settings, "hud_gateway_url", "https://gateway.test")
-    arrived = asyncio.Event()
+    arrived = Barrier(2, timeout=5)
     seen = {}
 
-    async def handler(request: httpx.Request) -> httpx.Response:
-        prompt = json.loads(request.content)["messages"][-1]["content"]
-        answer = prompt.split("<response>\n", 1)[1].split("\n</response>", 1)[0]
-        seen[answer] = request.headers["Authorization"]
-        if len(seen) == 2:
-            arrived.set()
-        await asyncio.wait_for(arrived.wait(), timeout=5)
-        assert env_module.settings.api_key == "process-key"
-        if fail_second and answer == "second":
-            return httpx.Response(400, json={"error": {"message": "judge rejected request"}})
-        return httpx.Response(
-            200,
-            json={
-                "choices": [
-                    {
-                        "message": {
-                            "content": '{"criterion_status":"MET","explanation":"fixture"}',
+    class Gateway(BaseHTTPRequestHandler):
+        def do_POST(self):
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            prompt = body["messages"][-1]["content"]
+            answer = prompt.split("<response>\n", 1)[1].split("\n</response>", 1)[0]
+            seen[answer] = self.headers["Authorization"]
+            arrived.wait()
+            assert env_module.settings.api_key == "process-key"
+            rejected = fail_second and answer == "second"
+            payload = json.dumps(
+                {"error": {"message": "judge rejected request"}}
+                if rejected
+                else {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": '{"criterion_status":"MET","explanation":"fixture"}',
+                            }
                         }
-                    }
-                ]
-            },
-        )
+                    ]
+                }
+            ).encode()
+            self.send_response(400 if rejected else 200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
 
-    monkeypatch.setattr(
-        gateway,
-        "DefaultAsyncHttpxClient",
-        partial(
-            gateway.DefaultAsyncHttpxClient,
-            transport=httpx.MockTransport(handler),
-        ),
-    )
     first_task = env_module.review_files(
         prompt="Give an answer.",
         attachments=[],
@@ -190,18 +187,26 @@ async def test_concurrent_sessions_use_the_runtime_credential(
         hud_api_key="first-key",
     )
     second_task = first_task.model_copy(update={"args": {**first_task.args, "hud_api_key": "second-key"}})
-    async with (
-        LocalRuntime(env_module.env)(first_task) as runtime,
-        connect(runtime) as first,
-        connect(runtime) as second,
-    ):
-        await first.start_task(first_task.id, first_task.args)
-        await second.start_task(second_task.id, second_task.args)
-        results = await asyncio.gather(
-            first.grade({"answer": "first"}),
-            second.grade({"answer": "second"}),
-            return_exceptions=True,
-        )
+    with ThreadingHTTPServer(("127.0.0.1", 0), Gateway) as server:
+        monkeypatch.setattr(env_module.settings, "hud_gateway_url", f"http://127.0.0.1:{server.server_port}")
+        thread = Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            async with (
+                LocalRuntime(env_module.env)(first_task) as runtime,
+                connect(runtime) as first,
+                connect(runtime) as second,
+            ):
+                await first.start_task(first_task.id, first_task.args)
+                await second.start_task(second_task.id, second_task.args)
+                results = await asyncio.gather(
+                    first.grade({"answer": "first"}),
+                    second.grade({"answer": "second"}),
+                    return_exceptions=True,
+                )
+        finally:
+            server.shutdown()
+            thread.join()
 
     assert seen == {"first": "Bearer process-key", "second": "Bearer process-key"}
     assert env_module.settings.api_key == "process-key"

--- a/environments/coding/env.py
+++ b/environments/coding/env.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shlex
 import shutil
 import subprocess
 import sys
@@ -17,7 +16,7 @@ from hud.graders import EvaluationResult, combine
 from hud.settings import settings
 from pydantic import Field
 
-from grader import JUnitGrader
+from grader import grade_tests
 
 logger = logging.getLogger(__name__)
 
@@ -166,21 +165,9 @@ async def _grade(
             isError=True,
         )
 
-    grader_command = shlex.join(
-        workspace.shell_argv(
-            test_command,
-            cwd=str(REPO_DIR),
-            env={
-                "HOME": "/tmp",
-                "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
-            },
-        )
-    )
-    test_result = await JUnitGrader.grade(
-        weight=1.0,
-        name="tests",
-        command=grader_command,
-        cwd=str(REPO_DIR),
+    test_result = await grade_tests(
+        workspace,
+        test_command,
         timeout_seconds=TEST_TIMEOUT,
         fail_to_pass=fail_to_pass,
         pass_to_pass=pass_to_pass,

--- a/environments/coding/grader.py
+++ b/environments/coding/grader.py
@@ -6,10 +6,10 @@ import shlex
 import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
 from xml.etree import ElementTree
 
-from hud.graders import BashGrader, SubScore
+from hud.environment import Workspace
+from hud.graders import SubScore
 
 
 @dataclass(frozen=True, slots=True)
@@ -121,50 +121,41 @@ def score_tests(
     return SubScore(name="tests", value=value, children=children, info=info)
 
 
-class JUnitGrader(BashGrader):
-    """Run a command and score selected JUnit test cases."""
+async def grade_tests(
+    workspace: Workspace,
+    command: str,
+    *,
+    timeout_seconds: float = 600,
+    fail_to_pass: list[str] | None = None,
+    pass_to_pass: list[str] | None = None,
+    binary: bool = False,
+) -> SubScore:
+    if "{junit_path}" not in command:
+        raise ValueError("test command must contain {junit_path}")
 
-    name = "JUnitGrader"
-
-    @classmethod
-    async def compute_score(
-        cls,
-        command: str | None = None,
-        cwd: str | None = None,
-        timeout_seconds: float | None = None,
-        fail_to_pass: list[str] | None = None,
-        pass_to_pass: list[str] | None = None,
-        binary: bool = False,
-        **kwargs: Any,
-    ) -> SubScore:
-        if command is None or "{junit_path}" not in command:
-            raise ValueError("JUnitGrader command must contain {junit_path}")
-
-        with tempfile.TemporaryDirectory(prefix=".hud-junit-", dir=cwd) as directory:
-            Path(directory).chmod(0o733)
-            report = Path(directory) / "report.xml"
-            bash = await super().compute_score(
-                command=command.replace("{junit_path}", shlex.quote(str(report))),
-                cwd=cwd,
-                timeout_seconds=timeout_seconds,
-                **kwargs,
-            )
-            if not report.is_file():
-                return bash.model_copy(
-                    update={
-                        "value": 0.0,
-                        "info": {**(bash.info or {}), "error": "test command did not write JUnit XML"},
-                    }
-                )
-            if binary and bash.value != 1.0:
-                return bash
-            try:
-                result = score_tests(parse_junit(report), fail_to_pass, pass_to_pass, binary)
-            except (OSError, ValueError) as exc:
-                return bash.model_copy(
-                    update={
-                        "value": 0.0,
-                        "info": {**(bash.info or {}), "error": str(exc)},
-                    }
-                )
-            return result.model_copy(update={"info": {**(result.info or {}), **(bash.info or {})}})
+    with tempfile.TemporaryDirectory(prefix=".hud-junit-", dir=workspace.root) as directory:
+        Path(directory).chmod(0o733)
+        report = Path(directory) / "report.xml"
+        process = await workspace.run(
+            ["/bin/bash", "-lc", command.replace("{junit_path}", shlex.quote(str(report)))],
+            cwd=str(workspace.root),
+            env={"HOME": "/tmp", "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1"},
+            max_wait=timeout_seconds,
+            scope="environment",
+        )
+        info = {
+            "exit_code": process.returncode,
+            "stdout": process.stdout.decode(errors="replace"),
+            "stderr": process.stderr.decode(errors="replace"),
+            "timed_out": process.timed_out,
+        }
+        failed = SubScore(name="tests", value=0.0, info=info)
+        if not report.is_file():
+            return failed.model_copy(update={"info": {**info, "error": "test command did not write JUnit XML"}})
+        if process.timed_out or (binary and process.returncode != 0):
+            return failed
+        try:
+            result = score_tests(parse_junit(report), fail_to_pass, pass_to_pass, binary)
+        except (OSError, ValueError) as exc:
+            return failed.model_copy(update={"info": {**info, "error": str(exc)}})
+        return result.model_copy(update={"info": {**(result.info or {}), **info}})

--- a/environments/coding/tests/conftest.py
+++ b/environments/coding/tests/conftest.py
@@ -1,8 +1,36 @@
 """Make the environment project importable when tests run from the SDK root."""
 
+import os
 import sys
 from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from hud.environment import Workspace
+from hud.environment.workspace import usable_bwrap
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+
+
+@pytest.fixture
+def isolated_workspace():
+    if sys.platform != "linux" or os.geteuid() != 0 or usable_bwrap() is None:
+        pytest.skip("requires Linux, root, and bubblewrap (run in the coding container)")
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def grading_workspace(tmp_path, monkeypatch, isolated_workspace):
+    import env as coding_env
+
+    root = tmp_path / "repo"
+    workspace = Workspace(root, guest_path=str(root), network=False, shell_uid=1000, require_isolation=True)
+    await workspace.start()
+    monkeypatch.setattr(coding_env, "workspace", workspace)
+    monkeypatch.setattr(coding_env, "REPO_DIR", root)
+    monkeypatch.setattr(coding_env, "_GIT", (*coding_env._GIT, "-c", f"safe.directory={root}"))
+    try:
+        yield workspace
+    finally:
+        await workspace.stop()

--- a/environments/coding/tests/test_grader.py
+++ b/environments/coding/tests/test_grader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from grader import JUnitCase, JUnitGrader, parse_junit, score_tests
+from grader import JUnitCase, grade_tests, parse_junit, score_tests
 
 
 def test_scoring_tracks_fail_to_pass_and_pass_to_pass(tmp_path: Path):
@@ -90,9 +90,9 @@ def test_parse_junit_rejects_malformed_report(tmp_path: Path):
         parse_junit(report)
 
 
-@pytest.mark.asyncio
-async def test_junit_grader_reports_missing_output(tmp_path: Path):
-    result = await JUnitGrader.compute_score(command="true {junit_path}", cwd=str(tmp_path))
+@pytest.mark.asyncio(loop_scope="session")
+async def test_junit_grader_reports_missing_output(grading_workspace):
+    result = await grade_tests(grading_workspace, "true {junit_path}")
 
     assert result.value == 0.0
     assert result.info is not None
@@ -100,18 +100,49 @@ async def test_junit_grader_reports_missing_output(tmp_path: Path):
     assert result.info["exit_code"] == 0
 
 
-@pytest.mark.asyncio
-async def test_binary_junit_grader_rejects_passing_report_from_failed_command(tmp_path: Path):
-    result = await JUnitGrader.compute_score(
+@pytest.mark.asyncio(loop_scope="session")
+async def test_binary_junit_grader_rejects_passing_report_from_failed_command(grading_workspace):
+    result = await grade_tests(
+        grading_workspace,
         command=(
             'printf \'<testsuite><testcase classname="tests.test_widget" '
             'name="test_fixed" /></testsuite>\' > {junit_path}; false'
         ),
-        cwd=str(tmp_path),
         binary=True,
     )
 
     assert result.value == 0.0
     assert result.info is not None
     assert result.info["exit_code"] == 1
+    assert "error" not in result.info
     assert "all_testcases" not in result.info
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_grading_runs_as_agent_after_session_termination(grading_workspace):
+    session = await grading_workspace.run(["/bin/bash", "-lc", "echo agent > agent.txt"])
+    assert session.returncode == 0
+    await grading_workspace.terminate_sessions()
+
+    result = await grade_tests(
+        grading_workspace,
+        'test "$(id -u)" = 1000 && test "$(cat agent.txt)" = agent && '
+        "grep -q localhost /etc/hosts && "
+        'printf \'<testsuite><testcase classname="tests" name="passed" /></testsuite>\' > {junit_path}',
+        binary=True,
+    )
+
+    assert result.value == 1.0
+    assert result.info["exit_code"] == 0
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_timed_out_grader_does_not_score_partial_report(grading_workspace):
+    result = await grade_tests(
+        grading_workspace,
+        'printf \'<testsuite><testcase classname="tests" name="passed" /></testsuite>\' > {junit_path}; sleep 30',
+        timeout_seconds=1,
+    )
+
+    assert result.value == 0.0
+    assert result.info["timed_out"] is True

--- a/environments/coding/tests/test_local_rollout.py
+++ b/environments/coding/tests/test_local_rollout.py
@@ -5,14 +5,17 @@ import shlex
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
 
 import pytest
 from hud import LocalRuntime, Run, connect
 from hud.environment import workspace as workspace_lib
 
+import tasks
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-PYTEST_COMMAND = f"{shlex.quote(sys.executable)} -m pytest -q test_widget.py --junitxml={{junit_path}}"
+PYTEST_COMMAND = (
+    f"{shlex.quote(sys.executable)} -m pytest -q -c /dev/null --rootdir=. test_widget.py --junitxml={{junit_path}}"
+)
 TEST_PATCH = """diff --git a/test_widget.py b/test_widget.py
 new file mode 100644
 --- /dev/null
@@ -35,31 +38,11 @@ pytestmark = pytest.mark.asyncio(loop_scope="session")
 
 def _git(cwd: Path, *args: str) -> None:
     subprocess.run(
-        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        ["git", "-c", f"safe.directory={cwd}", "-c", "user.name=t", "-c", "user.email=t@t", *args],
         cwd=cwd,
         check=True,
         capture_output=True,
     )
-
-
-@pytest.fixture
-def isolated_workspace(monkeypatch):
-    monkeypatch.setattr(workspace_lib, "usable_bwrap", lambda: "/usr/bin/true")
-    monkeypatch.setattr(
-        workspace_lib.Workspace,
-        "shell_argv",
-        lambda _self, command, **_kwargs: ["bash", "-lc", command],
-    )
-
-
-@pytest.fixture
-def grading_workspace(monkeypatch):
-    import env as coding_env
-
-    workspace = AsyncMock()
-    workspace.shell_argv = Mock(side_effect=lambda command, **_: ["bash", "-lc", command])
-    monkeypatch.setattr(coding_env, "workspace", workspace)
-    return workspace
 
 
 @pytest.fixture(scope="session")
@@ -92,19 +75,22 @@ def _coding_task():
     )
 
 
-async def _run_task(fixture_repo: Path, task) -> float:
-    os.environ["REPO_URL"] = str(fixture_repo)
+async def _run_task(fixture_repo: Path, task, monkeypatch) -> float:
+    monkeypatch.setenv("REPO_URL", str(fixture_repo))
+    monkeypatch.delenv("REPO_DIR", raising=False)
+    monkeypatch.delenv("BASELINE_DIR", raising=False)
     runtime = LocalRuntime(str(PROJECT_ROOT / "env.py"))
     async with runtime(task) as addr, connect(addr) as client:
         async with Run(client, task.id, task.args) as run:
             pass
+    assert not run.evaluation.get("isError"), run.evaluation
     return run.reward
 
 
 async def test_agent_fix_scores_one(fixture_repo, tmp_path, monkeypatch, grading_workspace):
     import env as coding_env
 
-    repo = tmp_path / "repo"
+    repo = grading_workspace.root
     subprocess.run(["git", "clone", "-q", str(fixture_repo), str(repo)], check=True)
     monkeypatch.setattr(coding_env, "REPO_DIR", repo)
     monkeypatch.setattr(coding_env, "BASELINE_DIR", tmp_path / "baseline")
@@ -116,11 +102,8 @@ async def test_agent_fix_scores_one(fixture_repo, tmp_path, monkeypatch, grading
     (repo / "widget.py").write_text("from fix import BROKEN\n")
     result = await task.asend("done")
 
-    assert result.reward == 1.0
+    assert result.reward == 1.0, result
     assert (repo / "fix.py").exists()
-    grading_workspace.terminate_sessions.assert_awaited_once_with()
-    grading_workspace.shell_argv.assert_called_once()
-    grading_workspace.discard_sandbox.assert_awaited_once_with()
 
 
 async def test_missing_junit_report_is_grading_error(
@@ -131,7 +114,7 @@ async def test_missing_junit_report_is_grading_error(
 ):
     import env as coding_env
 
-    repo = tmp_path / "repo"
+    repo = grading_workspace.root
     subprocess.run(["git", "clone", "-q", str(fixture_repo), str(repo)], check=True)
     monkeypatch.setattr(coding_env, "REPO_DIR", repo)
     monkeypatch.setattr(coding_env, "BASELINE_DIR", tmp_path / "baseline")
@@ -151,11 +134,22 @@ async def test_missing_junit_report_is_grading_error(
     assert result.isError is True
     assert result.content == "test command did not write JUnit XML"
     assert result.info["exit_code"] == 0
-    grading_workspace.discard_sandbox.assert_awaited_once_with()
 
 
-async def test_untouched_baseline_gets_regression_credit(fixture_repo, isolated_workspace):
-    assert await _run_task(fixture_repo, _coding_task()) == 0.5
+async def test_untouched_baseline_gets_regression_credit(fixture_repo, isolated_workspace, monkeypatch):
+    assert await _run_task(fixture_repo, _coding_task(), monkeypatch) == 0.5
+
+
+@pytest.mark.parametrize("task", tasks.tasks, ids=lambda task: task.slug)
+@pytest.mark.parametrize("fixed", [False, True], ids=["baseline", "reference-fix"])
+async def test_bundled_tasks_grade_in_workspace(task, fixed, isolated_workspace, tmp_path, monkeypatch):
+    bundle = tmp_path / "flask.bundle"
+    bundle.write_bytes((PROJECT_ROOT / "flask.bundle").read_bytes())
+    if fixed:
+        task = task.model_copy(
+            update={"args": {**task.args, "base_ref": f"origin/{task.slug.replace('-', '_')}_golden"}}
+        )
+    assert await _run_task(bundle, task, monkeypatch) == float(fixed)
 
 
 async def test_local_runtime_refuses_unisolated_non_root_workspace(
@@ -180,7 +174,7 @@ async def test_grading_discards_agent_git_config_and_test_changes(
 ):
     import env as coding_env
 
-    repo = tmp_path / "repo"
+    repo = grading_workspace.root
     subprocess.run(["git", "clone", "-q", str(fixture_repo), str(repo)], check=True)
     monkeypatch.setattr(coding_env, "REPO_DIR", repo)
     monkeypatch.setattr(coding_env, "BASELINE_DIR", tmp_path / "baseline")
@@ -203,9 +197,9 @@ async def test_grading_discards_agent_git_config_and_test_changes(
 
     result = await task.asend("done")
 
-    assert result.reward == 0.5
+    assert result.reward == 0.5, result
     config = subprocess.run(
-        ["git", "config", "--get", "filter.agent.clean"],
+        ["git", "-c", f"safe.directory={repo}", "config", "--get", "filter.agent.clean"],
         cwd=repo,
         capture_output=True,
         check=False,

--- a/environments/cua/env.py
+++ b/environments/cua/env.py
@@ -50,12 +50,10 @@ async def cua_task(
 ):
     """Run a computer-use task with shell checks, an LLM judge, or both.
 
-    Declaring ``hud_api_key`` opts hosted rollouts into key injection for the judge.
+    Declaring ``hud_api_key`` opts hosted rollouts into container-level HUD_API_KEY injection.
     """
     global _task_started
 
-    if hud_api_key and not settings.api_key:
-        settings.api_key = hud_api_key
     if not bash_checks and not grading_criteria:
         raise ValueError("CUA tasks require at least one grader")
     if any(c.get("weight", 1.0) < 0 for c in (bash_checks or [])):

--- a/environments/cua/tests/test_env.py
+++ b/environments/cua/tests/test_env.py
@@ -41,9 +41,10 @@ class TestGrading:
         with pytest.raises(ValueError, match="nonnegative"):
             await gen.asend(None)
 
-    async def test_no_key_judge_fails_before_prompt(self, monkeypatch):
+    @pytest.mark.parametrize("hud_api_key", [None, "task-key"])
+    async def test_no_runtime_key_judge_fails_before_prompt(self, monkeypatch, hud_api_key):
         monkeypatch.setattr(M.settings, "api_key", "", raising=False)
-        gen = GEN(prompt="p", grading_criteria=["anything"])
+        gen = GEN(prompt="p", grading_criteria=["anything"], hud_api_key=hud_api_key)
         with pytest.raises(RuntimeError, match="HUD_API_KEY"):
             await gen.asend(None)
 

--- a/hud/cli/__init__.py
+++ b/hud/cli/__init__.py
@@ -41,7 +41,7 @@ from .qa import qa_app  # noqa: E402
 from .serve import serve_command  # noqa: E402
 from .sync import sync_app  # noqa: E402
 from .task import task_app  # noqa: E402
-from .trace import trace_app  # noqa: E402
+from .trace import trace_command  # noqa: E402
 
 app.command(name="serve")(serve_command)
 app.command(name="deploy")(deploy_command)
@@ -50,7 +50,7 @@ app.command(name="init")(init_command)
 app.command(name="cancel")(cancel_command)
 app.add_typer(models_app, name="models")
 app.add_typer(jobs_app, name="jobs")
-app.add_typer(trace_app, name="trace")
+app.command(name="trace")(trace_command)
 app.add_typer(qa_app, name="qa")
 
 

--- a/hud/cli/tests/test_trace.py
+++ b/hud/cli/tests/test_trace.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
 
+import pytest
 from typer.testing import CliRunner
 
-from hud.cli import trace
+from hud.cli import app, trace
 from hud.settings import settings
-
-if TYPE_CHECKING:
-    import pytest
+from hud.utils.platform import PlatformClient
 
 
 def test_trace_link_uses_web_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -20,7 +19,29 @@ def test_trace_link_uses_web_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
         lambda _: [{"kind": "agent_message", "text": "done"}],
     )
 
-    result = CliRunner().invoke(trace.trace_app, [trace_id])
+    result = CliRunner().invoke(app, ["trace", trace_id])
 
     assert result.exit_code == 0
     assert "https://hud.ai/trace/03dd2a73-d3df-4d10-a54a-e3d87c2d530d" in result.stdout
+
+
+@pytest.mark.parametrize("options_first", [False, True])
+def test_trace_json_accepts_options_on_either_side_of_id(
+    monkeypatch: pytest.MonkeyPatch, options_first: bool
+) -> None:
+    trace_id = "03dd2a73d3df4d10a54ae3d87c2d530d"
+    events = [{"kind": "agent_message", "text": "done"}]
+    monkeypatch.setattr(settings, "api_key", "test-key")
+    monkeypatch.setattr(settings, "telemetry_local_dir", None)
+
+    def get_events(self: PlatformClient, path: str) -> dict[str, object]:
+        assert path == f"/trace/{trace_id}/events"
+        return {"events": events}
+
+    monkeypatch.setattr(PlatformClient, "get", get_events)
+
+    args = ["--json", trace_id] if options_first else [trace_id, "--json"]
+    result = CliRunner().invoke(app, ["trace", *args])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == events

--- a/hud/cli/trace.py
+++ b/hud/cli/trace.py
@@ -14,18 +14,8 @@ from rich.text import Text
 
 console = Console()
 
-trace_app = typer.Typer(
-    name="trace",
-    help="Inspect a rollout trace",
-    add_completion=False,
-    rich_markup_mode="rich",
-    no_args_is_help=True,
-)
 
-
-@trace_app.callback(invoke_without_command=True)
 def trace_command(
-    ctx: typer.Context,
     trace_id: str = typer.Argument(..., help="Trace ID (UUID or 32-hex OTel id)"),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON"),
     local_dir: str | None = typer.Option(
@@ -37,9 +27,6 @@ def trace_command(
     Checks ``HUD_TELEMETRY_LOCAL_DIR`` first (fast, no API needed), then
     falls back to ``GET /v2/trace/{id}/events`` on the platform.
     """
-    if ctx.invoked_subcommand is not None:
-        return
-
     from hud.cli.utils.api import require_api_key
     from hud.settings import settings
     from hud.telemetry.span import normalize_trace_id

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -165,6 +165,29 @@ async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_hosts_mount_does_not_require_access_to_private_credentials(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "hud.environment.workspace.usable_bwrap", lambda: Bubblewrap("/usr/bin/bwrap")
+    )
+    ws = Workspace(tmp_path / "root", network=False, track_files=False)
+    await ws.start()
+    try:
+        argv = ws.shell_argv("cat /etc/hosts")
+        hosts = Path(argv[argv.index("/etc/hosts") - 1])
+        key = ws.ssh_client_key_path
+        assert key is not None
+        assert not hosts.is_relative_to(key.parent)
+        assert (await asyncio.to_thread(key.parent.stat)).st_mode & 0o777 == 0o700
+        assert (await asyncio.to_thread(hosts.stat)).st_mode & 0o777 == 0o644
+        assert "localhost" in await asyncio.to_thread(hosts.read_text)
+    finally:
+        await ws.stop()
+    assert not await asyncio.to_thread(hosts.exists)
+
+
+@pytest.mark.asyncio
 async def test_sftp_subsystem_is_not_served(tmp_path: Path) -> None:
     ws = Workspace(tmp_path / "root")
     await ws.start()

--- a/hud/environment/tests/test_workspace.py
+++ b/hud/environment/tests/test_workspace.py
@@ -165,26 +165,30 @@ async def test_credentials_live_outside_the_served_root(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_hosts_mount_does_not_require_access_to_private_credentials(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(
-        "hud.environment.workspace.usable_bwrap", lambda: Bubblewrap("/usr/bin/bwrap")
+@pytest.mark.parametrize("guest_path", ["/workspace", "/tmp/hud-coding/123/workspace"])
+async def test_shell_user_can_access_guest_workspace_paths(tmp_path: Path, guest_path: str) -> None:
+    if sys.platform != "linux" or os.geteuid() != 0 or workspace_mod.usable_bwrap() is None:
+        pytest.skip("requires Linux, root, and usable bubblewrap")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "input.txt").write_text("hello\n")
+    ws = Workspace(
+        root, guest_path=guest_path, network=False, shell_uid=1000, require_isolation=True
     )
-    ws = Workspace(tmp_path / "root", network=False, track_files=False)
     await ws.start()
     try:
-        argv = ws.shell_argv("cat /etc/hosts")
-        hosts = Path(argv[argv.index("/etc/hosts") - 1])
-        key = ws.ssh_client_key_path
-        assert key is not None
-        assert not hosts.is_relative_to(key.parent)
-        assert (await asyncio.to_thread(key.parent.stat)).st_mode & 0o777 == 0o700
-        assert (await asyncio.to_thread(hosts.stat)).st_mode & 0o777 == 0o644
-        assert "localhost" in await asyncio.to_thread(hosts.read_text)
+        command = f"id -u; cat {guest_path}/input.txt; echo written > {guest_path}/output.txt"
+        async with await _connect(ws) as conn:
+            result = await conn.run(command)
+            assert result.exit_status == 0, result.stderr
+            assert result.stdout == "1000\nhello\n"
+        await ws.terminate_sessions()
+        captured = await ws.run(["sh", "-c", command], scope="environment")
+        assert captured.returncode == 0, captured.stderr
+        assert captured.stdout == b"1000\nhello\n"
+        assert (root / "output.txt").read_text() == "written\n"
     finally:
         await ws.stop()
-    assert not await asyncio.to_thread(hosts.exists)
 
 
 @pytest.mark.asyncio

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -1528,7 +1528,12 @@ class Workspace:
         peer_names = {peer.name for peer in self.peers}
         if collision := local_aliases & peer_names:
             raise ValueError(f"workspace local alias conflicts with peer {sorted(collision)[0]!r}")
-        path = self._configured_hosts_path or self._credentials_dir() / "hosts"
+        if self._configured_hosts_path is not None:
+            path = self._configured_hosts_path
+        else:
+            # Bubblewrap opens bind sources after dropping to the shell uid.
+            with tempfile.NamedTemporaryFile(prefix="hud-hosts-", delete=False) as hosts_file:
+                path = Path(hosts_file.name)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             hosts_text(

--- a/hud/environment/workspace.py
+++ b/hud/environment/workspace.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, Literal
 
 import asyncssh
@@ -1116,6 +1116,8 @@ class Workspace:
         bind_host_devices = not isolate_users if bind_devices is None else bind_devices
         for mount in self._system_mounts:
             argv.extend(mount.to_bwrap_args(bind_devices=bind_host_devices))
+        # Implicit bind-mount parents are root-only in bubblewrap.
+        argv.extend(["--dir", str(PurePosixPath(self._guest_path).parent)])
         argv.extend(["--bind", str(self.root), self._guest_path])
         selected_mounts = self.mounts if mounts is None else mounts
         for m in selected_mounts:
@@ -1528,12 +1530,7 @@ class Workspace:
         peer_names = {peer.name for peer in self.peers}
         if collision := local_aliases & peer_names:
             raise ValueError(f"workspace local alias conflicts with peer {sorted(collision)[0]!r}")
-        if self._configured_hosts_path is not None:
-            path = self._configured_hosts_path
-        else:
-            # Bubblewrap opens bind sources after dropping to the shell uid.
-            with tempfile.NamedTemporaryFile(prefix="hud-hosts-", delete=False) as hosts_file:
-                path = Path(hosts_file.name)
+        path = self._configured_hosts_path or self._credentials_dir() / "hosts"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
             hosts_text(

--- a/scripts/example_lifecycle.py
+++ b/scripts/example_lifecycle.py
@@ -10,36 +10,17 @@ import sys
 import time
 from pathlib import Path
 
-import httpx
-
 from hud.eval import Taskset
-from hud.utils.platform import PlatformClient
 
 
 def prepare(example: str) -> None:
     task = next(iter(Taskset.from_file("tasks.py")))
     Path(".hud").mkdir(exist_ok=True)
     if example == "argument-hints":
-        platform = PlatformClient.from_settings()
-        content = b"Examples of primes under 20: 2, 3, 5, 7, 11, 13, 17, 19.\n"
-        upload = platform.post(
-            "/data",
-            json={
-                "filename": "notes.txt",
-                "size_bytes": len(content),
-                "content_type": "text/plain",
-            },
-        )
-        file_id = upload["file"]["id"]
-        response = httpx.put(
-            upload["upload_url"],
-            content=content,
-            headers={"Content-Type": "text/plain"},
-            timeout=30,
-        )
-        response.raise_for_status()
-        platform.post(f"/data/{file_id}/complete")
-        task.args["attachments"] = [{"file_id": file_id}]
+        file_id = os.environ["HUD_CI_DATA_FILE_ID"]
+        if not file_id:
+            raise ValueError("HUD_CI_DATA_FILE_ID must reference the shared CI attachment")
+        task.args["attachments"] = [{"file_id": file_id, "path": "notes.txt"}]
         task.args["prompt"] = "Read files/notes.txt first. " + task.args["prompt"]
     Taskset(tasks=[task]).to_file(".hud/ci-tasks.json")
 

--- a/scripts/example_lifecycle.py
+++ b/scripts/example_lifecycle.py
@@ -109,7 +109,7 @@ async def check(example: str, solved: bool) -> None:
         "--env",
         f"HUD_GATEWAY_URL={SERVICE}",
         "--env",
-        "HUD_API_KEY=",
+        f"HUD_API_KEY={KEY}",
         "--env",
         "HUD_TELEMETRY_ENABLED=false",
         f"hud-example:{example}",
@@ -119,7 +119,6 @@ async def check(example: str, solved: bool) -> None:
         task = tasks[0]
         args = dict(task.args)
         if example == "cua":
-            args["hud_api_key"] = KEY
             args["bash_checks"] = [
                 {
                     **check,
@@ -134,7 +133,6 @@ async def check(example: str, solved: bool) -> None:
                 prompt="Read notes.txt and report the answer.",
                 attachments=[{"file_id": "notes"}],
                 criteria=[{"requirement": "Answers violet.", "weight": 1.0}],
-                hud_api_key=KEY,
             )
 
         async with connect(Runtime("tcp://127.0.0.1:8765"), ready_timeout=60) as client:

--- a/scripts/example_lifecycle.py
+++ b/scripts/example_lifecycle.py
@@ -1,4 +1,4 @@
-"""Prepare live example tasks, check their traces, and remove CI resources."""
+"""Prepare live example tasks and check their traces."""
 
 from __future__ import annotations
 
@@ -31,7 +31,6 @@ def prepare(example: str) -> None:
             },
         )
         file_id = upload["file"]["id"]
-        Path(".hud/ci-data-file.json").write_text(json.dumps({"id": file_id}))
         response = httpx.put(
             upload["upload_url"],
             content=content,
@@ -95,28 +94,13 @@ def check() -> None:
     )
 
 
-def cleanup() -> None:
-    platform = PlatformClient.from_settings()
-    try:
-        if (config := Path(".hud/config.json")).exists():
-            registry_id = json.loads(config.read_text())["registryId"]
-            platform.delete(f"/registry/{registry_id}")
-    finally:
-        if (data_file := Path(".hud/ci-data-file.json")).exists():
-            file_id = json.loads(data_file.read_text())["id"]
-            platform.delete(f"/data/{file_id}")
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     commands = parser.add_subparsers(dest="command", required=True)
     commands.add_parser("prepare").add_argument("example")
     commands.add_parser("check")
-    commands.add_parser("cleanup")
     args = parser.parse_args()
     if args.command == "prepare":
         prepare(args.example)
     elif args.command == "check":
         check()
-    else:
-        cleanup()

--- a/scripts/example_lifecycle.py
+++ b/scripts/example_lifecycle.py
@@ -1,0 +1,206 @@
+"""Exercise built example images through the HUD task and capability protocols."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from hud import Runtime, connect
+from hud.capabilities import RFBClient, SSHClient
+from hud.eval import Taskset
+
+KEY = "example-ci-key"
+SERVICE = "http://host.docker.internal:18080"
+REQUESTS: list[str] = []
+DOCKER = shutil.which("docker") or "/usr/bin/docker"
+SECURITY = Path(__file__).resolve().parents[1] / "hud/eval/docker-seccomp.json"
+
+
+class Services(BaseHTTPRequestHandler):
+    """HTTP fixtures for data-file storage and the inference gateway."""
+
+    def do_GET(self) -> None:
+        if self.path.startswith("/v2/") and self.headers.get("Authorization") != f"Bearer {KEY}":
+            self.send_error(401)
+            return
+        REQUESTS.append(self.path)
+        if self.path == "/v2/data/notes":
+            payload = json.dumps({"filename": "notes.txt"}).encode()
+        elif self.path == "/v2/data/notes/download":
+            payload = json.dumps({"url": f"{SERVICE}/notes.txt"}).encode()
+        elif self.path == "/notes.txt":
+            if self.headers.get("Authorization"):
+                self.send_error(400, "storage must not receive the HUD key")
+                return
+            payload = b"The answer is violet.\n"
+        elif self.path == "/page":
+            payload = b"<html><title>Example</title><body>free encyclopedia</body></html>"
+        else:
+            self.send_error(404)
+            return
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:
+        if self.path != "/chat/completions" or self.headers.get("Authorization") != f"Bearer {KEY}":
+            self.send_error(401)
+            return
+        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+        prompt = body["messages"][-1]["content"]
+        assert "<criterion>" in prompt and "<response>" in prompt
+        REQUESTS.append(self.path)
+        verdict = "UNMET" if "wrong answer" in prompt else "MET"
+        payload = json.dumps(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {"criterion_status": verdict, "explanation": "fixture"}
+                            ),
+                        },
+                        "finish_reason": "stop",
+                    }
+                ]
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def docker(*args: str) -> str:
+    return subprocess.run([DOCKER, *args], text=True, stdout=subprocess.PIPE, check=True).stdout
+
+
+async def check(example: str, solved: bool) -> None:
+    name = f"hud-example-{example}-{'pass' if solved else 'fail'}"
+    docker(
+        "run",
+        "--detach",
+        "--name",
+        name,
+        "--publish",
+        "127.0.0.1:8765:8765",
+        "--shm-size",
+        "2g",
+        "--add-host",
+        "host.docker.internal:host-gateway",
+        "--security-opt",
+        f"seccomp={SECURITY}",
+        "--security-opt",
+        "systempaths=unconfined",
+        "--security-opt",
+        "apparmor=unconfined",
+        "--env",
+        f"HUD_API_URL={SERVICE}",
+        "--env",
+        f"HUD_GATEWAY_URL={SERVICE}",
+        "--env",
+        "HUD_API_KEY=",
+        "--env",
+        "HUD_TELEMETRY_ENABLED=false",
+        f"hud-example:{example}",
+    )
+    try:
+        tasks = list(Taskset.from_file("tasks.py"))
+        task = tasks[0]
+        args = dict(task.args)
+        if example == "cua":
+            args["hud_api_key"] = KEY
+            args["bash_checks"] = [
+                {
+                    **check,
+                    "command": check["command"].replace(
+                        "https://www.wikipedia.org/", f"{SERVICE}/page"
+                    ),
+                }
+                for check in args["bash_checks"]
+            ]
+        elif example == "argument-hints":
+            args.update(
+                prompt="Read notes.txt and report the answer.",
+                attachments=[{"file_id": "notes"}],
+                criteria=[{"requirement": "Answers violet.", "weight": 1.0}],
+                hud_api_key=KEY,
+            )
+
+        async with connect(Runtime("tcp://127.0.0.1:8765"), ready_timeout=60) as client:
+            frame = await client.start_task(task.id, args)
+            assert frame.get("prompt"), frame
+            if example == "coding" and solved:
+                # Apply the golden source through the agent's shell, not through Docker.
+                source = docker(
+                    "exec",
+                    name,
+                    "git",
+                    "-C",
+                    "/hud/baseline",
+                    "show",
+                    "origin/flask_4992_golden:src/flask/config.py",
+                )
+                shell = await client.open("shell")
+                assert isinstance(shell, SSHClient)
+                await shell.write_text("/app/src/flask/config.py", source)
+            elif example == "cua":
+                screen = await client.open("screen")
+                assert isinstance(screen, RFBClient)
+                screenshot, mime_type = await screen.screenshot_png()
+                assert mime_type == "image/png" and screenshot.startswith(b"\x89PNG\r\n\x1a\n")
+                if solved:
+                    screen.conn.keyboard.press("Control_L", "l")
+                    screen.conn.keyboard.write(f"{SERVICE}/page")
+                    screen.conn.keyboard.press("Return")
+                    await screen.drain()
+                    for _ in range(30):
+                        if "/page" in REQUESTS:
+                            break
+                        await asyncio.sleep(0.2)
+                    assert "/page" in REQUESTS
+            elif example == "argument-hints":
+                assert frame["data_files"] == [{"path": "files/notes.txt", "file_id": "notes"}]
+                shell = await client.open("ssh")
+                assert isinstance(shell, SSHClient)
+                assert (
+                    await shell.read_text("/workspace/files/notes.txt") == "The answer is violet.\n"
+                )
+            answer = "4" if example == "blank" else "violet, free encyclopedia"
+            result = await client.grade({"answer": answer if solved else "wrong answer"})
+            assert not result.get("isError"), result
+            assert result["score"] == float(solved), result
+        print(f"{example}: {'passing' if solved else 'failing'} task verified")
+    finally:
+        print(docker("logs", name))
+        docker("rm", "--force", name)
+
+
+async def main() -> None:
+    example = sys.argv[1]
+    server = ThreadingHTTPServer(("0.0.0.0", 18080), Services)  # noqa: S104 - reachable by containers
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        await check(example, False)
+        await check(example, True)
+        if example in {"cua", "argument-hints"}:
+            assert REQUESTS.count("/chat/completions") == 2, REQUESTS
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/example_lifecycle.py
+++ b/scripts/example_lifecycle.py
@@ -1,204 +1,122 @@
-"""Exercise built example images through the HUD task and capability protocols."""
+"""Prepare live example tasks, check their traces, and remove CI resources."""
 
 from __future__ import annotations
 
-import asyncio
+import argparse
 import json
-import shutil
+import os
 import subprocess
 import sys
-import threading
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import time
 from pathlib import Path
 
-from hud import Runtime, connect
-from hud.capabilities import RFBClient, SSHClient
+import httpx
+
 from hud.eval import Taskset
-
-KEY = "example-ci-key"
-SERVICE = "http://host.docker.internal:18080"
-REQUESTS: list[str] = []
-DOCKER = shutil.which("docker") or "/usr/bin/docker"
-SECURITY = Path(__file__).resolve().parents[1] / "hud/eval/docker-seccomp.json"
+from hud.utils.platform import PlatformClient
 
 
-class Services(BaseHTTPRequestHandler):
-    """HTTP fixtures for data-file storage and the inference gateway."""
+def prepare(example: str) -> None:
+    task = next(iter(Taskset.from_file("tasks.py")))
+    Path(".hud").mkdir(exist_ok=True)
+    if example == "argument-hints":
+        platform = PlatformClient.from_settings()
+        content = b"Examples of primes under 20: 2, 3, 5, 7, 11, 13, 17, 19.\n"
+        upload = platform.post(
+            "/data",
+            json={
+                "filename": "notes.txt",
+                "size_bytes": len(content),
+                "content_type": "text/plain",
+            },
+        )
+        file_id = upload["file"]["id"]
+        Path(".hud/ci-data-file.json").write_text(json.dumps({"id": file_id}))
+        response = httpx.put(
+            upload["upload_url"],
+            content=content,
+            headers={"Content-Type": "text/plain"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        platform.post(f"/data/{file_id}/complete")
+        task.args["attachments"] = [{"file_id": file_id}]
+        task.args["prompt"] = "Read files/notes.txt first. " + task.args["prompt"]
+    Taskset(tasks=[task]).to_file(".hud/ci-tasks.json")
 
-    def do_GET(self) -> None:
-        if self.path.startswith("/v2/") and self.headers.get("Authorization") != f"Bearer {KEY}":
-            self.send_error(401)
+
+def check() -> None:
+    trace_dir = Path(os.environ["HUD_TELEMETRY_LOCAL_DIR"])
+    traces = list(trace_dir.glob("*.jsonl"))
+    assert len(traces) == 1, f"Expected one rollout trace, found {len(traces)}"
+    steps = [
+        span["attributes"]["hud.payload"]
+        for line in traces[0].read_text().splitlines()
+        if (span := json.loads(line))["attributes"].get("hud.schema") == "hud.step.v1"
+    ]
+    errors = [
+        step["error"]
+        for step in steps
+        if step["source"] in {"task", "agent", "system"} and step.get("error")
+    ]
+    assert not errors, errors
+    calls = [step["task_call"] for step in steps if step["source"] == "task"]
+    assert [call["phase"] for call in calls] == ["setup", "evaluate"], calls
+    assert calls[0]["result"].get("prompt"), "Task setup did not return a prompt"
+    grade = calls[1]["result"]
+    assert not grade.get("isError"), grade
+    assert isinstance(grade["score"], int | float) and 0 <= grade["score"] <= 1, grade
+    task = next(iter(Taskset.from_file(".hud/ci-tasks.json")))
+    if attachments := task.args.get("attachments"):
+        assert calls[0]["result"]["data_files"] == [
+            {"path": "files/notes.txt", "file_id": attachments[0]["file_id"]}
+        ]
+
+    # Unset local export so `hud trace` must read back from the platform.
+    env = {key: value for key, value in os.environ.items() if key != "HUD_TELEMETRY_LOCAL_DIR"}
+    for attempt in range(12):
+        result = subprocess.run(
+            [str(Path(sys.executable).with_name("hud")), "trace", traces[0].stem, "--json"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        events = json.loads(result.stdout) if result.returncode == 0 else []
+        if any(event["kind"] == "agent_message" for event in events):
+            (trace_dir / "remote-events.json").write_text(result.stdout)
+            print(f"Hosted lifecycle verified: {traces[0].stem}, score={grade['score']}")
             return
-        REQUESTS.append(self.path)
-        if self.path == "/v2/data/notes":
-            payload = json.dumps({"filename": "notes.txt"}).encode()
-        elif self.path == "/v2/data/notes/download":
-            payload = json.dumps({"url": f"{SERVICE}/notes.txt"}).encode()
-        elif self.path == "/notes.txt":
-            if self.headers.get("Authorization"):
-                self.send_error(400, "storage must not receive the HUD key")
-                return
-            payload = b"The answer is violet.\n"
-        elif self.path == "/page":
-            payload = b"<html><title>Example</title><body>free encyclopedia</body></html>"
-        else:
-            self.send_error(404)
-            return
-        self.send_response(200)
-        self.send_header("Content-Length", str(len(payload)))
-        self.end_headers()
-        self.wfile.write(payload)
-
-    def do_POST(self) -> None:
-        if self.path != "/chat/completions" or self.headers.get("Authorization") != f"Bearer {KEY}":
-            self.send_error(401)
-            return
-        body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
-        prompt = body["messages"][-1]["content"]
-        assert "<criterion>" in prompt and "<response>" in prompt
-        REQUESTS.append(self.path)
-        verdict = "UNMET" if "wrong answer" in prompt else "MET"
-        payload = json.dumps(
-            {
-                "choices": [
-                    {
-                        "index": 0,
-                        "message": {
-                            "role": "assistant",
-                            "content": json.dumps(
-                                {"criterion_status": verdict, "explanation": "fixture"}
-                            ),
-                        },
-                        "finish_reason": "stop",
-                    }
-                ]
-            }
-        ).encode()
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(payload)))
-        self.end_headers()
-        self.wfile.write(payload)
-
-
-def docker(*args: str) -> str:
-    return subprocess.run([DOCKER, *args], text=True, stdout=subprocess.PIPE, check=True).stdout
-
-
-async def check(example: str, solved: bool) -> None:
-    name = f"hud-example-{example}-{'pass' if solved else 'fail'}"
-    docker(
-        "run",
-        "--detach",
-        "--name",
-        name,
-        "--publish",
-        "127.0.0.1:8765:8765",
-        "--shm-size",
-        "2g",
-        "--add-host",
-        "host.docker.internal:host-gateway",
-        "--security-opt",
-        f"seccomp={SECURITY}",
-        "--security-opt",
-        "systempaths=unconfined",
-        "--security-opt",
-        "apparmor=unconfined",
-        "--env",
-        f"HUD_API_URL={SERVICE}",
-        "--env",
-        f"HUD_GATEWAY_URL={SERVICE}",
-        "--env",
-        f"HUD_API_KEY={KEY}",
-        "--env",
-        "HUD_TELEMETRY_ENABLED=false",
-        f"hud-example:{example}",
+        if attempt < 11:
+            time.sleep(5)
+    raise AssertionError(
+        f"No persisted agent events after 12 attempts: {result.stdout}\n{result.stderr}"
     )
+
+
+def cleanup() -> None:
+    platform = PlatformClient.from_settings()
     try:
-        tasks = list(Taskset.from_file("tasks.py"))
-        task = tasks[0]
-        args = dict(task.args)
-        if example == "cua":
-            args["bash_checks"] = [
-                {
-                    **check,
-                    "command": check["command"].replace(
-                        "https://www.wikipedia.org/", f"{SERVICE}/page"
-                    ),
-                }
-                for check in args["bash_checks"]
-            ]
-        elif example == "argument-hints":
-            args.update(
-                prompt="Read notes.txt and report the answer.",
-                attachments=[{"file_id": "notes"}],
-                criteria=[{"requirement": "Answers violet.", "weight": 1.0}],
-            )
-
-        async with connect(Runtime("tcp://127.0.0.1:8765"), ready_timeout=60) as client:
-            frame = await client.start_task(task.id, args)
-            assert frame.get("prompt"), frame
-            if example == "coding" and solved:
-                # Apply the golden source through the agent's shell, not through Docker.
-                source = docker(
-                    "exec",
-                    name,
-                    "git",
-                    "-C",
-                    "/hud/baseline",
-                    "show",
-                    "origin/flask_4992_golden:src/flask/config.py",
-                )
-                shell = await client.open("shell")
-                assert isinstance(shell, SSHClient)
-                await shell.write_text("/app/src/flask/config.py", source)
-            elif example == "cua":
-                screen = await client.open("screen")
-                assert isinstance(screen, RFBClient)
-                screenshot, mime_type = await screen.screenshot_png()
-                assert mime_type == "image/png" and screenshot.startswith(b"\x89PNG\r\n\x1a\n")
-                if solved:
-                    screen.conn.keyboard.press("Control_L", "l")
-                    screen.conn.keyboard.write(f"{SERVICE}/page")
-                    screen.conn.keyboard.press("Return")
-                    await screen.drain()
-                    for _ in range(30):
-                        if "/page" in REQUESTS:
-                            break
-                        await asyncio.sleep(0.2)
-                    assert "/page" in REQUESTS
-            elif example == "argument-hints":
-                assert frame["data_files"] == [{"path": "files/notes.txt", "file_id": "notes"}]
-                shell = await client.open("ssh")
-                assert isinstance(shell, SSHClient)
-                assert (
-                    await shell.read_text("/workspace/files/notes.txt") == "The answer is violet.\n"
-                )
-            answer = "4" if example == "blank" else "violet, free encyclopedia"
-            result = await client.grade({"answer": answer if solved else "wrong answer"})
-            assert not result.get("isError"), result
-            assert result["score"] == float(solved), result
-        print(f"{example}: {'passing' if solved else 'failing'} task verified")
+        if (config := Path(".hud/config.json")).exists():
+            registry_id = json.loads(config.read_text())["registryId"]
+            platform.delete(f"/registry/{registry_id}")
     finally:
-        print(docker("logs", name))
-        docker("rm", "--force", name)
-
-
-async def main() -> None:
-    example = sys.argv[1]
-    server = ThreadingHTTPServer(("0.0.0.0", 18080), Services)  # noqa: S104 - reachable by containers
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        await check(example, False)
-        await check(example, True)
-        if example in {"cua", "argument-hints"}:
-            assert REQUESTS.count("/chat/completions") == 2, REQUESTS
-    finally:
-        server.shutdown()
-        server.server_close()
-        thread.join()
+        if (data_file := Path(".hud/ci-data-file.json")).exists():
+            file_id = json.loads(data_file.read_text())["id"]
+            platform.delete(f"/data/{file_id}")
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("prepare").add_argument("example")
+    commands.add_parser("check")
+    commands.add_parser("cleanup")
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare(args.example)
+    elif args.command == "check":
+        check()
+    else:
+        cleanup()


### PR DESCRIPTION
Run the four example environments after pushes to main, using the existing approval-gated pre-release environment.

- Generate each project with hud init and install a wheel built from the checkout.
- Run the examples' deterministic tests, then use hud deploy --no-env and hud eval --runtime hud --gateway with one authored task, at most 10 agent steps, and a 15-minute evaluation timeout.
- Upload a real data-file attachment for argument-hints. Check successful setup, attachment declarations, and a numeric non-error grade; zero reward is valid.
- Read the trace back with hud trace --json without local fallback. Save trace artifacts and remove only the environment and attachment allocated by that CI run.
- Remove the local Docker/HTTP-fixture lifecycle harness. Only deployment, evaluation, and cleanup steps receive HUD_API_KEY; environment protections are unchanged.

This PR also fixes the workspace hosts bind source being unreadable after the shell UID drop without relaxing SSH credential permissions. CUA and argument-hints use the container's runtime HUD_API_KEY for storage and grading instead of mutating global settings from task arguments. Concurrent-session regression tests cover that boundary.

Validation: 91 focused CLI tests, 45 rollout tests, and 41 example tests passed locally. All four projects generated successfully; checkout-wheel installation and task export were exercised. Trace assertions accepted real local blank rollouts with both zero and full scores. Ruff, focused type checking, YAML parsing, and diff checks passed.

Live hosted deployment, inference, storage, and trace ingestion have not yet been exercised by the new job. That run requires this workflow on main and approval through pre-release. No release or environment-protection changes are included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now depends on live deploy, inference, and trace ingestion with secrets; workspace bwrap and grading path changes affect sandboxed agent environments on Linux.
> 
> **Overview**
> **CI now validates the four example environments on main (and via `workflow_dispatch`)** using the approval-gated `pre-release` environment instead of building and probing local Docker images. The `templates` job installs each init template with a wheel from the checkout, runs unit checks, **`hud deploy --no-env`**, then a capped **`hud eval`** (gateway, HUD runtime, 15m timeout). **`scripts/example_lifecycle.py`** prepares `.hud/ci-tasks.json` (including a real data file for argument-hints), asserts trace/setup/grade health, and verifies **`hud trace --json`** against the platform without local telemetry fallback; traces are uploaded as artifacts.
> 
> **Runtime credential model:** argument-hints and CUA stop using the task `hud_api_key` argument for API calls; staging, judging, and file fetch use the container **`HUD_API_KEY`** from settings. Docs and regression tests cover concurrent sessions and staging auth.
> 
> **Coding grading** replaces `JUnitGrader`/`BashGrader` with **`grade_tests`**, which runs hidden tests through **`Workspace.run`** at environment scope (including after session termination), with Linux/bubblewrap integration tests.
> 
> **Workspace isolation fix:** bubblewrap now creates the parent directory of the guest bind path so dropped shell users can read/write paths like `/workspace` and `/tmp/hud-coding/.../workspace`.
> 
> **CLI:** `hud trace` is a top-level command (not a Typer sub-app) with flexible `--json` flag ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d999a9f67aae34e946f9b9a8053f9e218b13bc81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->