### PR TITLE
fix(runtime): preserve structured grades for hosted rollouts

### DIFF
--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -131,6 +131,7 @@ class HostedRuntime:
         run.trace.trace_id = trace_id
         run.job_id = job_id
         run.group_id = group_id
+        run.slug = task.slug
         return run
 
     async def _submit_and_await(

--- a/hud/eval/runtime/hosted.py
+++ b/hud/eval/runtime/hosted.py
@@ -202,12 +202,17 @@ class HostedRuntime:
                 if run.trace.status == "cancelled"
                 else "rollout failed before grading"
             )
-        run.grade = Grade(
-            reward=float(reward) if reward is not None else 0.0,
-            is_error=ungraded_failure,
-            content=grade_error,
-            raw={"score": float(reward)} if reward is not None else {},
-        )
+        # Same grade frame local runs get from tasks.grade; scalar reward is ungraded-only.
+        evaluation_result = state.get("evaluation_result")
+        if isinstance(evaluation_result, dict):
+            run.grade = Grade.from_dict(evaluation_result)
+        else:
+            run.grade = Grade(
+                reward=float(reward) if reward is not None else 0.0,
+                is_error=ungraded_failure,
+                content=grade_error,
+                raw={"score": float(reward)} if reward is not None else {},
+            )
         run._runtime = f"hud://trace/{trace_id}"
         return run
 

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -189,7 +189,14 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
         [
             {"status": "pending"},
             {"status": "running"},
-            {"status": "completed", "reward": 0.5},
+            {
+                "status": "completed",
+                "reward": 0.5,
+                "evaluation_result": {
+                    "score": 0.5,
+                    "info": {"summary": {"passed": 3}},
+                },
+            },
         ]
     )
     monkeypatch.setattr(
@@ -227,6 +234,7 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert run.trace.trace_id == trace_id
     assert run.job_id == job_id
     assert run.group_id == "g1"
+    assert run.grade.info == {"summary": {"passed": 3}}
     assert platform.polled == 3
     (path, payload) = platform.posts[0]
     assert path == "/rollouts/submit"
@@ -608,7 +616,20 @@ async def test_submit_timeout_requests_platform_cancel(monkeypatch: pytest.Monke
 
 @pytest.mark.asyncio
 async def test_run_folds_completed_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
-    platform = _FakePlatform([{"status": "completed", "reward": 1.0, "error": None}])
+    platform = _FakePlatform(
+        [
+            {
+                "status": "completed",
+                "reward": 1.0,
+                "error": None,
+                "evaluation_result": {
+                    "score": 1.0,
+                    "info": {"episodes": 4},
+                    "content": "ok",
+                },
+            }
+        ]
+    )
     monkeypatch.setattr(
         "hud.eval.runtime.hosted.PlatformClient.from_settings", classmethod(lambda cls: platform)
     )
@@ -617,6 +638,8 @@ async def test_run_folds_completed_receipt(monkeypatch: pytest.MonkeyPatch) -> N
     run = await HostedRuntime(poll_interval=0.0).run(task, _agent(), job_id=uuid.uuid4().hex)
 
     assert run.reward == 1.0
+    assert run.grade.info == {"episodes": 4}
+    assert run.grade.content == "ok"
     assert run.trace.status == "completed"
     assert not run.trace.is_error
     assert run.runtime == f"hud://trace/{run.trace.trace_id}"

--- a/hud/eval/tests/test_hosted.py
+++ b/hud/eval/tests/test_hosted.py
@@ -234,7 +234,9 @@ async def test_run_submits_and_polls_to_terminal(monkeypatch: pytest.MonkeyPatch
     assert run.trace.trace_id == trace_id
     assert run.job_id == job_id
     assert run.group_id == "g1"
+    assert run.slug == "sums-add"
     assert run.grade.info == {"summary": {"passed": 3}}
+    assert Job(id="job", name="test", runs=[run]).results == {"sums-add": [run]}
     assert platform.polled == 3
     (path, payload) = platform.posts[0]
     assert path == "/rollouts/submit"


### PR DESCRIPTION
## Issue

Hosted rollouts reconstruct `Run.grade` from the terminal trace reward, which drops structured evaluation output such as `info`. They also omit `run.slug`, so `Job.results` cannot key hosted runs by task.

## Solution

`GET /v2/trace/{id}` now returns `evaluation_result` (`TraceDetailResponse` on platform main). `HostedRuntime` folds that frame with `Grade.from_dict`, the same path local runs use after `tasks.grade`. Ungraded terminals still reconstruct from the scalar reward. Hosted runs also keep `task.slug`.

## Outcome / Verification

Hosted `Run.grade` matches local `Run.grade` (reward, info, content). `Job.results` keys hosted runs by slug. `uv run pytest -q hud/eval/tests/test_hosted.py` — 36 passed.


Made with [Cursor](https://cursor.com)