### PR TITLE
feat(cookbooks): add before-and-after evaluation to Fireworks RL

### DIFF
--- a/cookbooks/fireworks-rl-training/README.md
+++ b/cookbooks/fireworks-rl-training/README.md
@@ -138,6 +138,54 @@ were nearly saturated on Qwen 3.8 27B, while smaller generation budgets cut
 off many answers. Inspect both correctness and output-token counts when
 calibrating; a clipped response does not establish arithmetic difficulty.
 
+## Compare before and after training
+
+Use `--eval-before` to evaluate the initial and final adapters on the same
+held-out taskset. Both evaluations use temperature 0 and the same token budget:
+
+```bash
+uv run train.py \
+  --eval-before \
+  --steps 8 \
+  --tasks-per-step 16 \
+  --group-size 4 \
+  --eval-tasks 128 \
+  --seed 42 \
+  --max-tokens 2048 \
+  --max-concurrent 8 \
+  --output-dir runs/before-after
+```
+
+This requests 512 training rollouts and 256 evaluation rollouts. The 16
+training tasks repeat across steps; all 128 evaluation tasks are held out.
+`--seed` controls task generation and splitting, not model sampling randomness.
+
+The output directory contains `config.json`, `eval-before.json`, and
+`eval-after.json`. Each evaluation records the checkpoint, prompts, full
+responses, rewards, grader info, output-token counts, and whether the response
+reached the token limit. Compare answers by prompt, including tasks that changed
+from correct to incorrect. Report token-limit and format failures alongside
+accuracy.
+
+Without `--eval-before`, the script performs only the final evaluation. Use a
+separate output directory for each experiment to preserve its artifacts.
+
+One run with the configuration above applied all eight updates:
+
+| Held-out metric | Before | After |
+| --- | ---: | ---: |
+| Correct answers | 100/128 (78.1%) | 126/128 (98.4%) |
+| Invalid final line | 19 | 0 |
+| Incorrect valid integer | 9 | 2 |
+| Responses at the token limit | 20 | 0 |
+| Mean output tokens | 1,085 | 704 |
+
+Accuracy increased by 20.3 percentage points: 27 tasks improved and one
+regressed. Twenty improvements came from responses previously at the token
+limit. This measures exact-answer success within the fixed budget, with shorter
+completed responses contributing to the gain. It is one run on this arithmetic
+distribution; repeat across training runs to assess reproducibility.
+
 ## Training flow
 
 Each training step uses a sampler snapshot of the current adapter:

--- a/cookbooks/fireworks-rl-training/test_train.py
+++ b/cookbooks/fireworks-rl-training/test_train.py
@@ -250,6 +250,7 @@ def test_training_lifecycle_with_mocked_fireworks(
     if calibrate:
         client.forward_backward.assert_not_called()
         client.optim_step.assert_not_called()
+        assert not (tmp_path / "eval-after.json").exists()
     else:
         datums, loss_fn = client.forward_backward.call_args.args
         assert loss_fn == "importance_sampling"
@@ -262,7 +263,140 @@ def test_training_lifecycle_with_mocked_fireworks(
         assert metric["updated"] is True
         assert metric["valid_rollouts"] == 2
         assert metric["reward_std_within_group"] > 0
+        assert (tmp_path / "eval-after.json").exists()
+    assert not (tmp_path / "eval-before.json").exists()
+    assert fireworks_service.create_sampling_client.return_value.sample.call_count == (
+        2 if calibrate else 3
+    )
     fireworks_service.close.assert_called_once()
+
+
+def test_evaluates_same_held_out_tasks_before_and_after_training(
+    monkeypatch, tmp_path, tokenizer, fireworks_service
+) -> None:
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(training, "get_tokenizer", lambda model: tokenizer)
+    monkeypatch.setattr(training, "FiretitanServiceClient", lambda **kwargs: fireworks_service)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "train.py",
+            "--steps",
+            "1",
+            "--tasks-per-step",
+            "2",
+            "--group-size",
+            "2",
+            "--eval-tasks",
+            "3",
+            "--max-concurrent",
+            "1",
+            "--max-tokens",
+            "9",
+            "--eval-before",
+            "--require-update",
+            "--output-dir",
+            str(tmp_path),
+        ],
+    )
+    args = training.parse_args()
+
+    asyncio.run(training.train(args))
+
+    requests = fireworks_service.create_sampling_client.return_value.sample.call_args_list
+    assert len(requests) == 10
+    before_requests, training_requests, after_requests = requests[:3], requests[3:7], requests[7:]
+    before_prompts = [call.kwargs["prompt"].to_ints() for call in before_requests]
+    assert before_prompts == [call.kwargs["prompt"].to_ints() for call in after_requests]
+    train_prompts = [call.kwargs["prompt"].to_ints() for call in training_requests]
+    assert set(map(tuple, before_prompts)).isdisjoint(map(tuple, train_prompts))
+    for before, after in zip(before_requests, after_requests, strict=True):
+        assert before.kwargs["sampling_params"] == after.kwargs["sampling_params"]
+        assert before.kwargs["sampling_params"].temperature == 0.0
+        assert before.kwargs["sampling_params"].max_tokens == args.max_tokens
+    assert all(call.kwargs["sampling_params"].temperature == 1.0 for call in training_requests)
+
+    events = [
+        name.rsplit(".", 1)[-1]
+        for name, _, _ in fireworks_service.mock_calls
+        if name.endswith(".sample") or name.endswith(".optim_step")
+    ]
+    assert events == ["sample"] * 7 + ["optim_step"] + ["sample"] * 3
+    client = fireworks_service.create_lora_training_client.return_value
+    datums, _ = client.forward_backward.call_args.args
+    assert len(datums) == 4
+    for datum, request in zip(datums, training_requests, strict=True):
+        prompt = request.kwargs["prompt"].to_ints()
+        assert datum.model_input.to_ints()[: len(prompt)] == prompt
+
+    before = json.loads((tmp_path / "eval-before.json").read_text())
+    after = json.loads((tmp_path / "eval-after.json").read_text())
+    assert before["snapshot"] == "test/run/initial"
+    assert after["snapshot"] == "test/run/final"
+    assert [sample["prompt"] for sample in before["samples"]] == [
+        sample["prompt"] for sample in after["samples"]
+    ]
+    for evaluation in (before, after):
+        assert evaluation["temperature"] == 0.0
+        assert evaluation["max_tokens"] == args.max_tokens
+        assert len(evaluation["samples"]) == 3
+        for sample in evaluation["samples"]:
+            operands = re.search(r"What is (\d+) \* (\d+)", sample["prompt"])
+            assert operands is not None
+            expected = int(operands[1]) * int(operands[2])
+            assert sample["info"]["expected"] == expected
+            assert sample["info"]["got"] == int(sample["answer"])
+            assert sample["reward"] == float(int(sample["answer"]) == expected)
+            tokens = tokenizer.encode(sample["answer"] + "<|im_end|>", add_special_tokens=False)
+            assert sample["output_tokens"] == len(tokens)
+            assert sample["at_token_limit"] is (len(tokens) == args.max_tokens)
+    assert all(sample["reward"] == 1.0 for sample in before["samples"])
+    assert all(sample["reward"] == 0.0 for sample in after["samples"])
+    config_text = (tmp_path / "config.json").read_text()
+    assert json.loads(config_text) == vars(args)
+    assert "test-key" not in config_text
+    metrics = [json.loads(line) for line in (tmp_path / "metrics.jsonl").read_text().splitlines()]
+    assert len(metrics) == 1
+    assert metrics[0]["training_datums"] == 4
+    assert metrics[0]["rollouts"] == 4
+
+
+def test_reusing_output_directory_replaces_evaluations_only_when_training(
+    monkeypatch, tmp_path, tokenizer, fireworks_service
+) -> None:
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-key")
+    monkeypatch.setattr(training, "get_tokenizer", lambda model: tokenizer)
+    monkeypatch.setattr(training, "FiretitanServiceClient", lambda **kwargs: fireworks_service)
+    argv = [
+        "train.py",
+        "--steps",
+        "1",
+        "--tasks-per-step",
+        "1",
+        "--group-size",
+        "2",
+        "--eval-tasks",
+        "2",
+        "--max-concurrent",
+        "1",
+        "--output-dir",
+        str(tmp_path),
+    ]
+    monkeypatch.setattr("sys.argv", argv + ["--eval-before"])
+    asyncio.run(training.train(training.parse_args()))
+    files = ["config.json", "eval-before.json", "eval-after.json", "metrics.jsonl"]
+    saved = {name: (tmp_path / name).read_text() for name in files}
+
+    monkeypatch.setattr("sys.argv", argv + ["--calibrate"])
+    asyncio.run(training.train(training.parse_args()))
+    assert {name: (tmp_path / name).read_text() for name in files} == saved
+
+    monkeypatch.setattr("sys.argv", argv)
+    asyncio.run(training.train(training.parse_args()))
+    assert not (tmp_path / "eval-before.json").exists()
+    assert (tmp_path / "eval-after.json").read_text() != saved["eval-after.json"]
+    assert json.loads((tmp_path / "config.json").read_text())["eval_before"] is False
+    assert fireworks_service.create_sampling_client.return_value.sample.call_count == 12
 
 
 @pytest.mark.parametrize("failure", ["sampling", "grading"])

--- a/cookbooks/fireworks-rl-training/train.py
+++ b/cookbooks/fireworks-rl-training/train.py
@@ -396,6 +396,65 @@ async def run_rollouts(
         sampler.close()
 
 
+async def evaluate_policy(
+    *,
+    service: FiretitanServiceClient,
+    training_client: Any,
+    tokenizer: Any,
+    renderer: Any,
+    snapshot_name: str,
+    taskset: Taskset,
+    runtime: Provider | HUDRuntime,
+    args: argparse.Namespace,
+    output_path: Path,
+) -> tuple[float, str]:
+    print(f"Evaluating {snapshot_name}: {len(taskset)} held-out tasks", flush=True)
+    runs, snapshot = await run_rollouts(
+        service=service,
+        training_client=training_client,
+        tokenizer=tokenizer,
+        renderer=renderer,
+        snapshot_name=snapshot_name,
+        taskset=taskset,
+        runtime=runtime,
+        group_size=1,
+        max_concurrent=args.max_concurrent,
+        max_tokens=args.max_tokens,
+        temperature=0.0,
+        timeout=args.sampling_timeout,
+        max_seq_len=args.max_seq_len,
+    )
+    samples = []
+    for run in runs:
+        sample = _sample(run)
+        assert sample is not None
+        output_tokens = len(sample.output_token_ids)
+        samples.append(
+            {
+                "prompt": run.prompt_text,
+                "reward": run.reward,
+                "info": run.grade.info,
+                "answer": run.trace.content,
+                "output_tokens": output_tokens,
+                "at_token_limit": output_tokens == args.max_tokens,
+            }
+        )
+    output_path.write_text(
+        json.dumps(
+            {
+                "snapshot": snapshot,
+                "temperature": 0.0,
+                "max_tokens": args.max_tokens,
+                "samples": samples,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return sum(run.reward for run in runs) / len(runs), snapshot
+
+
 def validate_args(args: argparse.Namespace) -> None:
     positive = {
         "--steps": args.steps,
@@ -418,6 +477,8 @@ def validate_args(args: argparse.Namespace) -> None:
         raise SystemExit("--tasks-file requires --env-path")
     if args.env_path and not args.tasks_file:
         raise SystemExit("--env-path requires --tasks-file")
+    if args.eval_before and args.calibrate:
+        raise SystemExit("--eval-before cannot be used with --calibrate")
 
 
 async def train(args: argparse.Namespace) -> None:
@@ -435,8 +496,14 @@ async def train(args: argparse.Namespace) -> None:
     output_dir = Path(args.output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     metrics_path = output_dir / "metrics.jsonl"
-    if not args.resume_from and not args.calibrate:
-        metrics_path.write_text("", encoding="utf-8")
+    if not args.calibrate:
+        for name in ("eval-before.json", "eval-after.json"):
+            (output_dir / name).unlink(missing_ok=True)
+        (output_dir / "config.json").write_text(
+            json.dumps(vars(args), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if not args.resume_from:
+            metrics_path.write_text("", encoding="utf-8")
 
     tokenizer = get_tokenizer(args.tokenizer_model)
     renderer = get_renderer(args.renderer, tokenizer)
@@ -481,6 +548,23 @@ async def train(args: argparse.Namespace) -> None:
             )
             report_calibration(runs, debug_samples=args.debug_samples)
             return
+
+        if args.eval_before:
+            baseline_reward, _ = await evaluate_policy(
+                service=service,
+                training_client=training_client,
+                tokenizer=tokenizer,
+                renderer=renderer,
+                snapshot_name="initial",
+                taskset=eval_taskset,
+                runtime=runtime,
+                args=args,
+                output_path=output_dir / "eval-before.json",
+            )
+            print(
+                f"Baseline reward={baseline_reward:.3f} on {len(eval_taskset)} held-out tasks",
+                flush=True,
+            )
 
         for step in range(1, args.steps + 1):
             started = time.perf_counter()
@@ -552,7 +636,7 @@ async def train(args: argparse.Namespace) -> None:
             )
 
         final_state = training_client.save_state("final-state").result()
-        eval_runs, final_snapshot = await run_rollouts(
+        eval_reward, final_snapshot = await evaluate_policy(
             service=service,
             training_client=training_client,
             tokenizer=tokenizer,
@@ -560,16 +644,11 @@ async def train(args: argparse.Namespace) -> None:
             snapshot_name="final",
             taskset=eval_taskset,
             runtime=runtime,
-            group_size=1,
-            max_concurrent=args.max_concurrent,
-            max_tokens=args.max_tokens,
-            temperature=0.0,
-            timeout=args.sampling_timeout,
-            max_seq_len=args.max_seq_len,
+            args=args,
+            output_path=output_dir / "eval-after.json",
         )
-        eval_reward = sum(run.reward for run in eval_runs) / len(eval_runs)
         print(
-            f"Evaluation reward={eval_reward:.3f} on {len(eval_runs)} held-out tasks\n"
+            f"Evaluation reward={eval_reward:.3f} on {len(eval_taskset)} held-out tasks\n"
             f"Sampler checkpoint: {final_snapshot}\n"
             f"Training checkpoint: {getattr(final_state, 'path', 'final-state')}\n"
             f"Metrics: {metrics_path}",
@@ -660,6 +739,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-concurrent", type=int, default=4, help="simultaneous rollouts")
     parser.add_argument(
         "--eval-tasks", type=int, default=16, help="held-out tasks for the final eval"
+    )
+    parser.add_argument(
+        "--eval-before",
+        action="store_true",
+        help="also evaluate the same held-out tasks before training for a matched comparison",
     )
     parser.add_argument(
         "--loss-fn",

--- a/docs/v6/cookbooks/fireworks-rl-training.mdx
+++ b/docs/v6/cookbooks/fireworks-rl-training.mdx
@@ -109,8 +109,8 @@ uv run train.py \
 
 Prompt rendering happens on the client, so the base model, tokenizer, and renderer must agree. The
 default renderer, `qwen3_8_disable_thinking` from `tinker-cookbook>=0.5.7`, disables thinking mode.
-This leaves enough of the generation budget for the model to emit the final answer that the
-grader reads.
+`--max-tokens` still limits the entire generated response; a response that reaches the limit may
+not include a final answer.
 
 ## Define the task and reward
 
@@ -257,6 +257,51 @@ generated tokens, and sampling logprobs on each `Run`. `make_training_batch` the
 Metrics are written to `runs/fireworks-serverless/metrics.jsonl`. Each row includes mean reward,
 within-group reward spread, valid rollout count, retained groups, training datums, whether an update
 was applied, loss, snapshot, and step duration.
+
+## Compare before and after training
+
+Add `--eval-before` to evaluate the initial and final adapters on the same held-out tasks,
+at temperature 0 with the same generation budget:
+
+```bash
+uv run train.py \
+  --eval-before \
+  --steps 8 \
+  --tasks-per-step 16 \
+  --group-size 4 \
+  --eval-tasks 128 \
+  --seed 42 \
+  --max-tokens 2048 \
+  --max-concurrent 8 \
+  --output-dir runs/before-after
+```
+
+This requests 512 training rollouts and 256 evaluation rollouts. Training repeats 16 task pairs;
+the 128 evaluation tasks are held out. `--seed` controls the task split, not model sampling randomness.
+
+The script saves `config.json`, `eval-before.json`, and `eval-after.json`. Each evaluation contains
+the checkpoint, prompts, responses, rewards, grader info, output-token counts, and an
+`at_token_limit` flag. Match results by prompt and inspect both improvements and regressions.
+Report format failures and responses at the token limit alongside accuracy; they can explain a
+change in reward.
+
+Use a separate output directory per experiment. Without `--eval-before`, only the final
+evaluation runs.
+
+One run with this configuration applied all eight updates and produced:
+
+| Held-out metric | Before | After |
+| --- | ---: | ---: |
+| Correct answers | 100/128 (78.1%) | 126/128 (98.4%) |
+| Invalid final line | 19 | 0 |
+| Incorrect valid integer | 9 | 2 |
+| Responses at the token limit | 20 | 0 |
+| Mean output tokens | 1,085 | 704 |
+
+Accuracy increased by 20.3 percentage points: 27 tasks improved and one regressed. Twenty
+improvements came from responses previously at the token limit. This measures exact-answer success
+within the fixed budget, with shorter completed responses contributing to the gain. It is one run
+on the multiplication task distribution; repeat across training runs to assess reproducibility.
 
 ## Save and resume
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cookbook and documentation changes around evaluation artifacts and CLI flags; no auth, billing, or core SDK behavior changes.
> 
> **Overview**
> Adds **`--eval-before`** to the Fireworks RL cookbook so the **initial** and **final** adapters are scored on the **same held-out tasks** at temperature 0 with a shared `--max-tokens` budget.
> 
> Training now centralizes evaluation in **`evaluate_policy`**, which writes **`eval-before.json`** / **`eval-after.json`** (plus **`config.json`**) with per-sample prompts, responses, rewards, grader info, output-token counts, and **`at_token_limit`**. Non-calibration runs refresh those eval artifacts in the output dir; **`--eval-before`** is rejected with **`--calibrate`**. Docs and the cookbook README document the workflow and an example before/after metrics table; **`test_train.py`** covers matched eval tasks, sampling settings, and output-directory reuse behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 332a973b019230be815a872a0658c3ae8ac16994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->