### PR TITLE
fix(environment): support 16 MiB control frames with explicit size errors

### DIFF
--- a/docs/v6/internals/control-channel.mdx
+++ b/docs/v6/internals/control-channel.mdx
@@ -73,6 +73,19 @@ Each request and response is one newline-delimited JSON frame. Calls on a
 `HudClient` are serialized, and reply ids must match the corresponding request.
 A malformed or unknown call receives a JSON-RPC error frame.
 
+Control requests and responses are limited to **16,777,216 bytes (16 MiB)** of
+encoded JSON, excluding the trailing newline. This includes the JSON-RPC
+wrapper and escaped strings, not just task arguments. Oversized outgoing
+requests fail before sending with the encoded size and limit; oversized
+responses become JSON-RPC errors. Hosted runs report these through the trace
+error. Both the driver and environment need the updated SDK to use the larger limit;
+older readers still impose the previous 64 KiB limit.
+
+Keep bulk task data in files and pass file IDs in the arguments, then load those
+files inside the environment. Large inline rubrics, prompts, and grading results
+also count toward the limit. Raw capability streams and file-tracking transfers
+have separate limits.
+
 ## One port, two connection types
 
 The TCP listener accepts many connections but publishes only one address. The

--- a/docs/v6/internals/control-channel.mdx
+++ b/docs/v6/internals/control-channel.mdx
@@ -73,18 +73,10 @@ Each request and response is one newline-delimited JSON frame. Calls on a
 `HudClient` are serialized, and reply ids must match the corresponding request.
 A malformed or unknown call receives a JSON-RPC error frame.
 
-Control requests and responses are limited to **16,777,216 bytes (16 MiB)** of
-encoded JSON, excluding the trailing newline. This includes the JSON-RPC
-wrapper and escaped strings, not just task arguments. Oversized outgoing
-requests fail before sending with the encoded size and limit; oversized
-responses become JSON-RPC errors. Hosted runs report these through the trace
-error. Both the driver and environment need the updated SDK to use the larger limit;
-older readers still impose the previous 64 KiB limit.
-
-Keep bulk task data in files and pass file IDs in the arguments, then load those
-files inside the environment. Large inline rubrics, prompts, and grading results
-also count toward the limit. Raw capability streams and file-tracking transfers
-have separate limits.
+Control requests and responses support up to **16 MiB (16,777,216 bytes)** of
+encoded JSON, including the JSON-RPC wrapper and escaped strings, excluding the
+trailing newline. Oversized frames produce an error with the encoded size and
+limit. For larger task data, pass file IDs and load the files in the environment.
 
 ## One port, two connection types
 

--- a/docs/v6/internals/control-channel.mdx
+++ b/docs/v6/internals/control-channel.mdx
@@ -75,8 +75,8 @@ A malformed or unknown call receives a JSON-RPC error frame.
 
 Control requests and responses support up to **16 MiB (16,777,216 bytes)** of
 encoded JSON, including the JSON-RPC wrapper and escaped strings, excluding the
-trailing newline. Oversized frames produce an error with the encoded size and
-limit. For larger task data, pass file IDs and load the files in the environment.
+trailing newline. Oversized frames produce a size-limit error. For larger task
+data, pass file IDs and load the files in the environment.
 
 ## One port, two connection types
 

--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -27,7 +27,7 @@ from hud.capabilities import (
     RFBClient,
     SSHClient,
 )
-from hud.environment.utils import read_frame, send_frame, splice
+from hud.environment.utils import CONTROL_FRAME_LIMIT_BYTES, read_frame, send_frame, splice
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -189,7 +189,9 @@ class HudClient:
                 self._tunnels.add(task)
                 try:
                     try:
-                        up_reader, up_writer = await asyncio.open_connection(host, port)
+                        up_reader, up_writer = await asyncio.open_connection(
+                            host, port, limit=CONTROL_FRAME_LIMIT_BYTES
+                        )
                     except OSError as exc:
                         LOGGER.warning(
                             "tunnel peer %s:%d connection failed: %s",
@@ -207,6 +209,7 @@ class HudClient:
                             "method": "tunnel.open",
                             "params": {"capability": capability.name},
                         },
+                        max_bytes=CONTROL_FRAME_LIMIT_BYTES,
                     )
                     opened = await read_frame(up_reader)
                     if opened is None or "error" in opened:
@@ -338,6 +341,7 @@ class HudClient:
                     await send_frame(
                         self._writer,
                         {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params},
+                        max_bytes=CONTROL_FRAME_LIMIT_BYTES,
                     )
                     reply = await read_frame(self._reader)
                     if reply is None:
@@ -387,7 +391,9 @@ async def _connect_ready(
     deadline = loop.time() + ready_timeout
     while True:
         try:
-            reader, writer = await asyncio.open_connection(host, port)
+            reader, writer = await asyncio.open_connection(
+                host, port, limit=CONTROL_FRAME_LIMIT_BYTES
+            )
         except OSError:
             if loop.time() >= deadline:
                 raise

--- a/hud/clients/client.py
+++ b/hud/clients/client.py
@@ -27,7 +27,13 @@ from hud.capabilities import (
     RFBClient,
     SSHClient,
 )
-from hud.environment.utils import CONTROL_FRAME_LIMIT_BYTES, read_frame, send_frame, splice
+from hud.environment.utils import (
+    CONTROL_FRAME_LIMIT_BYTES,
+    encode_frame,
+    read_frame,
+    send_frame,
+    splice,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -189,9 +195,7 @@ class HudClient:
                 self._tunnels.add(task)
                 try:
                     try:
-                        up_reader, up_writer = await asyncio.open_connection(
-                            host, port, limit=CONTROL_FRAME_LIMIT_BYTES
-                        )
+                        up_reader, up_writer = await asyncio.open_connection(host, port)
                     except OSError as exc:
                         LOGGER.warning(
                             "tunnel peer %s:%d connection failed: %s",
@@ -211,7 +215,7 @@ class HudClient:
                         },
                         max_bytes=CONTROL_FRAME_LIMIT_BYTES,
                     )
-                    opened = await read_frame(up_reader)
+                    opened = await read_frame(up_reader, max_bytes=CONTROL_FRAME_LIMIT_BYTES)
                     if opened is None or "error" in opened:
                         LOGGER.warning("tunnel.open %r refused: %s", capability.name, opened)
                         up_writer.close()
@@ -335,23 +339,25 @@ class HudClient:
         reply_timeout: float | None = None,
     ) -> dict[str, Any]:
         async with self._call_lock:
+            msg_id = next(self._ids)
+            frame = encode_frame(
+                {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params},
+                max_bytes=CONTROL_FRAME_LIMIT_BYTES,
+            )
             try:
                 async with asyncio.timeout(reply_timeout):
-                    msg_id = next(self._ids)
-                    await send_frame(
-                        self._writer,
-                        {"jsonrpc": "2.0", "id": msg_id, "method": method, "params": params},
-                        max_bytes=CONTROL_FRAME_LIMIT_BYTES,
-                    )
-                    reply = await read_frame(self._reader)
+                    self._writer.write(frame)
+                    await self._writer.drain()
+                    reply = await read_frame(self._reader, max_bytes=CONTROL_FRAME_LIMIT_BYTES)
                     if reply is None:
                         raise EOFError(f"env closed connection during {method!r}")
                     if reply.get("id") != msg_id:
                         self.abort()
-                        raise HudProtocolError(
-                            -32603,
-                            f"{method!r}: reply id did not match request",
-                        )
+                        if reply.get("id") is not None or "error" not in reply:
+                            raise HudProtocolError(
+                                -32603,
+                                f"{method!r}: reply id did not match request",
+                            )
                     if "error" in reply:
                         err = reply["error"]
                         raise HudProtocolError(
@@ -391,9 +397,7 @@ async def _connect_ready(
     deadline = loop.time() + ready_timeout
     while True:
         try:
-            reader, writer = await asyncio.open_connection(
-                host, port, limit=CONTROL_FRAME_LIMIT_BYTES
-            )
+            reader, writer = await asyncio.open_connection(host, port)
         except OSError:
             if loop.time() >= deadline:
                 raise

--- a/hud/clients/tests/test_connect.py
+++ b/hud/clients/tests/test_connect.py
@@ -18,7 +18,7 @@ import pytest
 
 import hud.clients.client as client_module
 from hud.capabilities import Capability, CapabilityClient
-from hud.clients import connect
+from hud.clients import HudProtocolError, connect
 from hud.environment.utils import read_frame, send_frame
 from hud.eval.runtime import Runtime
 
@@ -149,7 +149,7 @@ async def test_tunnel_connection_failure_warns_with_peer(
     port = server.sockets[0].getsockname()[1]
     open_connection = asyncio.open_connection
 
-    async def fail_tunnel_connection(host: str, peer_port: int, *, limit: int):
+    async def fail_tunnel_connection(host: str, peer_port: int):
         assert (host, peer_port) == ("127.0.0.1", port)
         raise OSError("peer unavailable")
 
@@ -326,6 +326,34 @@ async def test_connect_gives_up_at_the_deadline_when_the_env_never_serves() -> N
         with pytest.raises(EOFError, match="closed connection during 'hello'"):
             async with connect(Runtime(f"tcp://127.0.0.1:{port}"), ready_timeout=1.2):
                 pass
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+async def test_connection_level_error_is_reported_without_request_id() -> None:
+    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            await read_frame(reader)
+            await send_frame(writer, {"jsonrpc": "2.0", "id": 1, "result": HELLO_RESULT})
+            await read_frame(reader)
+            await send_frame(
+                writer,
+                {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {"code": -32000, "message": "frame exceeds size limit"},
+                },
+            )
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(handler, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        async with connect(Runtime(f"tcp://127.0.0.1:{port}")) as client:
+            with pytest.raises(HudProtocolError, match="frame exceeds size limit"):
+                await client.list_tasks()
     finally:
         server.close()
         await server.wait_closed()

--- a/hud/clients/tests/test_connect.py
+++ b/hud/clients/tests/test_connect.py
@@ -149,7 +149,7 @@ async def test_tunnel_connection_failure_warns_with_peer(
     port = server.sockets[0].getsockname()[1]
     open_connection = asyncio.open_connection
 
-    async def fail_tunnel_connection(host: str, peer_port: int):
+    async def fail_tunnel_connection(host: str, peer_port: int, *, limit: int):
         assert (host, peer_port) == ("127.0.0.1", port)
         raise OSError("peer unavailable")
 

--- a/hud/clients/tests/test_connect.py
+++ b/hud/clients/tests/test_connect.py
@@ -311,49 +311,33 @@ async def test_connect_uses_runtime_ready_timeout_param(
     }
 
 
-async def test_connect_gives_up_at_the_deadline_when_the_env_never_serves() -> None:
+@pytest.mark.parametrize("protocol_error", [False, True])
+async def test_connect_reports_handshake_failure(protocol_error: bool) -> None:
     async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        # Read the hello frame, then hang up without answering: guarantees the
-        # client sees EOF on the reply (not a racing write reset).
         try:
             await read_frame(reader)
+            if protocol_error:
+                await send_frame(
+                    writer,
+                    {
+                        "jsonrpc": "2.0",
+                        "id": None,
+                        "error": {"code": -32000, "message": "frame exceeds size limit"},
+                    },
+                )
         finally:
             writer.close()
 
     server = await asyncio.start_server(handler, "127.0.0.1", 0)
     port = server.sockets[0].getsockname()[1]
     try:
-        with pytest.raises(EOFError, match="closed connection during 'hello'"):
+        expected = HudProtocolError if protocol_error else EOFError
+        message = (
+            "frame exceeds size limit" if protocol_error else "closed connection during 'hello'"
+        )
+        with pytest.raises(expected, match=message):
             async with connect(Runtime(f"tcp://127.0.0.1:{port}"), ready_timeout=1.2):
                 pass
-    finally:
-        server.close()
-        await server.wait_closed()
-
-
-async def test_connection_level_error_is_reported_without_request_id() -> None:
-    async def handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-        try:
-            await read_frame(reader)
-            await send_frame(writer, {"jsonrpc": "2.0", "id": 1, "result": HELLO_RESULT})
-            await read_frame(reader)
-            await send_frame(
-                writer,
-                {
-                    "jsonrpc": "2.0",
-                    "id": None,
-                    "error": {"code": -32000, "message": "frame exceeds size limit"},
-                },
-            )
-        finally:
-            writer.close()
-
-    server = await asyncio.start_server(handler, "127.0.0.1", 0)
-    port = server.sockets[0].getsockname()[1]
-    try:
-        async with connect(Runtime(f"tcp://127.0.0.1:{port}")) as client:
-            with pytest.raises(HudProtocolError, match="frame exceeds size limit"):
-                await client.list_tasks()
     finally:
         server.close()
         await server.wait_closed()

--- a/hud/environment/server.py
+++ b/hud/environment/server.py
@@ -32,6 +32,7 @@ from .env import Answer, current_session_id
 from .utils import (
     CONTROL_FRAME_LIMIT_BYTES,
     FrameTooLargeError,
+    encode_frame,
     error,
     read_frame,
     reply,
@@ -218,7 +219,7 @@ async def _frames(
     msg: dict[str, Any] | None = first
     while msg is not None:
         yield msg
-        msg = await read_frame(reader)
+        msg = await read_frame(reader, max_bytes=CONTROL_FRAME_LIMIT_BYTES)
 
 
 class _ControlChannel:
@@ -305,18 +306,13 @@ class _ControlChannel:
         self._live.add(session_id)
         session_token = current_session_id.set(session_id)
 
-        async def reply_to(msg_id: int | None, result: dict[str, Any]) -> None:
+        async def reply_to(msg_id: int | str | None, result: dict[str, Any]) -> None:
             if msg_id is not None:
                 await send_frame(writer, reply(msg_id, result), max_bytes=CONTROL_FRAME_LIMIT_BYTES)
 
-        async def error_to(msg_id: int | None, code: int, message: str) -> None:
+        async def error_to(msg_id: int | str | None, code: int, message: str) -> None:
             if msg_id is not None:
-                try:
-                    await send_frame(
-                        writer, error(msg_id, code, message), max_bytes=CONTROL_FRAME_LIMIT_BYTES
-                    )
-                except FrameTooLargeError as exc:
-                    await send_frame(writer, error(msg_id, -32000, str(exc)))
+                await _send_control_error(writer, msg_id, code, message)
 
         try:
             async for msg in _frames(first, reader):
@@ -380,7 +376,11 @@ class _ControlChannel:
                         except KeyError:
                             await error_to(msg_id, -32602, f"unknown task: {task_id!r}")
                             continue
-                        await reply_to(msg_id, prompt)
+                        try:
+                            await reply_to(msg_id, prompt)
+                        except BaseException:
+                            await self.cancel(session_id)
+                            raise
 
                     elif method == "tasks.grade":
                         try:
@@ -412,6 +412,22 @@ class _ControlChannel:
             current_session_id.reset(session_token)
 
 
+async def _send_control_error(
+    writer: asyncio.StreamWriter, msg_id: int | str | None, code: int, message: str
+) -> None:
+    try:
+        frame = encode_frame(error(msg_id, code, message), max_bytes=CONTROL_FRAME_LIMIT_BYTES)
+    except FrameTooLargeError as exc:
+        try:
+            frame = encode_frame(
+                error(msg_id, -32000, str(exc)), max_bytes=CONTROL_FRAME_LIMIT_BYTES
+            )
+        except FrameTooLargeError:
+            frame = encode_frame(error(None, -32000, str(exc)), max_bytes=CONTROL_FRAME_LIMIT_BYTES)
+    writer.write(frame)
+    await writer.drain()
+
+
 async def _stream(
     env: Environment,
     msg: dict[str, Any],
@@ -432,16 +448,27 @@ async def _stream(
         parts = urlsplit(cap.url)
         if parts.hostname is None or parts.port is None:
             raise ValueError(f"capability {name!r} has no host:port to tunnel to")
+        response = (
+            encode_frame(reply(msg_id, {"capability": name}), max_bytes=CONTROL_FRAME_LIMIT_BYTES)
+            if msg_id is not None
+            else None
+        )
         backend = await asyncio.open_connection(parts.hostname, parts.port)
     except Exception as exc:
         LOGGER.warning("refusing capability stream: %s", exc)
         if msg_id is not None:
             code = -32602 if isinstance(exc, ValueError) else -32000
-            await send_frame(writer, error(msg_id, code, str(exc)))
+            await _send_control_error(writer, msg_id, code, str(exc))
         return
-    if msg_id is not None:
-        await send_frame(writer, reply(msg_id, {"capability": name}))
-    await splice((reader, writer), backend)
+    try:
+        if response is not None:
+            writer.write(response)
+            await writer.drain()
+        await splice((reader, writer), backend)
+    finally:
+        backend[1].close()
+        with contextlib.suppress(Exception):
+            await backend[1].wait_closed()
 
 
 async def bind(env: Environment, host: str = "127.0.0.1", port: int = 0) -> asyncio.Server:
@@ -470,21 +497,21 @@ async def bind(env: Environment, host: str = "127.0.0.1", port: int = 0) -> asyn
             active.add(task)
             task.add_done_callback(active.discard)
         try:
-            first = await read_frame(reader)
+            first = await read_frame(reader, max_bytes=CONTROL_FRAME_LIMIT_BYTES)
             if first is None:
                 return
             if first.get("method") == "tunnel.open":
                 await _stream(env, first, reader, writer)
             else:
                 await channel.session(first, reader, writer)
+        except FrameTooLargeError as exc:
+            await _send_control_error(writer, None, -32000, str(exc))
         finally:
             with contextlib.suppress(Exception):
                 writer.close()
                 await writer.wait_closed()
 
-    server = await asyncio.start_server(
-        accept, host=host, port=port, limit=CONTROL_FRAME_LIMIT_BYTES
-    )
+    server = await asyncio.start_server(accept, host=host, port=port)
     _SERVER_STATES[server] = _ServerState(handlers=active, channel=channel)
     sock = server.sockets[0].getsockname()
     LOGGER.info("env %r bound on %s:%s", env.name, sock[0], sock[1])

--- a/hud/environment/server.py
+++ b/hud/environment/server.py
@@ -378,7 +378,7 @@ class _ControlChannel:
                             continue
                         try:
                             await reply_to(msg_id, prompt)
-                        except BaseException:
+                        except FrameTooLargeError:
                             await self.cancel(session_id)
                             raise
 

--- a/hud/environment/server.py
+++ b/hud/environment/server.py
@@ -29,7 +29,15 @@ from pydantic import BaseModel, TypeAdapter, ValidationError
 from hud.graders.results import EvaluationResult
 
 from .env import Answer, current_session_id
-from .utils import error, read_frame, reply, send_frame, splice
+from .utils import (
+    CONTROL_FRAME_LIMIT_BYTES,
+    FrameTooLargeError,
+    error,
+    read_frame,
+    reply,
+    send_frame,
+    splice,
+)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, AsyncIterator
@@ -299,11 +307,16 @@ class _ControlChannel:
 
         async def reply_to(msg_id: int | None, result: dict[str, Any]) -> None:
             if msg_id is not None:
-                await send_frame(writer, reply(msg_id, result))
+                await send_frame(writer, reply(msg_id, result), max_bytes=CONTROL_FRAME_LIMIT_BYTES)
 
         async def error_to(msg_id: int | None, code: int, message: str) -> None:
             if msg_id is not None:
-                await send_frame(writer, error(msg_id, code, message))
+                try:
+                    await send_frame(
+                        writer, error(msg_id, code, message), max_bytes=CONTROL_FRAME_LIMIT_BYTES
+                    )
+                except FrameTooLargeError as exc:
+                    await send_frame(writer, error(msg_id, -32000, str(exc)))
 
         try:
             async for msg in _frames(first, reader):
@@ -469,7 +482,9 @@ async def bind(env: Environment, host: str = "127.0.0.1", port: int = 0) -> asyn
                 writer.close()
                 await writer.wait_closed()
 
-    server = await asyncio.start_server(accept, host=host, port=port)
+    server = await asyncio.start_server(
+        accept, host=host, port=port, limit=CONTROL_FRAME_LIMIT_BYTES
+    )
     _SERVER_STATES[server] = _ServerState(handlers=active, channel=channel)
     sock = server.sockets[0].getsockname()
     LOGGER.info("env %r bound on %s:%s", env.name, sock[0], sock[1])

--- a/hud/environment/tests/test_file_tracking.py
+++ b/hud/environment/tests/test_file_tracking.py
@@ -80,3 +80,22 @@ async def test_diff_snapshot_setup_roundtrip(tmp_path: Path) -> None:
         await writer.wait_closed()
         server.close()
         await server.wait_closed()
+
+
+async def test_file_transfer_larger_than_default_stream_limit(tmp_path: Path) -> None:
+    tracker = FileTracker(tmp_path)
+    tracker.take_baseline()
+    content = b"x" * 70000
+    (tmp_path / "large.xlsx").write_bytes(content)
+    server = await serve_file_tracking(tracker)
+    host, port = server.sockets[0].getsockname()[:2]
+    reader, writer = await asyncio.open_connection(host, port, limit=1024 * 1024)
+    try:
+        result = await _call(reader, writer, "flush")
+        captured = result["capture"]["files"][0]
+        assert base64.b64decode(captured["file"]["data"]) == content
+    finally:
+        writer.close()
+        await writer.wait_closed()
+        server.close()
+        await server.wait_closed()

--- a/hud/environment/tests/test_file_tracking.py
+++ b/hud/environment/tests/test_file_tracking.py
@@ -80,22 +80,3 @@ async def test_diff_snapshot_setup_roundtrip(tmp_path: Path) -> None:
         await writer.wait_closed()
         server.close()
         await server.wait_closed()
-
-
-async def test_file_transfer_larger_than_default_stream_limit(tmp_path: Path) -> None:
-    tracker = FileTracker(tmp_path)
-    tracker.take_baseline()
-    content = b"x" * 70000
-    (tmp_path / "large.xlsx").write_bytes(content)
-    server = await serve_file_tracking(tracker)
-    host, port = server.sockets[0].getsockname()[:2]
-    reader, writer = await asyncio.open_connection(host, port, limit=1024 * 1024)
-    try:
-        result = await _call(reader, writer, "flush")
-        captured = result["capture"]["files"][0]
-        assert base64.b64decode(captured["file"]["data"]) == content
-    finally:
-        writer.close()
-        await writer.wait_closed()
-        server.close()
-        await server.wait_closed()

--- a/hud/environment/tests/test_server.py
+++ b/hud/environment/tests/test_server.py
@@ -7,6 +7,7 @@ object, nor a ``{"score": ...}`` dict) instead of silently grading 0.0.
 
 from __future__ import annotations
 
+import json
 from typing import Literal
 
 import pytest
@@ -14,6 +15,7 @@ from pydantic import BaseModel
 
 from hud.clients import HudProtocolError
 from hud.environment import Answer, Environment
+from hud.environment.utils import FrameTooLargeError
 from hud.eval import Run
 from hud.graders import EvaluationResult, SubScore
 
@@ -167,3 +169,70 @@ async def test_start_coerces_postponed_rich_annotations() -> None:
         ) as run:
             run.trace.content = "x"
         assert run.prompt == "HELLO!!!"
+
+
+@pytest.mark.parametrize("extra_bytes", [0, 1])
+async def test_task_request_frame_size_boundary(extra_bytes: int) -> None:
+    env = Environment("frame-limit")
+    received: list[str] = []
+
+    @env.template()
+    async def task(data: str):
+        received.append(data)
+        yield "ready"
+        yield 1.0
+
+    frame = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tasks.start",
+        "params": {"id": "task", "args": {"data": ""}},
+    }
+    overhead = len(json.dumps(frame, separators=(",", ":")).encode())
+    data = "x" * (16 * 1024 * 1024 - overhead + extra_bytes)
+    async with served(env) as client:
+        if extra_bytes:
+            with pytest.raises(FrameTooLargeError, match="16777217 bytes; limit is 16777216 bytes"):
+                await client.start_task("task", {"data": data})
+            assert received == []
+        else:
+            await client.start_task("task", {"data": data})
+            assert received == [data]
+            await client.cancel()
+
+
+@pytest.mark.parametrize("result_kind", ["prompt", "grade", "error"])
+async def test_oversized_task_response_returns_protocol_error(result_kind: str) -> None:
+    env = Environment("large-response")
+
+    @env.template()
+    async def task():
+        if result_kind == "error":
+            raise ValueError("x" * (16 * 1024 * 1024))
+        yield "x" * (16 * 1024 * 1024) if result_kind == "prompt" else "ready"
+        yield {"score": 1.0, "detail": "x" * (16 * 1024 * 1024)}
+
+    async with served(env) as client:
+        with pytest.raises(HudProtocolError, match=r"response is .*limit is 16777216 bytes"):
+            await client.start_task("task")
+            await client.grade({"answer": "done"})
+        await client.cancel()
+        assert (await client.list_tasks())[0]["id"] == "task"
+
+
+@pytest.mark.parametrize("size", [72400, 1024 * 1024])
+async def test_large_task_arguments_prompt_and_grade_roundtrip(size: int) -> None:
+    env = Environment("large-task")
+    data = "x" * size
+
+    @env.template()
+    async def task(criteria: str):
+        yield criteria
+        yield {"score": 1.0, "detail": criteria}
+
+    async with served(env) as client:
+        async with Run(client, "task", {"criteria": data}) as run:
+            assert run.prompt == data
+            run.trace.content = "done"
+        assert run.reward == 1.0
+        assert run.evaluation["detail"] == data

--- a/hud/environment/tests/test_server.py
+++ b/hud/environment/tests/test_server.py
@@ -7,16 +7,19 @@ object, nor a ``{"score": ...}`` dict) instead of silently grading 0.0.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 from typing import Literal
+from urllib.parse import urlsplit
 
 import pytest
 from pydantic import BaseModel
 
-from hud.clients import HudProtocolError
+from hud.clients import HudProtocolError, connect
 from hud.environment import Answer, Environment
-from hud.environment.utils import FrameTooLargeError
-from hud.eval import Run
+from hud.environment.utils import FrameTooLargeError, encode_frame, read_frame, send_frame
+from hud.eval import LocalRuntime, Run, Task
 from hud.graders import EvaluationResult, SubScore
 
 from .conftest import served
@@ -195,6 +198,10 @@ async def test_task_request_frame_size_boundary(extra_bytes: int) -> None:
             with pytest.raises(FrameTooLargeError, match="16777217 bytes; limit is 16777216 bytes"):
                 await client.start_task("task", {"data": data})
             assert received == []
+            assert (await client.list_tasks())[0]["id"] == "task"
+            await client.start_task("task", {"data": "small"})
+            assert received == ["small"]
+            await client.cancel()
         else:
             await client.start_task("task", {"data": data})
             assert received == [data]
@@ -236,3 +243,74 @@ async def test_large_task_arguments_prompt_and_grade_roundtrip(size: int) -> Non
             run.trace.content = "done"
         assert run.reward == 1.0
         assert run.evaluation["detail"] == data
+
+
+async def test_rejected_start_response_tears_down_task_before_disconnect() -> None:
+    env = Environment("failed-start")
+    released = asyncio.Event()
+
+    @env.template()
+    async def task():
+        try:
+            yield "x" * (16 * 1024 * 1024)
+            yield 1.0
+        finally:
+            released.set()
+
+    async with LocalRuntime(env)(Task(env=env.name, id="task")) as runtime:
+        async with connect(runtime) as client:
+            with pytest.raises(HudProtocolError, match="limit is 16777216 bytes"):
+                await client.start_task("task")
+            assert released.is_set()
+        async with connect(runtime) as resumed:
+            with pytest.raises(HudProtocolError, match="no task in progress"):
+                await resumed.grade({"answer": "done"})
+
+
+@pytest.mark.parametrize("hello_first", [False, True])
+async def test_wire_request_over_limit_receives_error_before_disconnect(hello_first: bool) -> None:
+    env = Environment("wire-limit")
+    async with LocalRuntime(env)(Task(env=env.name, id="unused")) as runtime:
+        address = urlsplit(runtime.url)
+        reader, writer = await asyncio.open_connection(address.hostname, address.port)
+        try:
+            if hello_first:
+                await send_frame(writer, {"jsonrpc": "2.0", "id": 1, "method": "hello"})
+                assert await read_frame(reader) is not None
+            writer.write(
+                encode_frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "method": "tasks.start",
+                        "params": {"id": "unused", "args": {"data": "x" * (16 * 1024 * 1024)}},
+                    }
+                )
+            )
+            response = await asyncio.wait_for(read_frame(reader), timeout=5.0)
+            assert response is not None
+            assert response["id"] is None
+            assert "16777216 bytes" in response["error"]["message"]
+        finally:
+            writer.close()
+            with contextlib.suppress(ConnectionError):
+                await writer.wait_closed()
+
+
+async def test_large_request_id_cannot_make_fallback_error_exceed_limit() -> None:
+    env = Environment("large-id")
+    frame = {"jsonrpc": "2.0", "id": "", "method": "nope"}
+    overhead = len(encode_frame(frame)) - 1
+    frame["id"] = "x" * (16 * 1024 * 1024 - overhead)
+    async with LocalRuntime(env)(Task(env=env.name, id="unused")) as runtime:
+        address = urlsplit(runtime.url)
+        reader, writer = await asyncio.open_connection(address.hostname, address.port)
+        try:
+            await send_frame(writer, frame)
+            response = await asyncio.wait_for(read_frame(reader), timeout=5.0)
+            assert response is not None
+            assert response["id"] is None
+            assert "limit is 16777216 bytes" in response["error"]["message"]
+        finally:
+            writer.close()
+            await writer.wait_closed()

--- a/hud/environment/tests/test_server.py
+++ b/hud/environment/tests/test_server.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 from typing import Literal
 from urllib.parse import urlsplit
 
@@ -174,16 +173,14 @@ async def test_start_coerces_postponed_rich_annotations() -> None:
         assert run.prompt == "HELLO!!!"
 
 
-@pytest.mark.parametrize("extra_bytes", [0, 1])
-async def test_task_request_frame_size_boundary(extra_bytes: int) -> None:
+@pytest.mark.parametrize("frame_size", [72483, 1024 * 1024, 16777216, 16777217])
+async def test_task_frame_limit_and_retry(frame_size: int) -> None:
     env = Environment("frame-limit")
-    received: list[str] = []
 
     @env.template()
     async def task(data: str):
-        received.append(data)
-        yield "ready"
-        yield 1.0
+        yield data
+        yield {"score": 1.0, "detail": data}
 
     frame = {
         "jsonrpc": "2.0",
@@ -191,84 +188,48 @@ async def test_task_request_frame_size_boundary(extra_bytes: int) -> None:
         "method": "tasks.start",
         "params": {"id": "task", "args": {"data": ""}},
     }
-    overhead = len(json.dumps(frame, separators=(",", ":")).encode())
-    data = "x" * (16 * 1024 * 1024 - overhead + extra_bytes)
+    data = "x" * (frame_size - (len(encode_frame(frame)) - 1))
     async with served(env) as client:
-        if extra_bytes:
+        if frame_size > 16777216:
             with pytest.raises(FrameTooLargeError, match="16777217 bytes; limit is 16777216 bytes"):
                 await client.start_task("task", {"data": data})
-            assert received == []
-            assert (await client.list_tasks())[0]["id"] == "task"
-            await client.start_task("task", {"data": "small"})
-            assert received == ["small"]
-            await client.cancel()
-        else:
-            await client.start_task("task", {"data": data})
-            assert received == [data]
-            await client.cancel()
+            data = "small retry"
+        assert (await client.start_task("task", {"data": data}))["prompt"] == data
+        assert (await client.grade({"answer": "done"}))["detail"] == data
 
 
 @pytest.mark.parametrize("result_kind", ["prompt", "grade", "error"])
-async def test_oversized_task_response_returns_protocol_error(result_kind: str) -> None:
+async def test_oversized_response_releases_task_and_reports_error(result_kind: str) -> None:
     env = Environment("large-response")
-
-    @env.template()
-    async def task():
-        if result_kind == "error":
-            raise ValueError("x" * (16 * 1024 * 1024))
-        yield "x" * (16 * 1024 * 1024) if result_kind == "prompt" else "ready"
-        yield {"score": 1.0, "detail": "x" * (16 * 1024 * 1024)}
-
-    async with served(env) as client:
-        with pytest.raises(HudProtocolError, match=r"response is .*limit is 16777216 bytes"):
-            await client.start_task("task")
-            await client.grade({"answer": "done"})
-        await client.cancel()
-        assert (await client.list_tasks())[0]["id"] == "task"
-
-
-@pytest.mark.parametrize("size", [72400, 1024 * 1024])
-async def test_large_task_arguments_prompt_and_grade_roundtrip(size: int) -> None:
-    env = Environment("large-task")
-    data = "x" * size
-
-    @env.template()
-    async def task(criteria: str):
-        yield criteria
-        yield {"score": 1.0, "detail": criteria}
-
-    async with served(env) as client:
-        async with Run(client, "task", {"criteria": data}) as run:
-            assert run.prompt == data
-            run.trace.content = "done"
-        assert run.reward == 1.0
-        assert run.evaluation["detail"] == data
-
-
-async def test_rejected_start_response_tears_down_task_before_disconnect() -> None:
-    env = Environment("failed-start")
     released = asyncio.Event()
 
     @env.template()
     async def task():
         try:
-            yield "x" * (16 * 1024 * 1024)
-            yield 1.0
+            if result_kind == "error":
+                raise ValueError("x" * (16 * 1024 * 1024))
+            yield "x" * (16 * 1024 * 1024) if result_kind == "prompt" else "ready"
+            yield {"score": 1.0, "detail": "x" * (16 * 1024 * 1024)}
         finally:
             released.set()
 
     async with LocalRuntime(env)(Task(env=env.name, id="task")) as runtime:
         async with connect(runtime) as client:
-            with pytest.raises(HudProtocolError, match="limit is 16777216 bytes"):
+            with pytest.raises(HudProtocolError, match=r"response is .*limit is 16777216 bytes"):
                 await client.start_task("task")
+                await client.grade({"answer": "done"})
             assert released.is_set()
+            assert (await client.list_tasks())[0]["id"] == "task"
         async with connect(runtime) as resumed:
             with pytest.raises(HudProtocolError, match="no task in progress"):
                 await resumed.grade({"answer": "done"})
 
 
-@pytest.mark.parametrize("hello_first", [False, True])
-async def test_wire_request_over_limit_receives_error_before_disconnect(hello_first: bool) -> None:
+@pytest.mark.parametrize("hello_first,large_id", [(False, False), (True, False), (False, True)])
+async def test_wire_size_errors_are_bounded(hello_first: bool, large_id: bool) -> None:
+    frame = {"jsonrpc": "2.0", "id": "", "method": "nope"}
+    field = "id" if large_id else "padding"
+    frame[field] = "x" * (16777216 - (len(encode_frame(frame)) - 1) if large_id else 16777216)
     env = Environment("wire-limit")
     async with LocalRuntime(env)(Task(env=env.name, id="unused")) as runtime:
         address = urlsplit(runtime.url)
@@ -277,40 +238,11 @@ async def test_wire_request_over_limit_receives_error_before_disconnect(hello_fi
             if hello_first:
                 await send_frame(writer, {"jsonrpc": "2.0", "id": 1, "method": "hello"})
                 assert await read_frame(reader) is not None
-            writer.write(
-                encode_frame(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": 2,
-                        "method": "tasks.start",
-                        "params": {"id": "unused", "args": {"data": "x" * (16 * 1024 * 1024)}},
-                    }
-                )
-            )
+            writer.write(encode_frame(frame))
             response = await asyncio.wait_for(read_frame(reader), timeout=5.0)
-            assert response is not None
-            assert response["id"] is None
+            assert response is not None and response["id"] is None
             assert "16777216 bytes" in response["error"]["message"]
         finally:
             writer.close()
             with contextlib.suppress(ConnectionError):
                 await writer.wait_closed()
-
-
-async def test_large_request_id_cannot_make_fallback_error_exceed_limit() -> None:
-    env = Environment("large-id")
-    frame = {"jsonrpc": "2.0", "id": "", "method": "nope"}
-    overhead = len(encode_frame(frame)) - 1
-    frame["id"] = "x" * (16 * 1024 * 1024 - overhead)
-    async with LocalRuntime(env)(Task(env=env.name, id="unused")) as runtime:
-        address = urlsplit(runtime.url)
-        reader, writer = await asyncio.open_connection(address.hostname, address.port)
-        try:
-            await send_frame(writer, frame)
-            response = await asyncio.wait_for(read_frame(reader), timeout=5.0)
-            assert response is not None
-            assert response["id"] is None
-            assert "limit is 16777216 bytes" in response["error"]["message"]
-        finally:
-            writer.close()
-            await writer.wait_closed()

--- a/hud/environment/tests/test_sessions.py
+++ b/hud/environment/tests/test_sessions.py
@@ -9,6 +9,8 @@ split ``hud task start`` / ``hud task grade`` flow).
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from hud.clients import HudProtocolError, connect
@@ -54,11 +56,30 @@ async def test_restart_replaces_only_the_sessions_own_task() -> None:
         assert (await b.grade({"answer": "x"}))["tag"] == "b"
 
 
-async def test_disconnect_parks_the_task_for_a_later_connection() -> None:
+@pytest.mark.parametrize("write_error", [None, ConnectionError, asyncio.CancelledError])
+async def test_disconnect_parks_the_task_for_a_later_connection(
+    monkeypatch: pytest.MonkeyPatch, write_error: type[BaseException] | None
+) -> None:
+    real_write = asyncio.StreamWriter.write
+
+    def write(writer: asyncio.StreamWriter, data: bytes) -> None:
+        if write_error is not None and b'"prompt":' in data:
+            writer.close()
+            raise write_error()
+        real_write(writer, data)
+
+    monkeypatch.setattr(asyncio.StreamWriter, "write", write)
     async with LocalRuntime(_env())(_SESSION) as runtime:
         async with connect(runtime) as first:
-            await first.start_task("echo", {"tag": "parked"})
+            assert first.manifest is not None
+            session_id = first.manifest.session_id
+            if write_error is None:
+                await first.start_task("echo", {"tag": "parked"})
+            else:
+                with pytest.raises(EOFError):
+                    await first.start_task("echo", {"tag": "parked"})
         async with connect(runtime) as later:
+            await later.hello(session_id=session_id)
             assert (await later.grade({"answer": "x"}))["tag"] == "parked"
 
 

--- a/hud/environment/tests/test_tunnel.py
+++ b/hud/environment/tests/test_tunnel.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 from urllib.parse import urlsplit
 
 import pytest
 
 from hud.capabilities import Capability
 from hud.environment import Environment
-from hud.environment.utils import read_frame, send_frame
+from hud.environment.utils import encode_frame, read_frame, send_frame
 
 from .conftest import served
 
@@ -136,3 +137,43 @@ async def test_closing_the_client_tears_down_its_forwarders(echo_port: int) -> N
     with pytest.raises(OSError):
         _, writer = await asyncio.open_connection(parts.hostname, parts.port)
         writer.close()
+
+
+async def test_frame_assembly_preserves_raw_bytes_and_stream_backpressure() -> None:
+    reader = asyncio.StreamReader()
+    transport = Mock(spec=asyncio.Transport)
+    reader.set_transport(transport)
+    frame = {"padding": "x" * (192 * 1024)}
+    reader.feed_data(encode_frame(frame) + b"raw bytes")
+    assert await read_frame(reader, max_bytes=16 * 1024 * 1024) == frame
+    assert await reader.readexactly(9) == b"raw bytes"
+
+    transport.pause_reading.reset_mock()
+    reader.feed_data(b"x" * (128 * 1024 + 1))
+    transport.pause_reading.assert_called_once()
+
+
+async def test_large_tunnel_preface_preserves_coalesced_raw_bytes(echo_port: int) -> None:
+    async with served(_echo_env(echo_port)) as client:
+        assert client._endpoint is not None
+        reader, writer = await asyncio.open_connection(*client._endpoint)
+        try:
+            writer.write(
+                encode_frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "tunnel.open",
+                        "params": {"capability": "echo"},
+                        "padding": "x" * 70000,
+                    }
+                )
+                + b"raw bytes"
+            )
+            await writer.drain()
+            response = await read_frame(reader)
+            assert response is not None and "result" in response
+            assert await reader.readexactly(9) == b"raw bytes"
+        finally:
+            writer.close()
+            await writer.wait_closed()

--- a/hud/environment/tests/test_tunnel.py
+++ b/hud/environment/tests/test_tunnel.py
@@ -139,41 +139,17 @@ async def test_closing_the_client_tears_down_its_forwarders(echo_port: int) -> N
         writer.close()
 
 
-async def test_frame_assembly_preserves_raw_bytes_and_stream_backpressure() -> None:
+@pytest.mark.parametrize("frame_size", [70000, 16 * 1024 * 1024])
+async def test_buffered_frame_preserves_newline_boundary_and_backpressure(frame_size: int) -> None:
     reader = asyncio.StreamReader()
     transport = Mock(spec=asyncio.Transport)
     reader.set_transport(transport)
-    frame = {"padding": "x" * (192 * 1024)}
+    frame = {"padding": ""}
+    frame["padding"] = "x" * (frame_size - (len(encode_frame(frame)) - 1))
     reader.feed_data(encode_frame(frame) + b"raw bytes")
-    assert await read_frame(reader, max_bytes=16 * 1024 * 1024) == frame
+    assert await asyncio.wait_for(read_frame(reader, max_bytes=16 * 1024 * 1024), 1) == frame
     assert await reader.readexactly(9) == b"raw bytes"
 
     transport.pause_reading.reset_mock()
     reader.feed_data(b"x" * (128 * 1024 + 1))
     transport.pause_reading.assert_called_once()
-
-
-async def test_large_tunnel_preface_preserves_coalesced_raw_bytes(echo_port: int) -> None:
-    async with served(_echo_env(echo_port)) as client:
-        assert client._endpoint is not None
-        reader, writer = await asyncio.open_connection(*client._endpoint)
-        try:
-            writer.write(
-                encode_frame(
-                    {
-                        "jsonrpc": "2.0",
-                        "id": 1,
-                        "method": "tunnel.open",
-                        "params": {"capability": "echo"},
-                        "padding": "x" * 70000,
-                    }
-                )
-                + b"raw bytes"
-            )
-            await writer.drain()
-            response = await read_frame(reader)
-            assert response is not None and "result" in response
-            assert await reader.readexactly(9) == b"raw bytes"
-        finally:
-            writer.close()
-            await writer.wait_closed()

--- a/hud/environment/utils.py
+++ b/hud/environment/utils.py
@@ -17,13 +17,8 @@ class FrameTooLargeError(ValueError):
 # ─── JSON-RPC 2.0 framing ───
 
 
-async def send_frame(
-    writer: asyncio.StreamWriter,
-    msg: dict[str, Any],
-    *,
-    max_bytes: int | None = None,
-) -> None:
-    """Write one newline-delimited JSON frame and flush."""
+def encode_frame(msg: dict[str, Any], *, max_bytes: int | None = None) -> bytes:
+    """Encode and validate a newline-delimited JSON frame."""
     data = json.dumps(msg, separators=(",", ":")).encode("utf-8")
     if max_bytes is not None and len(data) > max_bytes:
         frame = f"{msg['method']!r} request" if "method" in msg else "response"
@@ -32,24 +27,59 @@ async def send_frame(
             "(excluding the newline). Reduce inline JSON; pass large task data by file ID "
             "and load it inside the environment."
         )
-    writer.write(data + b"\n")
+    return data + b"\n"
+
+
+async def send_frame(
+    writer: asyncio.StreamWriter,
+    msg: dict[str, Any],
+    *,
+    max_bytes: int | None = None,
+) -> None:
+    """Write one newline-delimited JSON frame and flush."""
+    writer.write(encode_frame(msg, max_bytes=max_bytes))
     await writer.drain()
 
 
-async def read_frame(reader: asyncio.StreamReader) -> dict[str, Any] | None:
-    """Read one frame; None on EOF."""
-    line = await reader.readline()
+async def read_frame(
+    reader: asyncio.StreamReader, *, max_bytes: int | None = None
+) -> dict[str, Any] | None:
+    """Read one frame; None on EOF. Oversized frames require closing the connection."""
+    if max_bytes is None:
+        line = await reader.readline()
+    else:
+        line = bytearray()
+        while True:
+            try:
+                chunk = await reader.readuntil(b"\n")
+            except asyncio.LimitOverrunError as exc:
+                if len(line) + exc.consumed > max_bytes:
+                    raise FrameTooLargeError(
+                        f"Control-channel frame exceeds the limit of {max_bytes} bytes "
+                        f"(received at least {len(line) + exc.consumed} bytes)."
+                    ) from exc
+                line.extend(await reader.readexactly(exc.consumed))
+                continue
+            except asyncio.IncompleteReadError as exc:
+                chunk = exc.partial
+            line.extend(chunk)
+            size = len(line) - int(line.endswith(b"\n"))
+            if size > max_bytes:
+                raise FrameTooLargeError(
+                    f"Control-channel frame is {size} bytes; limit is {max_bytes} bytes."
+                )
+            break
     if not line:
         return None
     return json.loads(line)
 
 
-def reply(msg_id: int, result: dict[str, Any]) -> dict[str, Any]:
+def reply(msg_id: int | str, result: dict[str, Any]) -> dict[str, Any]:
     """JSON-RPC 2.0 success response."""
     return {"jsonrpc": "2.0", "id": msg_id, "result": result}
 
 
-def error(msg_id: int, code: int, message: str) -> dict[str, Any]:
+def error(msg_id: int | str | None, code: int, message: str) -> dict[str, Any]:
     """JSON-RPC 2.0 error response."""
     return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}}
 
@@ -101,4 +131,4 @@ async def splice(
         await _drain_close()
 
 
-__all__ = ["error", "read_frame", "reply", "send_frame", "splice"]
+__all__ = ["encode_frame", "error", "read_frame", "reply", "send_frame", "splice"]

--- a/hud/environment/utils.py
+++ b/hud/environment/utils.py
@@ -7,12 +7,32 @@ import contextlib
 import json
 from typing import Any
 
+CONTROL_FRAME_LIMIT_BYTES = 16 * 1024 * 1024
+
+
+class FrameTooLargeError(ValueError):
+    """An encoded JSON-RPC frame exceeds its channel's byte limit."""
+
+
 # ─── JSON-RPC 2.0 framing ───
 
 
-async def send_frame(writer: asyncio.StreamWriter, msg: dict[str, Any]) -> None:
+async def send_frame(
+    writer: asyncio.StreamWriter,
+    msg: dict[str, Any],
+    *,
+    max_bytes: int | None = None,
+) -> None:
     """Write one newline-delimited JSON frame and flush."""
-    writer.write(json.dumps(msg, separators=(",", ":")).encode("utf-8") + b"\n")
+    data = json.dumps(msg, separators=(",", ":")).encode("utf-8")
+    if max_bytes is not None and len(data) > max_bytes:
+        frame = f"{msg['method']!r} request" if "method" in msg else "response"
+        raise FrameTooLargeError(
+            f"Control-channel {frame} is {len(data)} bytes; limit is {max_bytes} bytes "
+            "(excluding the newline). Reduce inline JSON; pass large task data by file ID "
+            "and load it inside the environment."
+        )
+    writer.write(data + b"\n")
     await writer.drain()
 
 

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -32,6 +32,7 @@ import hud.eval.run as run_module
 from hud.agents.base import Agent
 from hud.agents.openai_compatible import OpenAIChatAgent
 from hud.agents.types import OpenAIChatConfig
+from hud.clients.client import HudClient
 from hud.environment import Answer, Environment
 from hud.eval import Job, LocalRuntime, Runtime, SubprocessRuntime, Task, Taskset
 from hud.eval.run import Run, rollout
@@ -980,44 +981,58 @@ async def test_timeout_includes_grading() -> None:
 
 
 async def test_timeout_aborts_when_cancel_rpc_hangs(monkeypatch: pytest.MonkeyPatch) -> None:
-    from hud.clients.client import HudClient
-
     env = Environment("sums")
+    agent_started = asyncio.Event()
+    cancel_started = asyncio.Event()
 
     @env.template()
     async def add(a: int, b: int):
         yield f"add:{a}:{b}"
         await asyncio.Event().wait()
 
+    class WaitingAgent(Agent):
+        async def __call__(self, run: Run) -> None:
+            agent_started.set()
+            await asyncio.Event().wait()
+
     aborted: list[bool] = []
 
     async def hang_cancel(self: HudClient) -> None:
+        cancel_started.set()
         await asyncio.Event().wait()
 
     real_abort = HudClient.abort
+    real_wait = asyncio.wait
 
     def track_abort(self: HudClient) -> None:
         aborted.append(True)
         real_abort(self)
 
+    async def wait_after_agent_starts(
+        tasks: set[asyncio.Task[None]], **kwargs: Any
+    ) -> tuple[set[asyncio.Task[None]], set[asyncio.Task[None]]]:
+        # Exercise cancel/abort after connection setup, independent of startup speed.
+        await asyncio.wait_for(agent_started.wait(), timeout=5.0)
+        return await real_wait(tasks, **kwargs)
+
     monkeypatch.setattr(HudClient, "cancel", hang_cancel)
     monkeypatch.setattr(HudClient, "abort", track_abort)
+    monkeypatch.setattr(run_module.asyncio, "wait", wait_after_agent_starts)
 
-    loop = asyncio.get_running_loop()
-    started = loop.time()
-    run = await rollout(
-        _add_task(2, 3),
-        _SlowAgent(_solve_add),
-        runtime=LocalRuntime(env),
-        rollout_timeout=0.2,
+    run = await asyncio.wait_for(
+        rollout(
+            _add_task(2, 3),
+            WaitingAgent(),
+            runtime=LocalRuntime(env),
+            rollout_timeout=0.2,
+        ),
+        timeout=10.0,
     )
-    elapsed = loop.time() - started
 
     assert run.trace.status == "error"
     assert run.trace.stop_reason == "timeout"
+    assert cancel_started.is_set()
     assert aborted
-    # rollout_timeout (0.2) + cancel grace (2.0); must not hang forever on read_frame.
-    assert elapsed < 5.0
 
 
 async def test_timeout_does_not_wait_for_provider_cleanup() -> None:

--- a/hud/eval/tests/test_rollout.py
+++ b/hud/eval/tests/test_rollout.py
@@ -1381,3 +1381,31 @@ def test_prompt_text_flattens_text_turns_and_drops_non_text() -> None:
     )
     run = _run_with_prompt([{"role": "user", "content": "first"}, image, "second"])
     assert run.prompt_text == "first\n\nsecond"
+
+
+@pytest.mark.parametrize("character", ["x", "é"])
+async def test_oversized_task_args_become_trace_error_before_setup(character: str) -> None:
+    encoded_character_bytes = len(json.dumps(character)) - 2
+    data = character * (16 * 1024 * 1024 // encoded_character_bytes + 1)
+    env = Environment("large-task")
+    started = False
+
+    @env.template()
+    async def task(criteria: str):
+        nonlocal started
+        started = True
+        yield "ready"
+        yield 1.0
+
+    run = await rollout(
+        Task(env=env.name, id="task", args={"criteria": data}),
+        _FnAgent(lambda _: pytest.fail("agent must not launch")),
+        runtime=LocalRuntime(env),
+    )
+    assert not started
+    assert run.trace.is_error
+    assert "[starting task]" in (run.trace.error or "")
+    assert "'tasks.start' request" in (run.trace.error or "")
+    assert "limit is 16777216 bytes" in (run.trace.error or "")
+    assert "file ID" in (run.trace.error or "")
+    assert "EOFError" not in (run.trace.error or "")


### PR DESCRIPTION
A roughly 72 KB task-start request exceeded asyncio's implicit 64 KiB line limit, causing the environment to close the connection and the rollout to report only `EOFError`. Control requests and responses now support 16 MiB of encoded JSON. Frame assembly preserves newline-delimited framing and normal socket backpressure, including when a connection becomes a raw capability tunnel.

Requests are validated before transmission so a local size error leaves the client usable for retry. Task-start replies rejected by size validation cancel the suspended task; transport failures leave it parked for session resume. Oversized inbound frames receive a bounded protocol error before disconnect, and oversized response errors retain the request ID when it fits or use a null ID when it does not. File-tracking transfers retain their separate limits.

Validation:
- Environment, client, and rollout suites: 246 passed on Python 3.11 and 246 passed on Python 3.12. Reconnect regressions reproduce write failure and cancellation during the prompt response and verify the task remains resumable.
- Covers 72 KB and 1 MiB round trips, the exact 16 MiB boundary, escaped Unicode, retries after rejection, setup teardown and reconnect, raw over-limit requests, oversized request IDs, and tunnel bytes/backpressure.
- The existing cancellation timeout test synchronizes on agent startup before arming its short deadline and verifies the hung-cancel path is reached.
- Ruff lint/format, type checks on the changed implementation and regression tests, and `git diff --check` passed.

Both the rollout driver and environment image must use the updated SDK to exchange frames above 64 KiB. Existing readers retain their old limit. No runtime deployment or SDK release is included.
