### PR TITLE
release: 0.6.16.dev5

### DIFF
--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.16.dev4"
+__version__ = "0.6.16.dev5"


### PR DESCRIPTION
## Summary

Bump the HUD SDK package version from `0.6.16.dev4` to `0.6.16.dev5` for a prerelease containing everything merged since `v0.6.16.dev4`: nested rollout trace lineage, structured hosted grades from trace polling, 16 MiB control frames with explicit size errors, OpenAI prompt cache key reuse, the empty `shell_call` turn fix, the fastmcp bump, and the SDK example environments.

## Verification

- `uv build --wheel --out-dir /private/tmp/hud-python-release-dev5-dist`
- built `hud-0.6.16.dev5-py3-none-any.whl`
- wheel metadata reports `Version: 0.6.16.dev5`

After merge, publish GitHub prerelease `v0.6.16.dev5`; the release workflow builds and publishes the `hud` package to PyPI. Prerelease publication does not move the stable `docs` branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line version constant update with no behavioral or security impact.
> 
> **Overview**
> **Release bump** for the HUD SDK prerelease: `__version__` in `hud/version.py` moves from `0.6.16.dev4` to `0.6.16.dev5`.
> 
> This tags the package for build/publish (wheel/PyPI and GitHub prerelease `v0.6.16.dev5` per the release workflow). No runtime or API code changes in this diff—only the version identifier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 958b89f4b39c1c6b8985e6236882047c3ae6016f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->