### PR TITLE
release: 0.6.16

### DIFF
--- a/hud/version.py
+++ b/hud/version.py
@@ -4,4 +4,4 @@ Version information for the HUD SDK.
 
 from __future__ import annotations
 
-__version__ = "0.6.16.dev4"
+__version__ = "0.6.16"


### PR DESCRIPTION
## Summary

Bump the HUD SDK package version from `0.6.16.dev4` to `0.6.16` for the stable release covering everything merged since `v0.6.15`.

## Verification

- `uv build --wheel --out-dir /private/tmp/hud-python-release-0.6.16-dist`
- built `hud-0.6.16-py3-none-any.whl`
- wheel metadata reports `Version: 0.6.16`

After merge, publish GitHub release `v0.6.16`; the release workflow builds and publishes the `hud` package to PyPI and moves the `docs` branch to this release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant version string change with no runtime logic or API behavior changes.
> 
> **Overview**
> Sets the HUD SDK release version to **0.6.16** by changing `__version__` in `hud/version.py` from `0.6.16.dev4` to the stable `0.6.16` string. This is the packaging marker for the release that bundles changes since `v0.6.15`; post-merge steps (wheel build, GitHub release, PyPI publish, `docs` branch update) are described in the PR verification notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cad0c0fb30e980fc609a8ac3380cad8b1f05dfff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->