### PR TITLE
fix(agents): persist Anthropic refusal explanations

### DIFF
--- a/hud/agents/claude/agent.py
+++ b/hud/agents/claude/agent.py
@@ -403,6 +403,12 @@ class ClaudeAgent(ToolAgent[BetaMessageParam, ClaudeConfig]):
         if thinking_parts:
             result.reasoning = "\n".join(thinking_parts)
         result.finish_reason = response.stop_reason
+        if response.stop_reason == "refusal" and response.stop_details is not None:
+            explanation = response.stop_details.explanation
+            if explanation:
+                result.refusal = explanation
+            elif response.stop_details.category is not None:
+                result.refusal = f"This request was refused ({response.stop_details.category})."
         return result
 
     @staticmethod

--- a/hud/agents/tests/test_claude_agent.py
+++ b/hud/agents/tests/test_claude_agent.py
@@ -54,11 +54,12 @@ class FakeAnthropic:
         self.beta = SimpleNamespace(messages=FakeMessages(*outcomes))
 
 
-def _final(*content: Any, stop_reason: str) -> Any:
+def _final(*content: Any, stop_reason: str, stop_details: Any = None) -> Any:
     """A fake ``BetaMessage``: content blocks plus the always-present envelope."""
     return SimpleNamespace(
         content=list(content),
         stop_reason=stop_reason,
+        stop_details=stop_details,
         model="claude-test-v9",
         usage=SimpleNamespace(input_tokens=11, output_tokens=7, cache_read_input_tokens=3),
     )
@@ -127,6 +128,48 @@ async def test_get_response_done_on_text_only() -> None:
     result = await agent.get_response(_state(agent))
     assert result.done is True
     assert result.content == "done"
+    assert result.tool_calls == []
+    assert result.refusal is None
+
+
+async def test_get_response_surfaces_refusal_explanation() -> None:
+    explanation = (
+        "This request triggered restrictions on violative cyber content and was "
+        "blocked under Anthropic's Usage Policy."
+    )
+    final = _final(
+        stop_reason="refusal",
+        stop_details=SimpleNamespace(
+            type="refusal",
+            category="cyber",
+            explanation=explanation,
+        ),
+    )
+    agent = _agent(final)
+    result = await agent.get_response(_state(agent))
+
+    assert result.finish_reason == "refusal"
+    assert result.refusal == explanation
+    assert result.done is True
+    assert result.tool_calls == []
+
+
+async def test_get_response_surfaces_refusal_category_when_explanation_missing() -> None:
+    final = _final(
+        stop_reason="refusal",
+        stop_details=SimpleNamespace(
+            type="refusal",
+            category="cyber",
+            explanation=None,
+        ),
+    )
+    agent = _agent(final)
+    result = await agent.get_response(_state(agent))
+
+    assert result.finish_reason == "refusal"
+    assert result.refusal is not None
+    assert "cyber" in result.refusal
+    assert result.done is True
     assert result.tool_calls == []
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "fastmcp==3.2.0",
     # For all inference agents
     "openai>=2.45.0",
-    "anthropic>=0.78.0",
+    "anthropic>=0.98.0",
     "google-genai",
     # CLI dependencies
     "typer>=0.9.0",
@@ -122,7 +122,7 @@ agents = []
 
 # AWS Bedrock support for ClaudeAgent
 bedrock = [
-    "anthropic[bedrock]>=0.78.0",
+    "anthropic[bedrock]>=0.98.0",
 ]
 
 # Development dependencies - includes testing, linting, and automation tools


### PR DESCRIPTION
## Summary
- Claude HTTP 200 refusals (`stop_reason=refusal`) put the policy category and explanation on `stop_details`, but `ClaudeAgent` only copied `stop_reason` and left `AgentStep.refusal` empty.
- The trace UI already displays `event.refusal`; this copies Anthropic's explanation (or the category when explanation is missing) so Fable/Opus classifier refusals show the real reason instead of "The model refused this request."

## Test plan
- [x] `uv run pytest hud/agents/tests/test_claude_agent.py -q` (19 passed)
- [ ] Confirm a hosted Fable 5.1 refusal after the SDK pin is bumped shows the usage-policy text on the agent message


Made with [Cursor](https://cursor.com)