### PR TITLE
Fix typo in agent evaluation description

### DIFF
--- a/docs/v6/start/overview.mdx
+++ b/docs/v6/start/overview.mdx
@@ -181,7 +181,7 @@ the **agent** you want to evaluate.
 For standard models like Claude, GPT, or Gemini our **prebuilt harnesses** and our optional inference gateway
 let you switch between models just by choosing their name. 
 
-Running the agent evaluation produces a **run** (one rollout). Everry run is recorded into a **trace** - a full,
+Running the agent evaluation produces a **run** (one rollout). Every run is recorded into a **trace** - a full,
 replayable timeline of everything the agent did and how it was graded. Running a whole taskset bundles all 
 the runs into a single **job**. HUD enables executing runs in parallel with full isolation out of the box, and every
 run is traced on the [platform](https://hud.ai), so you can see exactly what the agent did in realtime.


### PR DESCRIPTION
Corrected a typo in the overview documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or behavioral impact.
> 
> **Overview**
> Fixes a single spelling error in the **Run your agent** section of the v6 start overview: **Everry** → **Every** in the sentence describing how each evaluation run is recorded as a trace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a2c6b93c66f5e36eab1edff451cd66b263fd7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->